### PR TITLE
feat(engine): agent role policy & boundaries (Feature 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,8 @@ dist/
 build/
 *.egg-info/
 
-# Operating manual + implementation plans: local-only, never published
-CLAUDE.md
-AGENTS.md
+# Development plans: local-only, never published.
+# (The operating manual — CLAUDE.md / AGENTS.md — is published; these detailed plans are not.)
 doberman_core_plan.md
 doberman_enterprise_plan.md
 doberman_implementation_plan.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,374 @@
+# CLAUDE.md — Doberman Operating Manual
+
+> This is the init file for this repository. It governs any AI agent (Claude Code, Codex, Cursor, etc.) working here.
+> It is the **HOW**. The **WHAT** — the feature roadmap and per-slice detail — lives in `README.md` (public summary)
+> and, if present in your working tree, the project development plan you keep alongside it.
+> Content is identical to `AGENTS.md`; keep the two in sync (or symlink one to the other).
+> If this file conflicts with a casual prompt instruction, **this file wins** unless a human overrides it in writing.
+
+---
+
+## 0. On startup (every session)
+
+1. Read this entire file, then skim `README.md` for the current feature set, versioning, and roadmap. If you keep a
+   local development plan alongside the repo, read the relevant slice there for the extra detail (objective, files,
+   edge cases, suggested tests, suggested commit message).
+2. `git status` + `git log --oneline -5`.
+3. Pick the **next slice** (the lowest-numbered unmerged slice in the planned order).
+4. If the repo lacks scaffolding (`pyproject.toml` / `.github/workflows/ci.yml`), do **Slice 0 (Bootstrap)** first (§6).
+5. Execute exactly **one slice** via **The Slice Loop** (§5), then **STOP** and report. Stop at every review checkpoint.
+
+---
+
+## 1. What this repository is
+
+**Doberman** is an adaptive authorization layer for coding agents, released publicly under **Apache-2.0**.
+
+It distributes as the `doberman` package (`src/doberman/`) and is designed to be **genuinely functional on its own** —
+schema, interfaces, the runtime harness, adapters, and the built-in rules all live here. It is **not** crippleware.
+
+Doberman is built to be **extensible**: it declares stable interfaces (`Rule` / `Detector` / `AuthProvider` /
+`AuditSink`) and a runtime registry that discovers implementations via **Python entry points**. Additional packages can
+register their own rules, detectors, auth providers, or audit sinks **without Doberman importing them by name** — the
+core never takes a static dependency on any plugin. With only `doberman` installed, it works (built-in protection);
+install a plugin package and its capabilities light up automatically.
+
+---
+
+## 2. Architecture & extension points
+
+The decision path is deliberately layered so the safety-critical core stays small, open, and auditable:
+
+- **Tool mediation (`doberman.proxy`)** — the chokepoint. Every tool call an agent makes is normalized into a
+  `SecurityObject` and routed through the decision engine. There is no path around it.
+- **Decision engine (`doberman.engine`)** — combines guardrail verdicts into a final **allow / authenticate / block**
+  decision. The execution rule and the raise-only `combine` are the safety invariants — they must stay open and
+  auditable.
+- **Objective guardrail + built-in rules (`doberman.engine.rules`)** — deterministic rules over the action: path
+  canonicalization & confinement, destructive-command detection, external-destination checks, basic secret-pattern and
+  encoded-exfil detection. New rules plug in through the `Rule` interface and the registry.
+- **Roles & boundaries (`doberman.roles`)** — the role schema and per-repo boundary matcher.
+- **Policy (`doberman.policy`)** — the default checklist and the strength modes (Light / Balanced / Strict / Paranoid).
+- **Storage & audit (`doberman.storage`)** — a local, redacted decision log plus the `AuditSink` interface so
+  additional sinks can be registered.
+- **Tiered auth (`doberman.auth`)** — local confirmation, TOTP 2FA, and narrow/temporary role elevation. Auth providers
+  plug in through the `AuthProvider` interface.
+- **Subjective guardrail & baseline (`doberman.engine`)** — the abnormality interface plus a basic local behavioral
+  baseline. Detectors plug in through the `Detector` interface.
+- **Policy-drift & poisoning defense (`doberman.learning` / `doberman.policy`)** — classifies policy changes as
+  strengthen vs weaken, gates weakening behind 2FA, and records changes in an append-only ledger. A core safety
+  invariant: nothing auto-loosens.
+
+**The plugin pattern (how to keep things decoupled):** declare the interface and registry in core; let other packages
+**register** implementations through their own `pyproject.toml` entry points (groups such as `doberman.rules`,
+`doberman.detectors`, `doberman.auth_providers`, `doberman.audit_sinks`). At runtime Doberman runs its built-in
+implementations **plus** whatever is registered. Build the interface + a built-in implementation first; an advanced
+implementation can then ship as a separate plugin package that depends on the now-merged extension point — never the
+other way around.
+
+---
+
+## 3. Prime directives (non-negotiable)
+
+These override everything. If a task would break one, **STOP and ask a human**.
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case → deny / `BLOCK`. The protected agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails/learning may auto-tighten; they may **never** silently loosen. Any weakening goes through the human-approved path (the policy-drift defense).
+3. **Never expose secrets.** Never commit/log/store raw secrets, keys, full private files, unredacted prompts, or `.doberman/` contents. Fingerprints/classifications/metadata only.
+4. **Keep the core decoupled.** The policy core (`doberman.engine`/`roles`/`policy`/`storage`/`learning`) must not import `doberman.proxy`. Enforced by `import-linter`.
+5. **No slice is "done" without tests + green CI.**
+6. **One slice = one PR.** Keep changes scoped to the slice.
+
+If you feel pressure to violate one of these to "make progress," that pressure is the bug. Stop.
+
+---
+
+## 4. Project snapshot
+
+- **What:** Doberman sits between a coding agent and its tools and turns every meaningful action into a risk-based **allow / authenticate / block** decision.
+- **Package:** distributes as `doberman` (`src/doberman/`).
+- **Stack:** Python 3.11+, MCP proxy (`mcp` SDK), local-first **SQLite** (`aiosqlite`), YAML policy in `.doberman/`, Pydantic v2, `pyotp`, a `doberman` CLI (Typer), `pytest`.
+- **Runtime data** (`.doberman/`, the DB, key files) is **never** committed.
+
+---
+
+## 5. The Slice Loop (run for every slice)
+
+**Step 1 — Read the slice.** Read its objective, files, changes, security considerations, edge cases, expected output,
+suggested tests, and suggested commit message (from your local development plan, with `README.md` as the public
+roadmap). Ambiguity or a Prime-Directive conflict → STOP and ask.
+
+**Step 2 — Branch:**
+```
+git checkout main && git pull
+git checkout -b feat/<feature-slug>/<slice-slug>
+```
+
+**Step 3 — Implement** the smallest change that satisfies the Objective, strictly inside the slice's scope. For
+extensible features, implement against the **interface** and register built-ins through the registry — never make the
+policy core reach sideways into the proxy adapter.
+
+**Step 4 — Write this slice's tests (required).** In `tests/unit/` or `tests/integration/`, create
+`test_<slice_topic>.py` covering at minimum: every item in the slice's **"Suggested tests"**, every **edge case**, and
+every behavioral **security consideration** (e.g. *"a `BLOCK` means the fake downstream server recorded nothing"*,
+*"a synthetic secret never appears in any log/output"*, *"`combine` never returns a verdict lower than either input"*).
+Prefer TDD; tests must be deterministic (no real network/clock/secrets — inject/fixture them).
+
+**Step 5 — Make sure GitHub Actions runs these tests.** Tests live under `tests/` so CI's `pytest` discovers them
+(`pytest --collect-only` to confirm). New dependency → add to `pyproject.toml`. New import boundary → update the
+`import-linter` contract. New CI step → update `.github/workflows/ci.yml` (minimal, same PR).
+
+**Step 6 — Green locally:**
+```
+ruff check . && ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing
+```
+Everything passes; do **not** weaken a test or invariant to get green.
+
+**Step 7 — Update docs and the README (required every slice).** With **every commit/slice** keep these in sync as part
+of the same change — never as an afterthought:
+- **`README.md`**: update the feature summary, versioning/changelog, quickstart, and roadmap so they reflect what now
+  exists. A slice that adds/changes public behavior **must** move the README.
+- Other docs (CLI/config/usage) as usual when behavior changed.
+
+**Step 8 — Commit** (Conventional Commits; tests ship **in the same PR** as the code, ideally same commit). Use the
+plan's "Suggested commit message." Never stage `.doberman/`, `*.db`, key files, `.env*` (they're gitignored — verify
+with `git status`).
+
+**Step 9 — Push the branch** (`git push -u origin <branch>`) — tests go with it, so CI runs them.
+
+**Step 10 — Open a PR to `main`**; fill the PR template. Confirm CI turns **green**. Red CI → fix on the branch and
+push again; never merge red.
+
+**Step 11 — Post the Slice Completion Report (§10) and STOP.** Don't start the next slice until approved/merged or told to continue.
+
+**Step 12 — If this was the last slice of a feature**, after merge post the Feature Review Checkpoint (§10) and STOP. Review checkpoints are mandatory pauses.
+
+---
+
+## 6. Slice 0 — Bootstrap (only if scaffolding is missing)
+
+Scaffold the repo + working CI + a trivial smoke test, committed on `chore/bootstrap-scaffolding` with
+`chore(repo): bootstrap project scaffolding and CI`.
+
+### `pyproject.toml`
+```toml
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.importlinter]
+root_package = "doberman"
+
+# Decoupling: the policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+```
+
+### `.github/workflows/ci.yml`
+```yaml
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+```
+> `--cov-fail-under=80` is a starting bar — raise it over time, never lower it to pass a PR.
+
+### `.gitignore`
+```gitignore
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+```
+
+### `.github/pull_request_template.md`
+```markdown
+## Slice
+- Feature / Slice: <id> — <title>
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-
+```
+
+> The authoritative scaffolding is the actual `pyproject.toml`, `.github/workflows/ci.yml`, and
+> `.github/pull_request_template.md` in the repo — the blocks above are the starting shape.
+
+---
+
+## 7. Architecture enforcement (summary)
+
+The decoupling is guaranteed in CI:
+1. **`import-linter` forbidden contract**: the policy core must not import `doberman.proxy`.
+2. **Plugin inversion**: extensible features connect through core-defined interfaces + entry-point discovery, so the
+   core holds no static reference to any plugin package.
+
+---
+
+## 8. Version control hygiene
+
+- **One slice = one branch = one PR.**
+- Branches: `feat/<feature-slug>/<slice-slug>` (or `fix/...`, `chore/...`).
+- Conventional Commits; small, building commits; **tests travel with code**.
+- **Never commit** secrets, keys, `.doberman/`, `*.db`, `.env*`. If you do by accident → STOP, tell a human, treat the value as leaked (rotate it).
+- Rebase (don't merge) to update a branch: `git fetch && git rebase origin/main`.
+
+---
+
+## 9. Security & explainability rules (every slice)
+
+- **Default deny:** wrap risky ops so exceptions yield `BLOCK` (or `AUTH` only where the plan says "fail upward").
+- **Redaction mandatory:** strip raw secrets/large payloads before logging/persisting; keep path **classes**, reason codes, verdicts, **HMAC fingerprints**. Test that a synthetic secret never appears.
+- **Keyed fingerprints:** HMAC-SHA256 with a local `0600`/keyring key (never committed) — plain hashes of low-entropy secrets are brute-forceable.
+- **Explainability first:** every `BLOCK`/`AUTH` carries `reason_codes` **and** a one-line human `explanation`. Reason codes are shared constants in `models.py`.
+- **Auth is action-bound:** approvals single-use + tied to one action id; elevations narrow + time-limited + (destructive) single-use; elevation never relaxes a hard block.
+- **Canonicalize before matching** paths (resolve `.`/`..`/symlinks, confine to repo root) via one shared helper.
+- **Logging never alters/blocks a decision** and never crashes the execution path.
+- **Don't oversell:** never claim secret detection (or any single rule) is airtight — it is defense-in-depth.
+
+---
+
+## 10. Reporting formats
+
+### Slice Completion Report (after every slice, then STOP)
+```
+SLICE COMPLETE — <feature> / <slice id> (<title>)
+Branch: <branch>    PR: #<n>    CI: <green | red+why>
+What I built: <2–3 lines>
+Tests added (run in CI): <files> — <what they cover>
+Security checks verified: <redaction / fail-closed / raise-only / etc.>
+Edge cases covered: <list>
+Decisions / assumptions: <or "none">
+Deviations from the plan: <none | what & why>
+Risks / tech debt introduced: <or "none">
+Next slice: <id — title>  (awaiting go-ahead)
+```
+
+### Feature Review Checkpoint (after the last slice of a feature, then STOP)
+```
+REVIEW CHECKPOINT — <Feature N: name>
+Built: ...
+Needs human testing: ...
+Decisions to review: ...
+Risks / shortcuts / tech debt: ...
+>> Paused. I will not start the next feature until told to proceed.
+```
+
+---
+
+## 11. Never do this
+
+- ❌ Do work outside the current slice's scope.
+- ❌ Skip a review checkpoint or start the next feature without a go-ahead.
+- ❌ Mark a slice "done" with missing/failing tests or red CI.
+- ❌ Weaken/stub a test or invariant to make CI pass.
+- ❌ Auto-loosen Doberman (all loosening goes through the human-approved policy-drift path).
+- ❌ Commit or log a secret, key, full private file, unredacted prompt, or `.doberman/` content.
+- ❌ Let `doberman.proxy` be imported by the policy core.
+- ❌ Add any path by which a protected agent could reach a real tool without going through the decision engine.
+- ❌ Invent requirements. Unclear plan or wrong-looking slice → STOP and ask.
+
+---
+
+## 12. Quick reference
+
+| You want to… | Do this |
+|---|---|
+| Know **what** to build | the development plan (slice detail) + `README.md` (public roadmap) |
+| Know **how** to build it | this file |
+| Start a slice | branch `feat/<feature>/<slice>` → follow §5 |
+| Finish a slice | tests added + pushed, CI green, decoupling check passes, **README updated** (§5 Step 7), Slice Completion Report, STOP |
+| Run checks | `ruff check . && ruff format --check . && lint-imports && pytest --cov=doberman` |
+| Hit ambiguity | STOP and ask |
+
+**Remember:** small safe commits · tests with every slice · CI green before "done" · the policy core stays decoupled from the proxy · when in doubt, **fail closed and ask.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,374 @@
+# CLAUDE.md — Doberman Operating Manual
+
+> This is the init file for this repository. It governs any AI agent (Claude Code, Codex, Cursor, etc.) working here.
+> It is the **HOW**. The **WHAT** — the feature roadmap and per-slice detail — lives in `README.md` (public summary)
+> and, if present in your working tree, the project development plan you keep alongside it.
+> Content is identical to `AGENTS.md`; keep the two in sync (or symlink one to the other).
+> If this file conflicts with a casual prompt instruction, **this file wins** unless a human overrides it in writing.
+
+---
+
+## 0. On startup (every session)
+
+1. Read this entire file, then skim `README.md` for the current feature set, versioning, and roadmap. If you keep a
+   local development plan alongside the repo, read the relevant slice there for the extra detail (objective, files,
+   edge cases, suggested tests, suggested commit message).
+2. `git status` + `git log --oneline -5`.
+3. Pick the **next slice** (the lowest-numbered unmerged slice in the planned order).
+4. If the repo lacks scaffolding (`pyproject.toml` / `.github/workflows/ci.yml`), do **Slice 0 (Bootstrap)** first (§6).
+5. Execute exactly **one slice** via **The Slice Loop** (§5), then **STOP** and report. Stop at every review checkpoint.
+
+---
+
+## 1. What this repository is
+
+**Doberman** is an adaptive authorization layer for coding agents, released publicly under **Apache-2.0**.
+
+It distributes as the `doberman` package (`src/doberman/`) and is designed to be **genuinely functional on its own** —
+schema, interfaces, the runtime harness, adapters, and the built-in rules all live here. It is **not** crippleware.
+
+Doberman is built to be **extensible**: it declares stable interfaces (`Rule` / `Detector` / `AuthProvider` /
+`AuditSink`) and a runtime registry that discovers implementations via **Python entry points**. Additional packages can
+register their own rules, detectors, auth providers, or audit sinks **without Doberman importing them by name** — the
+core never takes a static dependency on any plugin. With only `doberman` installed, it works (built-in protection);
+install a plugin package and its capabilities light up automatically.
+
+---
+
+## 2. Architecture & extension points
+
+The decision path is deliberately layered so the safety-critical core stays small, open, and auditable:
+
+- **Tool mediation (`doberman.proxy`)** — the chokepoint. Every tool call an agent makes is normalized into a
+  `SecurityObject` and routed through the decision engine. There is no path around it.
+- **Decision engine (`doberman.engine`)** — combines guardrail verdicts into a final **allow / authenticate / block**
+  decision. The execution rule and the raise-only `combine` are the safety invariants — they must stay open and
+  auditable.
+- **Objective guardrail + built-in rules (`doberman.engine.rules`)** — deterministic rules over the action: path
+  canonicalization & confinement, destructive-command detection, external-destination checks, basic secret-pattern and
+  encoded-exfil detection. New rules plug in through the `Rule` interface and the registry.
+- **Roles & boundaries (`doberman.roles`)** — the role schema and per-repo boundary matcher.
+- **Policy (`doberman.policy`)** — the default checklist and the strength modes (Light / Balanced / Strict / Paranoid).
+- **Storage & audit (`doberman.storage`)** — a local, redacted decision log plus the `AuditSink` interface so
+  additional sinks can be registered.
+- **Tiered auth (`doberman.auth`)** — local confirmation, TOTP 2FA, and narrow/temporary role elevation. Auth providers
+  plug in through the `AuthProvider` interface.
+- **Subjective guardrail & baseline (`doberman.engine`)** — the abnormality interface plus a basic local behavioral
+  baseline. Detectors plug in through the `Detector` interface.
+- **Policy-drift & poisoning defense (`doberman.learning` / `doberman.policy`)** — classifies policy changes as
+  strengthen vs weaken, gates weakening behind 2FA, and records changes in an append-only ledger. A core safety
+  invariant: nothing auto-loosens.
+
+**The plugin pattern (how to keep things decoupled):** declare the interface and registry in core; let other packages
+**register** implementations through their own `pyproject.toml` entry points (groups such as `doberman.rules`,
+`doberman.detectors`, `doberman.auth_providers`, `doberman.audit_sinks`). At runtime Doberman runs its built-in
+implementations **plus** whatever is registered. Build the interface + a built-in implementation first; an advanced
+implementation can then ship as a separate plugin package that depends on the now-merged extension point — never the
+other way around.
+
+---
+
+## 3. Prime directives (non-negotiable)
+
+These override everything. If a task would break one, **STOP and ask a human**.
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case → deny / `BLOCK`. The protected agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails/learning may auto-tighten; they may **never** silently loosen. Any weakening goes through the human-approved path (the policy-drift defense).
+3. **Never expose secrets.** Never commit/log/store raw secrets, keys, full private files, unredacted prompts, or `.doberman/` contents. Fingerprints/classifications/metadata only.
+4. **Keep the core decoupled.** The policy core (`doberman.engine`/`roles`/`policy`/`storage`/`learning`) must not import `doberman.proxy`. Enforced by `import-linter`.
+5. **No slice is "done" without tests + green CI.**
+6. **One slice = one PR.** Keep changes scoped to the slice.
+
+If you feel pressure to violate one of these to "make progress," that pressure is the bug. Stop.
+
+---
+
+## 4. Project snapshot
+
+- **What:** Doberman sits between a coding agent and its tools and turns every meaningful action into a risk-based **allow / authenticate / block** decision.
+- **Package:** distributes as `doberman` (`src/doberman/`).
+- **Stack:** Python 3.11+, MCP proxy (`mcp` SDK), local-first **SQLite** (`aiosqlite`), YAML policy in `.doberman/`, Pydantic v2, `pyotp`, a `doberman` CLI (Typer), `pytest`.
+- **Runtime data** (`.doberman/`, the DB, key files) is **never** committed.
+
+---
+
+## 5. The Slice Loop (run for every slice)
+
+**Step 1 — Read the slice.** Read its objective, files, changes, security considerations, edge cases, expected output,
+suggested tests, and suggested commit message (from your local development plan, with `README.md` as the public
+roadmap). Ambiguity or a Prime-Directive conflict → STOP and ask.
+
+**Step 2 — Branch:**
+```
+git checkout main && git pull
+git checkout -b feat/<feature-slug>/<slice-slug>
+```
+
+**Step 3 — Implement** the smallest change that satisfies the Objective, strictly inside the slice's scope. For
+extensible features, implement against the **interface** and register built-ins through the registry — never make the
+policy core reach sideways into the proxy adapter.
+
+**Step 4 — Write this slice's tests (required).** In `tests/unit/` or `tests/integration/`, create
+`test_<slice_topic>.py` covering at minimum: every item in the slice's **"Suggested tests"**, every **edge case**, and
+every behavioral **security consideration** (e.g. *"a `BLOCK` means the fake downstream server recorded nothing"*,
+*"a synthetic secret never appears in any log/output"*, *"`combine` never returns a verdict lower than either input"*).
+Prefer TDD; tests must be deterministic (no real network/clock/secrets — inject/fixture them).
+
+**Step 5 — Make sure GitHub Actions runs these tests.** Tests live under `tests/` so CI's `pytest` discovers them
+(`pytest --collect-only` to confirm). New dependency → add to `pyproject.toml`. New import boundary → update the
+`import-linter` contract. New CI step → update `.github/workflows/ci.yml` (minimal, same PR).
+
+**Step 6 — Green locally:**
+```
+ruff check . && ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing
+```
+Everything passes; do **not** weaken a test or invariant to get green.
+
+**Step 7 — Update docs and the README (required every slice).** With **every commit/slice** keep these in sync as part
+of the same change — never as an afterthought:
+- **`README.md`**: update the feature summary, versioning/changelog, quickstart, and roadmap so they reflect what now
+  exists. A slice that adds/changes public behavior **must** move the README.
+- Other docs (CLI/config/usage) as usual when behavior changed.
+
+**Step 8 — Commit** (Conventional Commits; tests ship **in the same PR** as the code, ideally same commit). Use the
+plan's "Suggested commit message." Never stage `.doberman/`, `*.db`, key files, `.env*` (they're gitignored — verify
+with `git status`).
+
+**Step 9 — Push the branch** (`git push -u origin <branch>`) — tests go with it, so CI runs them.
+
+**Step 10 — Open a PR to `main`**; fill the PR template. Confirm CI turns **green**. Red CI → fix on the branch and
+push again; never merge red.
+
+**Step 11 — Post the Slice Completion Report (§10) and STOP.** Don't start the next slice until approved/merged or told to continue.
+
+**Step 12 — If this was the last slice of a feature**, after merge post the Feature Review Checkpoint (§10) and STOP. Review checkpoints are mandatory pauses.
+
+---
+
+## 6. Slice 0 — Bootstrap (only if scaffolding is missing)
+
+Scaffold the repo + working CI + a trivial smoke test, committed on `chore/bootstrap-scaffolding` with
+`chore(repo): bootstrap project scaffolding and CI`.
+
+### `pyproject.toml`
+```toml
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.importlinter]
+root_package = "doberman"
+
+# Decoupling: the policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+```
+
+### `.github/workflows/ci.yml`
+```yaml
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+```
+> `--cov-fail-under=80` is a starting bar — raise it over time, never lower it to pass a PR.
+
+### `.gitignore`
+```gitignore
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+```
+
+### `.github/pull_request_template.md`
+```markdown
+## Slice
+- Feature / Slice: <id> — <title>
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-
+```
+
+> The authoritative scaffolding is the actual `pyproject.toml`, `.github/workflows/ci.yml`, and
+> `.github/pull_request_template.md` in the repo — the blocks above are the starting shape.
+
+---
+
+## 7. Architecture enforcement (summary)
+
+The decoupling is guaranteed in CI:
+1. **`import-linter` forbidden contract**: the policy core must not import `doberman.proxy`.
+2. **Plugin inversion**: extensible features connect through core-defined interfaces + entry-point discovery, so the
+   core holds no static reference to any plugin package.
+
+---
+
+## 8. Version control hygiene
+
+- **One slice = one branch = one PR.**
+- Branches: `feat/<feature-slug>/<slice-slug>` (or `fix/...`, `chore/...`).
+- Conventional Commits; small, building commits; **tests travel with code**.
+- **Never commit** secrets, keys, `.doberman/`, `*.db`, `.env*`. If you do by accident → STOP, tell a human, treat the value as leaked (rotate it).
+- Rebase (don't merge) to update a branch: `git fetch && git rebase origin/main`.
+
+---
+
+## 9. Security & explainability rules (every slice)
+
+- **Default deny:** wrap risky ops so exceptions yield `BLOCK` (or `AUTH` only where the plan says "fail upward").
+- **Redaction mandatory:** strip raw secrets/large payloads before logging/persisting; keep path **classes**, reason codes, verdicts, **HMAC fingerprints**. Test that a synthetic secret never appears.
+- **Keyed fingerprints:** HMAC-SHA256 with a local `0600`/keyring key (never committed) — plain hashes of low-entropy secrets are brute-forceable.
+- **Explainability first:** every `BLOCK`/`AUTH` carries `reason_codes` **and** a one-line human `explanation`. Reason codes are shared constants in `models.py`.
+- **Auth is action-bound:** approvals single-use + tied to one action id; elevations narrow + time-limited + (destructive) single-use; elevation never relaxes a hard block.
+- **Canonicalize before matching** paths (resolve `.`/`..`/symlinks, confine to repo root) via one shared helper.
+- **Logging never alters/blocks a decision** and never crashes the execution path.
+- **Don't oversell:** never claim secret detection (or any single rule) is airtight — it is defense-in-depth.
+
+---
+
+## 10. Reporting formats
+
+### Slice Completion Report (after every slice, then STOP)
+```
+SLICE COMPLETE — <feature> / <slice id> (<title>)
+Branch: <branch>    PR: #<n>    CI: <green | red+why>
+What I built: <2–3 lines>
+Tests added (run in CI): <files> — <what they cover>
+Security checks verified: <redaction / fail-closed / raise-only / etc.>
+Edge cases covered: <list>
+Decisions / assumptions: <or "none">
+Deviations from the plan: <none | what & why>
+Risks / tech debt introduced: <or "none">
+Next slice: <id — title>  (awaiting go-ahead)
+```
+
+### Feature Review Checkpoint (after the last slice of a feature, then STOP)
+```
+REVIEW CHECKPOINT — <Feature N: name>
+Built: ...
+Needs human testing: ...
+Decisions to review: ...
+Risks / shortcuts / tech debt: ...
+>> Paused. I will not start the next feature until told to proceed.
+```
+
+---
+
+## 11. Never do this
+
+- ❌ Do work outside the current slice's scope.
+- ❌ Skip a review checkpoint or start the next feature without a go-ahead.
+- ❌ Mark a slice "done" with missing/failing tests or red CI.
+- ❌ Weaken/stub a test or invariant to make CI pass.
+- ❌ Auto-loosen Doberman (all loosening goes through the human-approved policy-drift path).
+- ❌ Commit or log a secret, key, full private file, unredacted prompt, or `.doberman/` content.
+- ❌ Let `doberman.proxy` be imported by the policy core.
+- ❌ Add any path by which a protected agent could reach a real tool without going through the decision engine.
+- ❌ Invent requirements. Unclear plan or wrong-looking slice → STOP and ask.
+
+---
+
+## 12. Quick reference
+
+| You want to… | Do this |
+|---|---|
+| Know **what** to build | the development plan (slice detail) + `README.md` (public roadmap) |
+| Know **how** to build it | this file |
+| Start a slice | branch `feat/<feature>/<slice>` → follow §5 |
+| Finish a slice | tests added + pushed, CI green, decoupling check passes, **README updated** (§5 Step 7), Slice Completion Report, STOP |
+| Run checks | `ruff check . && ruff format --check . && lint-imports && pytest --cov=doberman` |
+| Hit ambiguity | STOP and ask |
+
+**Remember:** small safe commits · tests with every slice · CI green before "done" · the policy core stays decoupled from the proxy · when in doubt, **fail closed and ask.**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Doberman is a security layer for AI coding agents. It sits **on the tool-execution path** — the agent talks to Doberman, and Doberman talks to the real tools (filesystem, shell, git, network, package managers) over the [Model Context Protocol](https://modelcontextprotocol.io). Every meaningful action is intercepted, normalized into a redacted, structured **security object**, and run through a risk-based decision engine that returns one of three verdicts — **allow**, **authenticate**, or **block** — before the action is ever forwarded. The guiding principle is simple: *if Doberman isn't on the execution path, it's advisory, not protective.* Doberman is built to **fail closed** (any error or uncertainty denies the action) and to be **raise-only** (guardrails may automatically tighten, never silently loosen), so an agent can never reach a tool around it and a buggy rule can never make the system less safe.
 
 > ### Project status
-> **Alpha — pre-1.0, API unstable.** The interception layer (Feature 1), the decision engine (Feature 2), and the **objective guardrail** (Feature 3 — basic rules + the plugin seam) are implemented: Doberman now actively blocks the headline disasters (secret exfiltration, protected-path writes, catastrophic commands) and steps up authentication on sensitive or unknown actions. The subjective guardrail and roles arrive in upcoming versions (see the [Roadmap](#roadmap)). This is the open-source **core**; advanced/hosted capabilities live in a separate commercial edition.
+> **Alpha — pre-1.0, API unstable.** The interception layer (Feature 1), the decision engine (Feature 2), the **objective guardrail** (Feature 3 — basic rules + the plugin seam), and **agent role policy** (Feature 4 — role boundaries + the policy-source seam) are implemented: Doberman now actively blocks the headline disasters (secret exfiltration, protected-path writes, catastrophic commands), steps up authentication on sensitive or unknown actions, and escalates actions that cross the agent's role boundary. The subjective guardrail and the surfaces around the engine (capability scan, strength modes, real authentication, audit log) arrive in upcoming versions (see the [Roadmap](#roadmap)). This is the open-source **core**; advanced/hosted capabilities live in a separate commercial edition.
 
 ---
 
@@ -143,6 +143,15 @@ The deterministic, conservative rules for universal danger — the guardrail tha
 - **Plugin registry (extension point)** — additional rules/detectors are discovered via Python entry points (`doberman.rules`, `doberman.detectors`) and run alongside the built-ins. Plugins are bound by the same raise-only discipline (they can only *add* risk) and are loaded defensively — a misbehaving plugin is isolated, never crashes core, and core never imports any plugin by name. With nothing installed, only the built-ins run.
 - **Redaction throughout** — no rule ever puts a raw secret, path, argument value, or match excerpt into an explanation, reason, or log; explanations describe the *rule*, fingerprints are HMAC-only. Secret detection is defense-in-depth, not claimed airtight.
 
+### Feature 4 — Agent Role Policy & Boundaries · `v0.4.0` _(in review)_
+
+Makes the agent's **role** the top of the local authority hierarchy: an action that crosses the role's path boundaries escalates in the **objective** layer, so it cannot be learned away and casual user intent never lowers it.
+
+- **Built-in roles** — `frontend`, `backend`, `fullstack`, `devops`, `docs`, `test`, each declaring `allowed` / `suspicious` / `blocked` path globs (data in `roles/builtin_roles.yaml`). `blocked` wins on overlap; a target matched by no `allowed` glob is treated as out-of-scope (safe default). The active role is read from `.doberman/role.yaml` (a named built-in or an inline custom role); an unknown or malformed role falls back to the most-restrictive role.
+- **Boundary matcher** — classifies a target as allowed / suspicious / blocked through the **same** canonicalizer the path rule uses, so `..` traversal, symlink, and case bypasses cannot dodge a role boundary; a path escaping the repo root is treated as blocked.
+- **Cross-boundary escalation** — an out-of-scope target → **AUTH (`role_out_of_scope`)**, a role-blocked target → **BLOCK (`role_blocked_target`)**. The check lives in the objective layer; with no role configured it abstains, so role enforcement is opt-in.
+- **`PolicySource` seam (extension point)** — an ordered resolver merges policy from local sources (the agent role) plus any registered via the `doberman.policy_sources` entry-point group. The merge is **raise-only across sources** (a higher-authority source can only *tighten*), so an enterprise/org policy can outrank the role — without core importing the enterprise package.
+
 ---
 
 ## Design invariants
@@ -171,6 +180,13 @@ The version line maps to the development roadmap:
 ## Changelog
 
 This project keeps a changelog in the spirit of [Keep a Changelog](https://keepachangelog.com/).
+
+### `v0.4.0` — Agent Role Policy & Boundaries — _Unreleased (in review)_
+
+- **Slice 4.1** — built-in role definitions + schema (`allowed`/`suspicious`/`blocked` globs; `.doberman/role.yaml` active-role resolution).
+- **Slice 4.2** — role-boundary matcher (shared canonicalization; blocked-wins precedence; unmatched-by-allowed → suspicious).
+- **Slice 4.3** — cross-boundary escalation in the objective layer (`role_out_of_scope` → AUTH, `role_blocked_target` → BLOCK; user intent never lowers it).
+- **Slice 4.4** — ordered `PolicySource` resolver with authority layering (the enterprise seam; raise-only across sources; discovered via `doberman.policy_sources`).
 
 ### `v0.3.0` — Objective Guardrail — _Unreleased (in review)_
 
@@ -209,7 +225,6 @@ Upcoming versions add the guardrail *content* and the surfaces around the engine
 
 | Version | Theme |
 |---------|-------|
-| `v0.4.0` | **Agent role policy** — built-in roles and per-repo boundary matching. |
 | `v0.5.0` | **Capability discovery** — local scan and risk map. |
 | `v0.6.0` | **Policy checklist & strength modes** — Light / Balanced / Strict / Paranoid. |
 | `v0.7.0` | **Tiered authentication** — local confirmation, TOTP 2FA, narrow/temporary elevation. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doberman"
-version = "0.3.0"
+version = "0.4.0"
 description = "Adaptive authorization layer for coding agents (open core)"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"

--- a/src/doberman/__init__.py
+++ b/src/doberman/__init__.py
@@ -1,3 +1,3 @@
 """Doberman — adaptive authorization layer for coding agents (open core)."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/doberman/config.py
+++ b/src/doberman/config.py
@@ -1,0 +1,94 @@
+"""Local configuration loading (Feature 4+).
+
+Reads the per-repo Doberman configuration from ``.doberman/`` — currently the
+active agent role (``.doberman/role.yaml``). Configuration is **optional**: a
+repo with no ``.doberman/role.yaml`` simply has no active role, and role-based
+escalation stays dormant until the user sets one (F6 onboarding will write it).
+
+Resolution rules for the active role (fail toward restriction):
+
+* no ``.doberman/role.yaml`` → ``None`` (role enforcement is opt-in; the role
+  rule abstains so nothing benign is gratuitously blocked).
+* ``role: <name>`` naming a built-in → that built-in.
+* an *inline* custom role definition (``allowed``/``suspicious``/``blocked``) →
+  that custom :class:`RoleDefinition` (a permissive custom role is allowed but
+  logged — the user owns that choice).
+* a named role that does not resolve, or a malformed file →
+  :data:`MOST_RESTRICTIVE_ROLE` (a configured-but-unresolvable role must never
+  silently widen scope).
+
+This module is policy core: it must never import ``doberman.proxy``.
+"""
+
+import logging
+from pathlib import Path
+
+import yaml
+
+from doberman.roles.roles import (
+    MOST_RESTRICTIVE_ROLE,
+    RoleDefinition,
+    load_builtin_roles,
+)
+
+logger = logging.getLogger("doberman.config")
+
+#: Per-repo config directory (never committed; see .gitignore).
+CONFIG_DIR = ".doberman"
+ROLE_FILE = "role.yaml"
+
+
+def _role_file_path(repo_root: str) -> Path:
+    return Path(repo_root) / CONFIG_DIR / ROLE_FILE
+
+
+def load_active_role(repo_root: str = ".") -> RoleDefinition | None:
+    """Resolve the repo's active role, or ``None`` if none is configured.
+
+    Never raises: a malformed config fails closed to the most-restrictive role
+    rather than crashing the decision path.
+    """
+    path = _role_file_path(repo_root)
+    if not path.exists():
+        return None
+
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        logger.warning("could not read %s; falling back to the most-restrictive role", path)
+        return MOST_RESTRICTIVE_ROLE
+
+    if not isinstance(data, dict):
+        logger.warning("%s is not a mapping; using the most-restrictive role", path)
+        return MOST_RESTRICTIVE_ROLE
+
+    # Inline custom role definition takes precedence over a named built-in.
+    if any(key in data for key in ("allowed", "suspicious", "blocked")):
+        try:
+            role = RoleDefinition(
+                name=str(data.get("role") or data.get("name") or "custom"),
+                description=str(data.get("description", "")),
+                allowed=tuple(data.get("allowed") or ()),
+                suspicious=tuple(data.get("suspicious") or ()),
+                blocked=tuple(data.get("blocked") or ()),
+            )
+        except (TypeError, ValueError):
+            logger.warning("invalid inline role in %s; using the most-restrictive role", path)
+            return MOST_RESTRICTIVE_ROLE
+        if not role.blocked and not role.suspicious:
+            logger.warning(
+                "custom role %r declares no blocked/suspicious globs (permissive)", role.name
+            )
+        return role
+
+    name = data.get("role")
+    if not isinstance(name, str) or not name:
+        logger.warning("%s has no usable 'role'; using the most-restrictive role", path)
+        return MOST_RESTRICTIVE_ROLE
+
+    builtins = load_builtin_roles()
+    role = builtins.get(name)
+    if role is None:
+        logger.warning("unknown role %r; using the most-restrictive role", name)
+        return MOST_RESTRICTIVE_ROLE
+    return role

--- a/src/doberman/engine/registry.py
+++ b/src/doberman/engine/registry.py
@@ -36,6 +36,8 @@ logger = logging.getLogger("doberman.engine.registry")
 #: ``policy_sources``/``drift_observers`` against this same mechanism.
 RULE_GROUP = "doberman.rules"
 DETECTOR_GROUP = "doberman.detectors"
+#: Policy sources (Feature 4.4) register here; resolved by the policy layer.
+POLICY_SOURCE_GROUP = "doberman.policy_sources"
 
 
 def _iter_entry_points(group: str) -> Iterator[EntryPoint]:
@@ -54,11 +56,11 @@ def _iter_entry_points(group: str) -> Iterator[EntryPoint]:
     yield from selected
 
 
-def _instantiate(entry_point: EntryPoint) -> Guardrail | None:
-    """Load + instantiate one entry point into a Guardrail, or skip it.
+def _load_and_construct(entry_point: EntryPoint) -> object | None:
+    """Load an entry point and instantiate it if it is a class, or skip it.
 
-    Returns ``None`` (after logging) on any import/instantiation error or if the
-    loaded object is not Guardrail-shaped. We never let a plugin's failure
+    Returns ``None`` (after logging) on any import or constructor error. The
+    caller applies its own structural check. We never let a plugin's failure
     propagate — isolation is the whole contract.
     """
     try:
@@ -67,7 +69,6 @@ def _instantiate(entry_point: EntryPoint) -> Guardrail | None:
         logger.warning("skipping plugin %r: failed to import", getattr(entry_point, "name", "?"))
         return None
 
-    # The entry point may point at a class (instantiate it) or an instance.
     candidate = loaded
     if isinstance(loaded, type):
         try:
@@ -77,7 +78,18 @@ def _instantiate(entry_point: EntryPoint) -> Guardrail | None:
                 "skipping plugin %r: constructor raised", getattr(entry_point, "name", "?")
             )
             return None
+    return candidate
 
+
+def _instantiate(entry_point: EntryPoint) -> Guardrail | None:
+    """Load + instantiate one entry point into a Guardrail, or skip it.
+
+    Returns ``None`` (after logging) on any import/instantiation error or if the
+    loaded object is not Guardrail-shaped.
+    """
+    candidate = _load_and_construct(entry_point)
+    if candidate is None:
+        return None
     # Structural check only (runtime_checkable can't verify the signature) — the
     # real safety gate is that the objective guardrail validates every returned
     # value as a GuardrailResult and isolates exceptions.
@@ -110,3 +122,34 @@ def discover_rules() -> list[Guardrail]:
             if instance is not None:
                 plugins.append(instance)
     return plugins
+
+
+def discover_policy_sources() -> list[object]:
+    """Discover registered policy sources (Feature 4.4, group ``doberman.policy_sources``).
+
+    Loaded defensively like rules: an import/constructor failure, or an object
+    that is not policy-source-shaped (no ``snapshot``/``authority``), is logged
+    and skipped. Returns ``[]`` when nothing is installed. Core never imports a
+    source by name — the policy resolver merges whatever is registered.
+    """
+    # Local import avoids an engine<->policy import cycle at module load.
+    from doberman.policy.sources import _looks_like_policy_source
+
+    sources: list[object] = []
+    seen: set[str] = set()
+    for entry_point in _iter_entry_points(POLICY_SOURCE_GROUP):
+        key = f"{POLICY_SOURCE_GROUP}:{getattr(entry_point, 'name', id(entry_point))}"
+        if key in seen:
+            continue
+        seen.add(key)
+        candidate = _load_and_construct(entry_point)
+        if candidate is None:
+            continue
+        if not _looks_like_policy_source(candidate):
+            logger.warning(
+                "skipping policy source %r: not policy-source-shaped",
+                getattr(entry_point, "name", "?"),
+            )
+            continue
+        sources.append(candidate)
+    return sources

--- a/src/doberman/engine/rules/__init__.py
+++ b/src/doberman/engine/rules/__init__.py
@@ -15,21 +15,29 @@ entry-point registry (slice 3.8) — core never imports it.
 from doberman.engine.rules.commands import DestructiveCommandRule
 from doberman.engine.rules.destinations import ExternalDestinationRule
 from doberman.engine.rules.paths import ProtectedPathRule
+from doberman.engine.rules.policy_source import PolicySourceRule
+from doberman.engine.rules.role_boundary import RoleBoundaryRule
 from doberman.engine.rules.secrets import SecretLeakageRule
 
 #: The built-in rule set, in a stable order. ``ObjectiveGuardrail`` instantiates
-#: these with their defaults; F6 will later override the policy lists.
+#: these with their defaults; F6 will later override the policy lists. The role
+#: and policy-source rules abstain unless the context supplies a role / resolved
+#: policy, so they are inert until F4 wiring (or a registered source) is active.
 BUILTIN_RULE_TYPES = (
     SecretLeakageRule,
     ProtectedPathRule,
     DestructiveCommandRule,
     ExternalDestinationRule,
+    RoleBoundaryRule,
+    PolicySourceRule,
 )
 
 __all__ = [
     "BUILTIN_RULE_TYPES",
     "DestructiveCommandRule",
     "ExternalDestinationRule",
+    "PolicySourceRule",
     "ProtectedPathRule",
+    "RoleBoundaryRule",
     "SecretLeakageRule",
 ]

--- a/src/doberman/engine/rules/policy_source.py
+++ b/src/doberman/engine/rules/policy_source.py
@@ -1,0 +1,107 @@
+"""Policy-source enforcement rule (Feature 4, slice 4.4).
+
+Enforces a :class:`~doberman.policy.sources.ResolvedPolicy` — the merged result
+of all registered policy sources (the seam by which an enterprise/org authority
+can layer above the agent role). The resolved policy is handed in through
+``ctx.metadata['resolved_policy']``; with none present (the default, no extra
+sources installed) this rule abstains, so core behavior is unchanged.
+
+Verdicts (raise-only):
+
+* canonical target matches a resolved ``blocked`` glob → ``BLOCK (policy_source_blocked)``
+* canonical target matches a resolved ``sensitive`` glob → ``AUTH (policy_source_sensitive)``
+* otherwise abstain (``PASS``)
+
+Because the resolved policy is itself raise-only across sources (a higher
+authority can only tighten), a registered source can outrank the role here —
+but nothing can ever loosen a constraint a higher-authority source set.
+"""
+
+import fnmatch
+
+from doberman.canonical import canonicalize
+from doberman.models import (
+    ActionType,
+    EvalContext,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+from doberman.policy.sources import ResolvedPolicy
+
+_PATH_ACTION_TYPES = frozenset(
+    {ActionType.file_read, ActionType.file_write, ActionType.file_delete}
+)
+_DEFAULT_ROOT = "."
+
+
+def _candidate_paths(action: SecurityObject) -> list[str]:
+    raw_paths = action.metadata.get("raw_paths") if isinstance(action.metadata, dict) else None
+    if isinstance(raw_paths, (list, tuple)) and raw_paths:
+        return [str(p) for p in raw_paths if isinstance(p, str) and p]
+    if action.target:
+        return [action.target]
+    return []
+
+
+def _matches_any(relposix: str, globs: tuple[str, ...]) -> bool:
+    if not relposix:
+        return False
+    return any(fnmatch.fnmatch(relposix, pattern) for pattern in globs)
+
+
+class PolicySourceRule:
+    """Enforce a resolved, layered policy from registered policy sources."""
+
+    def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:
+        policy = ctx.metadata.get("resolved_policy") if isinstance(ctx.metadata, dict) else None
+        if not isinstance(policy, ResolvedPolicy) or policy.is_empty:
+            return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+        if action.action_type not in _PATH_ACTION_TYPES:
+            return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+
+        paths = _candidate_paths(action)
+        if not paths:
+            return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+
+        root = str(ctx.metadata.get("repo_root") or _DEFAULT_ROOT)
+
+        worst = GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+        for raw_path in paths:
+            result = self._evaluate_one(raw_path, root, policy)
+            if _verdict_rank(result) > _verdict_rank(worst):
+                worst = result
+            if worst.verdict is Verdict.BLOCK:
+                break
+        return worst
+
+    @staticmethod
+    def _evaluate_one(raw_path: str, root: str, policy: ResolvedPolicy) -> GuardrailResult:
+        canonical = canonicalize(raw_path, root=root)
+        rel = canonical.relposix
+        if _matches_any(rel, policy.blocked_globs):
+            return GuardrailResult(
+                verdict=Verdict.BLOCK,
+                risk=Risk.high,
+                reason_codes=[ReasonCode.policy_source_blocked],
+                explanation="Target is blocked by a higher-authority policy source.",
+            )
+        if _matches_any(rel, policy.sensitive_globs):
+            return GuardrailResult(
+                verdict=Verdict.AUTH,
+                risk=Risk.medium,
+                reason_codes=[ReasonCode.policy_source_sensitive],
+                explanation=(
+                    "Target is sensitive under a higher-authority policy source; "
+                    "authentication required."
+                ),
+            )
+        return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+
+
+def _verdict_rank(result: GuardrailResult) -> int:
+    from doberman.models import VERDICT_ORDER
+
+    return VERDICT_ORDER[result.verdict]

--- a/src/doberman/engine/rules/role_boundary.py
+++ b/src/doberman/engine/rules/role_boundary.py
@@ -1,0 +1,109 @@
+"""Role-boundary rule (Feature 4, slice 4.3).
+
+Escalates path actions that cross the active agent role's boundaries. This lives
+in the **objective** layer on purpose: role authority outranks casual user
+intent and must not be something the subjective/learning layer can soften — a
+frontend agent editing ``backend/auth/session.ts`` escalates no matter how
+friendly the prompt is.
+
+Verdicts (raise-only; the objective guardrail combines this with the other
+rules):
+
+* target classifies as ``blocked`` for the role → ``BLOCK (role_blocked_target)``
+* target classifies as ``suspicious`` (incl. out-of-scope-by-default) →
+  ``AUTH (role_out_of_scope)``
+* ``allowed`` / non-path action / no active role → abstain (``PASS``)
+
+SECURITY: the explanation names the role and the boundary class only — never
+the raw path. With ``ctx.role is None`` the rule abstains, so role enforcement
+is strictly opt-in and never silently blocks a repo that has not set a role.
+"""
+
+from doberman.models import (
+    ActionType,
+    EvalContext,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+from doberman.roles.roles import RoleBoundary, classify
+
+#: Only path-shaped actions are classified against role path globs. A shell or
+#: network action's ``target`` is a command/URL, not a path, so this rule
+#: abstains on them (the command/destination rules cover those).
+_PATH_ACTION_TYPES = frozenset(
+    {ActionType.file_read, ActionType.file_write, ActionType.file_delete}
+)
+
+_DEFAULT_ROOT = "."
+
+# Worst-wins ordering for batch actions.
+_SEVERITY = {
+    RoleBoundary.allowed: 0,
+    RoleBoundary.unknown: 0,
+    RoleBoundary.suspicious: 1,
+    RoleBoundary.blocked: 2,
+}
+
+
+def _candidate_paths(action: SecurityObject) -> list[str]:
+    raw_paths = action.metadata.get("raw_paths") if isinstance(action.metadata, dict) else None
+    if isinstance(raw_paths, (list, tuple)) and raw_paths:
+        return [str(p) for p in raw_paths if isinstance(p, str) and p]
+    if action.target:
+        return [action.target]
+    return []
+
+
+class RoleBoundaryRule:
+    """Escalate actions that cross the active role's path boundaries."""
+
+    def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:
+        role = ctx.role
+        if role is None:
+            return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+        if action.action_type not in _PATH_ACTION_TYPES:
+            return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+
+        paths = _candidate_paths(action)
+        if not paths:
+            return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+
+        root = _DEFAULT_ROOT
+        if isinstance(ctx.metadata, dict):
+            root = str(ctx.metadata.get("repo_root") or _DEFAULT_ROOT)
+
+        worst = RoleBoundary.allowed
+        for raw_path in paths:
+            boundary = classify(role, raw_path, root=root)
+            if _SEVERITY[boundary] > _SEVERITY[worst]:
+                worst = boundary
+            if worst is RoleBoundary.blocked:
+                break
+
+        return self._verdict_for(worst, role.name)
+
+    @staticmethod
+    def _verdict_for(boundary: RoleBoundary, role_name: str) -> GuardrailResult:
+        if boundary is RoleBoundary.blocked:
+            return GuardrailResult(
+                verdict=Verdict.BLOCK,
+                risk=Risk.high,
+                reason_codes=[ReasonCode.role_blocked_target],
+                explanation=(
+                    f"Target is forbidden for the active '{role_name}' role; blocked by role policy."
+                ),
+            )
+        if boundary is RoleBoundary.suspicious:
+            return GuardrailResult(
+                verdict=Verdict.AUTH,
+                risk=Risk.medium,
+                reason_codes=[ReasonCode.role_out_of_scope],
+                explanation=(
+                    f"Target is outside the active '{role_name}' role's scope; "
+                    "authentication required (role outranks user intent)."
+                ),
+            )
+        return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -12,6 +12,8 @@ from typing import Any
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, model_validator
 
+from doberman.roles.roles import RoleDefinition
+
 
 class ActionType(StrEnum):
     """What kind of action the agent is attempting."""
@@ -103,6 +105,12 @@ class ReasonCode(StrEnum):
     encoded_exfiltration = "encoded_exfiltration"
     rule_error = "rule_error"
 
+    # Feature 4 — agent role policy & boundaries (+ policy-source seam).
+    role_blocked_target = "role_blocked_target"
+    role_out_of_scope = "role_out_of_scope"
+    policy_source_blocked = "policy_source_blocked"
+    policy_source_sensitive = "policy_source_sensitive"
+
 
 class GuardrailResult(BaseModel):
     """A single guardrail's answer for one action (immutable).
@@ -136,8 +144,10 @@ class GuardrailResult(BaseModel):
 class EvalContext(BaseModel):
     """Context handed to every guardrail evaluation (immutable).
 
-    Deliberately near-empty for now; later features add the security mode
-    (F6), role boundaries (F4), and the baseline handle (F9).
+    Carries the active agent role (F4) so the objective layer can escalate
+    actions that cross the role's boundaries; later features add the security
+    mode (F6) and the baseline handle (F9). ``role`` is ``None`` when no role
+    is configured — role enforcement is opt-in and the role rule then abstains.
 
     NOTE: ``frozen=True`` is shallow — the ``metadata`` dict itself is
     mutable. Guardrails are pure functions by contract and MUST NOT mutate
@@ -146,6 +156,7 @@ class EvalContext(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
+    role: RoleDefinition | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/src/doberman/policy/sources.py
+++ b/src/doberman/policy/sources.py
@@ -1,0 +1,182 @@
+"""Ordered policy sources with authority layering (Feature 4, slice 4.4).
+
+The agent role (F4.3) is the top of the *local* authority hierarchy. But an
+enterprise/org deployment needs a way to layer a **higher** authority above the
+role — e.g. an org hard-policy that blocks a path the role would allow — without
+the public core ever importing the enterprise package.
+
+This module provides that seam:
+
+* :class:`PolicySource` — the interface a source implements (a name, an integer
+  ``authority``, and a :meth:`snapshot` returning blocked/sensitive globs).
+* :func:`resolve_policy` — merges an ordered set of sources into one
+  :class:`ResolvedPolicy`. The merge is **raise-only across sources**: it only
+  ever *unions* constraints, so a lower-authority source can never loosen a
+  higher one, and ``blocked`` always wins over ``sensitive`` on a tie.
+* Extra sources are discovered via the F3 entry-point registry (group
+  ``doberman.policy_sources``); with none installed, only the local sources
+  passed in are used and behavior is unchanged.
+
+This module is policy core. It imports the registry **lazily** (inside
+:func:`resolve_policy`) so there is no import cycle with the engine, and it
+never imports ``doberman.proxy``.
+"""
+
+from collections.abc import Iterable, Sequence
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from doberman.roles.roles import RoleDefinition
+
+#: Authority levels for the built-in local sources. Higher outranks lower; the
+#: enterprise registers sources above ``ROLE_AUTHORITY`` to outrank the role.
+DEFAULTS_AUTHORITY = 0
+LEARNED_AUTHORITY = 5
+ROLE_AUTHORITY = 10
+
+_WHOLE_TREE = {"*", "**", "**/*", "/**"}
+
+
+def _normalize_globs(globs: Iterable[str]) -> tuple[str, ...]:
+    """Lower-case, strip, and drop empty/whole-tree globs (canonical paths are lower-cased)."""
+    cleaned: list[str] = []
+    for raw in globs:
+        pattern = (raw or "").strip().lower()
+        if not pattern or pattern in _WHOLE_TREE:
+            continue
+        cleaned.append(pattern)
+    return tuple(dict.fromkeys(cleaned))
+
+
+class PolicySnapshot(BaseModel):
+    """One source's contribution to the effective policy (immutable)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    blocked_globs: tuple[str, ...] = ()
+    sensitive_globs: tuple[str, ...] = ()
+
+    def model_post_init(self, _context: object) -> None:
+        object.__setattr__(self, "blocked_globs", _normalize_globs(self.blocked_globs))
+        object.__setattr__(self, "sensitive_globs", _normalize_globs(self.sensitive_globs))
+
+
+@runtime_checkable
+class PolicySource(Protocol):
+    """A source of policy constraints, ordered by ``authority`` (higher wins).
+
+    Implementations live in core (local sources) or in separately-installed
+    packages registered via the ``doberman.policy_sources`` entry-point group.
+    A source may only ever *add* constraints (blocked/sensitive globs) — the
+    resolver guarantees it cannot loosen a higher-authority source.
+    """
+
+    name: str
+    authority: int
+
+    def snapshot(self) -> PolicySnapshot: ...
+
+
+class RoleSource:
+    """A :class:`PolicySource` derived from the active agent role."""
+
+    authority = ROLE_AUTHORITY
+
+    def __init__(self, role: RoleDefinition) -> None:
+        self._role = role
+        self.name = f"role:{role.name}"
+
+    def snapshot(self) -> PolicySnapshot:
+        # A role's blocked paths are hard blocks; its out-of-scope (suspicious)
+        # paths map to sensitive (AUTH).
+        return PolicySnapshot(
+            blocked_globs=self._role.blocked,
+            sensitive_globs=self._role.suspicious,
+        )
+
+
+class StaticSource:
+    """A simple :class:`PolicySource` with a fixed snapshot (local/test use)."""
+
+    def __init__(self, name: str, authority: int, snapshot: PolicySnapshot) -> None:
+        self.name = name
+        self.authority = authority
+        self._snapshot = snapshot
+
+    def snapshot(self) -> PolicySnapshot:
+        return self._snapshot
+
+
+class ResolvedPolicy(BaseModel):
+    """The merged effective policy across all sources (immutable, raise-only).
+
+    ``blocked_globs`` and ``sensitive_globs`` are the unions across sources,
+    with ``blocked`` taking precedence (a glob blocked by any source is removed
+    from ``sensitive``). ``contributors`` records ``(name, authority)`` per
+    source in ascending-authority order for audit/explainability.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    blocked_globs: tuple[str, ...] = ()
+    sensitive_globs: tuple[str, ...] = ()
+    contributors: tuple[tuple[str, int], ...] = Field(default_factory=tuple)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.blocked_globs and not self.sensitive_globs
+
+
+def _looks_like_policy_source(obj: object) -> bool:
+    """Structural check (the Protocol's isinstance is attribute-only)."""
+    return (
+        hasattr(obj, "authority")
+        and callable(getattr(obj, "snapshot", None))
+        and isinstance(getattr(obj, "name", None), str)
+    )
+
+
+def resolve_policy(
+    local_sources: Sequence[PolicySource] = (),
+    *,
+    discover: bool = True,
+) -> ResolvedPolicy:
+    """Merge ``local_sources`` plus any registered sources into one policy.
+
+    The merge is raise-only: blocked/sensitive globs are unioned across all
+    sources and ``blocked`` wins over ``sensitive`` on overlap, so a
+    lower-authority source can never weaken a higher one. With no sources at
+    all, returns an empty :class:`ResolvedPolicy` (callers then behave exactly
+    as if no policy layering existed).
+    """
+    sources: list[PolicySource] = [s for s in local_sources if _looks_like_policy_source(s)]
+    if discover:
+        # Lazy import: avoids an engine<->policy import cycle at module load.
+        from doberman.engine.registry import discover_policy_sources
+
+        sources.extend(discover_policy_sources())
+
+    # Ascending authority for stable, auditable contributor ordering. (The
+    # union merge below is order-independent, but the audit trail is not.)
+    sources.sort(key=lambda s: getattr(s, "authority", 0))
+
+    blocked: set[str] = set()
+    sensitive: set[str] = set()
+    contributors: list[tuple[str, int]] = []
+    for source in sources:
+        snap = source.snapshot()
+        blocked.update(snap.blocked_globs)
+        sensitive.update(snap.sensitive_globs)
+        contributors.append(
+            (str(getattr(source, "name", "?")), int(getattr(source, "authority", 0)))
+        )
+
+    # Blocked wins over sensitive on a tie (stricter constraint dominates).
+    sensitive -= blocked
+
+    return ResolvedPolicy(
+        blocked_globs=tuple(sorted(blocked)),
+        sensitive_globs=tuple(sorted(sensitive)),
+        contributors=tuple(contributors),
+    )

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from mcp.client.session import ClientSession
 from mcp.types import CallToolResult, TextContent
 
+from doberman.config import load_active_role
 from doberman.engine.decision_engine import PASS_STUB, Guardrail, decide
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.models import (
@@ -122,7 +123,12 @@ async def decide_and_execute(
     # content to detect secrets / parse commands. We hand it to them through
     # EvalContext.metadata, which is in-memory only and never logged or
     # persisted — the SecurityObject itself stays redacted for the audit log.
-    ctx = EvalContext(metadata={"raw_arguments": dict(arguments or {})})
+    # The active agent role (Feature 4) is loaded from .doberman/role.yaml; it
+    # is None when no role is configured, in which case the role rule abstains.
+    ctx = EvalContext(
+        role=load_active_role("."),
+        metadata={"raw_arguments": dict(arguments or {})},
+    )
 
     try:
         decision = decide(action, DEFAULT_OBJECTIVE, DEFAULT_SUBJECTIVE, ctx)

--- a/src/doberman/roles/builtin_roles.yaml
+++ b/src/doberman/roles/builtin_roles.yaml
@@ -1,0 +1,109 @@
+# Built-in agent roles (Feature 4).
+#
+# Each role declares three path-glob boundary sets, matched against the
+# CANONICAL, root-relative, lower-cased path (see doberman.canonical):
+#   allowed     in-scope; the agent may act here without a role escalation
+#   suspicious  out-of-scope but recoverable; step up to AUTH
+#   blocked     forbidden for this role; BLOCK (never, even with auth)
+#
+# Precedence is blocked > suspicious > allowed (blocked wins on overlap), and a
+# target matched by none of `allowed` is treated as suspicious (safe default:
+# nothing is implicitly in-scope). Globs are case-insensitive.
+#
+# The built-in roles map out-of-scope areas to `suspicious` (AUTH), keeping
+# `blocked` empty: hard universal blocks (.env, secrets, backend/auth) are
+# already enforced by the objective path rule, and a generic role should escalate
+# rather than hard-forbid. The `blocked` tier is for custom/enterprise roles that
+# need a role-specific hard prohibition.
+roles:
+  frontend:
+    description: "Frontend / UI work. Backend, infra, and secrets are out of scope."
+    allowed:
+      - "frontend/**"
+      - "src/components/**"
+      - "src/pages/**"
+      - "src/styles/**"
+      - "public/**"
+      - "**/*.css"
+      - "**/*.scss"
+    suspicious:
+      - "backend/**"
+      - "backend/auth/**"
+      - "api/**"
+      - "server/**"
+      - "src/server/**"
+      - "infra/**"
+      - ".github/workflows/**"
+    blocked: []
+  backend:
+    description: "Backend / API / service work. Frontend assets and CI are out of scope."
+    allowed:
+      - "backend/**"
+      - "api/**"
+      - "server/**"
+      - "src/server/**"
+      - "migrations/**"
+    suspicious:
+      - "frontend/**"
+      - "infra/**"
+      - ".github/workflows/**"
+    blocked: []
+  fullstack:
+    description: "Frontend and backend. Infra and CI still escalate."
+    allowed:
+      - "frontend/**"
+      - "backend/**"
+      - "api/**"
+      - "server/**"
+      - "src/**"
+      - "public/**"
+      - "migrations/**"
+    suspicious:
+      - "infra/**"
+      - ".github/workflows/**"
+    blocked: []
+  devops:
+    description: "Infrastructure, CI/CD, deployment. Application source is out of scope."
+    allowed:
+      - "infra/**"
+      - ".github/workflows/**"
+      - "deploy/**"
+      - "docker/**"
+      - "**/dockerfile"
+      - "**/*.tf"
+    suspicious:
+      - "backend/**"
+      - "frontend/**"
+      - "src/**"
+    blocked: []
+  docs:
+    description: "Documentation only. Code, infra, and CI escalate."
+    allowed:
+      - "docs/**"
+      - "**/*.md"
+      - "**/*.mdx"
+      - "**/*.rst"
+    suspicious:
+      - "src/**"
+      - "backend/**"
+      - "backend/auth/**"
+      - "frontend/**"
+      - "infra/**"
+      - ".github/workflows/**"
+    blocked: []
+  test:
+    description: "Tests and fixtures. Production source escalates."
+    allowed:
+      - "tests/**"
+      - "test/**"
+      - "**/*_test.py"
+      - "**/*.test.ts"
+      - "**/*.spec.ts"
+      - "**/__tests__/**"
+    suspicious:
+      - "src/**"
+      - "backend/**"
+      - "backend/auth/**"
+      - "frontend/**"
+      - "infra/**"
+    blocked: []

--- a/src/doberman/roles/roles.py
+++ b/src/doberman/roles/roles.py
@@ -1,0 +1,166 @@
+"""Agent role definitions, loading, and the role-boundary matcher (Feature 4).
+
+A *role* is the top of Doberman's **local** authority hierarchy: it declares
+which path globs an agent is in-scope for (`allowed`), which are out-of-scope
+but recoverable (`suspicious` → AUTH), and which are forbidden for that role
+(`blocked` → BLOCK). The thesis point is that the role outranks casual user
+intent — a frontend agent touching ``backend/auth/**`` escalates even if the
+prompt asks nicely (the escalation lives in the objective layer; see
+``engine/rules/role_boundary.py``).
+
+This module is part of the policy core and deliberately imports **only**
+``doberman.canonical`` (plus stdlib/pydantic/yaml) — never ``doberman.models``
+— so ``models`` can embed a :class:`RoleDefinition` in ``EvalContext`` without
+an import cycle, and never ``doberman.proxy`` (import-linter).
+
+SECURITY:
+
+* ``blocked`` wins on overlap, and a target matched by no ``allowed`` glob is
+  treated as ``suspicious`` (empty ``allowed`` ⇒ nothing implicitly in scope).
+* Matching always goes through the one shared :func:`doberman.canonical.canonicalize`
+  helper, so ``..`` traversal, symlink, and case bypasses cannot dodge a role
+  boundary; a target that escapes the repo root is treated as ``blocked``.
+"""
+
+from collections.abc import Iterable, Sequence
+from enum import StrEnum
+from fnmatch import fnmatch
+from importlib.resources import files
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+from doberman.canonical import canonicalize
+
+#: Repo root used when a caller does not supply one (matches the path rule).
+_DEFAULT_ROOT = "."
+
+#: Over-broad globs that would match everything are dropped from a boundary set
+#: (a blocked ``**`` would block every action; a suspicious ``**`` would AUTH
+#: everything). Mirrors the protected-path rule's sanitizer.
+_WHOLE_TREE = {"*", "**", "**/*", "/**"}
+
+
+class RoleBoundary(StrEnum):
+    """How a target relates to a role's scope."""
+
+    allowed = "allowed"
+    suspicious = "suspicious"
+    blocked = "blocked"
+    unknown = "unknown"  # non-path action — the role rule abstains
+
+
+def _normalize_globs(globs: Iterable[str]) -> tuple[str, ...]:
+    """Lower-case, strip, and drop empty/whole-tree globs.
+
+    Canonical paths are lower-cased, so globs must be too; whole-tree patterns
+    are dropped so a misconfiguration cannot make everything match.
+    """
+    cleaned: list[str] = []
+    for raw in globs:
+        pattern = (raw or "").strip().lower()
+        if not pattern or pattern in _WHOLE_TREE:
+            continue
+        cleaned.append(pattern)
+    return tuple(cleaned)
+
+
+class RoleDefinition(BaseModel):
+    """An agent role's path-boundary policy (immutable).
+
+    ``allowed``/``suspicious``/``blocked`` are path globs matched against the
+    canonical, root-relative, lower-cased target. They are normalized on
+    construction (lower-cased, whole-tree patterns dropped).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(min_length=1)
+    description: str = ""
+    allowed: tuple[str, ...] = ()
+    suspicious: tuple[str, ...] = ()
+    blocked: tuple[str, ...] = ()
+
+    def model_post_init(self, _context: object) -> None:
+        # Normalize globs once at construction. object.__setattr__ is required
+        # because the model is frozen.
+        object.__setattr__(self, "allowed", _normalize_globs(self.allowed))
+        object.__setattr__(self, "suspicious", _normalize_globs(self.suspicious))
+        object.__setattr__(self, "blocked", _normalize_globs(self.blocked))
+
+
+#: The most-restrictive fallback role: nothing is in scope, so every path
+#: action is at least ``suspicious`` (→ AUTH). Used when a configured role name
+#: cannot be resolved — fail toward restriction, never toward open scope.
+MOST_RESTRICTIVE_ROLE = RoleDefinition(
+    name="restricted",
+    description="Fallback role: nothing is implicitly in scope; everything escalates.",
+)
+
+
+def _matches_any(relposix: str, globs: Sequence[str]) -> bool:
+    if not relposix:
+        return False
+    return any(fnmatch(relposix, pattern) for pattern in globs)
+
+
+def load_builtin_roles() -> dict[str, RoleDefinition]:
+    """Load and validate the packaged built-in roles.
+
+    Returns a mapping of role name → :class:`RoleDefinition`. Raises
+    ``ValueError`` if the packaged data is malformed (a corrupt install should
+    fail loudly, not silently ship an empty role set).
+    """
+    raw = files("doberman.roles").joinpath("builtin_roles.yaml").read_text(encoding="utf-8")
+    data = yaml.safe_load(raw) or {}
+    roles_section = data.get("roles") if isinstance(data, dict) else None
+    if not isinstance(roles_section, dict) or not roles_section:
+        raise ValueError("builtin_roles.yaml must contain a non-empty 'roles' mapping")
+
+    roles: dict[str, RoleDefinition] = {}
+    for name, spec in roles_section.items():
+        spec = spec or {}
+        if not isinstance(spec, dict):
+            raise ValueError(f"role {name!r} must be a mapping")
+        roles[name] = RoleDefinition(
+            name=name,
+            description=str(spec.get("description", "")),
+            allowed=tuple(spec.get("allowed") or ()),
+            suspicious=tuple(spec.get("suspicious") or ()),
+            blocked=tuple(spec.get("blocked") or ()),
+        )
+    return roles
+
+
+def classify(
+    role: RoleDefinition,
+    target: str | None,
+    *,
+    root: str = _DEFAULT_ROOT,
+) -> RoleBoundary:
+    """Classify ``target`` against ``role``'s boundaries.
+
+    Returns:
+        ``unknown`` for a non-path action (no target); ``blocked`` if the
+        canonical path escapes the repo root or matches a ``blocked`` glob;
+        ``suspicious`` if it matches a ``suspicious`` glob *or* no ``allowed``
+        glob; ``allowed`` only when it matches an ``allowed`` glob and nothing
+        stricter. Precedence is blocked → suspicious → allowed.
+    """
+    if not target:
+        return RoleBoundary.unknown
+
+    canonical = canonicalize(target, root=root)
+    if canonical.escapes_root:
+        # Out of the repository entirely — never in scope for any role.
+        return RoleBoundary.blocked
+
+    rel = canonical.relposix
+    if _matches_any(rel, role.blocked):
+        return RoleBoundary.blocked
+    if _matches_any(rel, role.suspicious):
+        return RoleBoundary.suspicious
+    if _matches_any(rel, role.allowed):
+        return RoleBoundary.allowed
+    # Matched by nothing in `allowed` — out of scope, escalate (safe default).
+    return RoleBoundary.suspicious

--- a/tests/unit/test_core_is_standalone.py
+++ b/tests/unit/test_core_is_standalone.py
@@ -13,7 +13,7 @@ def test_core_imports_with_no_enterprise_installed():
 def test_version_is_exposed():
     import doberman
 
-    assert doberman.__version__ == "0.3.0"
+    assert doberman.__version__ == "0.4.0"
 
 
 def test_policy_core_packages_import_cleanly():

--- a/tests/unit/test_policy_sources.py
+++ b/tests/unit/test_policy_sources.py
@@ -1,0 +1,165 @@
+"""Slice 4.4 — ordered PolicySource resolver + authority layering (the seam).
+
+Covers: empty resolution; role→snapshot mapping; raise-only union across
+sources (blocked wins on tie, order-independent); discovery of a registered
+source via the entry-point registry; standalone behavior with nothing
+registered; and that a higher-authority registered source outranks the role via
+the PolicySourceRule.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from doberman.engine import registry
+from doberman.engine.rules.policy_source import PolicySourceRule
+from doberman.models import (
+    ActionType,
+    EvalContext,
+    ReasonCode,
+    SecurityObject,
+    Verdict,
+)
+from doberman.policy.sources import (
+    PolicySnapshot,
+    ResolvedPolicy,
+    RoleSource,
+    StaticSource,
+    resolve_policy,
+)
+from doberman.roles.roles import RoleDefinition
+
+
+# --- fakes for entry-point discovery (no package install needed) -------------
+class _FakeEntryPoint:
+    def __init__(self, name, loader):
+        self.name = name
+        self._loader = loader
+
+    def load(self):
+        return self._loader()
+
+
+class _FakeEntryPoints:
+    def __init__(self, by_group):
+        self._by_group = by_group
+
+    def select(self, *, group):
+        return list(self._by_group.get(group, []))
+
+
+@pytest.fixture
+def patch_policy_sources(monkeypatch):
+    def _install(*sources):
+        table = _FakeEntryPoints({registry.POLICY_SOURCE_GROUP: list(sources)})
+        monkeypatch.setattr(registry, "entry_points", lambda: table)
+
+    return _install
+
+
+def _action(target, action_type=ActionType.file_write):
+    return SecurityObject(
+        id="ps-1",
+        ts=datetime(2026, 6, 8, tzinfo=timezone.utc),
+        agent_role="x",
+        action_type=action_type,
+        tool_name="fs_write",
+        target=target,
+    )
+
+
+# --- resolver ---------------------------------------------------------------
+def test_no_sources_resolves_empty():
+    rp = resolve_policy(discover=False)
+    assert rp.is_empty
+
+
+def test_role_source_maps_blocked_and_suspicious():
+    role = RoleDefinition(name="r", blocked=["a/**"], suspicious=["b/**"])
+    snap = RoleSource(role).snapshot()
+    assert snap.blocked_globs == ("a/**",)
+    assert snap.sensitive_globs == ("b/**",)
+
+
+def test_blocked_wins_over_sensitive_on_tie():
+    a = StaticSource("a", 0, PolicySnapshot(sensitive_globs=["x/**"]))
+    b = StaticSource("b", 100, PolicySnapshot(blocked_globs=["x/**"]))
+    rp = resolve_policy([a, b], discover=False)
+    assert "x/**" in rp.blocked_globs
+    assert "x/**" not in rp.sensitive_globs
+
+
+def test_merge_is_order_independent_and_raise_only():
+    a = StaticSource("a", 0, PolicySnapshot(sensitive_globs=["x/**"]))
+    b = StaticSource("b", 100, PolicySnapshot(blocked_globs=["x/**"]))
+    forward = resolve_policy([a, b], discover=False)
+    backward = resolve_policy([b, a], discover=False)
+    assert forward.blocked_globs == backward.blocked_globs
+    assert forward.sensitive_globs == backward.sensitive_globs
+    # A lower-authority source cannot remove a higher source's blocked: x stays blocked.
+    assert "x/**" in forward.blocked_globs
+
+
+def test_discovers_a_registered_source(patch_policy_sources):
+    class _DiscoveredSource:
+        name = "enterprise-hard-policy"
+        authority = 100
+
+        def snapshot(self):
+            return PolicySnapshot(blocked_globs=["app/secret.txt"])
+
+    patch_policy_sources(_FakeEntryPoint("ent", _DiscoveredSource))
+    rp = resolve_policy(discover=True)
+    assert "app/secret.txt" in rp.blocked_globs
+    assert any(name == "enterprise-hard-policy" for name, _ in rp.contributors)
+
+
+def test_standalone_when_nothing_registered(patch_policy_sources):
+    patch_policy_sources()  # empty policy-source group
+    local = StaticSource("local", 0, PolicySnapshot(blocked_globs=["only/local/**"]))
+    rp = resolve_policy([local], discover=True)
+    assert rp.blocked_globs == ("only/local/**",)
+
+
+# --- rule -------------------------------------------------------------------
+def test_rule_abstains_without_a_resolved_policy(tmp_path):
+    ctx = EvalContext(metadata={"repo_root": str(tmp_path)})
+    assert PolicySourceRule().evaluate(_action("a.txt"), ctx).verdict is Verdict.PASS
+
+
+def test_rule_blocks_a_resolved_blocked_path(tmp_path):
+    rp = ResolvedPolicy(blocked_globs=("app/secret.txt",))
+    ctx = EvalContext(metadata={"repo_root": str(tmp_path), "resolved_policy": rp})
+    result = PolicySourceRule().evaluate(_action("app/secret.txt"), ctx)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.policy_source_blocked in result.reason_codes
+
+
+def test_rule_auths_a_resolved_sensitive_path(tmp_path):
+    rp = ResolvedPolicy(sensitive_globs=("app/config/**",))
+    ctx = EvalContext(metadata={"repo_root": str(tmp_path), "resolved_policy": rp})
+    result = PolicySourceRule().evaluate(_action("app/config/db.ini"), ctx)
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.policy_source_sensitive in result.reason_codes
+
+
+def test_high_authority_source_outranks_role(tmp_path, patch_policy_sources):
+    # Role allows app/**; a registered higher-authority source blocks app/secret.txt.
+    role = RoleDefinition(name="dev", allowed=["app/**"])
+
+    class _HardPolicy:
+        name = "org-hard-policy"
+        authority = 100
+
+        def snapshot(self):
+            return PolicySnapshot(blocked_globs=["app/secret.txt"])
+
+    patch_policy_sources(_FakeEntryPoint("org", _HardPolicy))
+    rp = resolve_policy([RoleSource(role)], discover=True)
+    ctx = EvalContext(metadata={"repo_root": str(tmp_path), "resolved_policy": rp})
+
+    # The path the role would allow is blocked by the higher-authority source.
+    blocked = PolicySourceRule().evaluate(_action("app/secret.txt"), ctx)
+    assert blocked.verdict is Verdict.BLOCK
+    # A sibling the source does not constrain is unaffected by the seam.
+    assert PolicySourceRule().evaluate(_action("app/main.py"), ctx).verdict is Verdict.PASS

--- a/tests/unit/test_role_escalation.py
+++ b/tests/unit/test_role_escalation.py
@@ -1,0 +1,94 @@
+"""Slice 4.3 — role escalation in the objective layer.
+
+Covers: out-of-scope path → AUTH; role-blocked path → BLOCK; user intent never
+lowers a role escalation; no active role → abstain; non-path action → abstain;
+the most-restrictive fallback escalates everything; and the role rule combines
+into the objective guardrail (so role authority sits in the objective layer and
+cannot be learned away).
+"""
+
+from datetime import datetime, timezone
+
+from doberman.engine.objective import ObjectiveGuardrail
+from doberman.engine.rules.role_boundary import RoleBoundaryRule
+from doberman.models import (
+    ActionType,
+    EvalContext,
+    ReasonCode,
+    SecurityObject,
+    SourceContext,
+    Verdict,
+)
+from doberman.roles.roles import MOST_RESTRICTIVE_ROLE, RoleDefinition, load_builtin_roles
+
+FRONTEND = load_builtin_roles()["frontend"]
+RULE = RoleBoundaryRule()
+
+
+def _action(target, action_type=ActionType.file_write, source=SourceContext.unknown):
+    return SecurityObject(
+        id="ra-1",
+        ts=datetime(2026, 6, 8, tzinfo=timezone.utc),
+        agent_role="frontend",
+        action_type=action_type,
+        tool_name="fs_write",
+        target=target,
+        source_context=source,
+    )
+
+
+def _ctx(role, tmp_path):
+    return EvalContext(role=role, metadata={"repo_root": str(tmp_path)})
+
+
+def test_out_of_scope_path_requires_auth(tmp_path):
+    result = RULE.evaluate(_action("src/utils/helper.ts"), _ctx(FRONTEND, tmp_path))
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.role_out_of_scope in result.reason_codes
+
+
+def test_in_scope_path_passes(tmp_path):
+    result = RULE.evaluate(_action("frontend/Button.tsx"), _ctx(FRONTEND, tmp_path))
+    assert result.verdict is Verdict.PASS
+
+
+def test_role_blocked_path_is_blocked(tmp_path):
+    role = RoleDefinition(name="scoped", allowed=["app/**"], blocked=["app/secret/**"])
+    result = RULE.evaluate(
+        _action("app/secret/key.txt", action_type=ActionType.file_delete), _ctx(role, tmp_path)
+    )
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.role_blocked_target in result.reason_codes
+
+
+def test_user_intent_does_not_lower_a_role_escalation(tmp_path):
+    # A friendly "the user asked for it" source must not soften the escalation —
+    # the role rule never consults source_context.
+    result = RULE.evaluate(
+        _action("backend/auth/session.ts", source=SourceContext.user), _ctx(FRONTEND, tmp_path)
+    )
+    assert result.verdict is Verdict.AUTH
+
+
+def test_no_active_role_abstains(tmp_path):
+    result = RULE.evaluate(_action("anything/at/all.py"), _ctx(None, tmp_path))
+    assert result.verdict is Verdict.PASS
+
+
+def test_non_path_action_abstains(tmp_path):
+    action = _action("rm -rf /", action_type=ActionType.shell_exec)
+    assert RULE.evaluate(action, _ctx(FRONTEND, tmp_path)).verdict is Verdict.PASS
+
+
+def test_missing_role_resolves_restrictive_and_escalates_everything(tmp_path):
+    # The most-restrictive fallback (used for an unknown configured role) treats
+    # every path as out of scope → AUTH.
+    result = RULE.evaluate(_action("frontend/Button.tsx"), _ctx(MOST_RESTRICTIVE_ROLE, tmp_path))
+    assert result.verdict is Verdict.AUTH
+
+
+def test_role_escalation_combines_into_the_objective_guardrail(tmp_path):
+    guardrail = ObjectiveGuardrail(load_plugins=False)
+    result = guardrail.evaluate(_action("src/utils/helper.ts"), _ctx(FRONTEND, tmp_path))
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.role_out_of_scope in result.reason_codes

--- a/tests/unit/test_role_matcher.py
+++ b/tests/unit/test_role_matcher.py
@@ -1,0 +1,52 @@
+"""Slice 4.2 — role-boundary matcher (classify).
+
+Covers: allowed/suspicious classification; unmatched-by-allowed → suspicious;
+blocked precedence (blocked wins on overlap); non-path → unknown; escapes-root →
+blocked; and that classification goes through the shared canonicalizer so a
+`..` traversal cannot dodge a boundary.
+"""
+
+from doberman.roles.roles import RoleBoundary, RoleDefinition, classify, load_builtin_roles
+
+ROLES = load_builtin_roles()
+FRONTEND = ROLES["frontend"]
+
+
+def test_allowed_path_classifies_allowed(tmp_path):
+    assert classify(FRONTEND, "frontend/Button.tsx", root=str(tmp_path)) is RoleBoundary.allowed
+
+
+def test_out_of_scope_path_classifies_suspicious(tmp_path):
+    assert (
+        classify(FRONTEND, "backend/auth/session.ts", root=str(tmp_path)) is RoleBoundary.suspicious
+    )
+
+
+def test_unmatched_by_allowed_defaults_to_suspicious(tmp_path):
+    # A path in none of the role's sets is out of scope → suspicious (safe default).
+    assert classify(FRONTEND, "random/notes.txt", root=str(tmp_path)) is RoleBoundary.suspicious
+
+
+def test_blocked_wins_on_overlap(tmp_path):
+    role = RoleDefinition(name="x", allowed=["src/**"], blocked=["src/secret/**"])
+    assert classify(role, "src/secret/key.txt", root=str(tmp_path)) is RoleBoundary.blocked
+    assert classify(role, "src/app.py", root=str(tmp_path)) is RoleBoundary.allowed
+
+
+def test_non_path_action_is_unknown(tmp_path):
+    assert classify(FRONTEND, None, root=str(tmp_path)) is RoleBoundary.unknown
+
+
+def test_path_escaping_repo_root_is_blocked(tmp_path):
+    assert classify(FRONTEND, "../../etc/passwd", root=str(tmp_path)) is RoleBoundary.blocked
+
+
+def test_traversal_is_canonicalized_before_matching(tmp_path):
+    # "frontend/../backend/auth/x" canonicalizes to backend/auth/x → suspicious,
+    # i.e. the traversal cannot launder an out-of-scope path into an allowed one.
+    result = classify(FRONTEND, "frontend/../backend/auth/x.ts", root=str(tmp_path))
+    assert result is RoleBoundary.suspicious
+
+
+def test_case_insensitive_matching(tmp_path):
+    assert classify(FRONTEND, "FRONTEND/Button.TSX", root=str(tmp_path)) is RoleBoundary.allowed

--- a/tests/unit/test_roles_schema.py
+++ b/tests/unit/test_roles_schema.py
@@ -1,0 +1,97 @@
+"""Slice 4.1 — built-in role definitions, schema, and active-role config.
+
+Covers: the built-ins load and validate; globs are normalized (lower-cased,
+whole-tree dropped); empty `allowed` means nothing is implicitly in scope; and
+`config.load_active_role` resolves named/inline/unknown/missing roles with the
+fail-toward-restriction rule.
+"""
+
+import pytest
+
+from doberman import config
+from doberman.roles.roles import (
+    MOST_RESTRICTIVE_ROLE,
+    RoleDefinition,
+    load_builtin_roles,
+)
+
+EXPECTED_ROLES = {"frontend", "backend", "fullstack", "devops", "docs", "test"}
+
+
+def test_builtins_load_and_validate():
+    roles = load_builtin_roles()
+    assert set(roles) == EXPECTED_ROLES
+    assert all(isinstance(r, RoleDefinition) for r in roles.values())
+    assert all(r.description for r in roles.values())
+
+
+def test_frontend_role_has_expected_scope():
+    roles = load_builtin_roles()
+    fe = roles["frontend"]
+    assert "frontend/**" in fe.allowed
+    assert "backend/auth/**" in fe.suspicious  # out of scope → AUTH, not blocked
+    assert fe.blocked == ()
+
+
+def test_globs_are_normalized_lowercased_and_tupled():
+    role = RoleDefinition(name="x", allowed=["Frontend/**", "  SRC/Pages/**  "])
+    assert role.allowed == ("frontend/**", "src/pages/**")
+    assert isinstance(role.allowed, tuple)
+
+
+def test_whole_tree_globs_are_dropped():
+    # A blocked "**" would block everything — it must be dropped, not honored.
+    role = RoleDefinition(name="x", blocked=["**", "*", "secrets/**"])
+    assert role.blocked == ("secrets/**",)
+
+
+def test_empty_allowed_means_nothing_in_scope():
+    assert MOST_RESTRICTIVE_ROLE.allowed == ()
+    assert MOST_RESTRICTIVE_ROLE.suspicious == ()
+    assert MOST_RESTRICTIVE_ROLE.blocked == ()
+
+
+def test_role_definition_rejects_empty_name():
+    with pytest.raises(ValueError):
+        RoleDefinition(name="")
+
+
+def test_load_active_role_returns_none_when_unconfigured(tmp_path):
+    # No .doberman/role.yaml → None (role enforcement is opt-in).
+    assert config.load_active_role(str(tmp_path)) is None
+
+
+def test_load_active_role_resolves_a_named_builtin(tmp_path):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text("role: backend\n", encoding="utf-8")
+    role = config.load_active_role(str(tmp_path))
+    assert role is not None
+    assert role.name == "backend"
+    assert "backend/**" in role.allowed
+
+
+def test_unknown_role_name_falls_back_to_most_restrictive(tmp_path):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text("role: wizard\n", encoding="utf-8")
+    assert config.load_active_role(str(tmp_path)) is MOST_RESTRICTIVE_ROLE
+
+
+def test_inline_custom_role_is_honored(tmp_path):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text(
+        "role: custom\nallowed: ['app/**']\nblocked: ['app/secret/**']\n", encoding="utf-8"
+    )
+    role = config.load_active_role(str(tmp_path))
+    assert role is not None
+    assert role.allowed == ("app/**",)
+    assert role.blocked == ("app/secret/**",)
+
+
+def test_malformed_role_file_fails_closed_to_restrictive(tmp_path):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text("- just\n- a\n- list\n", encoding="utf-8")
+    assert config.load_active_role(str(tmp_path)) is MOST_RESTRICTIVE_ROLE


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: F4 — Agent Role Policy & Boundaries (slices 4.1–4.4)
- Plan reference: doberman_core_plan.md

> **Stacked PR:** based on `feat/f3-objective-guardrail` (#8) → `feat/f2-decision-engine` (#7). GitHub re-targets as the stack merges.

## What this PR does
Makes the agent **role** the top of the local authority hierarchy. A path action that crosses the role's boundaries escalates in the **objective** layer, so it cannot be learned away and casual user intent never lowers it.

- **4.1 — Built-in roles + schema:** `RoleDefinition` + six built-ins (frontend/backend/fullstack/devops/docs/test) in `roles/builtin_roles.yaml`; globs normalized, `blocked` wins on overlap, empty `allowed` ⇒ nothing implicitly in scope. `config.load_active_role` reads `.doberman/role.yaml` (named or inline custom); missing → None (opt-in), unknown/malformed → most-restrictive.
- **4.2 — Boundary matcher:** `classify()` → allowed/suspicious/blocked/unknown via the **shared** canonicalizer (traversal/symlink/case bypasses caught; out-of-repo → blocked; unmatched-by-allowed → suspicious).
- **4.3 — Cross-boundary escalation:** `RoleBoundaryRule` in the objective layer → out-of-scope `AUTH (role_out_of_scope)`, role-blocked `BLOCK (role_blocked_target)`. Abstains when no role is configured; the proxy loads the active role into `EvalContext`.
- **4.4 — `PolicySource` seam (extension point):** ordered resolver merges local sources (role) + sources registered via `doberman.policy_sources`. **Raise-only across sources** (union; blocked wins on tie), so a higher-authority source outranks the role — without core importing enterprise. Enforced by `PolicySourceRule`.

## Tests added (run in CI)
- `tests/unit/test_roles_schema.py` — built-ins validate, glob normalization, active-role resolution (named/inline/unknown/missing/malformed).
- `tests/unit/test_role_matcher.py` — classification, blocked-precedence, traversal/case canonicalization, escapes-root, non-path → unknown.
- `tests/unit/test_role_escalation.py` — out-of-scope→AUTH, blocked→BLOCK, intent never lowers, no-role abstain, non-path abstain, most-restrictive escalates all, combines into the objective guardrail.
- `tests/unit/test_policy_sources.py` — empty resolution, role→snapshot, raise-only union (blocked wins, order-independent), entry-point discovery, standalone, and a higher-authority source outranking the role.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed (the PolicySource seam discovers nothing by default)

## Security checklist
- [x] Fails closed (unknown/malformed role → most-restrictive; out-of-repo → blocked)
- [x] No secret/path/argument value in any explanation (role reasons name the role + boundary class only)
- [x] Raise-only — role escalation lives in the objective layer; policy-source merge only ever tightens
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise (import-linter + standalone test)

## Edge cases covered / Deviations from plan / Risks introduced
- **Edge cases:** overlapping globs (blocked wins); traversal/symlink/case; out-of-repo; non-path actions; permissive custom role (logged); unknown/malformed config; conflicting sources (stricter wins); no registered sources (unchanged).
- **Deviations:** built-in roles map out-of-scope areas to `suspicious` (AUTH) and keep `blocked` empty (the universal hard blocks live in the F3 path rule; the role `blocked` tier is for custom/enterprise roles) — this matches the plan's "frontend → backend/auth = AUTH" expectation. The role and policy-source rules are added as objective built-ins that abstain unless a role / resolved policy is present, so existing behavior is unchanged.
- **Risks/debt:** one role per repo; static globs; a permissive custom role is allowed (by design, logged).

## Note for reviewers
The matching `HUMAN_TEST_CHECKLIST.md` F4 update lands as a **separate PR in `doberman-enterprise`**.
