### PR TITLE
feat(proxy): normalize tool calls into SecurityObject (Slice 1.3)

### DIFF
--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -11,20 +11,24 @@ error result, never a silent success or a bypass.
 from mcp.client.session import ClientSession
 from mcp.types import CallToolResult, TextContent
 
-from doberman.models import ReasonCode
+from doberman.models import ReasonCode, SecurityObject
+from doberman.proxy.normalize import normalize
 
 _DENIED_TEMPLATE = (
-    "doberman: downstream call failed; action denied (reason: {reason}; error class: {error_class})"
+    "doberman: downstream call failed; action denied "
+    "(reason: {reason}; error class: {error_class}; action id: {action_id})"
 )
 
 
-def _denied_result(reason: ReasonCode, error_class: str) -> CallToolResult:
+def _denied_result(reason: ReasonCode, error_class: str, action_id: str) -> CallToolResult:
     """Build a fail-closed error result (no payload or argument echo)."""
     return CallToolResult(
         content=[
             TextContent(
                 type="text",
-                text=_DENIED_TEMPLATE.format(reason=reason, error_class=error_class),
+                text=_DENIED_TEMPLATE.format(
+                    reason=reason, error_class=error_class, action_id=action_id
+                ),
             )
         ],
         isError=True,
@@ -42,16 +46,18 @@ async def decide_and_execute(
     stub — every call is forwarded — but the routing invariant (exactly one
     path, through this function) and the fail-closed error handling are real.
     """
+    action: SecurityObject = normalize(tool_name, arguments)
     # --- decision hook (Feature 2 wires the engine in here) -----------------
-    # verdict = PASS (pass-through stub)
+    # verdict = PASS (pass-through stub); `action` is what the engine judges.
     # ------------------------------------------------------------------------
     try:
         return await downstream.call_tool(tool_name, arguments or {})
     except Exception as exc:  # noqa: BLE001 — fail closed on ANY failure mode
         # Never re-raise into the serving path and never echo arguments:
-        # the agent gets a generic denial carrying a stable reason code.
+        # the agent gets a generic denial carrying a stable reason code and
+        # the action id for correlation with the interception log.
         # Deliberately `Exception`, not `BaseException`: cancellation
         # (asyncio.CancelledError) and interpreter shutdown must propagate —
         # swallowing them would break structured concurrency, and they carry
         # no payload to leak.
-        return _denied_result(ReasonCode.downstream_error, type(exc).__name__)
+        return _denied_result(ReasonCode.downstream_error, type(exc).__name__, action.id)

--- a/src/doberman/proxy/normalize.py
+++ b/src/doberman/proxy/normalize.py
@@ -36,7 +36,16 @@ _SECRET_SHAPES = re.compile(
 )
 
 # Argument keys whose values are secret-ish regardless of shape.
-_SENSITIVE_KEYS = re.compile(r"(?:pass(?:word)?|secret|token|api[_-]?key|credential)", re.I)
+_SENSITIVE_KEYS = re.compile(
+    r"(?:pass(?:word)?|secret|token|api[_-]?key|credential|auth|bearer|private[_-]?key)",
+    re.I,
+)
+
+# Don't bother shape-matching values shorter than the shortest secret shape.
+_MIN_SECRET_LENGTH = 16
+
+# Redaction recursion cap: anything nested deeper is redacted wholesale.
+_MAX_REDACTION_DEPTH = 16
 
 _TOOL_PREFIX_MAP: list[tuple[tuple[str, ...], ActionType]] = [
     (("fs_read", "file_read", "read_file"), ActionType.file_read),
@@ -61,20 +70,22 @@ def _map_action_type(tool_name: str) -> ActionType:
     return ActionType.other
 
 
-def _redact_value(key: str, value: Any) -> Any:
+def _redact_value(key: str, value: Any, depth: int = 0) -> Any:
     """Redact a single argument value (never raises)."""
+    if depth > _MAX_REDACTION_DEPTH:
+        return REDACTED  # too deep to inspect — redact wholesale
     if isinstance(value, str):
         if _SENSITIVE_KEYS.search(key):
             return REDACTED
         if len(value) > MAX_VALUE_LENGTH:
             return REDACTED
-        if _SECRET_SHAPES.search(value):
+        if len(value) >= _MIN_SECRET_LENGTH and _SECRET_SHAPES.search(value):
             return REDACTED
         return value
     if isinstance(value, list | tuple):
-        return [_redact_value(key, item) for item in value]
+        return [_redact_value(key, item, depth + 1) for item in value]
     if isinstance(value, dict):
-        return {str(k): _redact_value(str(k), v) for k, v in value.items()}
+        return {str(k): _redact_value(str(k), v, depth + 1) for k, v in value.items()}
     if isinstance(value, bool | int | float) or value is None:
         return value
     return REDACTED  # unknown types never pass through raw
@@ -107,21 +118,26 @@ def normalize(
 ) -> SecurityObject:
     """Turn one intercepted tool call into a SecurityObject. Never raises."""
     context = context or {}
+    safe_tool_name = tool_name if isinstance(tool_name, str) else "<unknown>"
     try:
         args = dict(arguments or {})
         action_type = _map_action_type(tool_name)
-        target, metadata = _extract_target(action_type, args)
+        # Extract the target from the REDACTED args so target /
+        # external_destination get exactly the same secret protections as
+        # raw_args_redacted (a redacted value yields target="<redacted>").
+        redacted_args = _redact_args(args)
+        target, metadata = _extract_target(action_type, redacted_args)
         external_destination = target if action_type is ActionType.network_request else None
         return SecurityObject(
             id=uuid.uuid4().hex,
             ts=datetime.now(timezone.utc),
             agent_role=str(context.get("agent_role", "unknown")),
             action_type=action_type,
-            tool_name=str(tool_name),
+            tool_name=safe_tool_name,
             target=target,
             external_destination=external_destination,
             source_context=SourceContext.unknown,
-            raw_args_redacted=_redact_args(args),
+            raw_args_redacted=redacted_args,
             metadata=metadata,
         )
     except Exception:  # noqa: BLE001 — normalization must never break the path
@@ -132,7 +148,7 @@ def normalize(
             ts=datetime.now(timezone.utc),
             agent_role="unknown",
             action_type=ActionType.other,
-            tool_name=str(tool_name) if isinstance(tool_name, str) else "<unknown>",
+            tool_name=safe_tool_name,
             risk=Risk.high,
             source_context=SourceContext.unknown,
             metadata={"reason_codes": [ReasonCode.normalization_failed]},

--- a/src/doberman/proxy/normalize.py
+++ b/src/doberman/proxy/normalize.py
@@ -1,0 +1,139 @@
+"""Normalize raw MCP tool calls into immutable :class:`SecurityObject`\\ s.
+
+The chokepoint hands every intercepted call to :func:`normalize` before the
+decision point. Normalization must NEVER raise on weird input: on any
+failure it produces a conservative object (``action_type=other``,
+``risk=high``) so the engine fails toward caution, and it never copies raw
+argument values into the object — values are redacted first.
+
+The redaction here is a deliberate stopgap (length- and shape-based); real
+secret detection arrives with Feature 3's rules.
+"""
+
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from doberman.models import ActionType, ReasonCode, Risk, SecurityObject, SourceContext
+
+REDACTED = "<redacted>"
+
+# Values longer than this are replaced wholesale — avoids logging huge blobs.
+MAX_VALUE_LENGTH = 256
+
+# Obvious secret shapes (stopgap until Feature 3's secret rules):
+# long unbroken token-ish strings, common key prefixes, key=value secrets.
+_SECRET_SHAPES = re.compile(
+    r"""
+    (?:AKIA[0-9A-Z]{16})                              # AWS access key id
+    | (?:sk-[A-Za-z0-9_\-]{16,})                      # api secret key prefix
+    | (?:gh[pousr]_[A-Za-z0-9]{20,})                  # github tokens
+    | (?:-----BEGIN[ A-Z]*PRIVATE\ KEY-----)          # PEM private key
+    | (?:\b[A-Za-z0-9+/_\-]{40,}\b)                   # long unbroken token
+    """,
+    re.VERBOSE,
+)
+
+# Argument keys whose values are secret-ish regardless of shape.
+_SENSITIVE_KEYS = re.compile(r"(?:pass(?:word)?|secret|token|api[_-]?key|credential)", re.I)
+
+_TOOL_PREFIX_MAP: list[tuple[tuple[str, ...], ActionType]] = [
+    (("fs_read", "file_read", "read_file"), ActionType.file_read),
+    (("fs_write", "file_write", "write_file"), ActionType.file_write),
+    (("fs_delete", "file_delete", "delete_file", "fs_rm"), ActionType.file_delete),
+    (("shell_exec", "shell", "bash", "exec"), ActionType.shell_exec),
+    (("net_", "http_", "fetch", "request"), ActionType.network_request),
+    (("git_",), ActionType.git_op),
+]
+
+# Keys commonly carrying the action's target, in priority order.
+_TARGET_KEYS = ("path", "file", "filename", "url", "command", "target")
+
+
+def _map_action_type(tool_name: str) -> ActionType:
+    name = tool_name.lower()
+    if "install" in name:
+        return ActionType.package_install
+    for prefixes, action_type in _TOOL_PREFIX_MAP:
+        if name.startswith(prefixes):
+            return action_type
+    return ActionType.other
+
+
+def _redact_value(key: str, value: Any) -> Any:
+    """Redact a single argument value (never raises)."""
+    if isinstance(value, str):
+        if _SENSITIVE_KEYS.search(key):
+            return REDACTED
+        if len(value) > MAX_VALUE_LENGTH:
+            return REDACTED
+        if _SECRET_SHAPES.search(value):
+            return REDACTED
+        return value
+    if isinstance(value, list | tuple):
+        return [_redact_value(key, item) for item in value]
+    if isinstance(value, dict):
+        return {str(k): _redact_value(str(k), v) for k, v in value.items()}
+    if isinstance(value, bool | int | float) or value is None:
+        return value
+    return REDACTED  # unknown types never pass through raw
+
+
+def _redact_args(arguments: dict[str, Any]) -> dict[str, Any]:
+    return {str(key): _redact_value(str(key), value) for key, value in arguments.items()}
+
+
+def _extract_target(action_type: ActionType, arguments: dict[str, Any]) -> tuple[str | None, dict]:
+    """Pick a representative target; extra info (e.g. path counts) → metadata."""
+    metadata: dict[str, Any] = {}
+    for key in _TARGET_KEYS:
+        value = arguments.get(key)
+        if isinstance(value, str) and value:
+            return value, metadata
+        if isinstance(value, list | tuple) and value:
+            # Path arrays: representative first element + count in metadata.
+            first = value[0]
+            if isinstance(first, str):
+                metadata["target_count"] = len(value)
+                return first, metadata
+    return None, metadata
+
+
+def normalize(
+    tool_name: str,
+    arguments: dict[str, Any] | None,
+    context: dict[str, Any] | None = None,
+) -> SecurityObject:
+    """Turn one intercepted tool call into a SecurityObject. Never raises."""
+    context = context or {}
+    try:
+        args = dict(arguments or {})
+        action_type = _map_action_type(tool_name)
+        target, metadata = _extract_target(action_type, args)
+        external_destination = target if action_type is ActionType.network_request else None
+        return SecurityObject(
+            id=uuid.uuid4().hex,
+            ts=datetime.now(timezone.utc),
+            agent_role=str(context.get("agent_role", "unknown")),
+            action_type=action_type,
+            tool_name=str(tool_name),
+            target=target,
+            external_destination=external_destination,
+            source_context=SourceContext.unknown,
+            raw_args_redacted=_redact_args(args),
+            metadata=metadata,
+        )
+    except Exception:  # noqa: BLE001 — normalization must never break the path
+        # Conservative fallback: unknown action at high risk, no argument
+        # values copied at all (we cannot trust that redaction succeeded).
+        return SecurityObject(
+            id=uuid.uuid4().hex,
+            ts=datetime.now(timezone.utc),
+            agent_role="unknown",
+            action_type=ActionType.other,
+            tool_name=str(tool_name) if isinstance(tool_name, str) else "<unknown>",
+            risk=Risk.high,
+            source_context=SourceContext.unknown,
+            metadata={"reason_codes": [ReasonCode.normalization_failed]},
+        )

--- a/tests/integration/test_proxy_passthrough.py
+++ b/tests/integration/test_proxy_passthrough.py
@@ -115,6 +115,24 @@ async def test_end_to_end_error_never_echoes_arguments():
         assert fake.calls == []
 
 
+async def test_every_call_is_normalized_before_execution(monkeypatch):
+    """Slice 1.3 wiring proof: the chokepoint normalizes each call."""
+    from doberman.proxy import normalize as normalize_mod
+
+    seen: list[str] = []
+    original = normalize_mod.normalize
+
+    def spy(tool_name, arguments, context=None):
+        seen.append(tool_name)
+        return original(tool_name, arguments, context)
+
+    monkeypatch.setattr("doberman.proxy.executor.normalize", spy)
+    async with proxied_session() as (_, agent):
+        await agent.call_tool("fs_write", {"path": "a.txt", "content": "x"})
+        await agent.call_tool("net_get", {"url": "https://example.com"})
+    assert seen == ["fs_write", "net_get"]
+
+
 async def test_every_call_routes_through_decide_and_execute(monkeypatch):
     routed: list[str] = []
     original = executor.decide_and_execute

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -116,6 +116,33 @@ def test_nested_structures_are_redacted():
     assert secret not in str(obj.raw_args_redacted)
 
 
+def test_authorization_header_redacted_even_when_short():
+    obj = normalize("net_get", {"url": "https://x.test", "headers": {"Authorization": "hunter2"}})
+    assert obj.raw_args_redacted["headers"]["Authorization"] == REDACTED
+
+
+def test_target_gets_same_redaction_as_args():
+    # A secret-shaped value used as the target must not survive into
+    # target/external_destination either.
+    secret_url = "https://x.test/cb?token=ghp_FAKEFAKEFAKEFAKEFAKE12345"  # noqa: S105
+    obj = normalize("net_get", {"url": secret_url})
+    assert obj.target == REDACTED
+    assert obj.external_destination == REDACTED
+    assert "ghp_" not in str(obj)
+
+    long_path = "p" * (MAX_VALUE_LENGTH + 1)
+    obj = normalize("fs_delete", {"path": long_path})
+    assert obj.target == REDACTED
+
+
+def test_deeply_nested_structures_redacted_wholesale():
+    value: dict = {"v": "benign"}
+    for _ in range(30):
+        value = {"nested": value}
+    obj = normalize("net_get", {"url": "https://x.test", "payload": value})
+    assert REDACTED in str(obj.raw_args_redacted["payload"])
+
+
 def test_unknown_value_types_never_pass_through_raw():
     class Weird:
         def __repr__(self) -> str:

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -1,0 +1,142 @@
+"""Slice 1.3 — tests for normalize(): mapping, targets, redaction, fallback."""
+
+import pytest
+
+from doberman.models import ActionType, Risk, SourceContext
+from doberman.proxy.normalize import MAX_VALUE_LENGTH, REDACTED, normalize
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "expected"),
+    [
+        ("fs_read", ActionType.file_read),
+        ("fs_write", ActionType.file_write),
+        ("fs_delete", ActionType.file_delete),
+        ("shell_exec", ActionType.shell_exec),
+        ("net_get", ActionType.network_request),
+        ("http_post", ActionType.network_request),
+        ("git_commit", ActionType.git_op),
+        ("pip_install", ActionType.package_install),
+        ("npm_install_package", ActionType.package_install),
+        ("totally_unknown_tool", ActionType.other),
+    ],
+)
+def test_tool_name_maps_to_action_type(tool_name, expected):
+    assert normalize(tool_name, {}).action_type is expected
+
+
+def test_filesystem_target_extracted():
+    obj = normalize("fs_delete", {"path": "backend/auth/session.ts"})
+    assert obj.target == "backend/auth/session.ts"
+    assert obj.external_destination is None
+
+
+def test_network_target_sets_external_destination():
+    obj = normalize("net_get", {"url": "https://example.com/data"})
+    assert obj.target == "https://example.com/data"
+    assert obj.external_destination == "https://example.com/data"
+
+
+def test_relative_url_still_extracted():
+    obj = normalize("net_get", {"url": "/api/items"})
+    assert obj.target == "/api/items"
+    assert obj.action_type is ActionType.network_request
+
+
+def test_shell_command_is_target():
+    obj = normalize("shell_exec", {"command": "echo hi"})
+    assert obj.target == "echo hi"
+
+
+def test_shell_with_no_args():
+    obj = normalize("shell_exec", {})
+    assert obj.target is None
+    assert obj.action_type is ActionType.shell_exec
+
+
+def test_path_array_uses_representative_target_plus_count():
+    obj = normalize("fs_delete", {"path": ["a.txt", "b.txt", "c.txt"]})
+    assert obj.target == "a.txt"
+    assert obj.metadata["target_count"] == 3
+
+
+def test_non_string_path_array_yields_no_target():
+    obj = normalize("fs_delete", {"path": [123, 456]})
+    assert obj.target is None
+    assert "target_count" not in obj.metadata
+
+
+def test_defaults_role_and_source():
+    obj = normalize("fs_write", {"path": "x", "content": "y"})
+    assert obj.agent_role == "unknown"
+    assert obj.source_context is SourceContext.unknown
+
+
+def test_context_can_set_agent_role():
+    obj = normalize("fs_write", {"path": "x"}, {"agent_role": "frontend_agent"})
+    assert obj.agent_role == "frontend_agent"
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "AKIAIOSFODNN7EXAMPLE",  # AWS-style key id
+        "sk-FAKEFAKEFAKEFAKEFAKE1234",  # api key prefix
+        "ghp_FAKEFAKEFAKEFAKEFAKE12345",  # github token
+        "-----BEGIN RSA PRIVATE KEY-----",  # PEM header
+        "A" * (MAX_VALUE_LENGTH + 1),  # oversized blob
+        "x" * 41,  # long unbroken token
+    ],
+)
+def test_secret_shaped_values_are_redacted(secret):
+    obj = normalize("fs_write", {"path": "ok.txt", "content": secret})
+    assert obj.raw_args_redacted["content"] == REDACTED
+    assert secret not in str(obj.raw_args_redacted)
+
+
+@pytest.mark.parametrize("key", ["password", "PASSWORD", "api_key", "apiKey_token", "secret"])
+def test_sensitive_keys_redacted_regardless_of_value(key):
+    obj = normalize("net_get", {"url": "https://x.test", key: "hunter2"})
+    assert obj.raw_args_redacted[key] == REDACTED
+
+
+def test_benign_values_pass_through():
+    obj = normalize("fs_write", {"path": "a.txt", "content": "hello world", "append": True})
+    assert obj.raw_args_redacted == {"path": "a.txt", "content": "hello world", "append": True}
+
+
+def test_nested_structures_are_redacted():
+    secret = "ghp_FAKEFAKEFAKEFAKEFAKE12345"  # noqa: S105 — synthetic test value
+    obj = normalize(
+        "net_get",
+        {"url": "https://x.test", "headers": {"Authorization": secret}, "tags": [secret, "ok"]},
+    )
+    assert obj.raw_args_redacted["headers"]["Authorization"] == REDACTED
+    assert obj.raw_args_redacted["tags"] == [REDACTED, "ok"]
+    assert secret not in str(obj.raw_args_redacted)
+
+
+def test_unknown_value_types_never_pass_through_raw():
+    class Weird:
+        def __repr__(self) -> str:
+            return "raw-internal-state"
+
+    obj = normalize("fs_write", {"path": "a.txt", "blob": Weird()})
+    assert obj.raw_args_redacted["blob"] == REDACTED
+
+
+def test_malformed_input_produces_conservative_object():
+    # arguments that are not a mapping at all
+    obj = normalize(None, "not-a-dict")  # type: ignore[arg-type]
+    assert obj.action_type is ActionType.other
+    assert obj.risk is Risk.high
+    assert "normalization_failed" in obj.metadata["reason_codes"]
+    assert obj.raw_args_redacted == {}  # nothing copied on failure
+    assert "not-a-dict" not in str(obj)
+
+
+def test_each_call_gets_unique_id_and_aware_ts():
+    a = normalize("fs_write", {"path": "x"})
+    b = normalize("fs_write", {"path": "x"})
+    assert a.id != b.id
+    assert a.ts.tzinfo is not None


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: F1 / Slice 1.3 — Normalize raw calls into `SecurityObject`
- Plan reference: doberman_core_plan.md

## What this PR does
- `src/doberman/proxy/normalize.py` — `normalize(tool_name, arguments, context) -> SecurityObject`: tool-name → `ActionType` mapping (fs_*/shell/net_*/http_*/git_*/\*install\* → other), target extraction (path / url / command; path arrays → representative target + `target_count` metadata; network targets also set `external_destination`), stopgap redaction into `raw_args_redacted` (length cap, secret shapes: AWS/api-key/GitHub-token/PEM/long-token, sensitive key names, recursive over lists/dicts, unknown object types never pass through raw), defaults `agent_role="unknown"` / `source_context=unknown` (placeholders until F4).
- **Never raises:** any normalization failure produces the conservative fallback — `action_type=other, risk=high`, `normalization_failed` reason code, zero argument values copied.
- Wires normalization into `decide_and_execute` (every call normalized before the decision hook); fail-closed denials now carry the `action id` for correlation with the (Slice 1.4) interception log.

## Tests added (run in CI)
- tests/unit/test_normalize.py — parametrized name→ActionType mapping; target extraction incl. path arrays, relative URLs, empty shell args; redaction of secret shapes/sensitive keys/nested structures/oversized blobs; benign values untouched; unknown value types redacted; malformed input → conservative object with nothing copied; unique ids + aware timestamps
- tests/integration/test_proxy_passthrough.py — wiring proof: every proxied call is normalized before execution (spy)

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (normalization failure → other/high conservative object; nothing copied)
- [x] No secret, full file, or unredacted prompt logged or committed (synthetic secrets asserted absent from the object)
- [x] Any guardrail/learning change is raise-only (N/A)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (fallback object carries normalization_failed; verdicts arrive in F2)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Path arrays, empty shell args, relative URLs (plan's listed edge cases) all tested
- Known debt (per plan): redaction is naive (length/shape-based) — Feature 3 brings real secret rules; role/source are placeholders until F4
