### PR TITLE
feat(engine): decision engine & execution rule (Feature 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,217 @@
-# Doberman
-Doberman is an Open-Source AI Agent security framework for guardrails, prompt injection defense, runtime policy enforcement, tool-use permissions, agent monitoring, audit logs, LLM safety, autonomous workflow protection and secure AI deployment.
+<div align="center">
 
-Key Words:
-AI Harness
-Agentic Harness
-AI Safety
-AI Security Framework
+# 🐕 Doberman
+
+**An adaptive authorization layer that sits between a coding agent and its tools.**
+
+[![CI](https://github.com/fu351/Doberman-Core/actions/workflows/ci.yml/badge.svg)](https://github.com/fu351/Doberman-Core/actions/workflows/ci.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
+[![Status](https://img.shields.io/badge/status-alpha-orange.svg)](#project-status)
+
+</div>
+
+---
+
+## Overview
+
+Doberman is a security layer for AI coding agents. It sits **on the tool-execution path** — the agent talks to Doberman, and Doberman talks to the real tools (filesystem, shell, git, network, package managers) over the [Model Context Protocol](https://modelcontextprotocol.io). Every meaningful action is intercepted, normalized into a redacted, structured **security object**, and run through a risk-based decision engine that returns one of three verdicts — **allow**, **authenticate**, or **block** — before the action is ever forwarded. The guiding principle is simple: *if Doberman isn't on the execution path, it's advisory, not protective.* Doberman is built to **fail closed** (any error or uncertainty denies the action) and to be **raise-only** (guardrails may automatically tighten, never silently loosen), so an agent can never reach a tool around it and a buggy rule can never make the system less safe.
+
+> ### Project status
+> **Alpha — pre-1.0, API unstable.** The interception layer (Feature 1) and the decision engine (Feature 2) are implemented. The bundled guardrails are currently permissive stubs — the **basic objective rules** (protected paths, dangerous commands, secret-leak and exfiltration detection) arrive in upcoming versions (see the [Roadmap](#roadmap)). This is the open-source **core**; advanced/hosted capabilities live in a separate commercial edition.
+
+---
+
+## Table of contents
+
+- [How it works](#how-it-works)
+- [Installation](#installation)
+- [Quickstart](#quickstart)
+- [Features](#features)
+- [Design invariants](#design-invariants)
+- [Versioning](#versioning)
+- [Changelog](#changelog)
+- [Roadmap](#roadmap)
+- [Contributing](#contributing)
+- [Security](#security)
+- [License](#license)
+
+---
+
+## How it works
+
+```
+                ┌─────────────────────── Doberman ───────────────────────┐
+   coding       │                                                         │     real
+   agent  ──────┼──▶  normalize  ──▶  decision engine  ──▶  enforce  ─────┼──▶  tool
+  (MCP client)  │   (SecurityObject)   (PASS/AUTH/BLOCK)    (chokepoint)   │   servers
+                │                                              │          │
+                │                                  redacted interception  │
+                │                                       log (JSON)        │
+                └─────────────────────────────────────────────────────────┘
+```
+
+1. **Intercept** — Doberman is an MCP *server* to the agent and an MCP *client* to the downstream tool servers. It re-exposes the downstream tools unchanged, so every `tools/call` flows through a single chokepoint.
+2. **Normalize** — each call becomes an immutable, redacted `SecurityObject` (action type, target, risk, redacted arguments, fingerprints). Normalization never raises; on bad input it produces a conservative high-risk object.
+3. **Decide** — the engine runs the objective guardrail first, then (if it passes) the subjective guardrail, combining results **raise-only** into a single explainable `Decision`.
+4. **Enforce** — `PASS` forwards the call; `AUTH` returns an "authentication required" error; `BLOCK` returns a "blocked by policy" error and the call is **never** forwarded. Any engine failure is itself a `BLOCK`.
+5. **Log** — every action is recorded as one redacted JSON line, correlated by a stable action id.
+
+---
+
+## Installation
+
+Requires **Python 3.11+**.
+
+```bash
+# clone
+git clone https://github.com/fu351/Doberman-Core.git
+cd Doberman-Core
+
+# create and activate a virtual environment
+python -m venv .venv
+# Windows:        .venv\Scripts\activate
+# macOS / Linux:  source .venv/bin/activate
+
+# install the package with dev tooling
+pip install -e ".[dev]"
+```
+
+### Verify your setup
+
+```bash
+ruff check .           # lint
+ruff format --check .  # format check
+lint-imports           # architecture / boundary contracts
+pytest                 # test suite (100% coverage gate at 80% in CI)
+```
+
+A green run means the core engine, proxy, and guardrail wiring all behave as specified.
+
+---
+
+## Quickstart
+
+At this stage Doberman is a **library**, not a standalone binary — you embed the proxy in front of a downstream MCP tool server. The proxy is created from an active downstream client session:
+
+```python
+from doberman.proxy.mcp_proxy import build_proxy_server
+
+# `downstream` is an mcp.client.session.ClientSession connected to your
+# real tool server. The returned MCP server re-exposes its tools and routes
+# every tools/call through Doberman's decision chokepoint.
+proxy = build_proxy_server(downstream)
+# ...serve `proxy` to the agent over your preferred MCP transport.
+```
+
+For a complete, runnable wiring (an in-process downstream + proxy + agent client),
+see [`tests/integration/test_proxy_passthrough.py`](./tests/integration/test_proxy_passthrough.py)
+and [`tests/integration/test_engine_blocks_reach_no_tool.py`](./tests/integration/test_engine_blocks_reach_no_tool.py).
+
+---
+
+## Features
+
+### Feature 1 — Tool Mediation Layer & Normalized Action Object · `v0.1.0`
+
+Puts Doberman physically between the agent and its tools and turns every tool call into structured, observable, redacted data.
+
+- **MCP proxy chokepoint** — re-exposes downstream tools; every `tools/call` is forced through one decision point. Fails closed (downstream/transport errors yield a sanitized error, never a silent success or a bypass).
+- **`SecurityObject` schema** — an immutable, frozen normalized action object (action type, target, risk, reversibility, source context, redacted arguments, payload fingerprints) plus a `GuardrailResult`/`Verdict`/`ReasonCode` vocabulary shared across the whole system.
+- **`normalize()`** — maps raw tool calls to action types, extracts targets, and redacts secret-shaped and oversized argument values. Never raises; degrades to a conservative high-risk object on malformed input.
+- **Redacted interception log** — one structured JSON line per action, correlated by a stable action id. Best-effort by contract: logging can never alter, block, or crash the execution path, and never emits raw secrets.
+
+### Feature 2 — Decision Engine & Execution Rule · `v0.2.0` _(in review)_
+
+Replaces the pass-through stub with the real control core, so every guardrail added later automatically obeys the safety rules.
+
+- **`Guardrail` interface & `Decision` model** — a pure `(action, ctx) → GuardrailResult` contract and a frozen, always-explained `Decision` audit record.
+- **Raise-only combination** — `combine()` takes the **max** verdict (`PASS < AUTH < BLOCK`), **max** risk, and the **union** of reasons. There is deliberately no code path that lowers either axis — verified by an exhaustive matrix and a randomized property test.
+- **Objective-first execution rule** — objective guardrail first; a `BLOCK`/`AUTH` short-circuits (the subjective guardrail can never weaken it); a non-allowlisted subjective `BLOCK` is clamped to `AUTH`. Objective errors fail **closed** (`BLOCK`); subjective errors fail **upward** (`AUTH`).
+- **Enforcement at the chokepoint** — the proxy now acts on verdicts: `PASS` forwards, `AUTH`/`BLOCK` return explanatory errors (reason codes + human explanation + action id) and **never** forward. A blocked call provably never reaches a tool; an engine failure is a `BLOCK`.
+
+---
+
+## Design invariants
+
+These two rules are non-negotiable and define the product:
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case, the action is **denied**. The agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails and learning may automatically *tighten*; they may **never** silently *loosen*. Any weakening must go through an explicit, human-approved path.
+
+Internally the policy core (`engine`, `roles`, `policy`, `storage`, `learning`) is decoupled from the proxy adapter, and the public core never depends on any private/commercial package — both enforced in CI by [import-linter](https://import-linter.readthedocs.io/).
+
+---
+
+## Versioning
+
+Doberman follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`). While the project is pre-1.0, the public API may change between minor versions.
+
+The version line maps to the development roadmap:
+
+- **Each numbered Feature is a minor version** (Feature 1 → `0.1.0`, Feature 2 → `0.2.0`, …).
+- **Each slice is a building block of that version** — a small, independently tested, reviewed unit of work. The slices that compose a release are listed under it in the [Changelog](#changelog).
+- Releases are cut as annotated git tags (`v0.1.0`, `v0.2.0`, …) once a feature's review checkpoint passes.
+
+---
+
+## Changelog
+
+This project keeps a changelog in the spirit of [Keep a Changelog](https://keepachangelog.com/).
+
+### `v0.2.0` — Decision Engine & Execution Rule — _Unreleased (in review)_
+
+- **Slice 2.1** — `Guardrail` interface & frozen, always-explained `Decision` model.
+- **Slice 2.2** — raise-only verdict/risk `combine()` with exhaustive + property tests.
+- **Slice 2.3** — objective-first execution-rule state machine (short-circuit, subjective clamp, fail-closed / fail-upward error paths).
+- **Slice 2.4** — verdict enforcement at the proxy chokepoint (blocked calls never run; engine failure → `BLOCK`).
+
+### `v0.1.0` — Tool Mediation Layer & Normalized Action Object
+
+- **Slice 1.1** — `SecurityObject`, `Verdict`, and reason-code schema.
+- **Slice 1.2** — pass-through MCP proxy: forward tool calls through a single chokepoint.
+- **Slice 1.3** — normalize tool calls into `SecurityObject` (mapping, target extraction, redaction).
+- **Slice 1.4** — structured, redacted interception logging.
+
+### `v0.0.0` — Bootstrap
+
+- Project scaffolding, packaging, and CI (lint, format, import-boundary contracts, tests, secret scanning).
+
+---
+
+## Roadmap
+
+Upcoming versions add the guardrail *content* and the surfaces around the engine (capability-level summary):
+
+| Version | Theme |
+|---------|-------|
+| `v0.3.0` | **Objective guardrail** — basic rules: protected paths, dangerous commands, external destinations, secret-leak and encoded-exfiltration detection, plus a rule plugin seam. |
+| `v0.4.0` | **Agent role policy** — built-in roles and per-repo boundary matching. |
+| `v0.5.0` | **Capability discovery** — local scan and risk map. |
+| `v0.6.0` | **Policy checklist & strength modes** — Light / Balanced / Strict / Paranoid. |
+| `v0.7.0` | **Tiered authentication** — local confirmation, TOTP 2FA, narrow/temporary elevation. |
+| `v0.8.0` | **Decision log & audit** — local redacted decision log + storage interface. |
+| `v0.9.0` | **Subjective guardrail** — abnormality interface + a basic local baseline. |
+| `v0.10.0` | **Policy-drift & poisoning defense** — strengthen/weaken classification, gated approvals, append-only ledger. |
+
+---
+
+## Contributing
+
+Contributions are welcome. The project is built in small, reviewable **slices**: one slice = one branch = one pull request, each shipping with its own tests and passing CI before merge. Please:
+
+- Keep the [design invariants](#design-invariants) intact (fail closed, raise-only).
+- Add tests for every change; do not weaken a test or invariant to get CI green.
+- Run `ruff check . && ruff format --check . && lint-imports && pytest` locally before opening a PR.
+
+---
+
+## Security
+
+Doberman is defense-in-depth, not a silver bullet — no single rule (including secret detection) is claimed to be airtight. Please do not commit secrets, keys, or raw payloads; the codebase only ever stores redacted metadata, classifications, and keyed fingerprints. To report a vulnerability, please open a private security advisory rather than a public issue.
+
+---
+
+## License
+
+[Apache License 2.0](./LICENSE) — © 2026 the Doberman authors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doberman"
-version = "0.0.0"
+version = "0.2.0"
 description = "Adaptive authorization layer for coding agents (open core)"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"

--- a/src/doberman/__init__.py
+++ b/src/doberman/__init__.py
@@ -1,3 +1,3 @@
 """Doberman — adaptive authorization layer for coding agents (open core)."""
 
-__version__ = "0.0.0"
+__version__ = "0.2.0"

--- a/src/doberman/engine/decision_engine.py
+++ b/src/doberman/engine/decision_engine.py
@@ -51,6 +51,24 @@ class Guardrail(Protocol):
         ...
 
 
+class StaticGuardrail:
+    """A guardrail that always returns a fixed result.
+
+    The MVP stub used until Feature 3 (objective) and Feature 9 (subjective)
+    provide real implementations; also handy in tests.
+    """
+
+    def __init__(self, result: GuardrailResult) -> None:
+        self._result = result
+
+    def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:
+        return self._result
+
+
+#: Default stubs: observe-everything (PASS/low) until F3/F9 land.
+PASS_STUB = StaticGuardrail(GuardrailResult(verdict=Verdict.PASS, risk=Risk.low))
+
+
 def max_verdict(a: Verdict, b: Verdict) -> Verdict:
     """The more severe of two verdicts (PASS < AUTH < BLOCK)."""
     return a if VERDICT_ORDER[a] >= VERDICT_ORDER[b] else b

--- a/src/doberman/engine/decision_engine.py
+++ b/src/doberman/engine/decision_engine.py
@@ -24,7 +24,9 @@ from doberman.models import (
 # Deliberately EMPTY in the MVP: the subjective guardrail escalates to AUTH,
 # it does not hard-block ("subjective is for escalation, not paternalism").
 # Growing this list is a policy weakening of the clamp and must go through
-# the Feature 10 human-approved path.
+# the Feature 10 human-approved path. NOTE: this is a module-global frozenset;
+# rebinding the NAME at runtime is possible for code inside the process trust
+# boundary and would bypass F10 — treat any runtime rebinding as an attack.
 SUBJECTIVE_HARD_BLOCK_ALLOWLIST: frozenset[ReasonCode] = frozenset()
 
 
@@ -91,8 +93,15 @@ def _safe_evaluate(
     error_code: ReasonCode,
     error_explanation: str,
 ) -> GuardrailResult:
-    """Run one guardrail; ANY failure (raise or junk return) yields the
-    configured conservative result instead of escaping the engine."""
+    """Run one guardrail; any ``Exception`` (raise or junk return) yields the
+    configured conservative result instead of escaping the engine.
+
+    ``BaseException`` (KeyboardInterrupt/SystemExit/CancelledError) is
+    deliberately NOT caught: those must unwind the stack — and an unwind is
+    fail-closed by construction, because the downstream forward only happens
+    on a *returned* PASS decision. A guardrail aborting the process can deny
+    service, never grant access.
+    """
     try:
         result = guardrail.evaluate(action, ctx)
     except Exception:  # noqa: BLE001 — the engine owns failure semantics

--- a/src/doberman/engine/decision_engine.py
+++ b/src/doberman/engine/decision_engine.py
@@ -1,21 +1,31 @@
-"""The decision engine: the `Guardrail` contract (and, next slices, the
-raise-only combination and the objective-first execution rule).
+"""The decision engine: the `Guardrail` contract, the raise-only
+combination, and the objective-first execution rule.
 
 This module is part of the policy core — it must never import
 ``doberman.proxy`` (enforced by import-linter).
 """
 
+from datetime import datetime, timezone
 from typing import Protocol, runtime_checkable
 
 from doberman.models import (
     RISK_ORDER,
     VERDICT_ORDER,
+    Decision,
     EvalContext,
     GuardrailResult,
+    ReasonCode,
     Risk,
     SecurityObject,
     Verdict,
 )
+
+# Reason codes for which a SUBJECTIVE BLOCK is honored as a hard block.
+# Deliberately EMPTY in the MVP: the subjective guardrail escalates to AUTH,
+# it does not hard-block ("subjective is for escalation, not paternalism").
+# Growing this list is a policy weakening of the clamp and must go through
+# the Feature 10 human-approved path.
+SUBJECTIVE_HARD_BLOCK_ALLOWLIST: frozenset[ReasonCode] = frozenset()
 
 
 @runtime_checkable
@@ -69,4 +79,111 @@ def combine(a: GuardrailResult, b: GuardrailResult | None) -> GuardrailResult:
         risk=max_risk(a.risk, b.risk),
         reason_codes=merged_reasons,
         explanation=explanation,
+    )
+
+
+def _safe_evaluate(
+    guardrail: Guardrail,
+    action: SecurityObject,
+    ctx: EvalContext,
+    *,
+    on_error_verdict: Verdict,
+    error_code: ReasonCode,
+    error_explanation: str,
+) -> GuardrailResult:
+    """Run one guardrail; ANY failure (raise or junk return) yields the
+    configured conservative result instead of escaping the engine."""
+    try:
+        result = guardrail.evaluate(action, ctx)
+    except Exception:  # noqa: BLE001 — the engine owns failure semantics
+        result = None
+    if not isinstance(result, GuardrailResult):
+        # Covers both the exception path and a signature-blind impostor
+        # returning garbage (the runtime_checkable Protocol cannot catch it).
+        return GuardrailResult(
+            verdict=on_error_verdict,
+            risk=Risk.high,
+            reason_codes=[error_code],
+            explanation=error_explanation,
+        )
+    return result
+
+
+def decide(
+    action: SecurityObject,
+    objective: Guardrail,
+    subjective: Guardrail,
+    ctx: EvalContext,
+) -> Decision:
+    """The execution rule (thesis §4/§8) — objective first, raise-only.
+
+    1. Run the objective guardrail. If it errors → **BLOCK** (fail closed).
+    2. Objective ``BLOCK`` → final BLOCK; subjective is NOT run.
+    3. Objective ``AUTH`` → final AUTH; subjective is NOT run (straight to
+       authentication — subjective can never weaken it).
+    4. Objective ``PASS`` → run the subjective guardrail (errors → treated
+       as AUTH, fail upward) and ``combine`` raise-only.
+    5. A subjective ``BLOCK`` is honored only if one of its reason codes is
+       on ``SUBJECTIVE_HARD_BLOCK_ALLOWLIST``; otherwise it is clamped to
+       ``AUTH`` (the original subjective result is preserved on the
+       Decision for audit).
+    """
+    objective_result = _safe_evaluate(
+        objective,
+        action,
+        ctx,
+        on_error_verdict=Verdict.BLOCK,
+        error_code=ReasonCode.objective_guardrail_error,
+        error_explanation="Objective guardrail failed; failing closed.",
+    )
+
+    # Steps 2–3: objective short-circuit — subjective never runs, so it can
+    # never weaken (or even observe) an objective AUTH/BLOCK.
+    if objective_result.verdict is not Verdict.PASS:
+        return Decision(
+            action_id=action.id,
+            final_verdict=objective_result.verdict,
+            final_risk=objective_result.risk,
+            objective=objective_result,
+            subjective=None,
+            reason_codes=list(objective_result.reason_codes),
+            explanation=objective_result.explanation,
+            decided_at=datetime.now(timezone.utc),
+        )
+
+    # Step 4: objective PASS → consult the subjective guardrail.
+    subjective_result = _safe_evaluate(
+        subjective,
+        action,
+        ctx,
+        on_error_verdict=Verdict.AUTH,
+        error_code=ReasonCode.subjective_guardrail_error,
+        error_explanation="Subjective guardrail failed; escalating to authentication.",
+    )
+
+    # Step 5: clamp a non-allowlisted subjective hard block to AUTH.
+    effective_subjective = subjective_result
+    if subjective_result.verdict is Verdict.BLOCK and not (
+        SUBJECTIVE_HARD_BLOCK_ALLOWLIST & set(subjective_result.reason_codes)
+    ):
+        effective_subjective = GuardrailResult(
+            verdict=Verdict.AUTH,
+            risk=subjective_result.risk,
+            reason_codes=[*subjective_result.reason_codes, ReasonCode.subjective_block_clamped],
+            explanation=(
+                f"{subjective_result.explanation} "
+                "(subjective block clamped to authentication; not on the hard-block allowlist)"
+            ).strip(),
+        )
+
+    combined = combine(objective_result, effective_subjective)
+    return Decision(
+        action_id=action.id,
+        final_verdict=combined.verdict,
+        final_risk=combined.risk,
+        objective=objective_result,
+        subjective=subjective_result,  # the ORIGINAL result, for audit truth
+        reason_codes=list(combined.reason_codes),
+        explanation=combined.explanation,
+        decided_at=datetime.now(timezone.utc),
     )

--- a/src/doberman/engine/decision_engine.py
+++ b/src/doberman/engine/decision_engine.py
@@ -18,6 +18,12 @@ class Guardrail(Protocol):
     mutation of the action (it is frozen anyway), one :class:`GuardrailResult`
     out. The engine — not the guardrail — owns combination and short-circuit
     semantics, so a guardrail can never lower another's verdict.
+
+    CAVEAT: ``isinstance(obj, Guardrail)`` is structural-only (method name,
+    not signature or return type) — ``runtime_checkable`` cannot verify more.
+    The engine must therefore never treat an isinstance check as a type-safety
+    gate: the real gate is that ``evaluate``'s return value is validated as a
+    ``GuardrailResult`` (anything else fails closed).
     """
 
     def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:

--- a/src/doberman/engine/decision_engine.py
+++ b/src/doberman/engine/decision_engine.py
@@ -1,0 +1,25 @@
+"""The decision engine: the `Guardrail` contract (and, next slices, the
+raise-only combination and the objective-first execution rule).
+
+This module is part of the policy core — it must never import
+``doberman.proxy`` (enforced by import-linter).
+"""
+
+from typing import Protocol, runtime_checkable
+
+from doberman.models import EvalContext, GuardrailResult, SecurityObject
+
+
+@runtime_checkable
+class Guardrail(Protocol):
+    """The contract every guardrail implements.
+
+    Guardrails are pure functions of ``(action, ctx)``: no side effects, no
+    mutation of the action (it is frozen anyway), one :class:`GuardrailResult`
+    out. The engine — not the guardrail — owns combination and short-circuit
+    semantics, so a guardrail can never lower another's verdict.
+    """
+
+    def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:
+        """Judge one action and return a verdict with reasons."""
+        ...

--- a/src/doberman/engine/decision_engine.py
+++ b/src/doberman/engine/decision_engine.py
@@ -7,7 +7,15 @@ This module is part of the policy core — it must never import
 
 from typing import Protocol, runtime_checkable
 
-from doberman.models import EvalContext, GuardrailResult, SecurityObject
+from doberman.models import (
+    RISK_ORDER,
+    VERDICT_ORDER,
+    EvalContext,
+    GuardrailResult,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
 
 
 @runtime_checkable
@@ -29,3 +37,35 @@ class Guardrail(Protocol):
     def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:
         """Judge one action and return a verdict with reasons."""
         ...
+
+
+def max_verdict(a: Verdict, b: Verdict) -> Verdict:
+    """The more severe of two verdicts (PASS < AUTH < BLOCK)."""
+    return a if VERDICT_ORDER[a] >= VERDICT_ORDER[b] else b
+
+
+def max_risk(a: Risk, b: Risk) -> Risk:
+    """The higher of two risk levels (low < medium < high < critical)."""
+    return a if RISK_ORDER[a] >= RISK_ORDER[b] else b
+
+
+def combine(a: GuardrailResult, b: GuardrailResult | None) -> GuardrailResult:
+    """Combine two guardrail results — RAISE-ONLY, by construction.
+
+    Returns the **max** verdict, the **max** risk, and the **union** of
+    reason codes (order-preserving, ``a`` first). There is deliberately no
+    code path that returns a verdict or risk lower than either input: the
+    only operations used are max() over the severity orderings and set
+    union over reasons. ``b is None`` (subjective skipped) returns ``a``
+    unchanged.
+    """
+    if b is None:
+        return a
+    merged_reasons = list(dict.fromkeys([*a.reason_codes, *b.reason_codes]))
+    explanation = " ".join(part for part in (a.explanation.strip(), b.explanation.strip()) if part)
+    return GuardrailResult(
+        verdict=max_verdict(a.verdict, b.verdict),
+        risk=max_risk(a.risk, b.risk),
+        reason_codes=merged_reasons,
+        explanation=explanation,
+    )

--- a/src/doberman/engine/decision_engine.py
+++ b/src/doberman/engine/decision_engine.py
@@ -56,11 +56,12 @@ def combine(a: GuardrailResult, b: GuardrailResult | None) -> GuardrailResult:
     reason codes (order-preserving, ``a`` first). There is deliberately no
     code path that returns a verdict or risk lower than either input: the
     only operations used are max() over the severity orderings and set
-    union over reasons. ``b is None`` (subjective skipped) returns ``a``
-    unchanged.
+    union over reasons. ``b is None`` (subjective skipped) returns a copy of
+    ``a`` (never the same instance — reason_codes is a mutable list and the
+    caller must not be able to alias it).
     """
     if b is None:
-        return a
+        return a.model_copy(deep=True)
     merged_reasons = list(dict.fromkeys([*a.reason_codes, *b.reason_codes]))
     explanation = " ".join(part for part in (a.explanation.strip(), b.explanation.strip()) if part)
     return GuardrailResult(

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -65,6 +65,13 @@ class Verdict(StrEnum):
     BLOCK = "BLOCK"
 
 
+# Severity orderings: combination may only ever move UP these scales
+# (raise-only). Shared by the Decision consistency check below and the
+# engine's combine().
+VERDICT_ORDER: dict[Verdict, int] = {Verdict.PASS: 0, Verdict.AUTH: 1, Verdict.BLOCK: 2}
+RISK_ORDER: dict[Risk, int] = {Risk.low: 0, Risk.medium: 1, Risk.high: 2, Risk.critical: 3}
+
+
 class ReasonCode(StrEnum):
     """Stable reason-code constants attached to every non-PASS decision.
 
@@ -106,6 +113,10 @@ class EvalContext(BaseModel):
 
     Deliberately near-empty for now; later features add the security mode
     (F6), role boundaries (F4), and the baseline handle (F9).
+
+    NOTE: ``frozen=True`` is shallow — the ``metadata`` dict itself is
+    mutable. Guardrails are pure functions by contract and MUST NOT mutate
+    it; the engine treats any mutation as a guardrail bug.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -150,6 +161,14 @@ class Decision(BaseModel):
     contributing guardrail results, and any non-PASS outcome must be
     explained (reason codes + human explanation). ``subjective`` is ``None``
     when the execution rule skipped it (objective short-circuit).
+
+    Consistency invariant: ``final_verdict`` can never be WEAKER than the
+    objective guardrail's verdict (objective is never overridden downward).
+    It MAY be weaker than ``subjective.verdict`` — the execution rule clamps
+    a non-allowlisted subjective BLOCK to AUTH by design.
+
+    ``action_id`` must equal the ``SecurityObject.id`` of the action being
+    decided (chain of custody for audit).
     """
 
     model_config = ConfigDict(frozen=True)
@@ -172,4 +191,18 @@ class Decision(BaseModel):
                 )
             if not self.explanation.strip():
                 raise ValueError(f"a {self.final_verdict} decision requires a human explanation")
+        return self
+
+    @model_validator(mode="after")
+    def _final_never_weaker_than_objective(self) -> "Decision":
+        if VERDICT_ORDER[self.final_verdict] < VERDICT_ORDER[self.objective.verdict]:
+            raise ValueError(
+                f"final_verdict {self.final_verdict} is weaker than the objective "
+                f"verdict {self.objective.verdict} — objective is never overridden downward"
+            )
+        if RISK_ORDER[self.final_risk] < RISK_ORDER[self.objective.risk]:
+            raise ValueError(
+                f"final_risk {self.final_risk} is lower than the objective "
+                f"risk {self.objective.risk} — risk is never lowered"
+            )
         return self

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -71,6 +71,11 @@ class Verdict(StrEnum):
 VERDICT_ORDER: dict[Verdict, int] = {Verdict.PASS: 0, Verdict.AUTH: 1, Verdict.BLOCK: 2}
 RISK_ORDER: dict[Risk, int] = {Risk.low: 0, Risk.medium: 1, Risk.high: 2, Risk.critical: 3}
 
+# Fail at import time if an enum member is ever added without an ordering —
+# a KeyError mid-decision would crash instead of failing closed.
+if set(VERDICT_ORDER) != set(Verdict) or set(RISK_ORDER) != set(Risk):  # pragma: no cover
+    raise RuntimeError("VERDICT_ORDER/RISK_ORDER must cover every enum member")
+
 
 class ReasonCode(StrEnum):
     """Stable reason-code constants attached to every non-PASS decision.

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -87,6 +87,9 @@ class ReasonCode(StrEnum):
     normalization_failed = "normalization_failed"
     unknown_tool = "unknown_tool"
     downstream_error = "downstream_error"
+    objective_guardrail_error = "objective_guardrail_error"
+    subjective_guardrail_error = "subjective_guardrail_error"
+    subjective_block_clamped = "subjective_block_clamped"
 
 
 class GuardrailResult(BaseModel):

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -97,6 +97,11 @@ class GuardrailResult(BaseModel):
 
     Explainability contract: every non-PASS verdict must carry at least one
     stable :class:`ReasonCode` and a human-readable explanation.
+
+    SECURITY: ``explanation`` is shown to the agent on AUTH/BLOCK. Guardrail
+    authors MUST NOT embed raw argument values, file contents, secret
+    material, or match excerpts in it — describe the rule, not the payload
+    (e.g. "path is under a protected directory", never the path's contents).
     """
 
     model_config = ConfigDict(frozen=True)

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -101,6 +101,18 @@ class GuardrailResult(BaseModel):
         return self
 
 
+class EvalContext(BaseModel):
+    """Context handed to every guardrail evaluation (immutable).
+
+    Deliberately near-empty for now; later features add the security mode
+    (F6), role boundaries (F4), and the baseline handle (F9).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
 class SecurityObject(BaseModel):
     """The normalized, redacted description of one intercepted action.
 
@@ -129,3 +141,35 @@ class SecurityObject(BaseModel):
     # enforced by normalize() and its tests, not by this type.
     raw_args_redacted: dict[str, Any] = Field(default_factory=dict)
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class Decision(BaseModel):
+    """The engine's final, immutable answer for one action.
+
+    This is the audit record's source of truth: it always carries the
+    contributing guardrail results, and any non-PASS outcome must be
+    explained (reason codes + human explanation). ``subjective`` is ``None``
+    when the execution rule skipped it (objective short-circuit).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    action_id: str = Field(min_length=1)
+    final_verdict: Verdict
+    final_risk: Risk
+    objective: GuardrailResult
+    subjective: GuardrailResult | None = None
+    reason_codes: list[ReasonCode] = Field(default_factory=list)
+    explanation: str = ""
+    decided_at: AwareDatetime
+
+    @model_validator(mode="after")
+    def _non_pass_must_be_explained(self) -> "Decision":
+        if self.final_verdict is not Verdict.PASS:
+            if not self.reason_codes:
+                raise ValueError(
+                    f"a {self.final_verdict} decision requires at least one reason code"
+                )
+            if not self.explanation.strip():
+                raise ValueError(f"a {self.final_verdict} decision requires a human explanation")
+        return self

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -2,23 +2,51 @@
 
 Every tool call intercepted by the proxy MUST flow through
 :func:`decide_and_execute` — there is no other route to a downstream tool.
-For now the decision hook is a pass-through (observation only); Feature 2
-replaces it with the real decision engine. The fail-closed contract is
-already in force: any error on the way to the downstream tool yields an
-error result, never a silent success or a bypass.
+The decision engine (Feature 2) judges every normalized action: ``PASS``
+forwards, ``AUTH`` returns an authentication-required error (real auth
+arrives with Feature 7), ``BLOCK`` returns a policy error and the call is
+NEVER forwarded. Any engine failure is itself a ``BLOCK`` (fail closed).
 """
+
+from datetime import datetime, timezone
 
 from mcp.client.session import ClientSession
 from mcp.types import CallToolResult, TextContent
 
-from doberman.models import ReasonCode, SecurityObject, Verdict
+from doberman.engine.decision_engine import PASS_STUB, Guardrail, decide
+from doberman.models import (
+    Decision,
+    EvalContext,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
 from doberman.proxy.interception_log import log_action
 from doberman.proxy.normalize import normalize
+
+# Guardrail implementations used by the proxy. Stubs (PASS/low) until
+# Feature 3 (objective rules) and Feature 9 (subjective baseline) replace
+# them. Module-level so tests can monkeypatch the policy without touching
+# the routing.
+DEFAULT_OBJECTIVE: Guardrail = PASS_STUB
+DEFAULT_SUBJECTIVE: Guardrail = PASS_STUB
 
 _DENIED_TEMPLATE = (
     "doberman: downstream call failed; action denied "
     "(reason: {reason}; error class: {error_class}; action id: {action_id})"
 )
+
+_VERDICT_TEMPLATES = {
+    Verdict.AUTH: (
+        "doberman: authentication required "
+        "(reasons: {reasons}; {explanation}; action id: {action_id})"
+    ),
+    Verdict.BLOCK: (
+        "doberman: blocked by policy (reasons: {reasons}; {explanation}; action id: {action_id})"
+    ),
+}
 
 
 def _denied_result(reason: ReasonCode, error_class: str, action_id: str) -> CallToolResult:
@@ -36,23 +64,70 @@ def _denied_result(reason: ReasonCode, error_class: str, action_id: str) -> Call
     )
 
 
+def _verdict_result(decision: Decision) -> CallToolResult:
+    """Agent-visible explanatory error for an AUTH/BLOCK decision."""
+    template = _VERDICT_TEMPLATES[decision.final_verdict]
+    return CallToolResult(
+        content=[
+            TextContent(
+                type="text",
+                text=template.format(
+                    reasons=", ".join(decision.reason_codes) or "unspecified",
+                    explanation=decision.explanation.strip() or "no further detail",
+                    action_id=decision.action_id,
+                ),
+            )
+        ],
+        isError=True,
+    )
+
+
+def _engine_failure_decision(action: SecurityObject) -> Decision:
+    """A synthetic fail-closed BLOCK used when the engine itself fails."""
+    blocked = GuardrailResult(
+        verdict=Verdict.BLOCK,
+        risk=Risk.high,
+        reason_codes=[ReasonCode.objective_guardrail_error],
+        explanation="Decision engine failed; failing closed.",
+    )
+    return Decision(
+        action_id=action.id,
+        final_verdict=Verdict.BLOCK,
+        final_risk=Risk.high,
+        objective=blocked,
+        subjective=None,
+        reason_codes=list(blocked.reason_codes),
+        explanation=blocked.explanation,
+        decided_at=datetime.now(timezone.utc),
+    )
+
+
 async def decide_and_execute(
     downstream: ClientSession,
     tool_name: str,
     arguments: dict | None,
 ) -> CallToolResult:
-    """Decide whether to execute a tool call, then (if allowed) forward it.
+    """Decide whether to execute a tool call, then act on the verdict.
 
-    This is THE chokepoint. The decision hook is currently a pass-through
-    stub — every call is forwarded — but the routing invariant (exactly one
-    path, through this function) and the fail-closed error handling are real.
+    This is THE chokepoint: normalize → decide → enforce. The downstream
+    forward happens in exactly one place, reachable only on a PASS decision.
     """
     action: SecurityObject = normalize(tool_name, arguments)
-    # --- decision hook (Feature 2 wires the engine in here) -----------------
-    verdict = Verdict.PASS  # pass-through stub; F2 replaces this with the engine result
-    # ------------------------------------------------------------------------
-    # Record every intercepted action (best-effort; never blocks execution).
-    log_action(action, verdict)
+
+    try:
+        decision = decide(action, DEFAULT_OBJECTIVE, DEFAULT_SUBJECTIVE, EvalContext())
+    except Exception:  # noqa: BLE001 — engine failure must fail closed, not crash
+        decision = _engine_failure_decision(action)
+
+    # Record every intercepted action with its REAL verdict (best-effort;
+    # never blocks execution).
+    log_action(action, decision.final_verdict)
+
+    if decision.final_verdict is not Verdict.PASS:
+        # AUTH (F7 adds the real challenge) and BLOCK both stop here:
+        # the downstream call below is never reached.
+        return _verdict_result(decision)
+
     try:
         return await downstream.call_tool(tool_name, arguments or {})
     except Exception as exc:  # noqa: BLE001 — fail closed on ANY failure mode

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -8,6 +8,7 @@ arrives with Feature 7), ``BLOCK`` returns a policy error and the call is
 NEVER forwarded. Any engine failure is itself a ``BLOCK`` (fail closed).
 """
 
+import logging
 from datetime import datetime, timezone
 
 from mcp.client.session import ClientSession
@@ -25,6 +26,8 @@ from doberman.models import (
 )
 from doberman.proxy.interception_log import log_action
 from doberman.proxy.normalize import normalize
+
+_engine_logger = logging.getLogger("doberman.proxy.engine")
 
 # Guardrail implementations used by the proxy. Stubs (PASS/low) until
 # Feature 3 (objective rules) and Feature 9 (subjective baseline) replace
@@ -117,10 +120,16 @@ async def decide_and_execute(
     try:
         decision = decide(action, DEFAULT_OBJECTIVE, DEFAULT_SUBJECTIVE, EvalContext())
     except Exception:  # noqa: BLE001 — engine failure must fail closed, not crash
+        # BaseException (CancelledError, SystemExit) propagates on purpose —
+        # an unwind is fail-closed by construction (the forward below is
+        # never reached). Log the failure server-side for forensics; the
+        # exception text never reaches the agent.
+        _engine_logger.exception("decision engine raised; failing closed (action %s)", action.id)
         decision = _engine_failure_decision(action)
 
-    # Record every intercepted action with its REAL verdict (best-effort;
-    # never blocks execution).
+    # Record every intercepted action with its REAL verdict. Logged BEFORE
+    # the verdict gate — safe because log_action can never bypass the gate
+    # (it swallows its own failures and forwards nothing).
     log_action(action, decision.final_verdict)
 
     if decision.final_verdict is not Verdict.PASS:

--- a/tests/integration/test_engine_blocks_reach_no_tool.py
+++ b/tests/integration/test_engine_blocks_reach_no_tool.py
@@ -1,0 +1,112 @@
+"""Slice 2.4 — verdicts are enforced: a BLOCK means the tool NEVER runs."""
+
+import json
+import logging
+
+from doberman.engine.decision_engine import StaticGuardrail
+from doberman.models import GuardrailResult, ReasonCode, Risk, Verdict
+from doberman.proxy import executor
+from doberman.proxy.interception_log import LOGGER_NAME
+
+from .test_proxy_passthrough import proxied_session
+
+BLOCKING = StaticGuardrail(
+    GuardrailResult(
+        verdict=Verdict.BLOCK,
+        risk=Risk.critical,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation="Stub objective blocks everything.",
+    )
+)
+
+AUTHING = StaticGuardrail(
+    GuardrailResult(
+        verdict=Verdict.AUTH,
+        risk=Risk.high,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation="Stub objective requires authentication.",
+    )
+)
+
+SUBJECTIVE_BLOCKING = StaticGuardrail(
+    GuardrailResult(
+        verdict=Verdict.BLOCK,
+        risk=Risk.high,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation="Stub subjective wants a hard block.",
+    )
+)
+
+
+async def test_pass_forwards_and_records():
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("fs_write", {"path": "a.txt", "content": "x"})
+        assert not result.isError
+        assert fake.calls == [("fs_write", {"path": "a.txt", "content": "x"})]
+
+
+async def test_block_returns_error_and_nothing_recorded(monkeypatch):
+    monkeypatch.setattr(executor, "DEFAULT_OBJECTIVE", BLOCKING)
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("fs_delete", {"path": "a.txt"})
+        assert result.isError
+        text = result.content[0].text
+        assert "blocked by policy" in text
+        assert "unknown_tool" in text  # reason codes are agent-visible
+        assert "Stub objective blocks everything." in text  # explanation too
+        # THE protective property: the fake downstream recorded NOTHING.
+        assert fake.calls == []
+
+
+async def test_auth_returns_error_and_nothing_recorded(monkeypatch):
+    monkeypatch.setattr(executor, "DEFAULT_OBJECTIVE", AUTHING)
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("shell_exec", {"command": "echo hi"})
+        assert result.isError
+        assert "authentication required" in result.content[0].text
+        assert fake.calls == []
+
+
+async def test_engine_exception_fails_closed(monkeypatch):
+    def exploding_decide(*args, **kwargs):
+        raise RuntimeError("engine exploded")
+
+    monkeypatch.setattr(executor, "decide", exploding_decide)
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("fs_write", {"path": "a.txt", "content": "x"})
+        assert result.isError
+        assert "blocked by policy" in result.content[0].text
+        assert "failing closed" in result.content[0].text.lower()
+        assert fake.calls == []
+
+
+async def test_subjective_block_clamps_to_auth_end_to_end(monkeypatch):
+    monkeypatch.setattr(executor, "DEFAULT_SUBJECTIVE", SUBJECTIVE_BLOCKING)
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("net_get", {"url": "https://example.com"})
+        assert result.isError
+        text = result.content[0].text
+        # Clamped: authentication, not a hard block.
+        assert "authentication required" in text
+        assert "subjective_block_clamped" in text
+        assert fake.calls == []
+
+
+async def test_log_records_real_verdict(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger=LOGGER_NAME)
+    monkeypatch.setattr(executor, "DEFAULT_OBJECTIVE", BLOCKING)
+    async with proxied_session() as (_, agent):
+        await agent.call_tool("fs_delete", {"path": "a.txt"})
+    records = [json.loads(r.message) for r in caplog.records if r.name == LOGGER_NAME]
+    assert len(records) == 1
+    assert records[0]["verdict"] == "BLOCK"  # not the old hardcoded PASS
+
+
+async def test_block_error_never_echoes_arguments(monkeypatch):
+    monkeypatch.setattr(executor, "DEFAULT_OBJECTIVE", BLOCKING)
+    secret = "AKIA-FAKE-BLOCKED-SECRET-99"  # noqa: S105 — synthetic test value
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("fs_write", {"path": "x", "content": secret})
+        assert result.isError
+        assert all(secret not in block.text for block in result.content)
+        assert fake.calls == []

--- a/tests/integration/test_engine_blocks_reach_no_tool.py
+++ b/tests/integration/test_engine_blocks_reach_no_tool.py
@@ -71,6 +71,8 @@ async def test_engine_exception_fails_closed(monkeypatch):
     def exploding_decide(*args, **kwargs):
         raise RuntimeError("engine exploded")
 
+    # Patches the from-import binding in executor.py — if executor ever
+    # switches to module-attribute calls (engine.decide), update this target.
     monkeypatch.setattr(executor, "decide", exploding_decide)
     async with proxied_session() as (fake, agent):
         result = await agent.call_tool("fs_write", {"path": "a.txt", "content": "x"})

--- a/tests/unit/test_core_is_standalone.py
+++ b/tests/unit/test_core_is_standalone.py
@@ -13,7 +13,7 @@ def test_core_imports_with_no_enterprise_installed():
 def test_version_is_exposed():
     import doberman
 
-    assert doberman.__version__ == "0.0.0"
+    assert doberman.__version__ == "0.2.0"
 
 
 def test_policy_core_packages_import_cleanly():

--- a/tests/unit/test_decision_models.py
+++ b/tests/unit/test_decision_models.py
@@ -68,35 +68,82 @@ def test_decision_valid_construction_pass():
     assert decision.reason_codes == []
 
 
-def test_decision_block_requires_reasons_and_explanation():
+@pytest.mark.parametrize("verdict", [Verdict.BLOCK, Verdict.AUTH])
+def test_decision_non_pass_requires_reasons_and_explanation(verdict):
+    objective = GuardrailResult(
+        verdict=verdict,
+        risk=Risk.high,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation="Unknown tool.",
+    )
     with pytest.raises(ValidationError):
         Decision(
             action_id="act-1",
-            final_verdict=Verdict.BLOCK,
+            final_verdict=verdict,
             final_risk=Risk.high,
-            objective=BLOCK_HIGH,
+            objective=objective,
             decided_at=NOW,
         )
     with pytest.raises(ValidationError):  # reasons present, explanation blank
         Decision(
             action_id="act-1",
-            final_verdict=Verdict.BLOCK,
+            final_verdict=verdict,
             final_risk=Risk.high,
-            objective=BLOCK_HIGH,
+            objective=objective,
             reason_codes=[ReasonCode.unknown_tool],
             explanation="   ",
             decided_at=NOW,
         )
     ok = Decision(
         action_id="act-1",
-        final_verdict=Verdict.BLOCK,
+        final_verdict=verdict,
         final_risk=Risk.high,
-        objective=BLOCK_HIGH,
+        objective=objective,
         reason_codes=[ReasonCode.unknown_tool],
-        explanation="Unknown tool is blocked.",
+        explanation="Unknown tool requires action.",
         decided_at=NOW,
     )
-    assert ok.final_verdict is Verdict.BLOCK
+    assert ok.final_verdict is verdict
+
+
+def test_decision_final_verdict_never_weaker_than_objective():
+    # A BLOCK objective cannot yield a PASS/AUTH decision (audit corruption).
+    with pytest.raises(ValidationError, match="weaker"):
+        Decision(
+            action_id="act-1",
+            final_verdict=Verdict.PASS,
+            final_risk=Risk.high,
+            objective=BLOCK_HIGH,
+            decided_at=NOW,
+        )
+    # Nor can final risk drop below the objective's risk.
+    with pytest.raises(ValidationError, match="never lowered"):
+        Decision(
+            action_id="act-1",
+            final_verdict=Verdict.BLOCK,
+            final_risk=Risk.low,
+            objective=BLOCK_HIGH,
+            reason_codes=[ReasonCode.unknown_tool],
+            explanation="Blocked.",
+            decided_at=NOW,
+        )
+
+
+def test_decision_may_be_weaker_than_subjective_due_to_clamp():
+    # The execution rule clamps a non-allowlisted subjective BLOCK to AUTH:
+    # final AUTH with subjective BLOCK is a LEGAL audit record.
+    decision = Decision(
+        action_id="act-1",
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.high,
+        objective=PASS_LOW,
+        subjective=BLOCK_HIGH,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation="Escalated to authentication (subjective block clamped).",
+        decided_at=NOW,
+    )
+    assert decision.subjective is not None
+    assert decision.final_verdict is Verdict.AUTH
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_decision_models.py
+++ b/tests/unit/test_decision_models.py
@@ -1,0 +1,133 @@
+"""Slice 2.1 — tests for the Guardrail contract, EvalContext, and Decision."""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from doberman.engine.decision_engine import Guardrail
+from doberman.models import (
+    Decision,
+    EvalContext,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+
+NOW = datetime(2026, 6, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+PASS_LOW = GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+BLOCK_HIGH = GuardrailResult(
+    verdict=Verdict.BLOCK,
+    risk=Risk.high,
+    reason_codes=[ReasonCode.unknown_tool],
+    explanation="Unknown tool.",
+)
+
+
+class StubGuardrail:
+    """Minimal structural implementation of the Guardrail Protocol."""
+
+    def __init__(self, result: GuardrailResult) -> None:
+        self._result = result
+
+    def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:
+        return self._result
+
+
+def test_stub_satisfies_protocol():
+    assert isinstance(StubGuardrail(PASS_LOW), Guardrail)
+
+
+def test_non_guardrail_does_not_satisfy_protocol():
+    class NotAGuardrail:
+        def judge(self):  # wrong method name
+            pass
+
+    assert not isinstance(NotAGuardrail(), Guardrail)
+
+
+def test_eval_context_is_frozen_with_defaults():
+    ctx = EvalContext()
+    assert ctx.metadata == {}
+    with pytest.raises(ValidationError, match="frozen"):
+        ctx.metadata = {"x": 1}
+
+
+def test_decision_valid_construction_pass():
+    decision = Decision(
+        action_id="act-1",
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=PASS_LOW,
+        decided_at=NOW,
+    )
+    assert decision.subjective is None  # subjective skipped is representable
+    assert decision.reason_codes == []
+
+
+def test_decision_block_requires_reasons_and_explanation():
+    with pytest.raises(ValidationError):
+        Decision(
+            action_id="act-1",
+            final_verdict=Verdict.BLOCK,
+            final_risk=Risk.high,
+            objective=BLOCK_HIGH,
+            decided_at=NOW,
+        )
+    with pytest.raises(ValidationError):  # reasons present, explanation blank
+        Decision(
+            action_id="act-1",
+            final_verdict=Verdict.BLOCK,
+            final_risk=Risk.high,
+            objective=BLOCK_HIGH,
+            reason_codes=[ReasonCode.unknown_tool],
+            explanation="   ",
+            decided_at=NOW,
+        )
+    ok = Decision(
+        action_id="act-1",
+        final_verdict=Verdict.BLOCK,
+        final_risk=Risk.high,
+        objective=BLOCK_HIGH,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation="Unknown tool is blocked.",
+        decided_at=NOW,
+    )
+    assert ok.final_verdict is Verdict.BLOCK
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"action_id": ""},
+        {"decided_at": datetime(2026, 6, 7, 12, 0, 0)},  # naive timestamp
+        {"final_verdict": "MAYBE"},
+        {"reason_codes": ["made_up_code"]},
+    ],
+)
+def test_decision_rejects_invalid_fields(overrides):
+    kwargs = dict(
+        action_id="act-1",
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=PASS_LOW,
+        decided_at=NOW,
+    )
+    kwargs.update(overrides)
+    with pytest.raises(ValidationError):
+        Decision(**kwargs)
+
+
+def test_decision_is_frozen():
+    decision = Decision(
+        action_id="act-1",
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=PASS_LOW,
+        decided_at=NOW,
+    )
+    with pytest.raises(ValidationError, match="frozen"):
+        decision.final_verdict = Verdict.BLOCK

--- a/tests/unit/test_execution_rule.py
+++ b/tests/unit/test_execution_rule.py
@@ -1,0 +1,179 @@
+"""Slice 2.3 — the execution-rule state machine, line by line vs the thesis."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from doberman.engine import decision_engine
+from doberman.engine.decision_engine import decide
+from doberman.models import (
+    ActionType,
+    EvalContext,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+
+CTX = EvalContext()
+
+ACTION = SecurityObject(
+    id="act-er-1",
+    ts=datetime(2026, 6, 7, 12, 0, 0, tzinfo=timezone.utc),
+    agent_role="unknown",
+    action_type=ActionType.file_delete,
+    tool_name="fs_delete",
+    target="backend/auth/session.ts",
+)
+
+
+def result(verdict: Verdict, risk: Risk = Risk.low) -> GuardrailResult:
+    if verdict is Verdict.PASS:
+        return GuardrailResult(verdict=verdict, risk=risk)
+    return GuardrailResult(
+        verdict=verdict,
+        risk=risk,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation=f"{verdict} from stub.",
+    )
+
+
+class CountingGuardrail:
+    def __init__(self, outcome: GuardrailResult | Exception | object) -> None:
+        self.outcome = outcome
+        self.calls = 0
+
+    def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:
+        self.calls += 1
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return self.outcome  # type: ignore[return-value]
+
+
+# --- The thesis table -------------------------------------------------------
+# (objective verdict, subjective verdict or None=skipped, expected final)
+THESIS_TABLE = [
+    (Verdict.BLOCK, None, Verdict.BLOCK),  # obj BLOCK → BLOCK, subjective skipped
+    (Verdict.AUTH, None, Verdict.AUTH),  # obj AUTH → AUTH, subjective skipped
+    (Verdict.PASS, Verdict.PASS, Verdict.PASS),  # both pass → PASS
+    (Verdict.PASS, Verdict.AUTH, Verdict.AUTH),  # subjective escalates → AUTH
+    (Verdict.PASS, Verdict.BLOCK, Verdict.AUTH),  # subjective block CLAMPED → AUTH
+]
+
+
+@pytest.mark.parametrize(("obj_verdict", "subj_verdict", "expected"), THESIS_TABLE)
+def test_thesis_execution_rule_table(obj_verdict, subj_verdict, expected):
+    objective = CountingGuardrail(result(obj_verdict, Risk.medium))
+    subjective = CountingGuardrail(
+        result(subj_verdict, Risk.medium) if subj_verdict else result(Verdict.PASS)
+    )
+    decision = decide(ACTION, objective, subjective, CTX)
+
+    assert decision.final_verdict is expected
+    assert objective.calls == 1
+    if subj_verdict is None:
+        # Short-circuit: subjective never ran and is absent from the record.
+        assert subjective.calls == 0
+        assert decision.subjective is None
+    else:
+        assert subjective.calls == 1
+        assert decision.subjective is not None
+
+
+def test_subjective_block_clamped_with_reason_and_audit_truth():
+    objective = CountingGuardrail(result(Verdict.PASS))
+    subjective = CountingGuardrail(result(Verdict.BLOCK, Risk.high))
+    decision = decide(ACTION, objective, subjective, CTX)
+
+    assert decision.final_verdict is Verdict.AUTH  # clamped
+    assert decision.final_risk is Risk.high  # risk NOT lowered by the clamp
+    assert ReasonCode.subjective_block_clamped in decision.reason_codes
+    # Audit truth: the original (unclamped) subjective result is preserved.
+    assert decision.subjective is not None
+    assert decision.subjective.verdict is Verdict.BLOCK
+
+
+def test_allowlisted_subjective_block_is_honored(monkeypatch):
+    monkeypatch.setattr(
+        decision_engine,
+        "SUBJECTIVE_HARD_BLOCK_ALLOWLIST",
+        frozenset({ReasonCode.unknown_tool}),
+    )
+    objective = CountingGuardrail(result(Verdict.PASS))
+    subjective = CountingGuardrail(result(Verdict.BLOCK, Risk.critical))
+    decision = decide(ACTION, objective, subjective, CTX)
+
+    assert decision.final_verdict is Verdict.BLOCK
+    assert ReasonCode.subjective_block_clamped not in decision.reason_codes
+
+
+def test_objective_error_fails_closed_and_skips_subjective():
+    objective = CountingGuardrail(RuntimeError("objective exploded"))
+    subjective = CountingGuardrail(result(Verdict.PASS))
+    decision = decide(ACTION, objective, subjective, CTX)
+
+    assert decision.final_verdict is Verdict.BLOCK
+    assert decision.final_risk is Risk.high
+    assert ReasonCode.objective_guardrail_error in decision.reason_codes
+    assert subjective.calls == 0
+    assert decision.subjective is None
+
+
+def test_subjective_error_fails_upward_to_auth():
+    objective = CountingGuardrail(result(Verdict.PASS))
+    subjective = CountingGuardrail(RuntimeError("subjective exploded"))
+    decision = decide(ACTION, objective, subjective, CTX)
+
+    assert decision.final_verdict is Verdict.AUTH  # fail upward, not open
+    assert ReasonCode.subjective_guardrail_error in decision.reason_codes
+    assert decision.explanation
+
+
+@pytest.mark.parametrize("garbage", ["not-a-result", None, 42, {"verdict": "PASS"}])
+def test_objective_garbage_return_fails_closed(garbage):
+    decision = decide(
+        ACTION, CountingGuardrail(garbage), CountingGuardrail(result(Verdict.PASS)), CTX
+    )
+    assert decision.final_verdict is Verdict.BLOCK
+    assert ReasonCode.objective_guardrail_error in decision.reason_codes
+
+
+@pytest.mark.parametrize("garbage", ["not-a-result", None, 42])
+def test_subjective_garbage_return_fails_upward(garbage):
+    decision = decide(
+        ACTION, CountingGuardrail(result(Verdict.PASS)), CountingGuardrail(garbage), CTX
+    )
+    assert decision.final_verdict is Verdict.AUTH
+    assert ReasonCode.subjective_guardrail_error in decision.reason_codes
+
+
+def test_risk_combines_raise_only_across_guardrails():
+    objective = CountingGuardrail(result(Verdict.PASS, Risk.low))
+    subjective = CountingGuardrail(result(Verdict.AUTH, Risk.high))
+    decision = decide(ACTION, objective, subjective, CTX)
+    assert decision.final_risk is Risk.high
+    assert decision.final_verdict is Verdict.AUTH
+
+
+def test_decision_carries_action_id_and_aware_timestamp():
+    decision = decide(
+        ACTION,
+        CountingGuardrail(result(Verdict.PASS)),
+        CountingGuardrail(result(Verdict.PASS)),
+        CTX,
+    )
+    assert decision.action_id == ACTION.id
+    assert decision.decided_at.tzinfo is not None
+
+
+def test_non_pass_decisions_always_explained():
+    for outcome in (Verdict.AUTH, Verdict.BLOCK):
+        decision = decide(
+            ACTION,
+            CountingGuardrail(result(outcome, Risk.medium)),
+            CountingGuardrail(result(Verdict.PASS)),
+            CTX,
+        )
+        assert decision.reason_codes
+        assert decision.explanation.strip()

--- a/tests/unit/test_execution_rule.py
+++ b/tests/unit/test_execution_rule.py
@@ -167,6 +167,33 @@ def test_decision_carries_action_id_and_aware_timestamp():
     assert decision.decided_at.tzinfo is not None
 
 
+def test_base_exception_unwinds_and_forwards_nothing():
+    # Documented behavior: BaseException is NOT converted to a verdict — it
+    # unwinds. Unwinding is fail-closed by construction (no Decision, no
+    # forward). The engine never converts an interrupt into an allow.
+    objective = CountingGuardrail(result(Verdict.PASS))
+
+    class Aborting:
+        def evaluate(self, action, ctx):
+            raise SystemExit(1)
+
+    with pytest.raises(SystemExit):
+        decide(ACTION, Aborting(), CountingGuardrail(result(Verdict.PASS)), CTX)
+    with pytest.raises(SystemExit):
+        decide(ACTION, objective, Aborting(), CTX)
+
+
+def test_decide_never_raises_for_any_valid_guardrail_outputs():
+    # Adversarial sweep: for EVERY pair of valid GuardrailResult outputs,
+    # decide() must return a valid Decision — never raise via the Decision
+    # validators (regression guard for validator/combine drift).
+    all_results = [result(v, r) for v in Verdict for r in Risk]
+    for obj in all_results:
+        for subj in all_results:
+            decision = decide(ACTION, CountingGuardrail(obj), CountingGuardrail(subj), CTX)
+            assert decision.action_id == ACTION.id
+
+
 def test_non_pass_decisions_always_explained():
     for outcome in (Verdict.AUTH, Verdict.BLOCK):
         decision = decide(

--- a/tests/unit/test_verdict_ordering.py
+++ b/tests/unit/test_verdict_ordering.py
@@ -51,35 +51,52 @@ def test_full_risk_matrix_takes_max(a, b):
     combined = combine(make_result(Verdict.PASS, a), make_result(Verdict.PASS, b))
     assert RISK_ORDER[combined.risk] == max(RISK_ORDER[a], RISK_ORDER[b])
     assert combined.risk == max_risk(a, b)
+    # Risk advances independently of verdict: mixed-verdict pairs too.
+    mixed = combine(make_result(Verdict.AUTH, a), make_result(Verdict.BLOCK, b))
+    assert mixed.risk == max_risk(a, b)
+    assert mixed.verdict is Verdict.BLOCK
 
 
-def test_none_passthrough_returns_a_unchanged():
+def test_none_passthrough_returns_equal_but_unaliased_copy():
     a = make_result(Verdict.AUTH, Risk.high)
-    assert combine(a, None) is a
+    out = combine(a, None)
+    assert out == a
+    assert out is not a
+    # No aliasing: mutating one reason list must not affect the other.
+    out.reason_codes.append(ReasonCode.downstream_error)
+    assert a.reason_codes == [ReasonCode.unknown_tool]
 
 
 def test_combine_never_lowers_property():
     """THE invariant: over many random pairs, combine never returns below
     max(a, b) on either axis, and never drops a reason code."""
-    rng = random.Random(20260607)  # noqa: S311 — deterministic test seed, not crypto
+    rng = random.Random(20260607)  # noqa: S311 — seeded PRNG for test determinism only
     codes = list(ReasonCode)
+
+    def random_result() -> GuardrailResult:
+        verdict = rng.choice(ALL_VERDICTS)
+        # PASS may legally carry ZERO reasons — include that in the distribution.
+        min_reasons = 0 if verdict is Verdict.PASS else 1
+        return make_result(
+            verdict,
+            rng.choice(ALL_RISKS),
+            reasons=rng.sample(codes, rng.randint(min_reasons, len(codes))),
+        )
+
     for _ in range(1000):
-        a = make_result(
-            rng.choice(ALL_VERDICTS),
-            rng.choice(ALL_RISKS),
-            reasons=rng.sample(codes, rng.randint(1, len(codes))),
-        )
-        b = make_result(
-            rng.choice(ALL_VERDICTS),
-            rng.choice(ALL_RISKS),
-            reasons=rng.sample(codes, rng.randint(1, len(codes))),
-        )
+        a = random_result()
+        b = random_result()
         combined = combine(a, b)
         assert VERDICT_ORDER[combined.verdict] >= VERDICT_ORDER[a.verdict]
         assert VERDICT_ORDER[combined.verdict] >= VERDICT_ORDER[b.verdict]
         assert RISK_ORDER[combined.risk] >= RISK_ORDER[a.risk]
         assert RISK_ORDER[combined.risk] >= RISK_ORDER[b.risk]
+        # No reason is ever lost...
         assert set(combined.reason_codes) == set(a.reason_codes) | set(b.reason_codes)
+        # ...and the union is order-preserving: a's codes (deduped) first,
+        # then b's new codes in b's order.
+        expected = list(dict.fromkeys([*a.reason_codes, *b.reason_codes]))
+        assert combined.reason_codes == expected
 
 
 def test_reason_union_is_deduplicated_and_order_preserving():

--- a/tests/unit/test_verdict_ordering.py
+++ b/tests/unit/test_verdict_ordering.py
@@ -1,0 +1,125 @@
+"""Slice 2.2 — the raise-only combination: the most important tests in the repo.
+
+`combine` must NEVER return a verdict or risk lower than either input.
+"""
+
+import random
+
+import pytest
+
+from doberman.engine.decision_engine import combine, max_risk, max_verdict
+from doberman.models import (
+    RISK_ORDER,
+    VERDICT_ORDER,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    Verdict,
+)
+
+ALL_VERDICTS = list(Verdict)
+ALL_RISKS = list(Risk)
+
+
+def make_result(
+    verdict: Verdict,
+    risk: Risk,
+    reasons: list[ReasonCode] | None = None,
+) -> GuardrailResult:
+    """Build a valid GuardrailResult (non-PASS needs reasons + explanation)."""
+    if verdict is Verdict.PASS:
+        return GuardrailResult(verdict=verdict, risk=risk, reason_codes=reasons or [])
+    return GuardrailResult(
+        verdict=verdict,
+        risk=risk,
+        reason_codes=reasons or [ReasonCode.unknown_tool],
+        explanation=f"{verdict} for testing.",
+    )
+
+
+@pytest.mark.parametrize("a", ALL_VERDICTS)
+@pytest.mark.parametrize("b", ALL_VERDICTS)
+def test_full_verdict_matrix_takes_max(a, b):
+    combined = combine(make_result(a, Risk.low), make_result(b, Risk.low))
+    assert VERDICT_ORDER[combined.verdict] == max(VERDICT_ORDER[a], VERDICT_ORDER[b])
+    assert combined.verdict == max_verdict(a, b)
+
+
+@pytest.mark.parametrize("a", ALL_RISKS)
+@pytest.mark.parametrize("b", ALL_RISKS)
+def test_full_risk_matrix_takes_max(a, b):
+    combined = combine(make_result(Verdict.PASS, a), make_result(Verdict.PASS, b))
+    assert RISK_ORDER[combined.risk] == max(RISK_ORDER[a], RISK_ORDER[b])
+    assert combined.risk == max_risk(a, b)
+
+
+def test_none_passthrough_returns_a_unchanged():
+    a = make_result(Verdict.AUTH, Risk.high)
+    assert combine(a, None) is a
+
+
+def test_combine_never_lowers_property():
+    """THE invariant: over many random pairs, combine never returns below
+    max(a, b) on either axis, and never drops a reason code."""
+    rng = random.Random(20260607)  # noqa: S311 — deterministic test seed, not crypto
+    codes = list(ReasonCode)
+    for _ in range(1000):
+        a = make_result(
+            rng.choice(ALL_VERDICTS),
+            rng.choice(ALL_RISKS),
+            reasons=rng.sample(codes, rng.randint(1, len(codes))),
+        )
+        b = make_result(
+            rng.choice(ALL_VERDICTS),
+            rng.choice(ALL_RISKS),
+            reasons=rng.sample(codes, rng.randint(1, len(codes))),
+        )
+        combined = combine(a, b)
+        assert VERDICT_ORDER[combined.verdict] >= VERDICT_ORDER[a.verdict]
+        assert VERDICT_ORDER[combined.verdict] >= VERDICT_ORDER[b.verdict]
+        assert RISK_ORDER[combined.risk] >= RISK_ORDER[a.risk]
+        assert RISK_ORDER[combined.risk] >= RISK_ORDER[b.risk]
+        assert set(combined.reason_codes) == set(a.reason_codes) | set(b.reason_codes)
+
+
+def test_reason_union_is_deduplicated_and_order_preserving():
+    a = make_result(Verdict.AUTH, Risk.medium, [ReasonCode.unknown_tool])
+    b = make_result(
+        Verdict.BLOCK,
+        Risk.high,
+        [ReasonCode.unknown_tool, ReasonCode.downstream_error],
+    )
+    combined = combine(a, b)
+    assert combined.reason_codes == [ReasonCode.unknown_tool, ReasonCode.downstream_error]
+
+
+def test_explanations_compose():
+    a = make_result(Verdict.AUTH, Risk.medium)
+    b = make_result(Verdict.BLOCK, Risk.high)
+    combined = combine(a, b)
+    assert "AUTH for testing." in combined.explanation
+    assert "BLOCK for testing." in combined.explanation
+
+
+def test_combined_non_pass_always_carries_reasons():
+    # Inputs are valid by construction, so any non-PASS combination keeps
+    # at least one reason — the model validator would reject otherwise.
+    a = make_result(Verdict.PASS, Risk.low)
+    b = make_result(Verdict.BLOCK, Risk.critical)
+    combined = combine(a, b)
+    assert combined.verdict is Verdict.BLOCK
+    assert combined.reason_codes  # never an unexplained non-PASS
+    assert combined.explanation.strip()
+
+
+@pytest.mark.parametrize(
+    ("a", "b", "expected"),
+    [
+        ((Verdict.PASS, Risk.low), (Verdict.AUTH, Risk.high), (Verdict.AUTH, Risk.high)),
+        ((Verdict.BLOCK, Risk.critical), (Verdict.PASS, Risk.low), (Verdict.BLOCK, Risk.critical)),
+        ((Verdict.AUTH, Risk.medium), (Verdict.AUTH, Risk.low), (Verdict.AUTH, Risk.medium)),
+    ],
+)
+def test_thesis_repl_examples(a, b, expected):
+    combined = combine(make_result(*a), make_result(*b))
+    assert (combined.verdict, combined.risk) == expected


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: F2 — Decision Engine & Execution Rule (slices 2.1–2.4)
- Plan reference: doberman_core_plan.md

## What this PR does
Replaces the pass-through stub with the real control core so every guardrail added later automatically obeys the safety rules:
- **2.1** — the `Guardrail` interface and a frozen, always-explained `Decision` model.
- **2.2** — raise-only verdict/risk `combine()` with exhaustive + property tests (never lowers a verdict or risk).
- **2.3** — the objective-first execution rule: objective first; a `BLOCK`/`AUTH` short-circuits (subjective can never weaken it); a non-allowlisted subjective `BLOCK` is clamped to `AUTH`. Objective errors fail **closed** (`BLOCK`); subjective errors fail **upward** (`AUTH`).
- **2.4** — enforcement at the proxy chokepoint: `PASS` forwards, `AUTH`/`BLOCK` return explanatory errors (reason codes + human explanation + action id) and **never** forward. A blocked call provably never reaches a tool; an engine failure is a `BLOCK`.

## Tests added (run in CI)
- `tests/unit/test_decision_models.py`, `tests/unit/test_verdict_ordering.py`, `tests/unit/test_execution_rule.py` — the model invariants, the raise-only property matrix, and the execution-rule state machine row-by-row.
- `tests/integration/test_engine_blocks_reach_no_tool.py` — a `BLOCK`/`AUTH` is never forwarded to the fake downstream server.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Guardrails are isolated: a raise or a non-`GuardrailResult` return becomes a conservative fail (`BLOCK` for objective, `AUTH` for subjective); `BaseException` is left to unwind (fail-closed by construction).
- Default guardrails are PASS stubs, so the system passes everything until Feature 3 supplies real rules — this PR delivers the *mechanism*, not policy.
