### PR TITLE
feat(proxy): add structured redacted interception logging (Slice 1.4)

### DIFF
--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -11,7 +11,8 @@ error result, never a silent success or a bypass.
 from mcp.client.session import ClientSession
 from mcp.types import CallToolResult, TextContent
 
-from doberman.models import ReasonCode, SecurityObject
+from doberman.models import ReasonCode, SecurityObject, Verdict
+from doberman.proxy.interception_log import log_action
 from doberman.proxy.normalize import normalize
 
 _DENIED_TEMPLATE = (
@@ -50,6 +51,8 @@ async def decide_and_execute(
     # --- decision hook (Feature 2 wires the engine in here) -----------------
     # verdict = PASS (pass-through stub); `action` is what the engine judges.
     # ------------------------------------------------------------------------
+    # Record every intercepted action (best-effort; never blocks execution).
+    log_action(action, Verdict.PASS)
     try:
         return await downstream.call_tool(tool_name, arguments or {})
     except Exception as exc:  # noqa: BLE001 — fail closed on ANY failure mode

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -49,10 +49,10 @@ async def decide_and_execute(
     """
     action: SecurityObject = normalize(tool_name, arguments)
     # --- decision hook (Feature 2 wires the engine in here) -----------------
-    # verdict = PASS (pass-through stub); `action` is what the engine judges.
+    verdict = Verdict.PASS  # pass-through stub; F2 replaces this with the engine result
     # ------------------------------------------------------------------------
     # Record every intercepted action (best-effort; never blocks execution).
-    log_action(action, Verdict.PASS)
+    log_action(action, verdict)
     try:
         return await downstream.call_tool(tool_name, arguments or {})
     except Exception as exc:  # noqa: BLE001 — fail closed on ANY failure mode

--- a/src/doberman/proxy/interception_log.py
+++ b/src/doberman/proxy/interception_log.py
@@ -18,6 +18,9 @@ from doberman.models import SecurityObject, Verdict
 
 LOGGER_NAME = "doberman.interception"
 
+# Pre-built fallback line: if json.dumps itself failed we cannot use it again.
+_LOG_FAILED_LINE = '{"event": "interception_log_failed"}'
+
 logger = logging.getLogger(LOGGER_NAME)
 
 
@@ -26,6 +29,11 @@ def log_action(action: SecurityObject, verdict: Verdict) -> None:
 
     Best-effort: any failure is swallowed (after a last-ditch plain-text
     note) — the execution path must never see an exception from here.
+
+    Deliberately swallows ``Exception`` only, never ``BaseException``:
+    cancellation (CancelledError), GeneratorExit, and interpreter shutdown
+    must propagate — swallowing them here would break structured
+    concurrency, and an unwind executes nothing downstream (fail closed).
     """
     try:
         record: dict[str, Any] = {
@@ -36,6 +44,6 @@ def log_action(action: SecurityObject, verdict: Verdict) -> None:
         logger.info(json.dumps(record, default=str, ensure_ascii=False))
     except Exception:  # noqa: BLE001 — logging must never break execution
         try:
-            logger.warning('{"event": "interception_log_failed"}')
+            logger.warning(_LOG_FAILED_LINE)
         except Exception:  # noqa: BLE001, S110 — give up silently by design
             pass

--- a/src/doberman/proxy/interception_log.py
+++ b/src/doberman/proxy/interception_log.py
@@ -1,0 +1,41 @@
+"""Structured, redacted interception logging (one JSON line per action).
+
+Every action that reaches the chokepoint is recorded with its redacted
+:class:`SecurityObject` and verdict, keyed by the stable ``action.id`` so
+later features (decision log, audit) can correlate. Two hard rules:
+
+1. Logging is best-effort and must NEVER raise into the execution path —
+   a logging failure must not alter, block, or crash a decision.
+2. Only redacted material enters the log: the SecurityObject is already
+   redacted by ``normalize()``; nothing else from the raw call is logged.
+"""
+
+import json
+import logging
+from typing import Any
+
+from doberman.models import SecurityObject, Verdict
+
+LOGGER_NAME = "doberman.interception"
+
+logger = logging.getLogger(LOGGER_NAME)
+
+
+def log_action(action: SecurityObject, verdict: Verdict) -> None:
+    """Emit one structured JSON log line for an intercepted action.
+
+    Best-effort: any failure is swallowed (after a last-ditch plain-text
+    note) — the execution path must never see an exception from here.
+    """
+    try:
+        record: dict[str, Any] = {
+            "event": "tool_call_intercepted",
+            "action": action.model_dump(mode="json"),
+            "verdict": verdict.value,
+        }
+        logger.info(json.dumps(record, default=str, ensure_ascii=False))
+    except Exception:  # noqa: BLE001 — logging must never break execution
+        try:
+            logger.warning('{"event": "interception_log_failed"}')
+        except Exception:  # noqa: BLE001, S110 — give up silently by design
+            pass

--- a/tests/integration/test_interception_log.py
+++ b/tests/integration/test_interception_log.py
@@ -1,0 +1,97 @@
+"""Slice 1.4 — tests for the structured, redacted interception log."""
+
+import json
+import logging
+import re
+
+import pytest
+
+from doberman.proxy import interception_log
+from doberman.proxy.interception_log import LOGGER_NAME
+
+from .test_proxy_passthrough import proxied_session
+
+
+def _log_records(caplog: pytest.LogCaptureFixture) -> list[dict]:
+    lines = [r.message for r in caplog.records if r.name == LOGGER_NAME]
+    return [json.loads(line) for line in lines]
+
+
+async def test_one_valid_json_line_per_call_with_action_id(caplog):
+    caplog.set_level(logging.INFO, logger=LOGGER_NAME)
+    async with proxied_session() as (_, agent):
+        await agent.call_tool("fs_write", {"path": "a.txt", "content": "hello"})
+        await agent.call_tool("shell_exec", {"command": "echo hi"})
+
+    records = _log_records(caplog)
+    assert len(records) == 2
+    for record in records:
+        assert record["event"] == "tool_call_intercepted"
+        assert record["verdict"] == "PASS"
+        assert record["action"]["id"]  # stable id for correlation
+    assert records[0]["action"]["tool_name"] == "fs_write"
+    assert records[0]["action"]["action_type"] == "file_write"
+    assert records[1]["action"]["target"] == "echo hi"
+
+
+async def test_synthetic_secret_never_appears_in_log(caplog):
+    caplog.set_level(logging.DEBUG)  # capture everything from every logger
+    secret = "AKIAFAKEFAKEFAKEFAKE"  # noqa: S105 — synthetic test value
+    async with proxied_session() as (_, agent):
+        await agent.call_tool("fs_write", {"path": "a.txt", "content": secret})
+        await agent.call_tool("net_get", {"url": "https://x.test", "api_key": secret})
+    assert secret not in caplog.text
+
+
+async def test_logging_failure_never_blocks_execution(caplog, monkeypatch):
+    caplog.set_level(logging.INFO, logger=LOGGER_NAME)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("log serialization broke")
+
+    monkeypatch.setattr(interception_log.json, "dumps", boom)
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("fs_write", {"path": "a.txt", "content": "x"})
+    # The call still executed and succeeded despite the logging failure.
+    assert not result.isError
+    assert fake.calls == [("fs_write", {"path": "a.txt", "content": "x"})]
+    # And the failure itself was noted (best-effort fallback line).
+    assert any("interception_log_failed" in r.message for r in caplog.records)
+
+
+def test_log_action_survives_total_logging_failure(monkeypatch):
+    # Even the last-ditch fallback failing must not raise into execution.
+    class ExplodingLogger:
+        def info(self, *args, **kwargs):
+            raise RuntimeError("logger broken")
+
+        def warning(self, *args, **kwargs):
+            raise RuntimeError("logger broken harder")
+
+    from doberman.models import Verdict
+    from doberman.proxy.normalize import normalize
+
+    monkeypatch.setattr(interception_log, "logger", ExplodingLogger())
+    action = normalize("fs_write", {"path": "x"})
+    interception_log.log_action(action, Verdict.PASS)  # must not raise
+
+
+async def test_failed_calls_are_still_logged_and_ids_correlate(caplog):
+    caplog.set_level(logging.INFO, logger=LOGGER_NAME)
+    from doberman.proxy import executor
+
+    from .test_proxy_passthrough import DeadSession
+
+    result = await executor.decide_and_execute(
+        DeadSession(),  # type: ignore[arg-type]
+        "fs_delete",
+        {"path": "a.txt"},
+    )
+    assert result.isError
+    records = _log_records(caplog)
+    assert len(records) == 1
+    logged_id = records[0]["action"]["id"]
+    # The denial the agent sees carries the same action id as the log line.
+    match = re.search(r"action id: ([0-9a-f]+)", result.content[0].text)
+    assert match is not None
+    assert match.group(1) == logged_id

--- a/tests/integration/test_interception_log.py
+++ b/tests/integration/test_interception_log.py
@@ -6,10 +6,12 @@ import re
 
 import pytest
 
-from doberman.proxy import interception_log
+from doberman.models import Verdict
+from doberman.proxy import executor, interception_log
 from doberman.proxy.interception_log import LOGGER_NAME
+from doberman.proxy.normalize import normalize
 
-from .test_proxy_passthrough import proxied_session
+from .test_proxy_passthrough import DeadSession, proxied_session
 
 
 def _log_records(caplog: pytest.LogCaptureFixture) -> list[dict]:
@@ -40,6 +42,9 @@ async def test_synthetic_secret_never_appears_in_log(caplog):
     async with proxied_session() as (_, agent):
         await agent.call_tool("fs_write", {"path": "a.txt", "content": secret})
         await agent.call_tool("net_get", {"url": "https://x.test", "api_key": secret})
+    # The redaction guarantee must actually have been exercised: both calls
+    # produced a log line, and neither contains the secret.
+    assert len(_log_records(caplog)) == 2
     assert secret not in caplog.text
 
 
@@ -68,9 +73,6 @@ def test_log_action_survives_total_logging_failure(monkeypatch):
         def warning(self, *args, **kwargs):
             raise RuntimeError("logger broken harder")
 
-    from doberman.models import Verdict
-    from doberman.proxy.normalize import normalize
-
     monkeypatch.setattr(interception_log, "logger", ExplodingLogger())
     action = normalize("fs_write", {"path": "x"})
     interception_log.log_action(action, Verdict.PASS)  # must not raise
@@ -78,10 +80,6 @@ def test_log_action_survives_total_logging_failure(monkeypatch):
 
 async def test_failed_calls_are_still_logged_and_ids_correlate(caplog):
     caplog.set_level(logging.INFO, logger=LOGGER_NAME)
-    from doberman.proxy import executor
-
-    from .test_proxy_passthrough import DeadSession
-
     result = await executor.decide_and_execute(
         DeadSession(),  # type: ignore[arg-type]
         "fs_delete",


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: F1 / Slice 1.4 — Structured, redacted interception log
- Plan reference: doberman_core_plan.md

## What this PR does
- `src/doberman/proxy/interception_log.py` — `log_action(action, verdict)`: one JSON log line per intercepted action (`event`, redacted `SecurityObject` dump, verdict — `PASS` for now) on the `doberman.interception` logger. Best-effort by contract: a serialization failure degrades to a plain fallback line; even a totally broken logger never raises into the execution path.
- Wired into `decide_and_execute`: every action is logged after normalization, before forwarding — failed/denied calls are logged too, and the agent-visible denial carries the same `action.id` as the log line (correlation).

## Tests added (run in CI)
tests/integration/test_interception_log.py:
- one valid JSON line per call, with action id, verdict PASS, correct tool/action/target fields
- a synthetic AWS-style key passed as file content AND as api_key arg never appears anywhere in captured logs (all loggers, DEBUG)
- logging failure (json.dumps raises) → the tool call still executes and succeeds; fallback line emitted
- totally broken logger (info+warning both raise) → log_action still never raises
- failed downstream call is still logged; denial's action id == logged action id

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (logging failures never alter/block the decision path)
- [x] No secret, full file, or unredacted prompt logged or committed (synthetic-secret test across all loggers)
- [x] Any guardrail/learning change is raise-only (N/A)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (denials carry reason code + action id; verdicts in F2)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- High volume: logging is synchronous stdlib logging (no I/O of its own beyond handlers) and strictly non-blocking semantics-wise (never raises); async/buffered handlers can be added later if profiling demands
- Known debt (per plan): nothing persisted yet — Feature 8 brings the decision log storage
