### PR TITLE
feat(discovery): capability discovery & local risk map (Feature 5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,8 @@ dist/
 build/
 *.egg-info/
 
-# Operating manual + implementation plans: local-only, never published
-CLAUDE.md
-AGENTS.md
+# Development plans: local-only, never published.
+# (The operating manual — CLAUDE.md / AGENTS.md — is published; these detailed plans are not.)
 doberman_core_plan.md
 doberman_enterprise_plan.md
 doberman_implementation_plan.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,374 @@
+# CLAUDE.md — Doberman Operating Manual
+
+> This is the init file for this repository. It governs any AI agent (Claude Code, Codex, Cursor, etc.) working here.
+> It is the **HOW**. The **WHAT** — the feature roadmap and per-slice detail — lives in `README.md` (public summary)
+> and, if present in your working tree, the project development plan you keep alongside it.
+> Content is identical to `AGENTS.md`; keep the two in sync (or symlink one to the other).
+> If this file conflicts with a casual prompt instruction, **this file wins** unless a human overrides it in writing.
+
+---
+
+## 0. On startup (every session)
+
+1. Read this entire file, then skim `README.md` for the current feature set, versioning, and roadmap. If you keep a
+   local development plan alongside the repo, read the relevant slice there for the extra detail (objective, files,
+   edge cases, suggested tests, suggested commit message).
+2. `git status` + `git log --oneline -5`.
+3. Pick the **next slice** (the lowest-numbered unmerged slice in the planned order).
+4. If the repo lacks scaffolding (`pyproject.toml` / `.github/workflows/ci.yml`), do **Slice 0 (Bootstrap)** first (§6).
+5. Execute exactly **one slice** via **The Slice Loop** (§5), then **STOP** and report. Stop at every review checkpoint.
+
+---
+
+## 1. What this repository is
+
+**Doberman** is an adaptive authorization layer for coding agents, released publicly under **Apache-2.0**.
+
+It distributes as the `doberman` package (`src/doberman/`) and is designed to be **genuinely functional on its own** —
+schema, interfaces, the runtime harness, adapters, and the built-in rules all live here. It is **not** crippleware.
+
+Doberman is built to be **extensible**: it declares stable interfaces (`Rule` / `Detector` / `AuthProvider` /
+`AuditSink`) and a runtime registry that discovers implementations via **Python entry points**. Additional packages can
+register their own rules, detectors, auth providers, or audit sinks **without Doberman importing them by name** — the
+core never takes a static dependency on any plugin. With only `doberman` installed, it works (built-in protection);
+install a plugin package and its capabilities light up automatically.
+
+---
+
+## 2. Architecture & extension points
+
+The decision path is deliberately layered so the safety-critical core stays small, open, and auditable:
+
+- **Tool mediation (`doberman.proxy`)** — the chokepoint. Every tool call an agent makes is normalized into a
+  `SecurityObject` and routed through the decision engine. There is no path around it.
+- **Decision engine (`doberman.engine`)** — combines guardrail verdicts into a final **allow / authenticate / block**
+  decision. The execution rule and the raise-only `combine` are the safety invariants — they must stay open and
+  auditable.
+- **Objective guardrail + built-in rules (`doberman.engine.rules`)** — deterministic rules over the action: path
+  canonicalization & confinement, destructive-command detection, external-destination checks, basic secret-pattern and
+  encoded-exfil detection. New rules plug in through the `Rule` interface and the registry.
+- **Roles & boundaries (`doberman.roles`)** — the role schema and per-repo boundary matcher.
+- **Policy (`doberman.policy`)** — the default checklist and the strength modes (Light / Balanced / Strict / Paranoid).
+- **Storage & audit (`doberman.storage`)** — a local, redacted decision log plus the `AuditSink` interface so
+  additional sinks can be registered.
+- **Tiered auth (`doberman.auth`)** — local confirmation, TOTP 2FA, and narrow/temporary role elevation. Auth providers
+  plug in through the `AuthProvider` interface.
+- **Subjective guardrail & baseline (`doberman.engine`)** — the abnormality interface plus a basic local behavioral
+  baseline. Detectors plug in through the `Detector` interface.
+- **Policy-drift & poisoning defense (`doberman.learning` / `doberman.policy`)** — classifies policy changes as
+  strengthen vs weaken, gates weakening behind 2FA, and records changes in an append-only ledger. A core safety
+  invariant: nothing auto-loosens.
+
+**The plugin pattern (how to keep things decoupled):** declare the interface and registry in core; let other packages
+**register** implementations through their own `pyproject.toml` entry points (groups such as `doberman.rules`,
+`doberman.detectors`, `doberman.auth_providers`, `doberman.audit_sinks`). At runtime Doberman runs its built-in
+implementations **plus** whatever is registered. Build the interface + a built-in implementation first; an advanced
+implementation can then ship as a separate plugin package that depends on the now-merged extension point — never the
+other way around.
+
+---
+
+## 3. Prime directives (non-negotiable)
+
+These override everything. If a task would break one, **STOP and ask a human**.
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case → deny / `BLOCK`. The protected agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails/learning may auto-tighten; they may **never** silently loosen. Any weakening goes through the human-approved path (the policy-drift defense).
+3. **Never expose secrets.** Never commit/log/store raw secrets, keys, full private files, unredacted prompts, or `.doberman/` contents. Fingerprints/classifications/metadata only.
+4. **Keep the core decoupled.** The policy core (`doberman.engine`/`roles`/`policy`/`storage`/`learning`) must not import `doberman.proxy`. Enforced by `import-linter`.
+5. **No slice is "done" without tests + green CI.**
+6. **One slice = one PR.** Keep changes scoped to the slice.
+
+If you feel pressure to violate one of these to "make progress," that pressure is the bug. Stop.
+
+---
+
+## 4. Project snapshot
+
+- **What:** Doberman sits between a coding agent and its tools and turns every meaningful action into a risk-based **allow / authenticate / block** decision.
+- **Package:** distributes as `doberman` (`src/doberman/`).
+- **Stack:** Python 3.11+, MCP proxy (`mcp` SDK), local-first **SQLite** (`aiosqlite`), YAML policy in `.doberman/`, Pydantic v2, `pyotp`, a `doberman` CLI (Typer), `pytest`.
+- **Runtime data** (`.doberman/`, the DB, key files) is **never** committed.
+
+---
+
+## 5. The Slice Loop (run for every slice)
+
+**Step 1 — Read the slice.** Read its objective, files, changes, security considerations, edge cases, expected output,
+suggested tests, and suggested commit message (from your local development plan, with `README.md` as the public
+roadmap). Ambiguity or a Prime-Directive conflict → STOP and ask.
+
+**Step 2 — Branch:**
+```
+git checkout main && git pull
+git checkout -b feat/<feature-slug>/<slice-slug>
+```
+
+**Step 3 — Implement** the smallest change that satisfies the Objective, strictly inside the slice's scope. For
+extensible features, implement against the **interface** and register built-ins through the registry — never make the
+policy core reach sideways into the proxy adapter.
+
+**Step 4 — Write this slice's tests (required).** In `tests/unit/` or `tests/integration/`, create
+`test_<slice_topic>.py` covering at minimum: every item in the slice's **"Suggested tests"**, every **edge case**, and
+every behavioral **security consideration** (e.g. *"a `BLOCK` means the fake downstream server recorded nothing"*,
+*"a synthetic secret never appears in any log/output"*, *"`combine` never returns a verdict lower than either input"*).
+Prefer TDD; tests must be deterministic (no real network/clock/secrets — inject/fixture them).
+
+**Step 5 — Make sure GitHub Actions runs these tests.** Tests live under `tests/` so CI's `pytest` discovers them
+(`pytest --collect-only` to confirm). New dependency → add to `pyproject.toml`. New import boundary → update the
+`import-linter` contract. New CI step → update `.github/workflows/ci.yml` (minimal, same PR).
+
+**Step 6 — Green locally:**
+```
+ruff check . && ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing
+```
+Everything passes; do **not** weaken a test or invariant to get green.
+
+**Step 7 — Update docs and the README (required every slice).** With **every commit/slice** keep these in sync as part
+of the same change — never as an afterthought:
+- **`README.md`**: update the feature summary, versioning/changelog, quickstart, and roadmap so they reflect what now
+  exists. A slice that adds/changes public behavior **must** move the README.
+- Other docs (CLI/config/usage) as usual when behavior changed.
+
+**Step 8 — Commit** (Conventional Commits; tests ship **in the same PR** as the code, ideally same commit). Use the
+plan's "Suggested commit message." Never stage `.doberman/`, `*.db`, key files, `.env*` (they're gitignored — verify
+with `git status`).
+
+**Step 9 — Push the branch** (`git push -u origin <branch>`) — tests go with it, so CI runs them.
+
+**Step 10 — Open a PR to `main`**; fill the PR template. Confirm CI turns **green**. Red CI → fix on the branch and
+push again; never merge red.
+
+**Step 11 — Post the Slice Completion Report (§10) and STOP.** Don't start the next slice until approved/merged or told to continue.
+
+**Step 12 — If this was the last slice of a feature**, after merge post the Feature Review Checkpoint (§10) and STOP. Review checkpoints are mandatory pauses.
+
+---
+
+## 6. Slice 0 — Bootstrap (only if scaffolding is missing)
+
+Scaffold the repo + working CI + a trivial smoke test, committed on `chore/bootstrap-scaffolding` with
+`chore(repo): bootstrap project scaffolding and CI`.
+
+### `pyproject.toml`
+```toml
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.importlinter]
+root_package = "doberman"
+
+# Decoupling: the policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+```
+
+### `.github/workflows/ci.yml`
+```yaml
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+```
+> `--cov-fail-under=80` is a starting bar — raise it over time, never lower it to pass a PR.
+
+### `.gitignore`
+```gitignore
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+```
+
+### `.github/pull_request_template.md`
+```markdown
+## Slice
+- Feature / Slice: <id> — <title>
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-
+```
+
+> The authoritative scaffolding is the actual `pyproject.toml`, `.github/workflows/ci.yml`, and
+> `.github/pull_request_template.md` in the repo — the blocks above are the starting shape.
+
+---
+
+## 7. Architecture enforcement (summary)
+
+The decoupling is guaranteed in CI:
+1. **`import-linter` forbidden contract**: the policy core must not import `doberman.proxy`.
+2. **Plugin inversion**: extensible features connect through core-defined interfaces + entry-point discovery, so the
+   core holds no static reference to any plugin package.
+
+---
+
+## 8. Version control hygiene
+
+- **One slice = one branch = one PR.**
+- Branches: `feat/<feature-slug>/<slice-slug>` (or `fix/...`, `chore/...`).
+- Conventional Commits; small, building commits; **tests travel with code**.
+- **Never commit** secrets, keys, `.doberman/`, `*.db`, `.env*`. If you do by accident → STOP, tell a human, treat the value as leaked (rotate it).
+- Rebase (don't merge) to update a branch: `git fetch && git rebase origin/main`.
+
+---
+
+## 9. Security & explainability rules (every slice)
+
+- **Default deny:** wrap risky ops so exceptions yield `BLOCK` (or `AUTH` only where the plan says "fail upward").
+- **Redaction mandatory:** strip raw secrets/large payloads before logging/persisting; keep path **classes**, reason codes, verdicts, **HMAC fingerprints**. Test that a synthetic secret never appears.
+- **Keyed fingerprints:** HMAC-SHA256 with a local `0600`/keyring key (never committed) — plain hashes of low-entropy secrets are brute-forceable.
+- **Explainability first:** every `BLOCK`/`AUTH` carries `reason_codes` **and** a one-line human `explanation`. Reason codes are shared constants in `models.py`.
+- **Auth is action-bound:** approvals single-use + tied to one action id; elevations narrow + time-limited + (destructive) single-use; elevation never relaxes a hard block.
+- **Canonicalize before matching** paths (resolve `.`/`..`/symlinks, confine to repo root) via one shared helper.
+- **Logging never alters/blocks a decision** and never crashes the execution path.
+- **Don't oversell:** never claim secret detection (or any single rule) is airtight — it is defense-in-depth.
+
+---
+
+## 10. Reporting formats
+
+### Slice Completion Report (after every slice, then STOP)
+```
+SLICE COMPLETE — <feature> / <slice id> (<title>)
+Branch: <branch>    PR: #<n>    CI: <green | red+why>
+What I built: <2–3 lines>
+Tests added (run in CI): <files> — <what they cover>
+Security checks verified: <redaction / fail-closed / raise-only / etc.>
+Edge cases covered: <list>
+Decisions / assumptions: <or "none">
+Deviations from the plan: <none | what & why>
+Risks / tech debt introduced: <or "none">
+Next slice: <id — title>  (awaiting go-ahead)
+```
+
+### Feature Review Checkpoint (after the last slice of a feature, then STOP)
+```
+REVIEW CHECKPOINT — <Feature N: name>
+Built: ...
+Needs human testing: ...
+Decisions to review: ...
+Risks / shortcuts / tech debt: ...
+>> Paused. I will not start the next feature until told to proceed.
+```
+
+---
+
+## 11. Never do this
+
+- ❌ Do work outside the current slice's scope.
+- ❌ Skip a review checkpoint or start the next feature without a go-ahead.
+- ❌ Mark a slice "done" with missing/failing tests or red CI.
+- ❌ Weaken/stub a test or invariant to make CI pass.
+- ❌ Auto-loosen Doberman (all loosening goes through the human-approved policy-drift path).
+- ❌ Commit or log a secret, key, full private file, unredacted prompt, or `.doberman/` content.
+- ❌ Let `doberman.proxy` be imported by the policy core.
+- ❌ Add any path by which a protected agent could reach a real tool without going through the decision engine.
+- ❌ Invent requirements. Unclear plan or wrong-looking slice → STOP and ask.
+
+---
+
+## 12. Quick reference
+
+| You want to… | Do this |
+|---|---|
+| Know **what** to build | the development plan (slice detail) + `README.md` (public roadmap) |
+| Know **how** to build it | this file |
+| Start a slice | branch `feat/<feature>/<slice>` → follow §5 |
+| Finish a slice | tests added + pushed, CI green, decoupling check passes, **README updated** (§5 Step 7), Slice Completion Report, STOP |
+| Run checks | `ruff check . && ruff format --check . && lint-imports && pytest --cov=doberman` |
+| Hit ambiguity | STOP and ask |
+
+**Remember:** small safe commits · tests with every slice · CI green before "done" · the policy core stays decoupled from the proxy · when in doubt, **fail closed and ask.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,374 @@
+# CLAUDE.md — Doberman Operating Manual
+
+> This is the init file for this repository. It governs any AI agent (Claude Code, Codex, Cursor, etc.) working here.
+> It is the **HOW**. The **WHAT** — the feature roadmap and per-slice detail — lives in `README.md` (public summary)
+> and, if present in your working tree, the project development plan you keep alongside it.
+> Content is identical to `AGENTS.md`; keep the two in sync (or symlink one to the other).
+> If this file conflicts with a casual prompt instruction, **this file wins** unless a human overrides it in writing.
+
+---
+
+## 0. On startup (every session)
+
+1. Read this entire file, then skim `README.md` for the current feature set, versioning, and roadmap. If you keep a
+   local development plan alongside the repo, read the relevant slice there for the extra detail (objective, files,
+   edge cases, suggested tests, suggested commit message).
+2. `git status` + `git log --oneline -5`.
+3. Pick the **next slice** (the lowest-numbered unmerged slice in the planned order).
+4. If the repo lacks scaffolding (`pyproject.toml` / `.github/workflows/ci.yml`), do **Slice 0 (Bootstrap)** first (§6).
+5. Execute exactly **one slice** via **The Slice Loop** (§5), then **STOP** and report. Stop at every review checkpoint.
+
+---
+
+## 1. What this repository is
+
+**Doberman** is an adaptive authorization layer for coding agents, released publicly under **Apache-2.0**.
+
+It distributes as the `doberman` package (`src/doberman/`) and is designed to be **genuinely functional on its own** —
+schema, interfaces, the runtime harness, adapters, and the built-in rules all live here. It is **not** crippleware.
+
+Doberman is built to be **extensible**: it declares stable interfaces (`Rule` / `Detector` / `AuthProvider` /
+`AuditSink`) and a runtime registry that discovers implementations via **Python entry points**. Additional packages can
+register their own rules, detectors, auth providers, or audit sinks **without Doberman importing them by name** — the
+core never takes a static dependency on any plugin. With only `doberman` installed, it works (built-in protection);
+install a plugin package and its capabilities light up automatically.
+
+---
+
+## 2. Architecture & extension points
+
+The decision path is deliberately layered so the safety-critical core stays small, open, and auditable:
+
+- **Tool mediation (`doberman.proxy`)** — the chokepoint. Every tool call an agent makes is normalized into a
+  `SecurityObject` and routed through the decision engine. There is no path around it.
+- **Decision engine (`doberman.engine`)** — combines guardrail verdicts into a final **allow / authenticate / block**
+  decision. The execution rule and the raise-only `combine` are the safety invariants — they must stay open and
+  auditable.
+- **Objective guardrail + built-in rules (`doberman.engine.rules`)** — deterministic rules over the action: path
+  canonicalization & confinement, destructive-command detection, external-destination checks, basic secret-pattern and
+  encoded-exfil detection. New rules plug in through the `Rule` interface and the registry.
+- **Roles & boundaries (`doberman.roles`)** — the role schema and per-repo boundary matcher.
+- **Policy (`doberman.policy`)** — the default checklist and the strength modes (Light / Balanced / Strict / Paranoid).
+- **Storage & audit (`doberman.storage`)** — a local, redacted decision log plus the `AuditSink` interface so
+  additional sinks can be registered.
+- **Tiered auth (`doberman.auth`)** — local confirmation, TOTP 2FA, and narrow/temporary role elevation. Auth providers
+  plug in through the `AuthProvider` interface.
+- **Subjective guardrail & baseline (`doberman.engine`)** — the abnormality interface plus a basic local behavioral
+  baseline. Detectors plug in through the `Detector` interface.
+- **Policy-drift & poisoning defense (`doberman.learning` / `doberman.policy`)** — classifies policy changes as
+  strengthen vs weaken, gates weakening behind 2FA, and records changes in an append-only ledger. A core safety
+  invariant: nothing auto-loosens.
+
+**The plugin pattern (how to keep things decoupled):** declare the interface and registry in core; let other packages
+**register** implementations through their own `pyproject.toml` entry points (groups such as `doberman.rules`,
+`doberman.detectors`, `doberman.auth_providers`, `doberman.audit_sinks`). At runtime Doberman runs its built-in
+implementations **plus** whatever is registered. Build the interface + a built-in implementation first; an advanced
+implementation can then ship as a separate plugin package that depends on the now-merged extension point — never the
+other way around.
+
+---
+
+## 3. Prime directives (non-negotiable)
+
+These override everything. If a task would break one, **STOP and ask a human**.
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case → deny / `BLOCK`. The protected agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails/learning may auto-tighten; they may **never** silently loosen. Any weakening goes through the human-approved path (the policy-drift defense).
+3. **Never expose secrets.** Never commit/log/store raw secrets, keys, full private files, unredacted prompts, or `.doberman/` contents. Fingerprints/classifications/metadata only.
+4. **Keep the core decoupled.** The policy core (`doberman.engine`/`roles`/`policy`/`storage`/`learning`) must not import `doberman.proxy`. Enforced by `import-linter`.
+5. **No slice is "done" without tests + green CI.**
+6. **One slice = one PR.** Keep changes scoped to the slice.
+
+If you feel pressure to violate one of these to "make progress," that pressure is the bug. Stop.
+
+---
+
+## 4. Project snapshot
+
+- **What:** Doberman sits between a coding agent and its tools and turns every meaningful action into a risk-based **allow / authenticate / block** decision.
+- **Package:** distributes as `doberman` (`src/doberman/`).
+- **Stack:** Python 3.11+, MCP proxy (`mcp` SDK), local-first **SQLite** (`aiosqlite`), YAML policy in `.doberman/`, Pydantic v2, `pyotp`, a `doberman` CLI (Typer), `pytest`.
+- **Runtime data** (`.doberman/`, the DB, key files) is **never** committed.
+
+---
+
+## 5. The Slice Loop (run for every slice)
+
+**Step 1 — Read the slice.** Read its objective, files, changes, security considerations, edge cases, expected output,
+suggested tests, and suggested commit message (from your local development plan, with `README.md` as the public
+roadmap). Ambiguity or a Prime-Directive conflict → STOP and ask.
+
+**Step 2 — Branch:**
+```
+git checkout main && git pull
+git checkout -b feat/<feature-slug>/<slice-slug>
+```
+
+**Step 3 — Implement** the smallest change that satisfies the Objective, strictly inside the slice's scope. For
+extensible features, implement against the **interface** and register built-ins through the registry — never make the
+policy core reach sideways into the proxy adapter.
+
+**Step 4 — Write this slice's tests (required).** In `tests/unit/` or `tests/integration/`, create
+`test_<slice_topic>.py` covering at minimum: every item in the slice's **"Suggested tests"**, every **edge case**, and
+every behavioral **security consideration** (e.g. *"a `BLOCK` means the fake downstream server recorded nothing"*,
+*"a synthetic secret never appears in any log/output"*, *"`combine` never returns a verdict lower than either input"*).
+Prefer TDD; tests must be deterministic (no real network/clock/secrets — inject/fixture them).
+
+**Step 5 — Make sure GitHub Actions runs these tests.** Tests live under `tests/` so CI's `pytest` discovers them
+(`pytest --collect-only` to confirm). New dependency → add to `pyproject.toml`. New import boundary → update the
+`import-linter` contract. New CI step → update `.github/workflows/ci.yml` (minimal, same PR).
+
+**Step 6 — Green locally:**
+```
+ruff check . && ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing
+```
+Everything passes; do **not** weaken a test or invariant to get green.
+
+**Step 7 — Update docs and the README (required every slice).** With **every commit/slice** keep these in sync as part
+of the same change — never as an afterthought:
+- **`README.md`**: update the feature summary, versioning/changelog, quickstart, and roadmap so they reflect what now
+  exists. A slice that adds/changes public behavior **must** move the README.
+- Other docs (CLI/config/usage) as usual when behavior changed.
+
+**Step 8 — Commit** (Conventional Commits; tests ship **in the same PR** as the code, ideally same commit). Use the
+plan's "Suggested commit message." Never stage `.doberman/`, `*.db`, key files, `.env*` (they're gitignored — verify
+with `git status`).
+
+**Step 9 — Push the branch** (`git push -u origin <branch>`) — tests go with it, so CI runs them.
+
+**Step 10 — Open a PR to `main`**; fill the PR template. Confirm CI turns **green**. Red CI → fix on the branch and
+push again; never merge red.
+
+**Step 11 — Post the Slice Completion Report (§10) and STOP.** Don't start the next slice until approved/merged or told to continue.
+
+**Step 12 — If this was the last slice of a feature**, after merge post the Feature Review Checkpoint (§10) and STOP. Review checkpoints are mandatory pauses.
+
+---
+
+## 6. Slice 0 — Bootstrap (only if scaffolding is missing)
+
+Scaffold the repo + working CI + a trivial smoke test, committed on `chore/bootstrap-scaffolding` with
+`chore(repo): bootstrap project scaffolding and CI`.
+
+### `pyproject.toml`
+```toml
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.importlinter]
+root_package = "doberman"
+
+# Decoupling: the policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+```
+
+### `.github/workflows/ci.yml`
+```yaml
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+```
+> `--cov-fail-under=80` is a starting bar — raise it over time, never lower it to pass a PR.
+
+### `.gitignore`
+```gitignore
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+```
+
+### `.github/pull_request_template.md`
+```markdown
+## Slice
+- Feature / Slice: <id> — <title>
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-
+```
+
+> The authoritative scaffolding is the actual `pyproject.toml`, `.github/workflows/ci.yml`, and
+> `.github/pull_request_template.md` in the repo — the blocks above are the starting shape.
+
+---
+
+## 7. Architecture enforcement (summary)
+
+The decoupling is guaranteed in CI:
+1. **`import-linter` forbidden contract**: the policy core must not import `doberman.proxy`.
+2. **Plugin inversion**: extensible features connect through core-defined interfaces + entry-point discovery, so the
+   core holds no static reference to any plugin package.
+
+---
+
+## 8. Version control hygiene
+
+- **One slice = one branch = one PR.**
+- Branches: `feat/<feature-slug>/<slice-slug>` (or `fix/...`, `chore/...`).
+- Conventional Commits; small, building commits; **tests travel with code**.
+- **Never commit** secrets, keys, `.doberman/`, `*.db`, `.env*`. If you do by accident → STOP, tell a human, treat the value as leaked (rotate it).
+- Rebase (don't merge) to update a branch: `git fetch && git rebase origin/main`.
+
+---
+
+## 9. Security & explainability rules (every slice)
+
+- **Default deny:** wrap risky ops so exceptions yield `BLOCK` (or `AUTH` only where the plan says "fail upward").
+- **Redaction mandatory:** strip raw secrets/large payloads before logging/persisting; keep path **classes**, reason codes, verdicts, **HMAC fingerprints**. Test that a synthetic secret never appears.
+- **Keyed fingerprints:** HMAC-SHA256 with a local `0600`/keyring key (never committed) — plain hashes of low-entropy secrets are brute-forceable.
+- **Explainability first:** every `BLOCK`/`AUTH` carries `reason_codes` **and** a one-line human `explanation`. Reason codes are shared constants in `models.py`.
+- **Auth is action-bound:** approvals single-use + tied to one action id; elevations narrow + time-limited + (destructive) single-use; elevation never relaxes a hard block.
+- **Canonicalize before matching** paths (resolve `.`/`..`/symlinks, confine to repo root) via one shared helper.
+- **Logging never alters/blocks a decision** and never crashes the execution path.
+- **Don't oversell:** never claim secret detection (or any single rule) is airtight — it is defense-in-depth.
+
+---
+
+## 10. Reporting formats
+
+### Slice Completion Report (after every slice, then STOP)
+```
+SLICE COMPLETE — <feature> / <slice id> (<title>)
+Branch: <branch>    PR: #<n>    CI: <green | red+why>
+What I built: <2–3 lines>
+Tests added (run in CI): <files> — <what they cover>
+Security checks verified: <redaction / fail-closed / raise-only / etc.>
+Edge cases covered: <list>
+Decisions / assumptions: <or "none">
+Deviations from the plan: <none | what & why>
+Risks / tech debt introduced: <or "none">
+Next slice: <id — title>  (awaiting go-ahead)
+```
+
+### Feature Review Checkpoint (after the last slice of a feature, then STOP)
+```
+REVIEW CHECKPOINT — <Feature N: name>
+Built: ...
+Needs human testing: ...
+Decisions to review: ...
+Risks / shortcuts / tech debt: ...
+>> Paused. I will not start the next feature until told to proceed.
+```
+
+---
+
+## 11. Never do this
+
+- ❌ Do work outside the current slice's scope.
+- ❌ Skip a review checkpoint or start the next feature without a go-ahead.
+- ❌ Mark a slice "done" with missing/failing tests or red CI.
+- ❌ Weaken/stub a test or invariant to make CI pass.
+- ❌ Auto-loosen Doberman (all loosening goes through the human-approved policy-drift path).
+- ❌ Commit or log a secret, key, full private file, unredacted prompt, or `.doberman/` content.
+- ❌ Let `doberman.proxy` be imported by the policy core.
+- ❌ Add any path by which a protected agent could reach a real tool without going through the decision engine.
+- ❌ Invent requirements. Unclear plan or wrong-looking slice → STOP and ask.
+
+---
+
+## 12. Quick reference
+
+| You want to… | Do this |
+|---|---|
+| Know **what** to build | the development plan (slice detail) + `README.md` (public roadmap) |
+| Know **how** to build it | this file |
+| Start a slice | branch `feat/<feature>/<slice>` → follow §5 |
+| Finish a slice | tests added + pushed, CI green, decoupling check passes, **README updated** (§5 Step 7), Slice Completion Report, STOP |
+| Run checks | `ruff check . && ruff format --check . && lint-imports && pytest --cov=doberman` |
+| Hit ambiguity | STOP and ask |
+
+**Remember:** small safe commits · tests with every slice · CI green before "done" · the policy core stays decoupled from the proxy · when in doubt, **fail closed and ask.**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Doberman is a security layer for AI coding agents. It sits **on the tool-execution path** — the agent talks to Doberman, and Doberman talks to the real tools (filesystem, shell, git, network, package managers) over the [Model Context Protocol](https://modelcontextprotocol.io). Every meaningful action is intercepted, normalized into a redacted, structured **security object**, and run through a risk-based decision engine that returns one of three verdicts — **allow**, **authenticate**, or **block** — before the action is ever forwarded. The guiding principle is simple: *if Doberman isn't on the execution path, it's advisory, not protective.* Doberman is built to **fail closed** (any error or uncertainty denies the action) and to be **raise-only** (guardrails may automatically tighten, never silently loosen), so an agent can never reach a tool around it and a buggy rule can never make the system less safe.
 
 > ### Project status
-> **Alpha — pre-1.0, API unstable.** The interception layer (Feature 1), the decision engine (Feature 2), the **objective guardrail** (Feature 3 — basic rules + the plugin seam), and **agent role policy** (Feature 4 — role boundaries + the policy-source seam) are implemented: Doberman now actively blocks the headline disasters (secret exfiltration, protected-path writes, catastrophic commands), steps up authentication on sensitive or unknown actions, and escalates actions that cross the agent's role boundary. The subjective guardrail and the surfaces around the engine (capability scan, strength modes, real authentication, audit log) arrive in upcoming versions (see the [Roadmap](#roadmap)). This is the open-source **core**; advanced/hosted capabilities live in a separate commercial edition.
+> **Alpha — pre-1.0, API unstable.** The interception layer (Feature 1), the decision engine (Feature 2), the **objective guardrail** (Feature 3 — basic rules + the plugin seam), **agent role policy** (Feature 4 — role boundaries + the policy-source seam), and **capability discovery** (Feature 5 — `doberman scan`) are implemented: Doberman now actively blocks the headline disasters (secret exfiltration, protected-path writes, catastrophic commands), steps up authentication on sensitive or unknown actions, escalates actions that cross the agent's role boundary, and can report the agent's blast radius. The subjective guardrail and the remaining surfaces around the engine (strength modes, real authentication, audit log) arrive in upcoming versions (see the [Roadmap](#roadmap)). This is the open-source **core**; advanced/hosted capabilities live in a separate commercial edition.
 
 ---
 
@@ -152,6 +152,14 @@ Makes the agent's **role** the top of the local authority hierarchy: an action t
 - **Cross-boundary escalation** — an out-of-scope target → **AUTH (`role_out_of_scope`)**, a role-blocked target → **BLOCK (`role_blocked_target`)**. The check lives in the objective layer; with no role configured it abstains, so role enforcement is opt-in.
 - **`PolicySource` seam (extension point)** — an ordered resolver merges policy from local sources (the agent role) plus any registered via the `doberman.policy_sources` entry-point group. The merge is **raise-only across sources** (a higher-authority source can only *tighten*), so an enterprise/org policy can outrank the role — without core importing the enterprise package.
 
+### Feature 5 — Capability Discovery & Local Risk Map · `v0.5.0` _(in review)_
+
+A read-only onboarding scan that answers "how much power does my agent actually have?" — the missing blast-radius picture.
+
+- **Capability enumeration** — infers capabilities from the downstream **tool list** (shell, filesystem read/write/delete, network, git, git-push, package install, env access) and a **read-only** scan of the repo's sensitive surface (`.env*`, `secrets/`, key material, `infra/`, CI workflows, migrations). Sensitive files are detected **by name/existence only — never read** — and nothing is ever written.
+- **Risk rating + map** — each capability is rated (`.env`/key material → critical; shell, fs-write/delete, network, git-push, package-install → high), and `doberman scan` renders a readable risk map (capability names, risk, path-class evidence — never secrets). The scan is depth- and count-bounded so a huge or hostile repo cannot make it run unbounded.
+- **`doberman` CLI** — the first command-line surface (`doberman scan`, `doberman version`), built with Typer.
+
 ---
 
 ## Design invariants
@@ -180,6 +188,11 @@ The version line maps to the development roadmap:
 ## Changelog
 
 This project keeps a changelog in the spirit of [Keep a Changelog](https://keepachangelog.com/).
+
+### `v0.5.0` — Capability Discovery & Local Risk Map — _Unreleased (in review)_
+
+- **Slice 5.1** — read-only capability enumeration (tools + sensitive-surface scan by name; depth/count bounded; never reads secret contents).
+- **Slice 5.2** — risk rating + `doberman scan` risk-map renderer + the `doberman` CLI (Typer).
 
 ### `v0.4.0` — Agent Role Policy & Boundaries — _Unreleased (in review)_
 
@@ -225,7 +238,6 @@ Upcoming versions add the guardrail *content* and the surfaces around the engine
 
 | Version | Theme |
 |---------|-------|
-| `v0.5.0` | **Capability discovery** — local scan and risk map. |
 | `v0.6.0` | **Policy checklist & strength modes** — Light / Balanced / Strict / Paranoid. |
 | `v0.7.0` | **Tiered authentication** — local confirmation, TOTP 2FA, narrow/temporary elevation. |
 | `v0.8.0` | **Decision log & audit** — local redacted decision log + storage interface. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doberman"
-version = "0.4.0"
+version = "0.5.0"
 description = "Adaptive authorization layer for coding agents (open core)"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"
@@ -8,6 +8,9 @@ dependencies = ["pydantic>=2", "mcp>=1.27,<2", "aiosqlite", "pyotp", "pyyaml", "
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[project.scripts]
+doberman = "doberman.cli.main:app"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/doberman/__init__.py
+++ b/src/doberman/__init__.py
@@ -1,3 +1,3 @@
 """Doberman — adaptive authorization layer for coding agents (open core)."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/doberman/cli/__init__.py
+++ b/src/doberman/cli/__init__.py
@@ -1,0 +1,1 @@
+"""The ``doberman`` command-line interface (Feature 5+)."""

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1,0 +1,40 @@
+"""The ``doberman`` CLI entry point (Feature 5).
+
+Currently exposes ``doberman scan`` — a read-only capability/risk-map report for
+the current repository. More commands (status, init, policy) arrive with later
+features.
+"""
+
+import typer
+
+from doberman import __version__
+from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, render_risk_map
+
+app = typer.Typer(
+    help="Doberman — adaptive authorization layer for coding agents.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+@app.command()
+def scan(
+    path: str = typer.Option(".", "--path", "-p", help="Repository root to scan."),
+) -> None:
+    """Show a read-only risk map of the agent's capabilities and sensitive surface.
+
+    Sensitive files are detected by name only and never read; nothing is written.
+    Tool-derived capabilities require a live proxy session and are omitted here.
+    """
+    capabilities = rate_capabilities(enumerate_capabilities(tools=[], repo_root=path))
+    typer.echo(render_risk_map(capabilities))
+
+
+@app.command()
+def version() -> None:
+    """Print the installed Doberman version."""
+    typer.echo(__version__)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/src/doberman/discovery/__init__.py
+++ b/src/doberman/discovery/__init__.py
@@ -1,0 +1,7 @@
+"""Local capability discovery and risk mapping (Feature 5).
+
+Read-only inspection of how much power an agent has — its tool capabilities plus
+the sensitive surface of the repository — rendered as a local risk map. This
+package never opens secret-file *contents* (it detects by name/existence) and
+never writes outside ``.doberman/``.
+"""

--- a/src/doberman/discovery/scan.py
+++ b/src/doberman/discovery/scan.py
@@ -1,0 +1,242 @@
+"""Capability enumeration, risk rating, and risk-map rendering (Feature 5).
+
+``enumerate_capabilities`` infers what an agent can do from (a) the downstream
+**tool list** and (b) a **read-only** scan of the repository's sensitive
+surface. ``rate_capabilities`` assigns a :class:`~doberman.models.Risk` to each,
+and ``render_risk_map`` turns them into a readable report.
+
+SECURITY:
+
+* The scan is strictly **read-only** and never opens a secret file's *contents*
+  — sensitive assets are detected by **name/existence** only.
+* The scan never writes anywhere (let alone outside ``.doberman/``).
+* The risk map contains capability names, categories, risk levels, and
+  path-class evidence — **never** file contents or secret material.
+* The scan is depth- and count-bounded so a huge or hostile repo cannot make it
+  run unbounded, and per-entry permission errors are skipped (and noted), never
+  raised into the caller.
+"""
+
+import fnmatch
+import os
+from dataclasses import dataclass, replace
+
+from doberman.models import Risk
+
+#: Bounds so a pathological repo cannot make the scan run unbounded.
+_MAX_DEPTH = 8
+_MAX_ENTRIES = 20_000
+
+#: Directories never worth scanning (huge, and not the agent's sensitive surface).
+_SKIP_DIRS = frozenset(
+    {".git", "node_modules", ".venv", "venv", "__pycache__", ".doberman", "dist", "build"}
+)
+
+
+@dataclass(frozen=True)
+class Capability:
+    """One discovered capability (immutable).
+
+    ``evidence`` holds path classes / tool names that triggered detection —
+    never file contents. ``risk`` is ``None`` until :func:`rate_capabilities`.
+    """
+
+    name: str
+    category: str
+    present: bool
+    evidence: tuple[str, ...] = ()
+    risk: Risk | None = None
+
+
+#: Tool-derived capabilities: capability name → (substring patterns, description).
+#: A capability is present if any tool name (lower-cased) contains a pattern.
+_TOOL_CAPABILITIES: dict[str, tuple[tuple[str, ...], str]] = {
+    "shell": (
+        ("shell", "exec", "bash", "command", "subprocess", "terminal"),
+        "Execute shell commands",
+    ),
+    "filesystem_write": (
+        ("write", "edit", "create", "save", "mkdir", "put_file"),
+        "Write or modify files",
+    ),
+    "filesystem_delete": (("delete", "unlink", "rmdir", "remove_file", "rm_"), "Delete files"),
+    "filesystem_read": (("read", "cat_", "open_file", "get_file", "view_file"), "Read files"),
+    "network": (
+        ("net", "http", "fetch", "url", "request", "curl", "download", "webhook"),
+        "Make network requests",
+    ),
+    "git": (("git",), "Run git operations"),
+    "git_push": (("push", "force_push"), "Push to remotes (including force-push)"),
+    "package_install": (
+        ("install", "pip_", "npm", "yarn", "apt", "brew", "cargo"),
+        "Install packages",
+    ),
+    "env_access": (
+        ("getenv", "environ", "env_var", "secret"),
+        "Access environment variables / secrets",
+    ),
+}
+
+#: Sensitive-surface capabilities: name → (glob patterns, description). A glob
+#: ending in "/" matches a directory name; others match file names.
+_SENSITIVE_SURFACE: dict[str, tuple[tuple[str, ...], str]] = {
+    "dotenv_visible": ((".env", ".env.*"), "Environment/secret files present"),
+    "secret_files": (("*.pem", "*.key", "id_rsa*", "id_ed25519*"), "Private key material present"),
+    "secrets_dir": (("secrets/",), "secrets/ directory present"),
+    "infra": (("infra/", "*.tf", "*.tfstate"), "Infrastructure-as-code present"),
+    "ci_workflows": ((".github/", "*.yml", "*.yaml"), "CI/CD workflow surface present"),
+    "migrations": (("migrations/",), "Database migrations present"),
+}
+
+
+def _tool_capabilities(tools: list[str]) -> list[Capability]:
+    lowered = [(t, t.lower()) for t in tools if isinstance(t, str)]
+    caps: list[Capability] = []
+    for name, (patterns, description) in _TOOL_CAPABILITIES.items():
+        evidence = tuple(sorted({orig for orig, low in lowered if any(p in low for p in patterns)}))
+        caps.append(
+            Capability(
+                name=name,
+                category="tool",
+                present=bool(evidence),
+                evidence=evidence if evidence else (description,),
+            )
+        )
+    return caps
+
+
+def _walk_names(repo_root: str) -> tuple[list[tuple[str, bool]], bool]:
+    """Yield (relative-posix-path, is_dir) for entries under ``repo_root``.
+
+    Bounded by depth and entry count; skips heavy/irrelevant dirs and any entry
+    that raises a permission error. Returns the entries plus a ``truncated``
+    flag (True if a bound or permission error curtailed the scan).
+    """
+    root = os.path.abspath(repo_root)
+    entries: list[tuple[str, bool]] = []
+    truncated = False
+    count = 0
+    for dirpath, dirnames, filenames in os.walk(root, onerror=lambda _e: None):
+        rel_dir = os.path.relpath(dirpath, root)
+        depth = 0 if rel_dir == "." else rel_dir.count(os.sep) + 1
+        if depth >= _MAX_DEPTH:
+            dirnames[:] = []
+            truncated = True
+            continue
+        # Prune heavy dirs in place so os.walk does not descend into them.
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        for d in dirnames:
+            rel = os.path.relpath(os.path.join(dirpath, d), root).replace(os.sep, "/")
+            entries.append((rel + "/", True))
+        for f in filenames:
+            rel = os.path.relpath(os.path.join(dirpath, f), root).replace(os.sep, "/")
+            entries.append((rel, False))
+            count += 1
+            if count >= _MAX_ENTRIES:
+                return entries, True
+    return entries, truncated
+
+
+def _matches(name_relposix: str, is_dir: bool, pattern: str) -> bool:
+    base = name_relposix.rsplit("/", 1)[-1] if not name_relposix.endswith("/") else name_relposix
+    if pattern.endswith("/"):
+        # Directory pattern: match the directory's base name anywhere in the tree.
+        if not is_dir:
+            return False
+        dir_base = name_relposix.rstrip("/").rsplit("/", 1)[-1] + "/"
+        return fnmatch.fnmatch(dir_base, pattern) or fnmatch.fnmatch(name_relposix, "*" + pattern)
+    if is_dir:
+        return False
+    return fnmatch.fnmatch(base, pattern)
+
+
+def _surface_capabilities(repo_root: str) -> tuple[list[Capability], bool]:
+    entries, truncated = _walk_names(repo_root)
+    caps: list[Capability] = []
+    for name, (patterns, description) in _SENSITIVE_SURFACE.items():
+        evidence: list[str] = []
+        for rel, is_dir in entries:
+            if any(_matches(rel, is_dir, p) for p in patterns):
+                evidence.append(rel)
+        # Cap evidence list so the map stays readable; we record names, never contents.
+        unique = sorted(set(evidence))[:10]
+        caps.append(
+            Capability(
+                name=name,
+                category="sensitive_surface",
+                present=bool(unique),
+                evidence=tuple(unique) if unique else (description,),
+            )
+        )
+    return caps, truncated
+
+
+def enumerate_capabilities(tools: list[str], repo_root: str = ".") -> list[Capability]:
+    """Enumerate agent capabilities from the tool list and a read-only repo scan.
+
+    Read-only; never opens secret-file contents (detection is by name/existence)
+    and never writes anywhere. Returns one :class:`Capability` per known
+    capability (present or not), unrated (see :func:`rate_capabilities`).
+    """
+    caps = _tool_capabilities(tools or [])
+    surface, _truncated = _surface_capabilities(repo_root)
+    return caps + surface
+
+
+#: Risk rating per capability (raise-only spirit: when unsure, rate higher).
+_RISK_BY_CAPABILITY: dict[str, Risk] = {
+    "dotenv_visible": Risk.critical,
+    "secret_files": Risk.critical,
+    "secrets_dir": Risk.critical,
+    "shell": Risk.high,
+    "filesystem_write": Risk.high,
+    "filesystem_delete": Risk.high,
+    "network": Risk.high,
+    "git_push": Risk.high,
+    "package_install": Risk.high,
+    "env_access": Risk.high,
+    "infra": Risk.high,
+    "git": Risk.medium,
+    "ci_workflows": Risk.medium,
+    "migrations": Risk.medium,
+    "filesystem_read": Risk.low,
+}
+
+
+def rate_capabilities(capabilities: list[Capability]) -> list[Capability]:
+    """Return copies of ``capabilities`` with a :class:`Risk` assigned to each.
+
+    On a conflicting/unknown signal we default to ``medium`` (never silently
+    low) — discovery should over-, not under-state blast radius.
+    """
+    return [
+        replace(cap, risk=_RISK_BY_CAPABILITY.get(cap.name, Risk.medium)) for cap in capabilities
+    ]
+
+
+_RISK_RANK = {Risk.critical: 3, Risk.high: 2, Risk.medium: 1, Risk.low: 0}
+
+
+def render_risk_map(capabilities: list[Capability]) -> str:
+    """Render a readable risk map. Present capabilities first, then by risk desc.
+
+    Contains capability names, risk, and path-class/tool evidence only — never
+    file contents.
+    """
+    rated = [c if c.risk is not None else replace(c, risk=Risk.medium) for c in capabilities]
+    rated.sort(key=lambda c: (not c.present, -_RISK_RANK[c.risk], c.name))
+
+    lines = ["Doberman capability risk map", "=" * 32]
+    for cap in rated:
+        marker = cap.risk.value.upper() if cap.present else "—"
+        status = "present" if cap.present else "absent"
+        evidence = ", ".join(cap.evidence[:3]) if cap.present else ""
+        line = f"[{marker:^8}] {cap.name:<20} ({status})"
+        if evidence:
+            line += f"  ← {evidence}"
+        lines.append(line)
+    lines.append("")
+    lines.append(
+        "Heuristic, read-only scan. Sensitive files are detected by name only (never read)."
+    )
+    return "\n".join(lines)

--- a/tests/unit/test_core_is_standalone.py
+++ b/tests/unit/test_core_is_standalone.py
@@ -13,7 +13,7 @@ def test_core_imports_with_no_enterprise_installed():
 def test_version_is_exposed():
     import doberman
 
-    assert doberman.__version__ == "0.4.0"
+    assert doberman.__version__ == "0.5.0"
 
 
 def test_policy_core_packages_import_cleanly():

--- a/tests/unit/test_discovery_scan.py
+++ b/tests/unit/test_discovery_scan.py
@@ -1,0 +1,74 @@
+"""Slice 5.1 — capability enumeration (read-only).
+
+Covers: tool-derived capability detection; sensitive-surface detection by
+name/existence (.env, secrets/, key material); that secret *contents* are never
+read; the depth bound; and graceful handling of an empty tool list / missing path.
+"""
+
+from doberman.discovery.scan import Capability, enumerate_capabilities
+
+FAKE_SECRET = "AKIAIOSFODNN7EXAMPLE"  # noqa: S105 — synthetic AWS example key
+
+
+def _by_name(caps: list[Capability]) -> dict[str, Capability]:
+    return {c.name: c for c in caps}
+
+
+def test_tool_capabilities_detected_from_tool_names(tmp_path):
+    caps = _by_name(
+        enumerate_capabilities(["shell_exec", "fs_write", "net_get", "git_push"], str(tmp_path))
+    )
+    assert caps["shell"].present
+    assert caps["filesystem_write"].present
+    assert caps["network"].present
+    assert caps["git"].present
+    assert caps["git_push"].present
+    # No read/delete tool was offered.
+    assert not caps["filesystem_read"].present
+    assert not caps["filesystem_delete"].present
+
+
+def test_empty_tool_list_yields_no_tool_capabilities(tmp_path):
+    caps = _by_name(enumerate_capabilities([], str(tmp_path)))
+    assert not caps["shell"].present
+    assert not caps["network"].present
+
+
+def test_dotenv_detected_by_name_without_reading_contents(tmp_path):
+    (tmp_path / ".env").write_text(f"AWS_SECRET={FAKE_SECRET}\n", encoding="utf-8")
+    caps = _by_name(enumerate_capabilities([], str(tmp_path)))
+    assert caps["dotenv_visible"].present
+    assert any(".env" in e for e in caps["dotenv_visible"].evidence)
+    # The secret VALUE must never appear in the evidence (we detect by name only).
+    assert all(FAKE_SECRET not in e for e in caps["dotenv_visible"].evidence)
+
+
+def test_secrets_dir_and_key_material_detected(tmp_path):
+    (tmp_path / "secrets").mkdir()
+    (tmp_path / "deploy.pem").write_text("not-a-real-key", encoding="utf-8")
+    caps = _by_name(enumerate_capabilities([], str(tmp_path)))
+    assert caps["secrets_dir"].present
+    assert caps["secret_files"].present
+
+
+def test_scan_is_depth_bounded(tmp_path):
+    # A .env buried far deeper than the depth bound must not be discovered.
+    deep = tmp_path
+    for i in range(12):
+        deep = deep / f"level{i}"
+    deep.mkdir(parents=True)
+    (deep / ".env").write_text("X=1", encoding="utf-8")
+    caps = _by_name(enumerate_capabilities([], str(tmp_path)))
+    assert not caps["dotenv_visible"].present
+
+
+def test_missing_path_does_not_crash(tmp_path):
+    caps = _by_name(enumerate_capabilities([], str(tmp_path / "does-not-exist")))
+    assert not caps["dotenv_visible"].present
+
+
+def test_secret_contents_never_appear_anywhere(tmp_path):
+    (tmp_path / ".env").write_text(f"KEY={FAKE_SECRET}\n", encoding="utf-8")
+    caps = enumerate_capabilities(["shell_exec"], str(tmp_path))
+    blob = " ".join(e for c in caps for e in c.evidence)
+    assert FAKE_SECRET not in blob

--- a/tests/unit/test_risk_map.py
+++ b/tests/unit/test_risk_map.py
@@ -1,0 +1,68 @@
+"""Slice 5.2 — risk rating, risk-map rendering, and the `doberman scan` CLI.
+
+Covers: the rating mapping; the renderer includes every capability and marks
+critical items distinctly; the CLI runs read-only and never prints secrets.
+"""
+
+from typer.testing import CliRunner
+
+from doberman import __version__
+from doberman.cli.main import app
+from doberman.discovery.scan import (
+    enumerate_capabilities,
+    rate_capabilities,
+    render_risk_map,
+)
+from doberman.models import Risk
+
+FAKE_SECRET = "AKIAIOSFODNN7EXAMPLE"  # noqa: S105 — synthetic AWS example key
+runner = CliRunner()
+
+
+def _rated(tmp_path):
+    return rate_capabilities(enumerate_capabilities(["shell_exec"], str(tmp_path)))
+
+
+def test_rating_mapping(tmp_path):
+    rated = {c.name: c for c in _rated(tmp_path)}
+    assert rated["dotenv_visible"].risk is Risk.critical
+    assert rated["shell"].risk is Risk.high
+    assert rated["filesystem_read"].risk is Risk.low
+
+
+def test_renderer_includes_every_capability(tmp_path):
+    rated = _rated(tmp_path)
+    out = render_risk_map(rated)
+    for cap in rated:
+        assert cap.name in out
+
+
+def test_renderer_marks_critical_present_items(tmp_path):
+    (tmp_path / ".env").write_text("X=1", encoding="utf-8")
+    rated = rate_capabilities(enumerate_capabilities([], str(tmp_path)))
+    out = render_risk_map(rated)
+    # The present .env capability is rendered with a CRITICAL marker.
+    assert "CRITICAL" in out
+    assert "dotenv_visible" in out
+
+
+def test_cli_scan_runs_and_reports(tmp_path):
+    (tmp_path / ".env").write_text(f"KEY={FAKE_SECRET}\n", encoding="utf-8")
+    result = runner.invoke(app, ["scan", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "risk map" in result.output.lower()
+    assert "dotenv_visible" in result.output
+    # The CLI must never echo a secret value.
+    assert FAKE_SECRET not in result.output
+
+
+def test_cli_version(tmp_path):
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert __version__ in result.output
+
+
+def test_cli_no_args_shows_help():
+    result = runner.invoke(app, [])
+    # no_args_is_help → exits non-zero with usage, listing the scan command.
+    assert "scan" in result.output.lower()


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: F5 — Capability Discovery & Local Risk Map (slices 5.1–5.2)
- Plan reference: doberman_core_plan.md

> **Stacked PR:** based on `feat/f4-role-policy` (#9) → #8 → #7.

## What this PR does
A read-only onboarding scan of "how much power does my agent have", rendered as a local risk map.

- **5.1 — Capability enumeration:** `enumerate_capabilities(tools, repo_root)` infers capabilities from the downstream tool list (shell, fs read/write/delete, network, git, git-push, package-install, env access) and a read-only repo scan of the sensitive surface (`.env*`, `secrets/`, key material, `infra/`, CI workflows, migrations). Detection is **by name/existence only — secret contents are never read**; nothing is written; the scan is depth- and count-bounded and skips heavy dirs + permission errors.
- **5.2 — Risk rating + `doberman scan`:** `rate_capabilities` assigns risk (`.env`/key material → critical; shell/fs-write/delete/network/git-push/package-install → high; default medium, never silently low). `render_risk_map` renders names + risk + path-class evidence only (never secrets). Adds the `doberman` CLI (Typer) with `scan` and `version`.

## Tests added (run in CI)
- `tests/unit/test_discovery_scan.py` — tool detection, `.env`/`secrets/`/key detection by name, depth bound, missing path, and **secret contents never appear** in evidence.
- `tests/unit/test_risk_map.py` — rating mapping, renderer includes every capability + marks critical, and the CLI runs read-only and never prints a secret.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list (local read-only scan; no hosted/fleet inventory)
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Read-only: never opens secret-file contents (detect by name/existence); never writes
- [x] No secret/contents in the risk map or evidence (synthetic-secret-never-appears tests included)
- [x] Bounded scan (depth + entry cap); permission errors skipped, never raised
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- **Edge cases:** empty tool list; missing path; deeply-nested file beyond the depth bound; heavy dirs skipped.
- **Deviations:** the CLI `doberman scan` runs with an empty tool list for now (tool capabilities need a live proxy session); it reports the repo sensitive surface and notes this.
- **Risks/debt:** capability inference is heuristic (substring tool-name matching, name-based surface detection) — noted in the report header.
