### PR TITLE
chore(repo): bootstrap project scaffolding and CI (Slice 0)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Pull Request
+
+## Slice
+- Repo: doberman-core | doberman-enterprise
+- Feature / Slice: <id> — <title>
+- Plan reference: doberman_implementation_plan.md
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Public-release safety (doberman-core only)
+- [ ] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
+- [ ] Core still builds/tests/runs with NO enterprise package installed
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+- [ ] doberman-core does not import doberman_enterprise
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - name: Standalone guarantee (no enterprise installed)
+        run: pip list | grep -i doberman-enterprise && exit 1 || echo "ok: core has no enterprise dependency"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture & repo boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
           cache: pip
       - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
       - name: Standalone guarantee (no enterprise installed)
-        run: pip list | grep -i doberman-enterprise && exit 1 || echo "ok: core has no enterprise dependency"
+        run: |
+          pip list | grep -i doberman-enterprise && exit 1 || echo "ok: core has no enterprise dependency"
       - run: ruff check .
       - run: ruff format --check .
       - name: Architecture & repo boundaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,11 @@ jobs:
       - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
       - name: Standalone guarantee (no enterprise installed)
         run: |
-          pip list | grep -i doberman-enterprise && exit 1 || echo "ok: core has no enterprise dependency"
+          if pip list | grep -qi doberman-enterprise; then
+            echo "FAIL: enterprise package found in core environment"
+            exit 1
+          fi
+          echo "ok: core has no enterprise dependency"
       - run: ruff check .
       - run: ruff format --check .
       - name: Architecture & repo boundaries
