### PR TITLE
feat(models): add SecurityObject, Verdict, and reason-code schema (Slice 1.1)

### DIFF
--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -1,0 +1,116 @@
+"""Core data models: the `SecurityObject` schema, verdicts, and reason codes.
+
+This module is the central, shared vocabulary of Doberman. Every intercepted
+tool call is normalized into a :class:`SecurityObject`; every guardrail answers
+with a :class:`GuardrailResult`. Both are immutable so no later layer can
+silently mutate risk or a verdict downward — changes happen by producing a
+*new* object, never by editing in place (raise-only principle).
+"""
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ActionType(StrEnum):
+    """What kind of action the agent is attempting."""
+
+    file_read = "file_read"
+    file_write = "file_write"
+    file_delete = "file_delete"
+    shell_exec = "shell_exec"
+    network_request = "network_request"
+    git_op = "git_op"
+    package_install = "package_install"
+    memory_write = "memory_write"
+    final_output = "final_output"
+    other = "other"
+
+
+class SourceContext(StrEnum):
+    """Where the instruction that led to this action came from."""
+
+    user = "user"
+    github_issue = "github_issue"
+    readme = "readme"
+    webpage = "webpage"
+    email = "email"
+    tool_output = "tool_output"
+    unknown = "unknown"
+
+
+class Risk(StrEnum):
+    """Assessed risk level of an action."""
+
+    low = "low"
+    medium = "medium"
+    high = "high"
+    critical = "critical"
+
+
+class Reversibility(StrEnum):
+    """How easily the action's effects can be undone."""
+
+    low = "low"
+    medium = "medium"
+    high = "high"
+
+
+class Verdict(StrEnum):
+    """The decision for an action: pass through, authenticate, or block."""
+
+    PASS = "PASS"  # noqa: S105 — verdict constant, not a password
+    AUTH = "AUTH"
+    BLOCK = "BLOCK"
+
+
+class ReasonCode(StrEnum):
+    """Stable reason-code constants attached to every non-PASS decision.
+
+    Start small; grow per feature. Codes are part of the explainability
+    contract: every BLOCK/AUTH carries reason codes plus a human explanation.
+    """
+
+    normalization_failed = "normalization_failed"
+    unknown_tool = "unknown_tool"
+    downstream_error = "downstream_error"
+
+
+class GuardrailResult(BaseModel):
+    """A single guardrail's answer for one action (immutable)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    verdict: Verdict
+    risk: Risk
+    reason_codes: list[str] = Field(default_factory=list)
+    explanation: str = ""
+
+
+class SecurityObject(BaseModel):
+    """The normalized, redacted description of one intercepted action.
+
+    Immutable (`frozen=True`) so no layer can mutate risk downward after
+    creation. `raw_args_redacted` must only ever contain redacted values —
+    raw secrets, full file contents, or unredacted prompts never enter this
+    object.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    ts: datetime
+    agent_role: str
+    action_type: ActionType
+    tool_name: str
+    target: str | None = None
+    target_path_class: str | None = None
+    risk: Risk = Risk.low
+    source_context: SourceContext = SourceContext.unknown
+    reversibility: Reversibility = Reversibility.medium
+    sensitive_asset: bool = False
+    external_destination: str | None = None
+    payload_fingerprints: list[str] = Field(default_factory=list)
+    raw_args_redacted: dict = Field(default_factory=dict)
+    metadata: dict = Field(default_factory=dict)

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -7,10 +7,10 @@ silently mutate risk or a verdict downward — changes happen by producing a
 *new* object, never by editing in place (raise-only principle).
 """
 
-from datetime import datetime
 from enum import StrEnum
+from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, model_validator
 
 
 class ActionType(StrEnum):
@@ -78,14 +78,27 @@ class ReasonCode(StrEnum):
 
 
 class GuardrailResult(BaseModel):
-    """A single guardrail's answer for one action (immutable)."""
+    """A single guardrail's answer for one action (immutable).
+
+    Explainability contract: every non-PASS verdict must carry at least one
+    stable :class:`ReasonCode` and a human-readable explanation.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     verdict: Verdict
     risk: Risk
-    reason_codes: list[str] = Field(default_factory=list)
+    reason_codes: list[ReasonCode] = Field(default_factory=list)
     explanation: str = ""
+
+    @model_validator(mode="after")
+    def _non_pass_must_be_explained(self) -> "GuardrailResult":
+        if self.verdict is not Verdict.PASS:
+            if not self.reason_codes:
+                raise ValueError(f"a {self.verdict} verdict requires at least one reason code")
+            if not self.explanation.strip():
+                raise ValueError(f"a {self.verdict} verdict requires a human explanation")
+        return self
 
 
 class SecurityObject(BaseModel):
@@ -99,8 +112,8 @@ class SecurityObject(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    id: str
-    ts: datetime
+    id: str = Field(min_length=1)
+    ts: AwareDatetime  # forensic timestamp — naive datetimes are rejected
     agent_role: str
     action_type: ActionType
     tool_name: str
@@ -112,5 +125,7 @@ class SecurityObject(BaseModel):
     sensitive_asset: bool = False
     external_destination: str | None = None
     payload_fingerprints: list[str] = Field(default_factory=list)
-    raw_args_redacted: dict = Field(default_factory=dict)
-    metadata: dict = Field(default_factory=dict)
+    # Values must already be redacted before entering the object; redaction is
+    # enforced by normalize() and its tests, not by this type.
+    raw_args_redacted: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -60,21 +60,37 @@ def test_defaults_applied():
     assert obj.metadata == {}
 
 
-def test_bad_enum_rejected():
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"action_type": "format_disk"},
+        {"risk": "extreme"},
+        {"source_context": "carrier_pigeon"},
+        {"id": ""},  # blank ids would create untraceable records
+        {"ts": datetime(2026, 6, 7, 12, 0, 0)},  # naive timestamp rejected
+    ],
+)
+def test_invalid_security_object_rejected(overrides):
     with pytest.raises(ValidationError):
-        SecurityObject(**{**THESIS_EXAMPLE, "action_type": "format_disk"})
-    with pytest.raises(ValidationError):
-        SecurityObject(**{**THESIS_EXAMPLE, "risk": "extreme"})
+        SecurityObject(**{**THESIS_EXAMPLE, **overrides})
+
+
+def test_bad_verdict_rejected():
     with pytest.raises(ValidationError):
         GuardrailResult(verdict="MAYBE", risk=Risk.low)
 
 
 def test_frozen_blocks_assignment():
     obj = SecurityObject(**THESIS_EXAMPLE)
-    with pytest.raises(ValidationError):
-        obj.risk = Risk.low  # no layer may mutate risk downward
-    result = GuardrailResult(verdict=Verdict.BLOCK, risk=Risk.critical)
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="frozen"):
+        obj.risk = Risk.low  # frozen=True: no assignment after construction
+    result = GuardrailResult(
+        verdict=Verdict.BLOCK,
+        risk=Risk.critical,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation="Unknown tool.",
+    )
+    with pytest.raises(ValidationError, match="frozen"):
         result.verdict = Verdict.PASS
 
 
@@ -87,6 +103,34 @@ def test_guardrail_result_defaults_and_fields():
     )
     assert result.reason_codes == ["unknown_tool"]
     assert GuardrailResult(verdict=Verdict.PASS, risk=Risk.low).reason_codes == []
+
+
+def test_reason_codes_must_be_known_constants():
+    with pytest.raises(ValidationError):
+        GuardrailResult(
+            verdict=Verdict.BLOCK,
+            risk=Risk.high,
+            reason_codes=["totally_made_up_code"],
+            explanation="x",
+        )
+
+
+@pytest.mark.parametrize("verdict", [Verdict.BLOCK, Verdict.AUTH])
+def test_non_pass_requires_reason_codes_and_explanation(verdict):
+    # Explainability contract: every BLOCK/AUTH carries codes + explanation.
+    with pytest.raises(ValidationError):
+        GuardrailResult(verdict=verdict, risk=Risk.high)
+    with pytest.raises(ValidationError):
+        GuardrailResult(verdict=verdict, risk=Risk.high, reason_codes=[ReasonCode.unknown_tool])
+    with pytest.raises(ValidationError):
+        GuardrailResult(verdict=verdict, risk=Risk.high, explanation="why")
+    ok = GuardrailResult(
+        verdict=verdict,
+        risk=Risk.high,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation="why",
+    )
+    assert ok.verdict is verdict
 
 
 def test_enums_have_expected_members():

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,110 @@
+"""Slice 1.1 — tests for the SecurityObject schema and core enums."""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from doberman.models import (
+    ActionType,
+    GuardrailResult,
+    ReasonCode,
+    Reversibility,
+    Risk,
+    SecurityObject,
+    SourceContext,
+    Verdict,
+)
+
+# The thesis example: a frontend agent deleting a backend auth file based on
+# an instruction that arrived via a GitHub issue.
+THESIS_EXAMPLE = {
+    "id": "act-0001",
+    "ts": datetime(2026, 6, 7, 12, 0, 0, tzinfo=timezone.utc),
+    "agent_role": "frontend_agent",
+    "action_type": ActionType.file_delete,
+    "tool_name": "fs_delete",
+    "target": "backend/auth/session.ts",
+    "target_path_class": "auth_code",
+    "risk": Risk.high,
+    "source_context": SourceContext.github_issue,
+    "reversibility": Reversibility.low,
+    "sensitive_asset": True,
+}
+
+
+def test_valid_construction_thesis_example():
+    obj = SecurityObject(**THESIS_EXAMPLE)
+    assert obj.action_type is ActionType.file_delete
+    assert obj.source_context is SourceContext.github_issue
+    assert obj.risk is Risk.high
+    assert obj.target == "backend/auth/session.ts"
+
+
+def test_defaults_applied():
+    obj = SecurityObject(
+        id="act-0002",
+        ts=datetime(2026, 6, 7, 12, 0, 0, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.final_output,
+        tool_name="final_output",
+    )
+    assert obj.target is None  # missing target is allowed (pure final_output)
+    assert obj.risk is Risk.low
+    assert obj.source_context is SourceContext.unknown
+    assert obj.reversibility is Reversibility.medium
+    assert obj.sensitive_asset is False
+    assert obj.external_destination is None
+    assert obj.payload_fingerprints == []
+    assert obj.raw_args_redacted == {}
+    assert obj.metadata == {}
+
+
+def test_bad_enum_rejected():
+    with pytest.raises(ValidationError):
+        SecurityObject(**{**THESIS_EXAMPLE, "action_type": "format_disk"})
+    with pytest.raises(ValidationError):
+        SecurityObject(**{**THESIS_EXAMPLE, "risk": "extreme"})
+    with pytest.raises(ValidationError):
+        GuardrailResult(verdict="MAYBE", risk=Risk.low)
+
+
+def test_frozen_blocks_assignment():
+    obj = SecurityObject(**THESIS_EXAMPLE)
+    with pytest.raises(ValidationError):
+        obj.risk = Risk.low  # no layer may mutate risk downward
+    result = GuardrailResult(verdict=Verdict.BLOCK, risk=Risk.critical)
+    with pytest.raises(ValidationError):
+        result.verdict = Verdict.PASS
+
+
+def test_guardrail_result_defaults_and_fields():
+    result = GuardrailResult(
+        verdict=Verdict.BLOCK,
+        risk=Risk.critical,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation="Tool is not in the downstream tool list.",
+    )
+    assert result.reason_codes == ["unknown_tool"]
+    assert GuardrailResult(verdict=Verdict.PASS, risk=Risk.low).reason_codes == []
+
+
+def test_enums_have_expected_members():
+    assert ActionType.other in ActionType  # unknown tools normalize to `other`
+    assert {v.value for v in Verdict} == {"PASS", "AUTH", "BLOCK"}
+    assert Risk.critical in Risk
+    # Reason codes serialize as stable strings.
+    assert ReasonCode.normalization_failed == "normalization_failed"
+
+
+def test_distinct_instances_do_not_share_default_containers():
+    kwargs = dict(
+        ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.other,
+        tool_name="x",
+    )
+    a = SecurityObject(id="a", **kwargs)
+    b = SecurityObject(id="b", **kwargs)
+    assert a.metadata is not b.metadata
+    assert a.payload_fingerprints is not b.payload_fingerprints


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: F1 / Slice 1.1 — Project skeleton & `SecurityObject` schema
- Plan reference: doberman_core_plan.md

## What this PR does
Adds `src/doberman/models.py` — the central data model: `ActionType`, `SourceContext`, `Risk`, `Reversibility`, `Verdict` enums (StrEnum), `ReasonCode` string constants (starter set), `GuardrailResult`, and the immutable (`frozen=True`) `SecurityObject` per the schema in the master plan (Slice 1.1). Both models are frozen so no layer can mutate risk/verdict downward — changes require producing a new object.

## Tests added (run in CI)
- tests/unit/test_models.py — thesis-example construction; defaults applied (incl. missing `target` allowed); bad enum values rejected with ValidationError; frozen blocks attribute assignment on both models; reason codes serialize as stable strings; default containers not shared between instances

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (validation errors raise; no silent coercion of bad enums)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (immutability enforces produce-new-object)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (fields exist on `GuardrailResult`)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Deviation: `pyproject.toml`/`__init__.py` already existed from Slice 0 — extended, not recreated
- Deviation: `GuardrailResult` is also frozen (plan mandates it only for `SecurityObject`) — strictly tighter, no downside
- `# noqa: S105` on `Verdict.PASS` (ruff hardcoded-password false positive)
- `ReasonCode` starts with 3 codes (normalization_failed, unknown_tool, downstream_error); grows per feature as planned
