### PR TITLE
feat(policy): policy checklist & security strength modes (Feature 6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,8 @@ dist/
 build/
 *.egg-info/
 
-# Operating manual + implementation plans: local-only, never published
-CLAUDE.md
-AGENTS.md
+# Development plans: local-only, never published.
+# (The operating manual — CLAUDE.md / AGENTS.md — is published; these detailed plans are not.)
 doberman_core_plan.md
 doberman_enterprise_plan.md
 doberman_implementation_plan.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,374 @@
+# CLAUDE.md — Doberman Operating Manual
+
+> This is the init file for this repository. It governs any AI agent (Claude Code, Codex, Cursor, etc.) working here.
+> It is the **HOW**. The **WHAT** — the feature roadmap and per-slice detail — lives in `README.md` (public summary)
+> and, if present in your working tree, the project development plan you keep alongside it.
+> Content is identical to `AGENTS.md`; keep the two in sync (or symlink one to the other).
+> If this file conflicts with a casual prompt instruction, **this file wins** unless a human overrides it in writing.
+
+---
+
+## 0. On startup (every session)
+
+1. Read this entire file, then skim `README.md` for the current feature set, versioning, and roadmap. If you keep a
+   local development plan alongside the repo, read the relevant slice there for the extra detail (objective, files,
+   edge cases, suggested tests, suggested commit message).
+2. `git status` + `git log --oneline -5`.
+3. Pick the **next slice** (the lowest-numbered unmerged slice in the planned order).
+4. If the repo lacks scaffolding (`pyproject.toml` / `.github/workflows/ci.yml`), do **Slice 0 (Bootstrap)** first (§6).
+5. Execute exactly **one slice** via **The Slice Loop** (§5), then **STOP** and report. Stop at every review checkpoint.
+
+---
+
+## 1. What this repository is
+
+**Doberman** is an adaptive authorization layer for coding agents, released publicly under **Apache-2.0**.
+
+It distributes as the `doberman` package (`src/doberman/`) and is designed to be **genuinely functional on its own** —
+schema, interfaces, the runtime harness, adapters, and the built-in rules all live here. It is **not** crippleware.
+
+Doberman is built to be **extensible**: it declares stable interfaces (`Rule` / `Detector` / `AuthProvider` /
+`AuditSink`) and a runtime registry that discovers implementations via **Python entry points**. Additional packages can
+register their own rules, detectors, auth providers, or audit sinks **without Doberman importing them by name** — the
+core never takes a static dependency on any plugin. With only `doberman` installed, it works (built-in protection);
+install a plugin package and its capabilities light up automatically.
+
+---
+
+## 2. Architecture & extension points
+
+The decision path is deliberately layered so the safety-critical core stays small, open, and auditable:
+
+- **Tool mediation (`doberman.proxy`)** — the chokepoint. Every tool call an agent makes is normalized into a
+  `SecurityObject` and routed through the decision engine. There is no path around it.
+- **Decision engine (`doberman.engine`)** — combines guardrail verdicts into a final **allow / authenticate / block**
+  decision. The execution rule and the raise-only `combine` are the safety invariants — they must stay open and
+  auditable.
+- **Objective guardrail + built-in rules (`doberman.engine.rules`)** — deterministic rules over the action: path
+  canonicalization & confinement, destructive-command detection, external-destination checks, basic secret-pattern and
+  encoded-exfil detection. New rules plug in through the `Rule` interface and the registry.
+- **Roles & boundaries (`doberman.roles`)** — the role schema and per-repo boundary matcher.
+- **Policy (`doberman.policy`)** — the default checklist and the strength modes (Light / Balanced / Strict / Paranoid).
+- **Storage & audit (`doberman.storage`)** — a local, redacted decision log plus the `AuditSink` interface so
+  additional sinks can be registered.
+- **Tiered auth (`doberman.auth`)** — local confirmation, TOTP 2FA, and narrow/temporary role elevation. Auth providers
+  plug in through the `AuthProvider` interface.
+- **Subjective guardrail & baseline (`doberman.engine`)** — the abnormality interface plus a basic local behavioral
+  baseline. Detectors plug in through the `Detector` interface.
+- **Policy-drift & poisoning defense (`doberman.learning` / `doberman.policy`)** — classifies policy changes as
+  strengthen vs weaken, gates weakening behind 2FA, and records changes in an append-only ledger. A core safety
+  invariant: nothing auto-loosens.
+
+**The plugin pattern (how to keep things decoupled):** declare the interface and registry in core; let other packages
+**register** implementations through their own `pyproject.toml` entry points (groups such as `doberman.rules`,
+`doberman.detectors`, `doberman.auth_providers`, `doberman.audit_sinks`). At runtime Doberman runs its built-in
+implementations **plus** whatever is registered. Build the interface + a built-in implementation first; an advanced
+implementation can then ship as a separate plugin package that depends on the now-merged extension point — never the
+other way around.
+
+---
+
+## 3. Prime directives (non-negotiable)
+
+These override everything. If a task would break one, **STOP and ask a human**.
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case → deny / `BLOCK`. The protected agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails/learning may auto-tighten; they may **never** silently loosen. Any weakening goes through the human-approved path (the policy-drift defense).
+3. **Never expose secrets.** Never commit/log/store raw secrets, keys, full private files, unredacted prompts, or `.doberman/` contents. Fingerprints/classifications/metadata only.
+4. **Keep the core decoupled.** The policy core (`doberman.engine`/`roles`/`policy`/`storage`/`learning`) must not import `doberman.proxy`. Enforced by `import-linter`.
+5. **No slice is "done" without tests + green CI.**
+6. **One slice = one PR.** Keep changes scoped to the slice.
+
+If you feel pressure to violate one of these to "make progress," that pressure is the bug. Stop.
+
+---
+
+## 4. Project snapshot
+
+- **What:** Doberman sits between a coding agent and its tools and turns every meaningful action into a risk-based **allow / authenticate / block** decision.
+- **Package:** distributes as `doberman` (`src/doberman/`).
+- **Stack:** Python 3.11+, MCP proxy (`mcp` SDK), local-first **SQLite** (`aiosqlite`), YAML policy in `.doberman/`, Pydantic v2, `pyotp`, a `doberman` CLI (Typer), `pytest`.
+- **Runtime data** (`.doberman/`, the DB, key files) is **never** committed.
+
+---
+
+## 5. The Slice Loop (run for every slice)
+
+**Step 1 — Read the slice.** Read its objective, files, changes, security considerations, edge cases, expected output,
+suggested tests, and suggested commit message (from your local development plan, with `README.md` as the public
+roadmap). Ambiguity or a Prime-Directive conflict → STOP and ask.
+
+**Step 2 — Branch:**
+```
+git checkout main && git pull
+git checkout -b feat/<feature-slug>/<slice-slug>
+```
+
+**Step 3 — Implement** the smallest change that satisfies the Objective, strictly inside the slice's scope. For
+extensible features, implement against the **interface** and register built-ins through the registry — never make the
+policy core reach sideways into the proxy adapter.
+
+**Step 4 — Write this slice's tests (required).** In `tests/unit/` or `tests/integration/`, create
+`test_<slice_topic>.py` covering at minimum: every item in the slice's **"Suggested tests"**, every **edge case**, and
+every behavioral **security consideration** (e.g. *"a `BLOCK` means the fake downstream server recorded nothing"*,
+*"a synthetic secret never appears in any log/output"*, *"`combine` never returns a verdict lower than either input"*).
+Prefer TDD; tests must be deterministic (no real network/clock/secrets — inject/fixture them).
+
+**Step 5 — Make sure GitHub Actions runs these tests.** Tests live under `tests/` so CI's `pytest` discovers them
+(`pytest --collect-only` to confirm). New dependency → add to `pyproject.toml`. New import boundary → update the
+`import-linter` contract. New CI step → update `.github/workflows/ci.yml` (minimal, same PR).
+
+**Step 6 — Green locally:**
+```
+ruff check . && ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing
+```
+Everything passes; do **not** weaken a test or invariant to get green.
+
+**Step 7 — Update docs and the README (required every slice).** With **every commit/slice** keep these in sync as part
+of the same change — never as an afterthought:
+- **`README.md`**: update the feature summary, versioning/changelog, quickstart, and roadmap so they reflect what now
+  exists. A slice that adds/changes public behavior **must** move the README.
+- Other docs (CLI/config/usage) as usual when behavior changed.
+
+**Step 8 — Commit** (Conventional Commits; tests ship **in the same PR** as the code, ideally same commit). Use the
+plan's "Suggested commit message." Never stage `.doberman/`, `*.db`, key files, `.env*` (they're gitignored — verify
+with `git status`).
+
+**Step 9 — Push the branch** (`git push -u origin <branch>`) — tests go with it, so CI runs them.
+
+**Step 10 — Open a PR to `main`**; fill the PR template. Confirm CI turns **green**. Red CI → fix on the branch and
+push again; never merge red.
+
+**Step 11 — Post the Slice Completion Report (§10) and STOP.** Don't start the next slice until approved/merged or told to continue.
+
+**Step 12 — If this was the last slice of a feature**, after merge post the Feature Review Checkpoint (§10) and STOP. Review checkpoints are mandatory pauses.
+
+---
+
+## 6. Slice 0 — Bootstrap (only if scaffolding is missing)
+
+Scaffold the repo + working CI + a trivial smoke test, committed on `chore/bootstrap-scaffolding` with
+`chore(repo): bootstrap project scaffolding and CI`.
+
+### `pyproject.toml`
+```toml
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.importlinter]
+root_package = "doberman"
+
+# Decoupling: the policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+```
+
+### `.github/workflows/ci.yml`
+```yaml
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+```
+> `--cov-fail-under=80` is a starting bar — raise it over time, never lower it to pass a PR.
+
+### `.gitignore`
+```gitignore
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+```
+
+### `.github/pull_request_template.md`
+```markdown
+## Slice
+- Feature / Slice: <id> — <title>
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-
+```
+
+> The authoritative scaffolding is the actual `pyproject.toml`, `.github/workflows/ci.yml`, and
+> `.github/pull_request_template.md` in the repo — the blocks above are the starting shape.
+
+---
+
+## 7. Architecture enforcement (summary)
+
+The decoupling is guaranteed in CI:
+1. **`import-linter` forbidden contract**: the policy core must not import `doberman.proxy`.
+2. **Plugin inversion**: extensible features connect through core-defined interfaces + entry-point discovery, so the
+   core holds no static reference to any plugin package.
+
+---
+
+## 8. Version control hygiene
+
+- **One slice = one branch = one PR.**
+- Branches: `feat/<feature-slug>/<slice-slug>` (or `fix/...`, `chore/...`).
+- Conventional Commits; small, building commits; **tests travel with code**.
+- **Never commit** secrets, keys, `.doberman/`, `*.db`, `.env*`. If you do by accident → STOP, tell a human, treat the value as leaked (rotate it).
+- Rebase (don't merge) to update a branch: `git fetch && git rebase origin/main`.
+
+---
+
+## 9. Security & explainability rules (every slice)
+
+- **Default deny:** wrap risky ops so exceptions yield `BLOCK` (or `AUTH` only where the plan says "fail upward").
+- **Redaction mandatory:** strip raw secrets/large payloads before logging/persisting; keep path **classes**, reason codes, verdicts, **HMAC fingerprints**. Test that a synthetic secret never appears.
+- **Keyed fingerprints:** HMAC-SHA256 with a local `0600`/keyring key (never committed) — plain hashes of low-entropy secrets are brute-forceable.
+- **Explainability first:** every `BLOCK`/`AUTH` carries `reason_codes` **and** a one-line human `explanation`. Reason codes are shared constants in `models.py`.
+- **Auth is action-bound:** approvals single-use + tied to one action id; elevations narrow + time-limited + (destructive) single-use; elevation never relaxes a hard block.
+- **Canonicalize before matching** paths (resolve `.`/`..`/symlinks, confine to repo root) via one shared helper.
+- **Logging never alters/blocks a decision** and never crashes the execution path.
+- **Don't oversell:** never claim secret detection (or any single rule) is airtight — it is defense-in-depth.
+
+---
+
+## 10. Reporting formats
+
+### Slice Completion Report (after every slice, then STOP)
+```
+SLICE COMPLETE — <feature> / <slice id> (<title>)
+Branch: <branch>    PR: #<n>    CI: <green | red+why>
+What I built: <2–3 lines>
+Tests added (run in CI): <files> — <what they cover>
+Security checks verified: <redaction / fail-closed / raise-only / etc.>
+Edge cases covered: <list>
+Decisions / assumptions: <or "none">
+Deviations from the plan: <none | what & why>
+Risks / tech debt introduced: <or "none">
+Next slice: <id — title>  (awaiting go-ahead)
+```
+
+### Feature Review Checkpoint (after the last slice of a feature, then STOP)
+```
+REVIEW CHECKPOINT — <Feature N: name>
+Built: ...
+Needs human testing: ...
+Decisions to review: ...
+Risks / shortcuts / tech debt: ...
+>> Paused. I will not start the next feature until told to proceed.
+```
+
+---
+
+## 11. Never do this
+
+- ❌ Do work outside the current slice's scope.
+- ❌ Skip a review checkpoint or start the next feature without a go-ahead.
+- ❌ Mark a slice "done" with missing/failing tests or red CI.
+- ❌ Weaken/stub a test or invariant to make CI pass.
+- ❌ Auto-loosen Doberman (all loosening goes through the human-approved policy-drift path).
+- ❌ Commit or log a secret, key, full private file, unredacted prompt, or `.doberman/` content.
+- ❌ Let `doberman.proxy` be imported by the policy core.
+- ❌ Add any path by which a protected agent could reach a real tool without going through the decision engine.
+- ❌ Invent requirements. Unclear plan or wrong-looking slice → STOP and ask.
+
+---
+
+## 12. Quick reference
+
+| You want to… | Do this |
+|---|---|
+| Know **what** to build | the development plan (slice detail) + `README.md` (public roadmap) |
+| Know **how** to build it | this file |
+| Start a slice | branch `feat/<feature>/<slice>` → follow §5 |
+| Finish a slice | tests added + pushed, CI green, decoupling check passes, **README updated** (§5 Step 7), Slice Completion Report, STOP |
+| Run checks | `ruff check . && ruff format --check . && lint-imports && pytest --cov=doberman` |
+| Hit ambiguity | STOP and ask |
+
+**Remember:** small safe commits · tests with every slice · CI green before "done" · the policy core stays decoupled from the proxy · when in doubt, **fail closed and ask.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,374 @@
+# CLAUDE.md — Doberman Operating Manual
+
+> This is the init file for this repository. It governs any AI agent (Claude Code, Codex, Cursor, etc.) working here.
+> It is the **HOW**. The **WHAT** — the feature roadmap and per-slice detail — lives in `README.md` (public summary)
+> and, if present in your working tree, the project development plan you keep alongside it.
+> Content is identical to `AGENTS.md`; keep the two in sync (or symlink one to the other).
+> If this file conflicts with a casual prompt instruction, **this file wins** unless a human overrides it in writing.
+
+---
+
+## 0. On startup (every session)
+
+1. Read this entire file, then skim `README.md` for the current feature set, versioning, and roadmap. If you keep a
+   local development plan alongside the repo, read the relevant slice there for the extra detail (objective, files,
+   edge cases, suggested tests, suggested commit message).
+2. `git status` + `git log --oneline -5`.
+3. Pick the **next slice** (the lowest-numbered unmerged slice in the planned order).
+4. If the repo lacks scaffolding (`pyproject.toml` / `.github/workflows/ci.yml`), do **Slice 0 (Bootstrap)** first (§6).
+5. Execute exactly **one slice** via **The Slice Loop** (§5), then **STOP** and report. Stop at every review checkpoint.
+
+---
+
+## 1. What this repository is
+
+**Doberman** is an adaptive authorization layer for coding agents, released publicly under **Apache-2.0**.
+
+It distributes as the `doberman` package (`src/doberman/`) and is designed to be **genuinely functional on its own** —
+schema, interfaces, the runtime harness, adapters, and the built-in rules all live here. It is **not** crippleware.
+
+Doberman is built to be **extensible**: it declares stable interfaces (`Rule` / `Detector` / `AuthProvider` /
+`AuditSink`) and a runtime registry that discovers implementations via **Python entry points**. Additional packages can
+register their own rules, detectors, auth providers, or audit sinks **without Doberman importing them by name** — the
+core never takes a static dependency on any plugin. With only `doberman` installed, it works (built-in protection);
+install a plugin package and its capabilities light up automatically.
+
+---
+
+## 2. Architecture & extension points
+
+The decision path is deliberately layered so the safety-critical core stays small, open, and auditable:
+
+- **Tool mediation (`doberman.proxy`)** — the chokepoint. Every tool call an agent makes is normalized into a
+  `SecurityObject` and routed through the decision engine. There is no path around it.
+- **Decision engine (`doberman.engine`)** — combines guardrail verdicts into a final **allow / authenticate / block**
+  decision. The execution rule and the raise-only `combine` are the safety invariants — they must stay open and
+  auditable.
+- **Objective guardrail + built-in rules (`doberman.engine.rules`)** — deterministic rules over the action: path
+  canonicalization & confinement, destructive-command detection, external-destination checks, basic secret-pattern and
+  encoded-exfil detection. New rules plug in through the `Rule` interface and the registry.
+- **Roles & boundaries (`doberman.roles`)** — the role schema and per-repo boundary matcher.
+- **Policy (`doberman.policy`)** — the default checklist and the strength modes (Light / Balanced / Strict / Paranoid).
+- **Storage & audit (`doberman.storage`)** — a local, redacted decision log plus the `AuditSink` interface so
+  additional sinks can be registered.
+- **Tiered auth (`doberman.auth`)** — local confirmation, TOTP 2FA, and narrow/temporary role elevation. Auth providers
+  plug in through the `AuthProvider` interface.
+- **Subjective guardrail & baseline (`doberman.engine`)** — the abnormality interface plus a basic local behavioral
+  baseline. Detectors plug in through the `Detector` interface.
+- **Policy-drift & poisoning defense (`doberman.learning` / `doberman.policy`)** — classifies policy changes as
+  strengthen vs weaken, gates weakening behind 2FA, and records changes in an append-only ledger. A core safety
+  invariant: nothing auto-loosens.
+
+**The plugin pattern (how to keep things decoupled):** declare the interface and registry in core; let other packages
+**register** implementations through their own `pyproject.toml` entry points (groups such as `doberman.rules`,
+`doberman.detectors`, `doberman.auth_providers`, `doberman.audit_sinks`). At runtime Doberman runs its built-in
+implementations **plus** whatever is registered. Build the interface + a built-in implementation first; an advanced
+implementation can then ship as a separate plugin package that depends on the now-merged extension point — never the
+other way around.
+
+---
+
+## 3. Prime directives (non-negotiable)
+
+These override everything. If a task would break one, **STOP and ask a human**.
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case → deny / `BLOCK`. The protected agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails/learning may auto-tighten; they may **never** silently loosen. Any weakening goes through the human-approved path (the policy-drift defense).
+3. **Never expose secrets.** Never commit/log/store raw secrets, keys, full private files, unredacted prompts, or `.doberman/` contents. Fingerprints/classifications/metadata only.
+4. **Keep the core decoupled.** The policy core (`doberman.engine`/`roles`/`policy`/`storage`/`learning`) must not import `doberman.proxy`. Enforced by `import-linter`.
+5. **No slice is "done" without tests + green CI.**
+6. **One slice = one PR.** Keep changes scoped to the slice.
+
+If you feel pressure to violate one of these to "make progress," that pressure is the bug. Stop.
+
+---
+
+## 4. Project snapshot
+
+- **What:** Doberman sits between a coding agent and its tools and turns every meaningful action into a risk-based **allow / authenticate / block** decision.
+- **Package:** distributes as `doberman` (`src/doberman/`).
+- **Stack:** Python 3.11+, MCP proxy (`mcp` SDK), local-first **SQLite** (`aiosqlite`), YAML policy in `.doberman/`, Pydantic v2, `pyotp`, a `doberman` CLI (Typer), `pytest`.
+- **Runtime data** (`.doberman/`, the DB, key files) is **never** committed.
+
+---
+
+## 5. The Slice Loop (run for every slice)
+
+**Step 1 — Read the slice.** Read its objective, files, changes, security considerations, edge cases, expected output,
+suggested tests, and suggested commit message (from your local development plan, with `README.md` as the public
+roadmap). Ambiguity or a Prime-Directive conflict → STOP and ask.
+
+**Step 2 — Branch:**
+```
+git checkout main && git pull
+git checkout -b feat/<feature-slug>/<slice-slug>
+```
+
+**Step 3 — Implement** the smallest change that satisfies the Objective, strictly inside the slice's scope. For
+extensible features, implement against the **interface** and register built-ins through the registry — never make the
+policy core reach sideways into the proxy adapter.
+
+**Step 4 — Write this slice's tests (required).** In `tests/unit/` or `tests/integration/`, create
+`test_<slice_topic>.py` covering at minimum: every item in the slice's **"Suggested tests"**, every **edge case**, and
+every behavioral **security consideration** (e.g. *"a `BLOCK` means the fake downstream server recorded nothing"*,
+*"a synthetic secret never appears in any log/output"*, *"`combine` never returns a verdict lower than either input"*).
+Prefer TDD; tests must be deterministic (no real network/clock/secrets — inject/fixture them).
+
+**Step 5 — Make sure GitHub Actions runs these tests.** Tests live under `tests/` so CI's `pytest` discovers them
+(`pytest --collect-only` to confirm). New dependency → add to `pyproject.toml`. New import boundary → update the
+`import-linter` contract. New CI step → update `.github/workflows/ci.yml` (minimal, same PR).
+
+**Step 6 — Green locally:**
+```
+ruff check . && ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing
+```
+Everything passes; do **not** weaken a test or invariant to get green.
+
+**Step 7 — Update docs and the README (required every slice).** With **every commit/slice** keep these in sync as part
+of the same change — never as an afterthought:
+- **`README.md`**: update the feature summary, versioning/changelog, quickstart, and roadmap so they reflect what now
+  exists. A slice that adds/changes public behavior **must** move the README.
+- Other docs (CLI/config/usage) as usual when behavior changed.
+
+**Step 8 — Commit** (Conventional Commits; tests ship **in the same PR** as the code, ideally same commit). Use the
+plan's "Suggested commit message." Never stage `.doberman/`, `*.db`, key files, `.env*` (they're gitignored — verify
+with `git status`).
+
+**Step 9 — Push the branch** (`git push -u origin <branch>`) — tests go with it, so CI runs them.
+
+**Step 10 — Open a PR to `main`**; fill the PR template. Confirm CI turns **green**. Red CI → fix on the branch and
+push again; never merge red.
+
+**Step 11 — Post the Slice Completion Report (§10) and STOP.** Don't start the next slice until approved/merged or told to continue.
+
+**Step 12 — If this was the last slice of a feature**, after merge post the Feature Review Checkpoint (§10) and STOP. Review checkpoints are mandatory pauses.
+
+---
+
+## 6. Slice 0 — Bootstrap (only if scaffolding is missing)
+
+Scaffold the repo + working CI + a trivial smoke test, committed on `chore/bootstrap-scaffolding` with
+`chore(repo): bootstrap project scaffolding and CI`.
+
+### `pyproject.toml`
+```toml
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.importlinter]
+root_package = "doberman"
+
+# Decoupling: the policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+```
+
+### `.github/workflows/ci.yml`
+```yaml
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+```
+> `--cov-fail-under=80` is a starting bar — raise it over time, never lower it to pass a PR.
+
+### `.gitignore`
+```gitignore
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+```
+
+### `.github/pull_request_template.md`
+```markdown
+## Slice
+- Feature / Slice: <id> — <title>
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-
+```
+
+> The authoritative scaffolding is the actual `pyproject.toml`, `.github/workflows/ci.yml`, and
+> `.github/pull_request_template.md` in the repo — the blocks above are the starting shape.
+
+---
+
+## 7. Architecture enforcement (summary)
+
+The decoupling is guaranteed in CI:
+1. **`import-linter` forbidden contract**: the policy core must not import `doberman.proxy`.
+2. **Plugin inversion**: extensible features connect through core-defined interfaces + entry-point discovery, so the
+   core holds no static reference to any plugin package.
+
+---
+
+## 8. Version control hygiene
+
+- **One slice = one branch = one PR.**
+- Branches: `feat/<feature-slug>/<slice-slug>` (or `fix/...`, `chore/...`).
+- Conventional Commits; small, building commits; **tests travel with code**.
+- **Never commit** secrets, keys, `.doberman/`, `*.db`, `.env*`. If you do by accident → STOP, tell a human, treat the value as leaked (rotate it).
+- Rebase (don't merge) to update a branch: `git fetch && git rebase origin/main`.
+
+---
+
+## 9. Security & explainability rules (every slice)
+
+- **Default deny:** wrap risky ops so exceptions yield `BLOCK` (or `AUTH` only where the plan says "fail upward").
+- **Redaction mandatory:** strip raw secrets/large payloads before logging/persisting; keep path **classes**, reason codes, verdicts, **HMAC fingerprints**. Test that a synthetic secret never appears.
+- **Keyed fingerprints:** HMAC-SHA256 with a local `0600`/keyring key (never committed) — plain hashes of low-entropy secrets are brute-forceable.
+- **Explainability first:** every `BLOCK`/`AUTH` carries `reason_codes` **and** a one-line human `explanation`. Reason codes are shared constants in `models.py`.
+- **Auth is action-bound:** approvals single-use + tied to one action id; elevations narrow + time-limited + (destructive) single-use; elevation never relaxes a hard block.
+- **Canonicalize before matching** paths (resolve `.`/`..`/symlinks, confine to repo root) via one shared helper.
+- **Logging never alters/blocks a decision** and never crashes the execution path.
+- **Don't oversell:** never claim secret detection (or any single rule) is airtight — it is defense-in-depth.
+
+---
+
+## 10. Reporting formats
+
+### Slice Completion Report (after every slice, then STOP)
+```
+SLICE COMPLETE — <feature> / <slice id> (<title>)
+Branch: <branch>    PR: #<n>    CI: <green | red+why>
+What I built: <2–3 lines>
+Tests added (run in CI): <files> — <what they cover>
+Security checks verified: <redaction / fail-closed / raise-only / etc.>
+Edge cases covered: <list>
+Decisions / assumptions: <or "none">
+Deviations from the plan: <none | what & why>
+Risks / tech debt introduced: <or "none">
+Next slice: <id — title>  (awaiting go-ahead)
+```
+
+### Feature Review Checkpoint (after the last slice of a feature, then STOP)
+```
+REVIEW CHECKPOINT — <Feature N: name>
+Built: ...
+Needs human testing: ...
+Decisions to review: ...
+Risks / shortcuts / tech debt: ...
+>> Paused. I will not start the next feature until told to proceed.
+```
+
+---
+
+## 11. Never do this
+
+- ❌ Do work outside the current slice's scope.
+- ❌ Skip a review checkpoint or start the next feature without a go-ahead.
+- ❌ Mark a slice "done" with missing/failing tests or red CI.
+- ❌ Weaken/stub a test or invariant to make CI pass.
+- ❌ Auto-loosen Doberman (all loosening goes through the human-approved policy-drift path).
+- ❌ Commit or log a secret, key, full private file, unredacted prompt, or `.doberman/` content.
+- ❌ Let `doberman.proxy` be imported by the policy core.
+- ❌ Add any path by which a protected agent could reach a real tool without going through the decision engine.
+- ❌ Invent requirements. Unclear plan or wrong-looking slice → STOP and ask.
+
+---
+
+## 12. Quick reference
+
+| You want to… | Do this |
+|---|---|
+| Know **what** to build | the development plan (slice detail) + `README.md` (public roadmap) |
+| Know **how** to build it | this file |
+| Start a slice | branch `feat/<feature>/<slice>` → follow §5 |
+| Finish a slice | tests added + pushed, CI green, decoupling check passes, **README updated** (§5 Step 7), Slice Completion Report, STOP |
+| Run checks | `ruff check . && ruff format --check . && lint-imports && pytest --cov=doberman` |
+| Hit ambiguity | STOP and ask |
+
+**Remember:** small safe commits · tests with every slice · CI green before "done" · the policy core stays decoupled from the proxy · when in doubt, **fail closed and ask.**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Doberman is a security layer for AI coding agents. It sits **on the tool-execution path** — the agent talks to Doberman, and Doberman talks to the real tools (filesystem, shell, git, network, package managers) over the [Model Context Protocol](https://modelcontextprotocol.io). Every meaningful action is intercepted, normalized into a redacted, structured **security object**, and run through a risk-based decision engine that returns one of three verdicts — **allow**, **authenticate**, or **block** — before the action is ever forwarded. The guiding principle is simple: *if Doberman isn't on the execution path, it's advisory, not protective.* Doberman is built to **fail closed** (any error or uncertainty denies the action) and to be **raise-only** (guardrails may automatically tighten, never silently loosen), so an agent can never reach a tool around it and a buggy rule can never make the system less safe.
 
 > ### Project status
-> **Alpha — pre-1.0, API unstable.** The interception layer (Feature 1), the decision engine (Feature 2), the **objective guardrail** (Feature 3 — basic rules + the plugin seam), **agent role policy** (Feature 4 — role boundaries + the policy-source seam), and **capability discovery** (Feature 5 — `doberman scan`) are implemented: Doberman now actively blocks the headline disasters (secret exfiltration, protected-path writes, catastrophic commands), steps up authentication on sensitive or unknown actions, escalates actions that cross the agent's role boundary, and can report the agent's blast radius. The subjective guardrail and the remaining surfaces around the engine (strength modes, real authentication, audit log) arrive in upcoming versions (see the [Roadmap](#roadmap)). This is the open-source **core**; advanced/hosted capabilities live in a separate commercial edition.
+> **Alpha — pre-1.0, API unstable.** The interception layer (Feature 1), the decision engine (Feature 2), the **objective guardrail** (Feature 3 — basic rules + the plugin seam), **agent role policy** (Feature 4 — role boundaries + the policy-source seam), **capability discovery** (Feature 5 — `doberman scan`), and **policy checklist + strength modes** (Feature 6) are implemented: Doberman now actively blocks the headline disasters (secret exfiltration, protected-path writes, catastrophic commands), steps up authentication on sensitive or unknown actions, escalates actions that cross the agent's role boundary, reports the agent's blast radius, and offers one Light/Balanced/Strict/Paranoid dial over good defaults. The subjective guardrail and the remaining surfaces around the engine (real authentication, audit log) arrive in upcoming versions (see the [Roadmap](#roadmap)). This is the open-source **core**; advanced/hosted capabilities live in a separate commercial edition.
 
 ---
 
@@ -160,6 +160,14 @@ A read-only onboarding scan that answers "how much power does my agent actually 
 - **Risk rating + map** — each capability is rated (`.env`/key material → critical; shell, fs-write/delete, network, git-push, package-install → high), and `doberman scan` renders a readable risk map (capability names, risk, path-class evidence — never secrets). The scan is depth- and count-bounded so a huge or hostile repo cannot make it run unbounded.
 - **`doberman` CLI** — the first command-line surface (`doberman scan`, `doberman version`), built with Typer.
 
+### Feature 6 — Policy Checklist & Security Strength Modes · `v0.6.0` _(in review)_
+
+Good defaults as the product: a pre-checked policy generated from role + discovery, and one strength dial instead of dozens of toggles.
+
+- **Recommended checklist** — `recommend_policy(role, capabilities)` produces an editable `PolicyDoc` (persisted to `.doberman/policies.yaml`): core hard-blocks (always present, enabled, **non-disableable here**), plus step-ups tailored to the role and discovered capabilities (an item whose capability is absent is kept and marked N/A). `doberman review [--yes]` views/saves it; disabling a core hard-block is refused (that requires the Feature 10 flow).
+- **Strength modes** — `doberman mode <light|balanced|strict|paranoid>` (default **Balanced**) tunes step-up thresholds: stricter modes step up to AUTH sooner (e.g. the bulk-delete threshold drops from 100 → 25 → 10 → 3). Modes **only move step-ups** — the hard-block **floor is identical across every mode**, and even Light keeps all core BLOCKs. An unknown mode is rejected; a corrupt stored mode fails to the strictest.
+- **`doberman status`** — shows the active role, mode, and policy summary.
+
 ---
 
 ## Design invariants
@@ -188,6 +196,12 @@ The version line maps to the development roadmap:
 ## Changelog
 
 This project keeps a changelog in the spirit of [Keep a Changelog](https://keepachangelog.com/).
+
+### `v0.6.0` — Policy Checklist & Security Strength Modes — _Unreleased (in review)_
+
+- **Slice 6.1** — recommended policy checklist (`recommend_policy`; core hard-blocks always present, step-ups tailored to role/capabilities).
+- **Slice 6.2** — `doberman review` to view/persist `.doberman/policies.yaml` (core blocks non-disableable; atomic save).
+- **Slice 6.3** — Light/Balanced/Strict/Paranoid modes (`doberman mode`/`status`); thresholds tune step-ups only, the hard-block floor is mode-independent.
 
 ### `v0.5.0` — Capability Discovery & Local Risk Map — _Unreleased (in review)_
 
@@ -238,7 +252,6 @@ Upcoming versions add the guardrail *content* and the surfaces around the engine
 
 | Version | Theme |
 |---------|-------|
-| `v0.6.0` | **Policy checklist & strength modes** — Light / Balanced / Strict / Paranoid. |
 | `v0.7.0` | **Tiered authentication** — local confirmation, TOTP 2FA, narrow/temporary elevation. |
 | `v0.8.0` | **Decision log & audit** — local redacted decision log + storage interface. |
 | `v0.9.0` | **Subjective guardrail** — abnormality interface + a basic local baseline. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doberman"
-version = "0.5.0"
+version = "0.6.0"
 description = "Adaptive authorization layer for coding agents (open core)"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"

--- a/src/doberman/__init__.py
+++ b/src/doberman/__init__.py
@@ -1,3 +1,3 @@
 """Doberman — adaptive authorization layer for coding agents (open core)."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -8,7 +8,10 @@ features.
 import typer
 
 from doberman import __version__
+from doberman.config import load_active_role, load_mode, load_policy, save_mode, save_policy
 from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, render_risk_map
+from doberman.policy.checklist import recommend_policy
+from doberman.policy.modes import SecurityMode
 
 app = typer.Typer(
     help="Doberman — adaptive authorization layer for coding agents.",
@@ -28,6 +31,77 @@ def scan(
     """
     capabilities = rate_capabilities(enumerate_capabilities(tools=[], repo_root=path))
     typer.echo(render_risk_map(capabilities))
+
+
+@app.command()
+def review(
+    path: str = typer.Option(".", "--path", "-p", help="Repository root."),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Accept the recommended policy and save it."
+    ),
+) -> None:
+    """Review (and with --yes, save) the recommended policy checklist.
+
+    Core hard blocks are shown but are not disableable here (that requires the
+    policy-change approval flow). Without --yes this is read-only.
+    """
+    role = load_active_role(path)
+    capabilities = rate_capabilities(enumerate_capabilities(tools=[], repo_root=path))
+    doc = load_policy(path) or recommend_policy(role, capabilities)
+
+    typer.echo("Doberman policy checklist")
+    typer.echo("=" * 32)
+    for item in doc.items:
+        box = "[x]" if item.enabled else "[ ]"
+        tags = []
+        if item.core:
+            tags.append("core/non-disableable")
+        if not item.applicable:
+            tags.append("N/A — capability absent")
+        suffix = f"  ({', '.join(tags)})" if tags else ""
+        typer.echo(f"{box} {item.verdict.value:<5} {item.id}{suffix}")
+    typer.echo(f"\nMode: {doc.mode}")
+
+    if yes:
+        save_policy(doc, path)
+        typer.echo(f"\nSaved policy to {path}/.doberman/policies.yaml")
+    else:
+        typer.echo("\n(read-only; re-run with --yes to save)")
+
+
+@app.command()
+def mode(
+    name: str = typer.Argument(None, help="Mode to set (light/balanced/strict/paranoid)."),
+    path: str = typer.Option(".", "--path", "-p", help="Repository root."),
+) -> None:
+    """Show or set the security strength mode."""
+    if name is None:
+        typer.echo(load_mode(path))
+        return
+    try:
+        saved = save_mode(name, path)
+    except ValueError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+    typer.echo(f"mode set to {saved}")
+
+
+@app.command()
+def status(
+    path: str = typer.Option(".", "--path", "-p", help="Repository root."),
+) -> None:
+    """Show the active role, security mode, and policy summary."""
+    role = load_active_role(path)
+    doc = load_policy(path)
+    typer.echo("Doberman status")
+    typer.echo("=" * 32)
+    typer.echo(f"Role:   {role.name if role else '(none — role enforcement off)'}")
+    typer.echo(f"Mode:   {load_mode(path)}  (of: {', '.join(m.value for m in SecurityMode)})")
+    if doc is None:
+        typer.echo("Policy: (none saved — run `doberman review --yes`)")
+    else:
+        enabled = sum(1 for it in doc.items if it.enabled)
+        typer.echo(f"Policy: {enabled}/{len(doc.items)} items enabled")
 
 
 @app.command()

--- a/src/doberman/config.py
+++ b/src/doberman/config.py
@@ -25,6 +25,8 @@ from pathlib import Path
 
 import yaml
 
+from doberman.policy.checklist import PolicyDoc, recommend_policy
+from doberman.policy.modes import DEFAULT_MODE, resolve_mode
 from doberman.roles.roles import (
     MOST_RESTRICTIVE_ROLE,
     RoleDefinition,
@@ -36,10 +38,15 @@ logger = logging.getLogger("doberman.config")
 #: Per-repo config directory (never committed; see .gitignore).
 CONFIG_DIR = ".doberman"
 ROLE_FILE = "role.yaml"
+POLICY_FILE = "policies.yaml"
 
 
 def _role_file_path(repo_root: str) -> Path:
     return Path(repo_root) / CONFIG_DIR / ROLE_FILE
+
+
+def _policy_file_path(repo_root: str) -> Path:
+    return Path(repo_root) / CONFIG_DIR / POLICY_FILE
 
 
 def load_active_role(repo_root: str = ".") -> RoleDefinition | None:
@@ -92,3 +99,68 @@ def load_active_role(repo_root: str = ".") -> RoleDefinition | None:
         logger.warning("unknown role %r; using the most-restrictive role", name)
         return MOST_RESTRICTIVE_ROLE
     return role
+
+
+def load_policy(repo_root: str = ".") -> PolicyDoc | None:
+    """Load the saved policy checklist, or ``None`` if none is saved.
+
+    Never raises: a corrupt/unreadable file logs and returns ``None`` (callers
+    fall back to the recommended defaults), never crashes the decision path.
+    """
+    path = _policy_file_path(repo_root)
+    if not path.exists():
+        return None
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        logger.warning("could not read %s; ignoring saved policy", path)
+        return None
+    if not isinstance(data, dict):
+        logger.warning("%s is not a mapping; ignoring saved policy", path)
+        return None
+    try:
+        return PolicyDoc.from_mapping(data)
+    except (TypeError, ValueError, KeyError):
+        logger.warning("invalid policy in %s; ignoring saved policy", path)
+        return None
+
+
+def save_policy(doc: PolicyDoc, repo_root: str = ".") -> None:
+    """Persist ``doc`` to ``.doberman/policies.yaml`` (creating the dir).
+
+    Writes via a temp file + replace so a failed write never corrupts a prior
+    valid policy file.
+    """
+    path = _policy_file_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = yaml.safe_dump(doc.to_mapping(), sort_keys=False)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
+
+
+def load_mode(repo_root: str = ".") -> str:
+    """Return the active security mode name (default Balanced).
+
+    Reads the mode from the saved policy; an unknown/garbage stored mode falls
+    back to the default rather than failing.
+    """
+    doc = load_policy(repo_root)
+    if doc is None:
+        return DEFAULT_MODE.value
+    try:
+        return resolve_mode(doc.mode).value
+    except ValueError:
+        logger.warning("saved mode %r is unknown; using %s", doc.mode, DEFAULT_MODE.value)
+        return DEFAULT_MODE.value
+
+
+def save_mode(name: str, repo_root: str = ".") -> str:
+    """Validate and persist the security mode; returns the canonical name.
+
+    Raises ``ValueError`` on an unknown mode (the caller surfaces the error).
+    """
+    mode = resolve_mode(name)
+    doc = load_policy(repo_root) or recommend_policy()
+    save_policy(doc.with_mode(mode.value), repo_root)
+    return mode.value

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -42,6 +42,7 @@ from doberman.models import (
     SecurityObject,
     Verdict,
 )
+from doberman.policy.modes import thresholds_for
 
 #: Default bulk-operation threshold: deleting/touching this many paths in one
 #: command steps up to AUTH. Overridable (F6 wires this from policy/mode).
@@ -268,10 +269,12 @@ class DestructiveCommandRule:
     def __init__(
         self,
         protected_branches: Iterable[str] = DEFAULT_PROTECTED_BRANCHES,
-        bulk_threshold: int = DEFAULT_BULK_THRESHOLD,
+        bulk_threshold: int | None = None,
     ) -> None:
         self._protected = tuple(protected_branches)
-        self._bulk_threshold = bulk_threshold
+        # None → derive the bulk threshold from the active security mode (F6);
+        # an explicit value overrides the mode (used by tests).
+        self._bulk_threshold_override = bulk_threshold
 
     def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:
         # Only relevant to shell/git actions. A non-command action abstains.
@@ -282,9 +285,12 @@ class DestructiveCommandRule:
         if not command or not command.strip():
             return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
 
-        return self._classify_line(command)
+        threshold = self._bulk_threshold_override
+        if threshold is None:
+            threshold = thresholds_for(getattr(ctx, "mode", "balanced")).bulk_delete_threshold
+        return self._classify_line(command, threshold)
 
-    def _classify_line(self, command: str) -> GuardrailResult:
+    def _classify_line(self, command: str, bulk_threshold: int) -> GuardrailResult:
         worst: GuardrailResult = GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
         saw_unparseable = False
 
@@ -321,7 +327,7 @@ class DestructiveCommandRule:
                 pending.extend(_payload_segments(tokens))
                 continue
 
-            verdict = _segment_verdict(tokens, self._protected, self._bulk_threshold)
+            verdict = _segment_verdict(tokens, self._protected, bulk_threshold)
             if verdict is not None:
                 worst = _max_result(worst, verdict)
                 if worst.verdict is Verdict.BLOCK:

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -157,6 +157,9 @@ class EvalContext(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     role: RoleDefinition | None = None
+    #: Active security strength mode (F6): "light"/"balanced"/"strict"/"paranoid".
+    #: Tunes step-up thresholds only; the hard-block floor is mode-independent.
+    mode: str = "balanced"
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/src/doberman/policy/checklist.py
+++ b/src/doberman/policy/checklist.py
@@ -1,0 +1,221 @@
+"""Recommended policy checklist (Feature 6, slice 6.1).
+
+Generates a pre-checked policy (hard-blocks + step-ups) from the agent role and
+the discovered capabilities, as an editable :class:`PolicyDoc` that persists to
+``.doberman/policies.yaml``. Good defaults are the product: everything ships
+**enabled** (safe-by-default), and the **core hard blocks are always present and
+not removable here** — disabling one requires the Feature 10 human-approved path.
+
+This module is policy core: it imports only ``doberman`` models/roles and never
+the proxy.
+"""
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+from doberman.models import Verdict
+from doberman.roles.roles import RoleDefinition
+
+CATEGORY_HARD_BLOCK = "hard_block"
+CATEGORY_STEP_UP = "step_up"
+
+
+@dataclass(frozen=True)
+class PolicyItem:
+    """One checklist item (immutable).
+
+    ``core`` items are non-disableable here (a core hard block can only be
+    removed through F10). ``applicable`` is False when the item's capability is
+    not present in this repo (kept in the doc, marked N/A) — never silently
+    dropped.
+    """
+
+    id: str
+    description: str
+    category: str
+    verdict: Verdict
+    enabled: bool = True
+    core: bool = False
+    applicable: bool = True
+
+
+#: Core hard blocks — always present, always enabled, never disableable here.
+_CORE_HARD_BLOCKS: tuple[PolicyItem, ...] = (
+    PolicyItem(
+        "hard_block.secret_exfiltration",
+        "Block sending secret material to an external destination.",
+        CATEGORY_HARD_BLOCK,
+        Verdict.BLOCK,
+        core=True,
+    ),
+    PolicyItem(
+        "hard_block.protected_path",
+        "Block writes/deletes to protected paths (.env, secrets, keys).",
+        CATEGORY_HARD_BLOCK,
+        Verdict.BLOCK,
+        core=True,
+    ),
+    PolicyItem(
+        "hard_block.destructive_command",
+        "Block catastrophic commands (rm -rf /, disk wipes, force-push to protected branches).",
+        CATEGORY_HARD_BLOCK,
+        Verdict.BLOCK,
+        core=True,
+    ),
+    PolicyItem(
+        "hard_block.repo_escape",
+        "Block actions whose target resolves outside the repository boundary.",
+        CATEGORY_HARD_BLOCK,
+        Verdict.BLOCK,
+        core=True,
+    ),
+)
+
+#: Tunable step-ups. ``requires_capability`` (if set) marks the item N/A when the
+#: capability is absent from the discovered surface.
+_STEP_UPS: tuple[tuple[PolicyItem, str | None], ...] = (
+    (
+        PolicyItem(
+            "step_up.sensitive_path",
+            "Require auth for sensitive paths (backend/auth, infra, CI).",
+            CATEGORY_STEP_UP,
+            Verdict.AUTH,
+        ),
+        None,
+    ),
+    (
+        PolicyItem(
+            "step_up.sensitive_secret_access",
+            "Require auth to read/write local secret material.",
+            CATEGORY_STEP_UP,
+            Verdict.AUTH,
+        ),
+        None,
+    ),
+    (
+        PolicyItem(
+            "step_up.unknown_destination",
+            "Require auth for requests to unknown external destinations.",
+            CATEGORY_STEP_UP,
+            Verdict.AUTH,
+        ),
+        "network",
+    ),
+    (
+        PolicyItem(
+            "step_up.bulk_operation",
+            "Require auth for bulk deletes at/over the mode threshold.",
+            CATEGORY_STEP_UP,
+            Verdict.AUTH,
+        ),
+        None,
+    ),
+    (
+        PolicyItem(
+            "step_up.encoded_exfiltration",
+            "Require auth for encoded/indirect exfiltration carriers.",
+            CATEGORY_STEP_UP,
+            Verdict.AUTH,
+        ),
+        None,
+    ),
+)
+
+
+@dataclass(frozen=True)
+class PolicyDoc:
+    """The editable policy document (immutable; edits return new copies)."""
+
+    items: tuple[PolicyItem, ...]
+    mode: str = "balanced"
+
+    def get(self, item_id: str) -> PolicyItem | None:
+        return next((it for it in self.items if it.id == item_id), None)
+
+    def with_item_enabled(self, item_id: str, enabled: bool) -> "PolicyDoc":
+        """Return a copy with one item toggled.
+
+        Refuses to disable a core item — that must go through F10 — by raising
+        ``ValueError`` (never silently allow a hard block to be turned off).
+        """
+        target = self.get(item_id)
+        if target is None:
+            raise KeyError(f"unknown policy item {item_id!r}")
+        if target.core and not enabled:
+            raise ValueError(
+                f"{item_id} is a core hard block and cannot be disabled here "
+                "(requires the policy-change approval flow)"
+            )
+        new_items = tuple(
+            replace(it, enabled=enabled) if it.id == item_id else it for it in self.items
+        )
+        return replace(self, items=new_items)
+
+    def with_mode(self, mode: str) -> "PolicyDoc":
+        return replace(self, mode=mode)
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "items": [
+                {
+                    "id": it.id,
+                    "description": it.description,
+                    "category": it.category,
+                    "verdict": it.verdict.value,
+                    "enabled": it.enabled,
+                    "core": it.core,
+                    "applicable": it.applicable,
+                }
+                for it in self.items
+            ],
+        }
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> "PolicyDoc":
+        items = tuple(
+            PolicyItem(
+                id=str(raw["id"]),
+                description=str(raw.get("description", "")),
+                category=str(raw.get("category", CATEGORY_STEP_UP)),
+                verdict=Verdict(raw.get("verdict", "AUTH")),
+                enabled=bool(raw.get("enabled", True)),
+                core=bool(raw.get("core", False)),
+                applicable=bool(raw.get("applicable", True)),
+            )
+            for raw in data.get("items", [])
+            if isinstance(raw, dict) and raw.get("id")
+        )
+        return cls(items=items, mode=str(data.get("mode", "balanced")))
+
+
+def recommend_policy(
+    role: RoleDefinition | None = None,
+    capabilities: list[Any] | None = None,
+) -> PolicyDoc:
+    """Build the recommended (pre-checked) policy for this repo.
+
+    Core hard blocks are always included and enabled. Step-ups are enabled by
+    default; one whose capability is absent is kept but marked not-applicable.
+    If a role is active, an out-of-scope step-up is added.
+    """
+    present_caps = {
+        getattr(c, "name", None) for c in (capabilities or []) if getattr(c, "present", False)
+    }
+
+    items: list[PolicyItem] = list(_CORE_HARD_BLOCKS)
+    for item, required_cap in _STEP_UPS:
+        applicable = required_cap is None or required_cap in present_caps
+        items.append(replace(item, applicable=applicable))
+
+    if role is not None:
+        items.append(
+            PolicyItem(
+                "step_up.role_out_of_scope",
+                f"Require auth for actions outside the active '{role.name}' role's scope.",
+                CATEGORY_STEP_UP,
+                Verdict.AUTH,
+            )
+        )
+
+    return PolicyDoc(items=tuple(items), mode="balanced")

--- a/src/doberman/policy/modes.py
+++ b/src/doberman/policy/modes.py
@@ -1,0 +1,113 @@
+"""Security strength modes (Feature 6, slice 6.3).
+
+One dial — **Light / Balanced / Strict / Paranoid** (default Balanced) — tunes
+how aggressively Doberman steps up to authentication, instead of dozens of
+toggles. Stricter modes lower step-up thresholds (→ *more* AUTH); they never
+touch the **floor** of core hard blocks, which are identical across every mode.
+
+SECURITY: modes may only tune **step-ups** (AUTH thresholds). They can never
+remove or weaken a core hard **BLOCK** — that floor (:data:`FLOOR_HARD_BLOCKS`)
+is mode-independent, and even Light keeps every one of them. Loosening a hard
+block is not a mode change; it is a policy weakening that must go through the
+Feature 10 human-approved path.
+
+This module is policy core: it imports only ``doberman.models`` and never the
+proxy.
+"""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from doberman.models import ReasonCode
+
+
+class SecurityMode(StrEnum):
+    """The four security strength modes, from most permissive to most strict."""
+
+    light = "light"
+    balanced = "balanced"
+    strict = "strict"
+    paranoid = "paranoid"
+
+
+#: The default mode when none is configured.
+DEFAULT_MODE = SecurityMode.balanced
+
+
+@dataclass(frozen=True)
+class ModeThresholds:
+    """Tunable step-up thresholds for a mode (never affects hard blocks).
+
+    Attributes:
+        bulk_delete_threshold: delete operand count at/above which a delete
+            steps up to AUTH (lower = stricter = more AUTH).
+        escalate_out_of_scope: whether an out-of-scope (role) action steps up.
+        escalate_unknown_destination: whether an unknown network destination
+            steps up on its own.
+        escalate_unusual: whether an unusual/abnormal action (F9) steps up.
+    """
+
+    bulk_delete_threshold: int
+    escalate_out_of_scope: bool = True
+    escalate_unknown_destination: bool = True
+    escalate_unusual: bool = True
+
+
+#: Per-mode thresholds. Stricter modes lower the bulk threshold (more AUTH);
+#: Balanced's 25 matches the historical default so existing behavior is stable.
+MODES: dict[SecurityMode, ModeThresholds] = {
+    SecurityMode.light: ModeThresholds(
+        bulk_delete_threshold=100,
+        escalate_unusual=False,
+    ),
+    SecurityMode.balanced: ModeThresholds(
+        bulk_delete_threshold=25,
+    ),
+    SecurityMode.strict: ModeThresholds(
+        bulk_delete_threshold=10,
+    ),
+    SecurityMode.paranoid: ModeThresholds(
+        bulk_delete_threshold=3,
+    ),
+}
+
+#: The non-negotiable floor: reason codes that are ALWAYS a hard BLOCK, in every
+#: mode. No mode or checklist toggle removes these (that requires F10's flow).
+FLOOR_HARD_BLOCKS: frozenset[ReasonCode] = frozenset(
+    {
+        ReasonCode.secret_exfiltration,
+        ReasonCode.protected_path_blocked,
+        ReasonCode.destructive_command,
+        ReasonCode.role_blocked_target,
+        ReasonCode.policy_source_blocked,
+    }
+)
+
+
+def resolve_mode(name: str | SecurityMode) -> SecurityMode:
+    """Resolve a mode name (case-insensitive) to a :class:`SecurityMode`.
+
+    Raises ``ValueError`` on an unknown mode — an unrecognized strength setting
+    must be rejected, never silently treated as permissive.
+    """
+    if isinstance(name, SecurityMode):
+        return name
+    try:
+        return SecurityMode(str(name).strip().lower())
+    except ValueError as exc:
+        valid = ", ".join(m.value for m in SecurityMode)
+        raise ValueError(f"unknown security mode {name!r}; valid modes: {valid}") from exc
+
+
+def thresholds_for(name: str | SecurityMode) -> ModeThresholds:
+    """Return the :class:`ModeThresholds` for ``name``.
+
+    An unknown/garbage mode falls back to the **strictest** thresholds (fail
+    toward more authentication, never less) rather than raising — callers in the
+    decision path must never crash on a bad stored mode.
+    """
+    try:
+        mode = resolve_mode(name)
+    except ValueError:
+        return MODES[SecurityMode.paranoid]
+    return MODES[mode]

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from mcp.client.session import ClientSession
 from mcp.types import CallToolResult, TextContent
 
-from doberman.config import load_active_role
+from doberman.config import load_active_role, load_mode
 from doberman.engine.decision_engine import PASS_STUB, Guardrail, decide
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.models import (
@@ -127,6 +127,7 @@ async def decide_and_execute(
     # is None when no role is configured, in which case the role rule abstains.
     ctx = EvalContext(
         role=load_active_role("."),
+        mode=load_mode("."),
         metadata={"raw_arguments": dict(arguments or {})},
     )
 

--- a/tests/integration/test_policy_review.py
+++ b/tests/integration/test_policy_review.py
@@ -1,0 +1,68 @@
+"""Slice 6.2 — review + persist policy via the CLI.
+
+Covers: `doberman review --yes` saves a valid policies.yaml; read-only review
+does not write; mode set/get round-trips; an unknown mode is rejected; a core
+hard block is not disableable; status reports role+mode; and a persisted toggle
+survives a reload.
+"""
+
+import pytest
+from typer.testing import CliRunner
+
+from doberman import config
+from doberman.cli.main import app
+from doberman.policy.checklist import recommend_policy
+
+runner = CliRunner()
+
+
+def test_review_yes_saves_policy(tmp_path):
+    result = runner.invoke(app, ["review", "--path", str(tmp_path), "--yes"])
+    assert result.exit_code == 0
+    assert (tmp_path / ".doberman" / "policies.yaml").exists()
+    doc = config.load_policy(str(tmp_path))
+    assert doc is not None
+    assert any(it.core for it in doc.items)
+
+
+def test_review_readonly_does_not_save(tmp_path):
+    result = runner.invoke(app, ["review", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert not (tmp_path / ".doberman" / "policies.yaml").exists()
+
+
+def test_mode_set_then_get_round_trips(tmp_path):
+    assert runner.invoke(app, ["mode", "strict", "--path", str(tmp_path)]).exit_code == 0
+    assert config.load_mode(str(tmp_path)) == "strict"
+    shown = runner.invoke(app, ["mode", "--path", str(tmp_path)])
+    assert "strict" in shown.output
+
+
+def test_unknown_mode_is_rejected(tmp_path):
+    result = runner.invoke(app, ["mode", "turbo", "--path", str(tmp_path)])
+    assert result.exit_code == 2
+    # The bad mode must not have created/changed a policy file.
+    assert config.load_mode(str(tmp_path)) == "balanced"
+
+
+def test_core_block_not_disableable_via_api():
+    doc = recommend_policy()
+    core_id = next(it.id for it in doc.items if it.core)
+    with pytest.raises(ValueError):
+        doc.with_item_enabled(core_id, False)
+
+
+def test_status_reports_role_and_mode(tmp_path):
+    runner.invoke(app, ["mode", "paranoid", "--path", str(tmp_path)])
+    result = runner.invoke(app, ["status", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "paranoid" in result.output
+    assert "Role" in result.output
+
+
+def test_persisted_toggle_survives_reload(tmp_path):
+    doc = recommend_policy().with_item_enabled("step_up.bulk_operation", False)
+    config.save_policy(doc, str(tmp_path))
+    reloaded = config.load_policy(str(tmp_path))
+    assert reloaded is not None
+    assert reloaded.get("step_up.bulk_operation").enabled is False

--- a/tests/unit/test_checklist.py
+++ b/tests/unit/test_checklist.py
@@ -1,0 +1,71 @@
+"""Slice 6.1 — recommended policy checklist.
+
+Covers: core hard-blocks always present + enabled + non-disableable; step-ups
+enabled by default; role tailoring; capability tailoring (N/A when absent);
+immutable toggles; and round-trip serialization.
+"""
+
+import pytest
+
+from doberman.discovery.scan import Capability
+from doberman.models import Verdict
+from doberman.policy.checklist import CATEGORY_HARD_BLOCK, PolicyDoc, recommend_policy
+from doberman.roles.roles import load_builtin_roles
+
+
+def test_core_hard_blocks_present_enabled_and_blocking():
+    doc = recommend_policy()
+    core = [it for it in doc.items if it.core]
+    assert len(core) >= 4
+    for it in core:
+        assert it.enabled
+        assert it.verdict is Verdict.BLOCK
+        assert it.category == CATEGORY_HARD_BLOCK
+
+
+def test_step_ups_enabled_by_default():
+    doc = recommend_policy()
+    step_ups = [it for it in doc.items if not it.core]
+    assert step_ups
+    assert all(it.enabled for it in step_ups)
+
+
+def test_role_tailoring_adds_out_of_scope_item():
+    fe = load_builtin_roles()["frontend"]
+    assert recommend_policy(role=fe).get("step_up.role_out_of_scope") is not None
+    assert recommend_policy(role=None).get("step_up.role_out_of_scope") is None
+
+
+def test_capability_tailoring_marks_network_item_na_when_absent():
+    no_net = recommend_policy(capabilities=[])
+    item = no_net.get("step_up.unknown_destination")
+    assert item is not None
+    assert not item.applicable
+
+    with_net = recommend_policy(
+        capabilities=[Capability(name="network", category="tool", present=True)]
+    )
+    assert with_net.get("step_up.unknown_destination").applicable
+
+
+def test_core_item_cannot_be_disabled_here():
+    doc = recommend_policy()
+    core_id = next(it.id for it in doc.items if it.core)
+    with pytest.raises(ValueError):
+        doc.with_item_enabled(core_id, False)
+
+
+def test_step_up_toggle_is_immutable():
+    doc = recommend_policy()
+    sid = "step_up.bulk_operation"
+    toggled = doc.with_item_enabled(sid, False)
+    assert toggled.get(sid).enabled is False
+    assert doc.get(sid).enabled is True  # original unchanged
+
+
+def test_roundtrip_serialization_preserves_items_and_core_flag():
+    doc = recommend_policy(role=load_builtin_roles()["backend"])
+    restored = PolicyDoc.from_mapping(doc.to_mapping())
+    assert restored.mode == doc.mode
+    assert [it.id for it in restored.items] == [it.id for it in doc.items]
+    assert restored.get("hard_block.protected_path").core

--- a/tests/unit/test_core_is_standalone.py
+++ b/tests/unit/test_core_is_standalone.py
@@ -13,7 +13,7 @@ def test_core_imports_with_no_enterprise_installed():
 def test_version_is_exposed():
     import doberman
 
-    assert doberman.__version__ == "0.5.0"
+    assert doberman.__version__ == "0.6.0"
 
 
 def test_policy_core_packages_import_cleanly():

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -1,0 +1,83 @@
+"""Slice 6.3 — security strength modes.
+
+Covers: per-mode thresholds; default Balanced; unknown mode rejected; the
+strictest fallback for a garbage stored mode; the hard-block floor is identical
+across modes (only step-ups move); and that stricter modes produce more AUTH.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from doberman.engine.rules.commands import DestructiveCommandRule
+from doberman.models import ActionType, EvalContext, ReasonCode, SecurityObject, Verdict
+from doberman.policy.modes import (
+    DEFAULT_MODE,
+    FLOOR_HARD_BLOCKS,
+    MODES,
+    SecurityMode,
+    resolve_mode,
+    thresholds_for,
+)
+
+RULE = DestructiveCommandRule()
+BULK_15 = "rm " + " ".join(f"f{i}" for i in range(15))  # 15 delete operands
+
+
+def _run(command: str, mode: str):
+    action = SecurityObject(
+        id="m1",
+        ts=datetime(2026, 6, 8, tzinfo=timezone.utc),
+        agent_role="x",
+        action_type=ActionType.shell_exec,
+        tool_name="shell",
+        target=command,
+    )
+    ctx = EvalContext(mode=mode, metadata={"raw_arguments": {"command": command}})
+    return RULE.evaluate(action, ctx)
+
+
+def test_default_mode_is_balanced():
+    assert DEFAULT_MODE is SecurityMode.balanced
+
+
+def test_thresholds_get_stricter_with_mode():
+    light = thresholds_for("light").bulk_delete_threshold
+    balanced = thresholds_for("balanced").bulk_delete_threshold
+    strict = thresholds_for("strict").bulk_delete_threshold
+    paranoid = thresholds_for("paranoid").bulk_delete_threshold
+    assert light > balanced > strict > paranoid
+
+
+def test_resolve_mode_is_case_insensitive():
+    assert resolve_mode("STRICT") is SecurityMode.strict
+
+
+def test_unknown_mode_is_rejected():
+    with pytest.raises(ValueError):
+        resolve_mode("turbo")
+
+
+def test_garbage_mode_falls_back_to_strictest():
+    assert thresholds_for("turbo") == MODES[SecurityMode.paranoid]
+
+
+def test_floor_contains_the_core_hard_blocks():
+    assert ReasonCode.secret_exfiltration in FLOOR_HARD_BLOCKS
+    assert ReasonCode.destructive_command in FLOOR_HARD_BLOCKS
+    assert ReasonCode.protected_path_blocked in FLOOR_HARD_BLOCKS
+
+
+def test_more_auth_under_stricter_modes():
+    # 15 operands: below Light/Balanced thresholds, at/above Strict/Paranoid.
+    assert _run(BULK_15, "light").verdict is Verdict.PASS
+    assert _run(BULK_15, "balanced").verdict is Verdict.PASS
+    assert _run(BULK_15, "strict").verdict is Verdict.AUTH
+    assert _run(BULK_15, "paranoid").verdict is Verdict.AUTH
+
+
+def test_hard_block_is_identical_across_modes():
+    for mode in ("light", "balanced", "strict", "paranoid"):
+        result = _run("rm -rf /", mode)
+        assert result.verdict is Verdict.BLOCK
+        assert ReasonCode.destructive_command in result.reason_codes


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: F6 — Policy Checklist & Security Strength Modes (slices 6.1–6.3)
- Plan reference: doberman_core_plan.md

> **Stacked PR:** based on `feat/f5-capability-discovery` (#10) → #9 → #8 → #7.

## What this PR does
Good defaults as the product: a pre-checked policy from role + discovery, plus one strength dial instead of dozens of toggles.

- **6.1 — Recommended checklist:** `recommend_policy(role, capabilities)` → an editable `PolicyDoc`. Core hard-blocks are always present, enabled, and **non-disableable here** (disabling one requires the F10 flow); step-ups are tailored to the role and discovered capabilities (an absent-capability item is kept and marked N/A).
- **6.2 — Review + persist:** `doberman review [--yes]` views/saves `.doberman/policies.yaml` (atomic write keeps a prior valid file on failure); a core hard-block cannot be toggled off (`with_item_enabled` raises).
- **6.3 — Strength modes:** `doberman mode <light|balanced|strict|paranoid>` (default Balanced) tunes step-up thresholds only — bulk-delete threshold 100/25/10/3 — while the **hard-block floor is identical across every mode**. `EvalContext.mode` is read by the destructive-command rule; an unknown mode is rejected; a garbage stored mode falls back to the strictest. Adds `doberman status`.

## Tests added (run in CI)
- `tests/unit/test_checklist.py` — core blocks present/enabled/non-disableable, step-up defaults, role + capability tailoring, immutable toggle, round-trip serialization.
- `tests/unit/test_modes.py` — per-mode thresholds, default Balanced, unknown rejected, strictest fallback, floor membership, **more AUTH under stricter modes**, and BLOCK identical across modes.
- `tests/integration/test_policy_review.py` — CLI `review --yes` save / read-only, `mode` set+get, unknown mode → exit 2 (file unchanged), status, persisted-toggle reload.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list (no shared/org templates — those are enterprise)
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Raise-only / floor: modes tune step-ups only; the hard-block floor is mode-independent; even Light keeps all core BLOCKs
- [x] A core hard-block cannot be disabled here (routed to F10); unknown mode rejected; corrupt config fails closed (strictest / keep prior file)
- [x] No secrets in policy files or output
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- **Edge cases:** no-network capability (item kept, N/A); custom role; unknown mode; corrupt/garbage stored mode; core-block disable attempt; atomic save.
- **Deviations:** the recommended checklist is a declarative document; the engine consumes the **mode** today via the destructive-command bulk threshold (the natural threshold consumer), with the policy doc as the editable source of truth. Further per-item engine wiring can follow as rules gain tunables.
- **Risks/debt:** CLI/YAML editing only; modes are coarse by design.

## Note for reviewers
The matching `HUMAN_TEST_CHECKLIST.md` F6 update lands as a **separate PR in `doberman-enterprise`**.