@@ -36,5 +40,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
-      - uses: gitleaks/gitleaks-action@v2
-        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "false"
+          GITLEAKS_ENABLE_SUMMARY: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,402 @@
+# CLAUDE.md — Doberman Workspace Operating Manual
+
+> This is the **workspace-root** init file. It governs any AI agent (Claude Code, Codex, Cursor, etc.) working anywhere in this workspace.
+> It is the **HOW**. `doberman_implementation_plan.md` is the **WHAT** (features → slices).
+> Content is identical to `AGENTS.md`; keep the two in sync (or symlink one to the other).
+> If this file conflicts with a casual prompt instruction, **this file wins** unless a human overrides it in writing.
+
+---
+
+## 0. On startup (every session)
+
+1. Read this entire file, then `doberman_implementation_plan.md`.
+2. Identify the workspace: there are **two repositories** — `doberman-core` (public) and `doberman-enterprise` (private). See §1.
+3. `git status` + `git log --oneline -5` in the relevant repo.
+4. Pick the **next slice** from the plan (lowest-numbered unmerged slice, in the order of the plan's Final Integration Plan).
+5. **Decide which repo the slice targets** using the mapping in §2. If the slice is *split*, the public part is a core slice and the proprietary/hosted part is a separate enterprise slice — they are **separate PRs in separate repos**.
+6. If that repo lacks scaffolding (`pyproject.toml` / `.github/workflows/ci.yml`), do **Slice 0 (Bootstrap)** for that repo first (§6).
+7. Execute exactly **one slice** via **The Slice Loop** (§5), then **STOP** and report. Stop at every review checkpoint.
+
+---
+
+## 1. Workspace & repositories
+
+This workspace contains two repos with a hard boundary between them.
+
+### `doberman-core` — **public, Apache-2.0**
+Only put code here that can be **safely released publicly, forever**.
+
+**Allowed:** runtime harness · SDK · policy schema · basic rule engine · adapters · examples · tests · public docs.
+
+**Not allowed:** enterprise features · hosted/cloud code · proprietary detection logic · customer data · secrets · private deployment scripts · commercial-license code.
+
+### `doberman-enterprise` — **private, proprietary**
+**Allowed:** cloud dashboard · hosted monitoring · audit logs (centralized/compliance-grade) · enterprise policy management · org/team controls · advanced detection · premium rule packs · billing · SSO/RBAC · compliance workflows.
+
+### Dependency direction (the hard rule)
+- `doberman-enterprise` **may** depend on `doberman-core`.
+- `doberman-core` **must never** depend on `doberman-enterprise`.
+- Enforced in CI (§7). The public core must build, test, and run **with zero enterprise code installed**.
+
+### When in doubt → keep it private, but keep the core useful
+- If you are unsure whether a piece of **detection logic, data handling, or commercial functionality** belongs in core or enterprise, put it in **enterprise**. Public release is **irreversible**; moving code private→public later is safe.
+- But the open core must be **genuinely functional on its own**, not crippleware: schema, interfaces, the runtime harness, adapters, and **basic** rules always live in core.
+- If a slice would require core to know about an enterprise concept, you have the boundary wrong — STOP and ask.
+
+---
+
+## 2. Where each part of the implementation plan lives
+
+Map every slice to a repo before coding. The headline: **the MVP is almost entirely `doberman-core`.** `doberman-enterprise` is the team/enterprise + advanced-detection layer (the plan's Phase 4–5 and "advanced detection").
+
+| Plan feature | Repo | Split? | What goes where |
+|---|---|---|---|
+| **F1** Tool Mediation & `SecurityObject` | `core` | no | runtime harness, MCP **adapter**, SDK, `SecurityObject` **policy schema** |
+| **F2** Decision Engine & Execution Rule | `core` | no | the safety invariants (execution rule, raise-only `combine`) — must be open & auditable |
+| **F3** Objective Guardrail | **both** | **yes** | core: the `Rule` **interface** + the **basic** rules (paths, commands, destinations, basic secret patterns, encoded-exfil). enterprise: **advanced detection + premium rule packs** (proprietary logic) registered via the interface |
+| **F4** Agent Role Policy & Boundaries | **both** | **yes** | core: role **schema** + per-repo boundary matcher. enterprise: **enterprise policy management**, **org/team** role controls |
+| **F5** Capability Discovery & Risk Map | **both** | **yes** | core: **local** scan + local risk map (CLI). enterprise: fleet **agent inventory**, hosted **risk dashboards** |
+| **F6** Policy Checklist & Strength Modes | **both** | **yes** | core: default checklist + Light/Balanced/Strict/Paranoid modes. enterprise: **shared/org policy templates & defaults** |
+| **F7** Tiered Auth & Role Elevation | **both** | **yes** | core: **local** confirm, TOTP 2FA, narrow/temporary elevation. enterprise: **SSO/RBAC**, hosted/push approval workflows |
+| **F8** Decision Log & Audit | **both** | **yes** | core: **local, redacted decision log** + storage **interface** (needed for local explainability). enterprise: **centralized audit logs**, hosted **monitoring**, SIEM export, **compliance workflows** |
+| **F9** Subjective Guardrail & Baseline | **both** | **yes** | core: the abnormality **interface** + a **basic** local baseline. enterprise: **advanced detection** (UEBA-style behavioral models) |
+| **F10** Policy-Drift & Poisoning Defense | **both** | **yes** | core: the **mechanism** (classify strengthen/weaken, 2FA gate, append-only ledger) — a core safety invariant. enterprise: org-wide drift **monitoring** + **compliance reporting** |
+| Examples, SDK, public docs, broad test suite | `core` | — | |
+| Billing, cloud dashboard, hosted monitoring, premium rule packs, SSO/RBAC, compliance | `enterprise` | — | not in the MVP; plan Phase 4–5 |
+
+### The interface / plugin pattern (how split features stay clean)
+For every split feature, **core defines a stable interface and a runtime registry; enterprise ships packages that *register* implementations** — core never imports enterprise by name.
+
+- Core declares an abstract `Rule` / `Detector` / `AuthProvider` / `AuditSink` (per the relevant feature) plus a registry that **loads whatever is installed via Python entry points**.
+- Enterprise packages implement those interfaces and advertise them through their own `pyproject.toml` entry points (e.g. group `doberman.rules`, `doberman.detectors`, `doberman.audit_sinks`).
+- At runtime Doberman runs core's basic implementations **plus** any registered plugins. With only core installed, it still works (basic protection). With enterprise installed, premium detection/audit/SSO light up.
+- This is exactly the decoupling discipline the plan already mandates inside core (the policy core must not import the proxy adapter) — now extended across the repo boundary.
+
+**Rule of thumb for a split slice:** build the **interface + basic core implementation as a `core` slice first**; build the **advanced/proprietary/hosted implementation as a separate `enterprise` slice** that depends on the now-merged core interface.
+
+---
+
+## 3. Prime directives (non-negotiable)
+
+These override everything. If a task would break one, **STOP and ask a human**.
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case → deny / `BLOCK`. The protected agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails/learning may auto-tighten; they may **never** silently loosen. Any weakening goes through the human-approved path (Feature 10).
+3. **Never expose secrets.** Never commit/log/store raw secrets, keys, full private files, unredacted prompts, customer data, or `.doberman/` contents. Fingerprints/classifications/metadata only.
+4. **Respect the repo boundary.** `doberman-core` is public and Apache-2.0 — it may contain **nothing** from the "not allowed" list (§1). `doberman-core` **must never import or reference `doberman_enterprise`**. Public release is irreversible; when unsure, keep it private.
+5. **No slice is "done" without tests + green CI**, in the repo it belongs to.
+6. **Keep cores decoupled.** Inside `doberman-core`, the policy core (`doberman.engine`/`roles`/`policy`/`storage`/`learning`) must not import `doberman.proxy`. Enforced by `import-linter`.
+7. **One slice = one PR = one repo.** Never let a single PR touch both repos.
+
+If you feel pressure to violate one of these to "make progress," that pressure is the bug. Stop.
+
+---
+
+## 4. Project snapshot
+
+- **What:** Doberman sits between a coding agent and its tools and turns every meaningful action into a risk-based **allow / authenticate / block** decision.
+- **Packages:** core distributes as `doberman` (`src/doberman/`); enterprise distributes as `doberman_enterprise` (separate repo) and **depends on `doberman`**.
+- **Stack:** Python 3.11+, MCP proxy (`mcp` SDK), local-first **SQLite** (`aiosqlite`), YAML policy in `.doberman/`, Pydantic v2, `pyotp`, a `doberman` CLI (Typer), `pytest`.
+- **Layouts:** see the plan's "Repository layout." Runtime data (`.doberman/`, the DB, key files) is **never** committed.
+
+---
+
+## 5. The Slice Loop (run for every slice)
+
+**Step 0 — Route to a repo.** Using §2, decide the target repo. If the slice is split, work only the part for the chosen repo; the other part is its own slice/PR in the other repo. Confirm the part you put in `doberman-core` contains nothing from the §1 "not allowed" list.
+
+**Step 1 — Read the slice** in `doberman_implementation_plan.md` (Objective, files, changes, security considerations, edge cases, expected output, suggested tests, suggested commit message). Ambiguity or a Prime-Directive conflict → STOP and ask.
+
+**Step 2 — Branch** (in the right repo):
+```
+git checkout main && git pull
+git checkout -b feat/<feature-slug>/<slice-slug>
+```
+
+**Step 3 — Implement** the smallest change that satisfies the Objective, strictly inside the slice's scope and the repo boundary. For split features, implement against the **interface** (core) or **register a plugin** (enterprise) — never make core import enterprise.
+
+**Step 4 — Write this slice's tests (required).** In `tests/unit/` or `tests/integration/`, create `test_<slice_topic>.py` covering at minimum: every item in the slice's **"Suggested tests"**, every **edge case**, and every behavioral **security consideration** (e.g. *"a `BLOCK` means the fake downstream server recorded nothing"*, *"a synthetic secret never appears in any log/output"*, *"`combine` never returns a verdict lower than either input"*). For `doberman-core` slices, also confirm the **standalone** guarantee (core works with no enterprise installed). Prefer TDD; tests must be deterministic (no real network/clock/secrets — inject/fixture them).
+
+**Step 5 — Make sure GitHub Actions runs these tests.** Tests live under `tests/` so CI's `pytest` discovers them (`pytest --collect-only` to confirm). New dependency → add to that repo's `pyproject.toml`. New import boundary → update its `import-linter` contract. New CI step → update that repo's `.github/workflows/ci.yml` (minimal, same PR).
+
+**Step 6 — Green locally:**
+```
+ruff check . && ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing       # (--cov=doberman_enterprise in the enterprise repo)
+```
+Everything passes; do **not** weaken a test or invariant to get green.
+
+**Step 7 — Update docs** if usage/CLI/config/public behavior changed.
+
+**Step 8 — Commit** (Conventional Commits; tests ship **in the same PR** as the code, ideally same commit). Primary commit uses the plan's "Suggested commit message." Never stage `.doberman/`, `*.db`, key files, `.env*` (they're gitignored — verify with `git status`).
+
+**Step 9 — Push the branch** (`git push -u origin <branch>`) — tests go with it, so CI runs them.
+
+**Step 10 — Open a PR to `main`** in that repo; fill the PR template (note the **Repo** and, for core, the **public-release safety** checkbox). Confirm CI turns **green**. Red CI → fix on the branch and push again; never merge red.
+
+**Step 11 — Post the Slice Completion Report (§10) and STOP.** Don't start the next slice until approved/merged or told to continue.
+
+**Step 12 — If this was the last slice of a feature**, after merge post the Feature Review Checkpoint (§10) and STOP. Review checkpoints are mandatory pauses.
+
+---
+
+## 6. Slice 0 — Bootstrap (per repo, only if scaffolding is missing)
+
+Each repo gets its own scaffolding + working CI + a trivial smoke test, committed on `chore/bootstrap-scaffolding` with `chore(repo): bootstrap project scaffolding and CI`. Commit `CLAUDE.md`/`AGENTS.md` into each repo (and the plan into `doberman-core`).
+
+### `doberman-core` — `pyproject.toml`
+```toml
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.importlinter]
+root_package = "doberman"
+
+# Inside-core decoupling: policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+
+# Cross-repo boundary: the public core must never import the private enterprise package.
+[[tool.importlinter.contracts]]
+name = "Public core must not depend on the private enterprise package"
+type = "forbidden"
+source_modules = ["doberman"]
+forbidden_modules = ["doberman_enterprise"]
+```
+
+### `doberman-core` — `.github/workflows/ci.yml`
+```yaml
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - name: Standalone guarantee (no enterprise installed)
+        run: pip list | grep -i doberman-enterprise && exit 1 || echo "ok: core has no enterprise dependency"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture & repo boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+```
+> `--cov-fail-under=80` is a starting bar — raise it over time, never lower it to pass a PR.
+
+### `doberman-core` — standalone test (commit in Slice 0)
+```python
+# tests/unit/test_core_is_standalone.py
+import sys
+
+def test_core_imports_with_no_enterprise_installed():
+    import doberman  # must succeed with zero enterprise deps
+    assert "doberman_enterprise" not in sys.modules
+```
+
+### `doberman-enterprise` — bootstrap deltas (vs core)
+- `pyproject.toml`: `name = "doberman_enterprise"`, **proprietary license** (not Apache-2.0), and a dependency on core: `dependencies = ["doberman @ <git/url or version>", ...]`. Coverage `source = ["doberman_enterprise"]`.
+- CI: same shape, but **install core first** and `--cov=doberman_enterprise`. Add jobs as needed (license-header check, private-registry auth). **Do not** publish artifacts publicly.
+- `import-linter`: enterprise may import `doberman` (the public interfaces) freely; add any internal enterprise layering contracts you need.
+- An enterprise PR may register premium rule packs / detectors via entry points — never by editing core.
+
+### Both repos — `.gitignore`
+```gitignore
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+```
+
+### Both repos — `.github/pull_request_template.md`
+```markdown
+## Slice
+- Repo: doberman-core | doberman-enterprise
+- Feature / Slice: <id> — <title>
+- Plan reference: doberman_implementation_plan.md
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Public-release safety (doberman-core only)
+- [ ] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
+- [ ] Core still builds/tests/runs with NO enterprise package installed
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+- [ ] doberman-core does not import doberman_enterprise
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-
+```
+
+---
+
+## 7. Cross-repo dependency enforcement (summary)
+
+The boundary is guaranteed three ways, all in CI:
+1. **`import-linter` forbidden contract** in core: `doberman` may not import `doberman_enterprise`.
+2. **Standalone install + test** in core's CI: enterprise is **not installed**, and a test asserts `import doberman` succeeds and `doberman_enterprise` is absent.
+3. **Plugin inversion**: split features connect through core-defined interfaces + entry-point discovery, so core has no static reference to enterprise.
+
+Enterprise freely depends on core (installed as the `doberman` package). Never the reverse.
+
+---
+
+## 8. Version control hygiene
+
+- **One slice = one branch = one PR = one repo.** Never span both repos in a PR.
+- Branches: `feat/<feature-slug>/<slice-slug>` (or `fix/...`, `chore/...`).
+- Conventional Commits; small, building commits; **tests travel with code**.
+- **Never commit** secrets, keys, `.doberman/`, `*.db`, `.env*`. If you do by accident → STOP, tell a human, treat the value as leaked (rotate it).
+- Rebase (don't merge) to update a branch: `git fetch && git rebase origin/main`.
+
+---
+
+## 9. Security & explainability rules (every slice)
+
+- **Default deny:** wrap risky ops so exceptions yield `BLOCK` (or `AUTH` only where the plan says "fail upward").
+- **Redaction mandatory:** strip raw secrets/large payloads before logging/persisting; keep path **classes**, reason codes, verdicts, **HMAC fingerprints**. Test that a synthetic secret never appears.
+- **Keyed fingerprints:** HMAC-SHA256 with a local `0600`/keyring key (never committed) — plain hashes of low-entropy secrets are brute-forceable.
+- **Explainability first:** every `BLOCK`/`AUTH` carries `reason_codes` **and** a one-line human `explanation`. Reason codes are shared constants in `models.py`.
+- **Auth is action-bound:** approvals single-use + tied to one action id; elevations narrow + time-limited + (destructive) single-use; elevation never relaxes a hard block.
+- **Canonicalize before matching** paths (resolve `.`/`..`/symlinks, confine to repo root) via one shared helper.
+- **Logging never alters/blocks a decision** and never crashes the execution path.
+- **Don't oversell:** never claim secret detection (or any single rule) is airtight — it is defense-in-depth.
+
+---
+
+## 10. Reporting formats
+
+### Slice Completion Report (after every slice, then STOP)
+```
+SLICE COMPLETE — <repo> :: <feature> / <slice id> (<title>)
+Branch: <branch>    PR: #<n>    CI: <green | red+why>
+What I built: <2–3 lines>
+Tests added (run in CI): <files> — <what they cover>
+Repo-boundary check: <core has no enterprise refs / N/A for enterprise>
+Security checks verified: <redaction / fail-closed / raise-only / etc.>
+Edge cases covered: <list>
+Decisions / assumptions: <or "none">
+Deviations from the plan: <none | what & why>
+Risks / tech debt introduced: <or "none">
+Next slice: <repo :: id — title>  (awaiting go-ahead)
+```
+
+### Feature Review Checkpoint (after the last slice of a feature, then STOP)
+```
+REVIEW CHECKPOINT — <Feature N: name>
+Built (and in which repo[s]): ...
+Needs human testing: ...
+Decisions to review: ...
+Risks / shortcuts / tech debt: ...
+>> Paused. I will not start the next feature until told to proceed.
+```
+
+---
+
+## 11. Never do this
+
+- ❌ Put anything from the §1 "not allowed" list into **doberman-core** (enterprise/hosted code, proprietary detection, customer data, secrets, commercial-license code).
+- ❌ Make **doberman-core** import or reference **doberman_enterprise**, or any enterprise concept.
+- ❌ Span both repos in one PR, or do work outside the current slice's scope.
+- ❌ Skip a review checkpoint or start the next feature without a go-ahead.
+- ❌ Mark a slice "done" with missing/failing tests or red CI.
+- ❌ Weaken/stub a test or invariant to make CI pass.
+- ❌ Auto-loosen Doberman (all loosening goes through the Feature 10 human-approved path).
+- ❌ Commit or log a secret, key, full private file, unredacted prompt, or `.doberman/` content.
+- ❌ Let `doberman.proxy` be imported by the policy core.
+- ❌ Add any path by which a protected agent could reach a real tool without going through the decision engine.
+- ❌ Invent requirements. Unclear plan or wrong-looking slice → STOP and ask.
+
+---
+
+## 12. Quick reference
+
+| You want to… | Do this |
+|---|---|
+| Know **what** to build | `doberman_implementation_plan.md` |
+| Know **how** to build it | this file |
+| Decide the repo for a slice | §2 mapping; split → interface in core, plugin in enterprise; when unsure → enterprise |
+| Start a slice | route to repo (§5 Step 0) → branch `feat/<feature>/<slice>` → follow §5 |
+| Finish a slice | tests added + pushed, CI green, boundary checks pass, Slice Completion Report, STOP |
+| Run checks (core) | `ruff check . && ruff format --check . && lint-imports && pytest --cov=doberman` |
+| Hit ambiguity / boundary doubt | STOP and ask — when unsure about public vs private, keep it **private** |
+
+**Remember:** small safe commits · tests with every slice · CI green before "done" · public core stays clean and standalone · enterprise depends on core, never the reverse · when in doubt, **fail closed and ask.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,402 @@
+# CLAUDE.md — Doberman Workspace Operating Manual
+
+> This is the **workspace-root** init file. It governs any AI agent (Claude Code, Codex, Cursor, etc.) working anywhere in this workspace.
+> It is the **HOW**. `doberman_implementation_plan.md` is the **WHAT** (features → slices).
+> Content is identical to `AGENTS.md`; keep the two in sync (or symlink one to the other).
+> If this file conflicts with a casual prompt instruction, **this file wins** unless a human overrides it in writing.
+
+---
+
+## 0. On startup (every session)
+
+1. Read this entire file, then `doberman_implementation_plan.md`.
+2. Identify the workspace: there are **two repositories** — `doberman-core` (public) and `doberman-enterprise` (private). See §1.
+3. `git status` + `git log --oneline -5` in the relevant repo.
+4. Pick the **next slice** from the plan (lowest-numbered unmerged slice, in the order of the plan's Final Integration Plan).
+5. **Decide which repo the slice targets** using the mapping in §2. If the slice is *split*, the public part is a core slice and the proprietary/hosted part is a separate enterprise slice — they are **separate PRs in separate repos**.
+6. If that repo lacks scaffolding (`pyproject.toml` / `.github/workflows/ci.yml`), do **Slice 0 (Bootstrap)** for that repo first (§6).
+7. Execute exactly **one slice** via **The Slice Loop** (§5), then **STOP** and report. Stop at every review checkpoint.
+
+---
+
+## 1. Workspace & repositories
+
+This workspace contains two repos with a hard boundary between them.
+
+### `doberman-core` — **public, Apache-2.0**
+Only put code here that can be **safely released publicly, forever**.
+
+**Allowed:** runtime harness · SDK · policy schema · basic rule engine · adapters · examples · tests · public docs.
+
+**Not allowed:** enterprise features · hosted/cloud code · proprietary detection logic · customer data · secrets · private deployment scripts · commercial-license code.
+
+### `doberman-enterprise` — **private, proprietary**
+**Allowed:** cloud dashboard · hosted monitoring · audit logs (centralized/compliance-grade) · enterprise policy management · org/team controls · advanced detection · premium rule packs · billing · SSO/RBAC · compliance workflows.
+
+### Dependency direction (the hard rule)
+- `doberman-enterprise` **may** depend on `doberman-core`.
+- `doberman-core` **must never** depend on `doberman-enterprise`.
+- Enforced in CI (§7). The public core must build, test, and run **with zero enterprise code installed**.
+
+### When in doubt → keep it private, but keep the core useful
+- If you are unsure whether a piece of **detection logic, data handling, or commercial functionality** belongs in core or enterprise, put it in **enterprise**. Public release is **irreversible**; moving code private→public later is safe.
+- But the open core must be **genuinely functional on its own**, not crippleware: schema, interfaces, the runtime harness, adapters, and **basic** rules always live in core.
+- If a slice would require core to know about an enterprise concept, you have the boundary wrong — STOP and ask.
+
+---
+
+## 2. Where each part of the implementation plan lives
+
+Map every slice to a repo before coding. The headline: **the MVP is almost entirely `doberman-core`.** `doberman-enterprise` is the team/enterprise + advanced-detection layer (the plan's Phase 4–5 and "advanced detection").
+
+| Plan feature | Repo | Split? | What goes where |
+|---|---|---|---|
+| **F1** Tool Mediation & `SecurityObject` | `core` | no | runtime harness, MCP **adapter**, SDK, `SecurityObject` **policy schema** |
+| **F2** Decision Engine & Execution Rule | `core` | no | the safety invariants (execution rule, raise-only `combine`) — must be open & auditable |
+| **F3** Objective Guardrail | **both** | **yes** | core: the `Rule` **interface** + the **basic** rules (paths, commands, destinations, basic secret patterns, encoded-exfil). enterprise: **advanced detection + premium rule packs** (proprietary logic) registered via the interface |
+| **F4** Agent Role Policy & Boundaries | **both** | **yes** | core: role **schema** + per-repo boundary matcher. enterprise: **enterprise policy management**, **org/team** role controls |
+| **F5** Capability Discovery & Risk Map | **both** | **yes** | core: **local** scan + local risk map (CLI). enterprise: fleet **agent inventory**, hosted **risk dashboards** |
+| **F6** Policy Checklist & Strength Modes | **both** | **yes** | core: default checklist + Light/Balanced/Strict/Paranoid modes. enterprise: **shared/org policy templates & defaults** |
+| **F7** Tiered Auth & Role Elevation | **both** | **yes** | core: **local** confirm, TOTP 2FA, narrow/temporary elevation. enterprise: **SSO/RBAC**, hosted/push approval workflows |
+| **F8** Decision Log & Audit | **both** | **yes** | core: **local, redacted decision log** + storage **interface** (needed for local explainability). enterprise: **centralized audit logs**, hosted **monitoring**, SIEM export, **compliance workflows** |
+| **F9** Subjective Guardrail & Baseline | **both** | **yes** | core: the abnormality **interface** + a **basic** local baseline. enterprise: **advanced detection** (UEBA-style behavioral models) |
+| **F10** Policy-Drift & Poisoning Defense | **both** | **yes** | core: the **mechanism** (classify strengthen/weaken, 2FA gate, append-only ledger) — a core safety invariant. enterprise: org-wide drift **monitoring** + **compliance reporting** |
+| Examples, SDK, public docs, broad test suite | `core` | — | |
+| Billing, cloud dashboard, hosted monitoring, premium rule packs, SSO/RBAC, compliance | `enterprise` | — | not in the MVP; plan Phase 4–5 |
+
+### The interface / plugin pattern (how split features stay clean)
+For every split feature, **core defines a stable interface and a runtime registry; enterprise ships packages that *register* implementations** — core never imports enterprise by name.
+
+- Core declares an abstract `Rule` / `Detector` / `AuthProvider` / `AuditSink` (per the relevant feature) plus a registry that **loads whatever is installed via Python entry points**.
+- Enterprise packages implement those interfaces and advertise them through their own `pyproject.toml` entry points (e.g. group `doberman.rules`, `doberman.detectors`, `doberman.audit_sinks`).
+- At runtime Doberman runs core's basic implementations **plus** any registered plugins. With only core installed, it still works (basic protection). With enterprise installed, premium detection/audit/SSO light up.
+- This is exactly the decoupling discipline the plan already mandates inside core (the policy core must not import the proxy adapter) — now extended across the repo boundary.
+
+**Rule of thumb for a split slice:** build the **interface + basic core implementation as a `core` slice first**; build the **advanced/proprietary/hosted implementation as a separate `enterprise` slice** that depends on the now-merged core interface.
+
+---
+
+## 3. Prime directives (non-negotiable)
+
+These override everything. If a task would break one, **STOP and ask a human**.
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case → deny / `BLOCK`. The protected agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails/learning may auto-tighten; they may **never** silently loosen. Any weakening goes through the human-approved path (Feature 10).
+3. **Never expose secrets.** Never commit/log/store raw secrets, keys, full private files, unredacted prompts, customer data, or `.doberman/` contents. Fingerprints/classifications/metadata only.
+4. **Respect the repo boundary.** `doberman-core` is public and Apache-2.0 — it may contain **nothing** from the "not allowed" list (§1). `doberman-core` **must never import or reference `doberman_enterprise`**. Public release is irreversible; when unsure, keep it private.
+5. **No slice is "done" without tests + green CI**, in the repo it belongs to.
+6. **Keep cores decoupled.** Inside `doberman-core`, the policy core (`doberman.engine`/`roles`/`policy`/`storage`/`learning`) must not import `doberman.proxy`. Enforced by `import-linter`.
+7. **One slice = one PR = one repo.** Never let a single PR touch both repos.
+
+If you feel pressure to violate one of these to "make progress," that pressure is the bug. Stop.
+
+---
+
+## 4. Project snapshot
+
+- **What:** Doberman sits between a coding agent and its tools and turns every meaningful action into a risk-based **allow / authenticate / block** decision.
+- **Packages:** core distributes as `doberman` (`src/doberman/`); enterprise distributes as `doberman_enterprise` (separate repo) and **depends on `doberman`**.
+- **Stack:** Python 3.11+, MCP proxy (`mcp` SDK), local-first **SQLite** (`aiosqlite`), YAML policy in `.doberman/`, Pydantic v2, `pyotp`, a `doberman` CLI (Typer), `pytest`.
+- **Layouts:** see the plan's "Repository layout." Runtime data (`.doberman/`, the DB, key files) is **never** committed.
+
+---
+
+## 5. The Slice Loop (run for every slice)
+
+**Step 0 — Route to a repo.** Using §2, decide the target repo. If the slice is split, work only the part for the chosen repo; the other part is its own slice/PR in the other repo. Confirm the part you put in `doberman-core` contains nothing from the §1 "not allowed" list.
+
+**Step 1 — Read the slice** in `doberman_implementation_plan.md` (Objective, files, changes, security considerations, edge cases, expected output, suggested tests, suggested commit message). Ambiguity or a Prime-Directive conflict → STOP and ask.
+
+**Step 2 — Branch** (in the right repo):
+```
+git checkout main && git pull
+git checkout -b feat/<feature-slug>/<slice-slug>
+```
+
+**Step 3 — Implement** the smallest change that satisfies the Objective, strictly inside the slice's scope and the repo boundary. For split features, implement against the **interface** (core) or **register a plugin** (enterprise) — never make core import enterprise.
+
+**Step 4 — Write this slice's tests (required).** In `tests/unit/` or `tests/integration/`, create `test_<slice_topic>.py` covering at minimum: every item in the slice's **"Suggested tests"**, every **edge case**, and every behavioral **security consideration** (e.g. *"a `BLOCK` means the fake downstream server recorded nothing"*, *"a synthetic secret never appears in any log/output"*, *"`combine` never returns a verdict lower than either input"*). For `doberman-core` slices, also confirm the **standalone** guarantee (core works with no enterprise installed). Prefer TDD; tests must be deterministic (no real network/clock/secrets — inject/fixture them).
+
+**Step 5 — Make sure GitHub Actions runs these tests.** Tests live under `tests/` so CI's `pytest` discovers them (`pytest --collect-only` to confirm). New dependency → add to that repo's `pyproject.toml`. New import boundary → update its `import-linter` contract. New CI step → update that repo's `.github/workflows/ci.yml` (minimal, same PR).
+
+**Step 6 — Green locally:**
+```
+ruff check . && ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing       # (--cov=doberman_enterprise in the enterprise repo)
+```
+Everything passes; do **not** weaken a test or invariant to get green.
+
+**Step 7 — Update docs** if usage/CLI/config/public behavior changed.
+
+**Step 8 — Commit** (Conventional Commits; tests ship **in the same PR** as the code, ideally same commit). Primary commit uses the plan's "Suggested commit message." Never stage `.doberman/`, `*.db`, key files, `.env*` (they're gitignored — verify with `git status`).
+
+**Step 9 — Push the branch** (`git push -u origin <branch>`) — tests go with it, so CI runs them.
+
+**Step 10 — Open a PR to `main`** in that repo; fill the PR template (note the **Repo** and, for core, the **public-release safety** checkbox). Confirm CI turns **green**. Red CI → fix on the branch and push again; never merge red.
+
+**Step 11 — Post the Slice Completion Report (§10) and STOP.** Don't start the next slice until approved/merged or told to continue.
+
+**Step 12 — If this was the last slice of a feature**, after merge post the Feature Review Checkpoint (§10) and STOP. Review checkpoints are mandatory pauses.
+
+---
+
+## 6. Slice 0 — Bootstrap (per repo, only if scaffolding is missing)
+
+Each repo gets its own scaffolding + working CI + a trivial smoke test, committed on `chore/bootstrap-scaffolding` with `chore(repo): bootstrap project scaffolding and CI`. Commit `CLAUDE.md`/`AGENTS.md` into each repo (and the plan into `doberman-core`).
+
+### `doberman-core` — `pyproject.toml`
+```toml
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.importlinter]
+root_package = "doberman"
+
+# Inside-core decoupling: policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+
+# Cross-repo boundary: the public core must never import the private enterprise package.
+[[tool.importlinter.contracts]]
+name = "Public core must not depend on the private enterprise package"
+type = "forbidden"
+source_modules = ["doberman"]
+forbidden_modules = ["doberman_enterprise"]
+```
+
+### `doberman-core` — `.github/workflows/ci.yml`
+```yaml
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - name: Standalone guarantee (no enterprise installed)
+        run: pip list | grep -i doberman-enterprise && exit 1 || echo "ok: core has no enterprise dependency"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture & repo boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+```
+> `--cov-fail-under=80` is a starting bar — raise it over time, never lower it to pass a PR.
+
+### `doberman-core` — standalone test (commit in Slice 0)
+```python
+# tests/unit/test_core_is_standalone.py
+import sys
+
+def test_core_imports_with_no_enterprise_installed():
+    import doberman  # must succeed with zero enterprise deps
+    assert "doberman_enterprise" not in sys.modules
+```
+
+### `doberman-enterprise` — bootstrap deltas (vs core)
+- `pyproject.toml`: `name = "doberman_enterprise"`, **proprietary license** (not Apache-2.0), and a dependency on core: `dependencies = ["doberman @ <git/url or version>", ...]`. Coverage `source = ["doberman_enterprise"]`.
+- CI: same shape, but **install core first** and `--cov=doberman_enterprise`. Add jobs as needed (license-header check, private-registry auth). **Do not** publish artifacts publicly.
+- `import-linter`: enterprise may import `doberman` (the public interfaces) freely; add any internal enterprise layering contracts you need.
+- An enterprise PR may register premium rule packs / detectors via entry points — never by editing core.
+
+### Both repos — `.gitignore`
+```gitignore
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+```
+
+### Both repos — `.github/pull_request_template.md`
+```markdown
+## Slice
+- Repo: doberman-core | doberman-enterprise
+- Feature / Slice: <id> — <title>
+- Plan reference: doberman_implementation_plan.md
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Public-release safety (doberman-core only)
+- [ ] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
+- [ ] Core still builds/tests/runs with NO enterprise package installed
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+- [ ] doberman-core does not import doberman_enterprise
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-
+```
+
+---
+
+## 7. Cross-repo dependency enforcement (summary)
+
+The boundary is guaranteed three ways, all in CI:
+1. **`import-linter` forbidden contract** in core: `doberman` may not import `doberman_enterprise`.
+2. **Standalone install + test** in core's CI: enterprise is **not installed**, and a test asserts `import doberman` succeeds and `doberman_enterprise` is absent.
+3. **Plugin inversion**: split features connect through core-defined interfaces + entry-point discovery, so core has no static reference to enterprise.
+
+Enterprise freely depends on core (installed as the `doberman` package). Never the reverse.
+
+---
+
+## 8. Version control hygiene
+
+- **One slice = one branch = one PR = one repo.** Never span both repos in a PR.
+- Branches: `feat/<feature-slug>/<slice-slug>` (or `fix/...`, `chore/...`).
+- Conventional Commits; small, building commits; **tests travel with code**.
+- **Never commit** secrets, keys, `.doberman/`, `*.db`, `.env*`. If you do by accident → STOP, tell a human, treat the value as leaked (rotate it).
+- Rebase (don't merge) to update a branch: `git fetch && git rebase origin/main`.
+
+---
+
+## 9. Security & explainability rules (every slice)
+
+- **Default deny:** wrap risky ops so exceptions yield `BLOCK` (or `AUTH` only where the plan says "fail upward").
+- **Redaction mandatory:** strip raw secrets/large payloads before logging/persisting; keep path **classes**, reason codes, verdicts, **HMAC fingerprints**. Test that a synthetic secret never appears.
+- **Keyed fingerprints:** HMAC-SHA256 with a local `0600`/keyring key (never committed) — plain hashes of low-entropy secrets are brute-forceable.
+- **Explainability first:** every `BLOCK`/`AUTH` carries `reason_codes` **and** a one-line human `explanation`. Reason codes are shared constants in `models.py`.
+- **Auth is action-bound:** approvals single-use + tied to one action id; elevations narrow + time-limited + (destructive) single-use; elevation never relaxes a hard block.
+- **Canonicalize before matching** paths (resolve `.`/`..`/symlinks, confine to repo root) via one shared helper.
+- **Logging never alters/blocks a decision** and never crashes the execution path.
+- **Don't oversell:** never claim secret detection (or any single rule) is airtight — it is defense-in-depth.
+
+---
+
+## 10. Reporting formats
+
+### Slice Completion Report (after every slice, then STOP)
+```
+SLICE COMPLETE — <repo> :: <feature> / <slice id> (<title>)
+Branch: <branch>    PR: #<n>    CI: <green | red+why>
+What I built: <2–3 lines>
+Tests added (run in CI): <files> — <what they cover>
+Repo-boundary check: <core has no enterprise refs / N/A for enterprise>
+Security checks verified: <redaction / fail-closed / raise-only / etc.>
+Edge cases covered: <list>
+Decisions / assumptions: <or "none">
+Deviations from the plan: <none | what & why>
+Risks / tech debt introduced: <or "none">
+Next slice: <repo :: id — title>  (awaiting go-ahead)
+```
+
+### Feature Review Checkpoint (after the last slice of a feature, then STOP)
+```
+REVIEW CHECKPOINT — <Feature N: name>
+Built (and in which repo[s]): ...
+Needs human testing: ...
+Decisions to review: ...
+Risks / shortcuts / tech debt: ...
+>> Paused. I will not start the next feature until told to proceed.
+```
+
+---
+
+## 11. Never do this
+
+- ❌ Put anything from the §1 "not allowed" list into **doberman-core** (enterprise/hosted code, proprietary detection, customer data, secrets, commercial-license code).
+- ❌ Make **doberman-core** import or reference **doberman_enterprise**, or any enterprise concept.
+- ❌ Span both repos in one PR, or do work outside the current slice's scope.
+- ❌ Skip a review checkpoint or start the next feature without a go-ahead.
+- ❌ Mark a slice "done" with missing/failing tests or red CI.
+- ❌ Weaken/stub a test or invariant to make CI pass.
+- ❌ Auto-loosen Doberman (all loosening goes through the Feature 10 human-approved path).
+- ❌ Commit or log a secret, key, full private file, unredacted prompt, or `.doberman/` content.
+- ❌ Let `doberman.proxy` be imported by the policy core.
+- ❌ Add any path by which a protected agent could reach a real tool without going through the decision engine.
+- ❌ Invent requirements. Unclear plan or wrong-looking slice → STOP and ask.
+
+---
+
+## 12. Quick reference
+
+| You want to… | Do this |
+|---|---|
+| Know **what** to build | `doberman_implementation_plan.md` |
+| Know **how** to build it | this file |
+| Decide the repo for a slice | §2 mapping; split → interface in core, plugin in enterprise; when unsure → enterprise |
+| Start a slice | route to repo (§5 Step 0) → branch `feat/<feature>/<slice>` → follow §5 |
+| Finish a slice | tests added + pushed, CI green, boundary checks pass, Slice Completion Report, STOP |
+| Run checks (core) | `ruff check . && ruff format --check . && lint-imports && pytest --cov=doberman` |
+| Hit ambiguity / boundary doubt | STOP and ask — when unsure about public vs private, keep it **private** |
+
+**Remember:** small safe commits · tests with every slice · CI green before "done" · public core stays clean and standalone · enterprise depends on core, never the reverse · when in doubt, **fail closed and ask.**

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,54 @@
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101"]   # pytest tests use bare asserts by design
+
+[tool.importlinter]
+root_package = "doberman"
+include_external_packages = true
+
+# Inside-core decoupling: policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+
+# Cross-repo boundary: the public core must never import the private enterprise package.
+[[tool.importlinter.contracts]]
+name = "Public core must not depend on the private enterprise package"
+type = "forbidden"
+source_modules = ["doberman"]
+forbidden_modules = ["doberman_enterprise"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "dober
 forbidden_modules = ["doberman.proxy"]
 
 # Cross-repo boundary: the public core must never import the private enterprise package.
+# NOTE: defense-in-depth only — enterprise is never installed in core CI, so this contract
+# is trivially kept there; the CI "standalone guarantee" step is the operative guard.
 [[tool.importlinter.contracts]]
 name = "Public core must not depend on the private enterprise package"
 type = "forbidden"

--- a/src/doberman/__init__.py
+++ b/src/doberman/__init__.py
@@ -1,0 +1,3 @@
+"""Doberman — adaptive authorization layer for coding agents (open core)."""
+
+__version__ = "0.0.0"

--- a/src/doberman/engine/__init__.py
+++ b/src/doberman/engine/__init__.py
@@ -1,0 +1,1 @@
+"""Decision engine (policy core). Must never import doberman.proxy."""

--- a/src/doberman/learning/__init__.py
+++ b/src/doberman/learning/__init__.py
@@ -1,0 +1,1 @@
+"""Baseline learning — raise-only (policy core). Must never import doberman.proxy."""

--- a/src/doberman/policy/__init__.py
+++ b/src/doberman/policy/__init__.py
@@ -1,0 +1,1 @@
+"""SecurityObject policy schema and checklist (policy core). Must never import doberman.proxy."""

--- a/src/doberman/proxy/__init__.py
+++ b/src/doberman/proxy/__init__.py
@@ -1,0 +1,1 @@
+"""MCP proxy adapter. May import the policy core; never the reverse."""

--- a/src/doberman/roles/__init__.py
+++ b/src/doberman/roles/__init__.py
@@ -1,0 +1,1 @@
+"""Agent role policy and boundaries (policy core). Must never import doberman.proxy."""

--- a/src/doberman/storage/__init__.py
+++ b/src/doberman/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Local-first storage (policy core). Must never import doberman.proxy."""

--- a/tests/unit/test_core_is_standalone.py
+++ b/tests/unit/test_core_is_standalone.py
@@ -1,0 +1,25 @@
+"""Slice 0 — bootstrap smoke tests and the standalone guarantee."""
+
+import sys
+
+
+def test_core_imports_with_no_enterprise_installed():
+    import doberman  # noqa: F401 — must succeed with zero enterprise deps
+
+    assert "doberman_enterprise" not in sys.modules
+
+
+def test_version_is_exposed():
+    import doberman
+
+    assert doberman.__version__ == "0.0.0"
+
+
+def test_policy_core_packages_import_cleanly():
+    import doberman.engine  # noqa: F401
+    import doberman.learning  # noqa: F401
+    import doberman.policy  # noqa: F401
+    import doberman.roles  # noqa: F401
+    import doberman.storage  # noqa: F401
+
+    assert "doberman.proxy" not in sys.modules


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: Slice 0 — Bootstrap scaffolding + CI
- Plan reference: CLAUDE.md §6 (doberman_implementation_plan.md not yet in workspace)

## What this PR does
Bootstraps the public open-core repo: pyproject.toml (hatchling, ruff with I/B/S lints, import-linter boundary contracts, pytest + coverage), GitHub Actions CI (3.11/3.12 matrix, ruff check/format, lint-imports, pytest with --cov-fail-under=80, standalone-guarantee step, gitleaks secret scan), Apache-2.0 LICENSE, .gitignore, PR template, package skeleton (engine/roles/policy/storage/learning/proxy), CLAUDE.md/AGENTS.md.

## Tests added (run in CI)
- tests/unit/test_core_is_standalone.py — core imports with zero enterprise deps; doberman_enterprise absent from sys.modules; version exposed; policy-core packages import without pulling in doberman.proxy

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (N/A — no decision logic yet)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (N/A)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (N/A)
- [x] doberman-core does not import doberman_enterprise (enforced by import-linter + CI standalone check)

## Edge cases covered / Deviations from plan / Risks introduced
- Deviation: added ruff per-file-ignores S101 for tests (pytest asserts) and include_external_packages=true for import-linter (required for the external doberman_enterprise forbidden contract)
- Deviation: doberman_implementation_plan.md does not exist in the workspace yet, so it could not be committed here
- Package modules are empty skeletons; real implementations come in Feature slices
