### PR TITLE
feat(auth): tiered authentication & role elevation (Feature 7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,8 @@ dist/
 build/
 *.egg-info/
 
-# Operating manual + implementation plans: local-only, never published
-CLAUDE.md
-AGENTS.md
+# Development plans: local-only, never published.
+# (The operating manual — CLAUDE.md / AGENTS.md — is published; these detailed plans are not.)
 doberman_core_plan.md
 doberman_enterprise_plan.md
 doberman_implementation_plan.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,374 @@
+# CLAUDE.md — Doberman Operating Manual
+
+> This is the init file for this repository. It governs any AI agent (Claude Code, Codex, Cursor, etc.) working here.
+> It is the **HOW**. The **WHAT** — the feature roadmap and per-slice detail — lives in `README.md` (public summary)
+> and, if present in your working tree, the project development plan you keep alongside it.
+> Content is identical to `AGENTS.md`; keep the two in sync (or symlink one to the other).
+> If this file conflicts with a casual prompt instruction, **this file wins** unless a human overrides it in writing.
+
+---
+
+## 0. On startup (every session)
+
+1. Read this entire file, then skim `README.md` for the current feature set, versioning, and roadmap. If you keep a
+   local development plan alongside the repo, read the relevant slice there for the extra detail (objective, files,
+   edge cases, suggested tests, suggested commit message).
+2. `git status` + `git log --oneline -5`.
+3. Pick the **next slice** (the lowest-numbered unmerged slice in the planned order).
+4. If the repo lacks scaffolding (`pyproject.toml` / `.github/workflows/ci.yml`), do **Slice 0 (Bootstrap)** first (§6).
+5. Execute exactly **one slice** via **The Slice Loop** (§5), then **STOP** and report. Stop at every review checkpoint.
+
+---
+
+## 1. What this repository is
+
+**Doberman** is an adaptive authorization layer for coding agents, released publicly under **Apache-2.0**.
+
+It distributes as the `doberman` package (`src/doberman/`) and is designed to be **genuinely functional on its own** —
+schema, interfaces, the runtime harness, adapters, and the built-in rules all live here. It is **not** crippleware.
+
+Doberman is built to be **extensible**: it declares stable interfaces (`Rule` / `Detector` / `AuthProvider` /
+`AuditSink`) and a runtime registry that discovers implementations via **Python entry points**. Additional packages can
+register their own rules, detectors, auth providers, or audit sinks **without Doberman importing them by name** — the
+core never takes a static dependency on any plugin. With only `doberman` installed, it works (built-in protection);
+install a plugin package and its capabilities light up automatically.
+
+---
+
+## 2. Architecture & extension points
+
+The decision path is deliberately layered so the safety-critical core stays small, open, and auditable:
+
+- **Tool mediation (`doberman.proxy`)** — the chokepoint. Every tool call an agent makes is normalized into a
+  `SecurityObject` and routed through the decision engine. There is no path around it.
+- **Decision engine (`doberman.engine`)** — combines guardrail verdicts into a final **allow / authenticate / block**
+  decision. The execution rule and the raise-only `combine` are the safety invariants — they must stay open and
+  auditable.
+- **Objective guardrail + built-in rules (`doberman.engine.rules`)** — deterministic rules over the action: path
+  canonicalization & confinement, destructive-command detection, external-destination checks, basic secret-pattern and
+  encoded-exfil detection. New rules plug in through the `Rule` interface and the registry.
+- **Roles & boundaries (`doberman.roles`)** — the role schema and per-repo boundary matcher.
+- **Policy (`doberman.policy`)** — the default checklist and the strength modes (Light / Balanced / Strict / Paranoid).
+- **Storage & audit (`doberman.storage`)** — a local, redacted decision log plus the `AuditSink` interface so
+  additional sinks can be registered.
+- **Tiered auth (`doberman.auth`)** — local confirmation, TOTP 2FA, and narrow/temporary role elevation. Auth providers
+  plug in through the `AuthProvider` interface.
+- **Subjective guardrail & baseline (`doberman.engine`)** — the abnormality interface plus a basic local behavioral
+  baseline. Detectors plug in through the `Detector` interface.
+- **Policy-drift & poisoning defense (`doberman.learning` / `doberman.policy`)** — classifies policy changes as
+  strengthen vs weaken, gates weakening behind 2FA, and records changes in an append-only ledger. A core safety
+  invariant: nothing auto-loosens.
+
+**The plugin pattern (how to keep things decoupled):** declare the interface and registry in core; let other packages
+**register** implementations through their own `pyproject.toml` entry points (groups such as `doberman.rules`,
+`doberman.detectors`, `doberman.auth_providers`, `doberman.audit_sinks`). At runtime Doberman runs its built-in
+implementations **plus** whatever is registered. Build the interface + a built-in implementation first; an advanced
+implementation can then ship as a separate plugin package that depends on the now-merged extension point — never the
+other way around.
+
+---
+
+## 3. Prime directives (non-negotiable)
+
+These override everything. If a task would break one, **STOP and ask a human**.
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case → deny / `BLOCK`. The protected agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails/learning may auto-tighten; they may **never** silently loosen. Any weakening goes through the human-approved path (the policy-drift defense).
+3. **Never expose secrets.** Never commit/log/store raw secrets, keys, full private files, unredacted prompts, or `.doberman/` contents. Fingerprints/classifications/metadata only.
+4. **Keep the core decoupled.** The policy core (`doberman.engine`/`roles`/`policy`/`storage`/`learning`) must not import `doberman.proxy`. Enforced by `import-linter`.
+5. **No slice is "done" without tests + green CI.**
+6. **One slice = one PR.** Keep changes scoped to the slice.
+
+If you feel pressure to violate one of these to "make progress," that pressure is the bug. Stop.
+
+---
+
+## 4. Project snapshot
+
+- **What:** Doberman sits between a coding agent and its tools and turns every meaningful action into a risk-based **allow / authenticate / block** decision.
+- **Package:** distributes as `doberman` (`src/doberman/`).
+- **Stack:** Python 3.11+, MCP proxy (`mcp` SDK), local-first **SQLite** (`aiosqlite`), YAML policy in `.doberman/`, Pydantic v2, `pyotp`, a `doberman` CLI (Typer), `pytest`.
+- **Runtime data** (`.doberman/`, the DB, key files) is **never** committed.
+
+---
+
+## 5. The Slice Loop (run for every slice)
+
+**Step 1 — Read the slice.** Read its objective, files, changes, security considerations, edge cases, expected output,
+suggested tests, and suggested commit message (from your local development plan, with `README.md` as the public
+roadmap). Ambiguity or a Prime-Directive conflict → STOP and ask.
+
+**Step 2 — Branch:**
+```
+git checkout main && git pull
+git checkout -b feat/<feature-slug>/<slice-slug>
+```
+
+**Step 3 — Implement** the smallest change that satisfies the Objective, strictly inside the slice's scope. For
+extensible features, implement against the **interface** and register built-ins through the registry — never make the
+policy core reach sideways into the proxy adapter.
+
+**Step 4 — Write this slice's tests (required).** In `tests/unit/` or `tests/integration/`, create
+`test_<slice_topic>.py` covering at minimum: every item in the slice's **"Suggested tests"**, every **edge case**, and
+every behavioral **security consideration** (e.g. *"a `BLOCK` means the fake downstream server recorded nothing"*,
+*"a synthetic secret never appears in any log/output"*, *"`combine` never returns a verdict lower than either input"*).
+Prefer TDD; tests must be deterministic (no real network/clock/secrets — inject/fixture them).
+
+**Step 5 — Make sure GitHub Actions runs these tests.** Tests live under `tests/` so CI's `pytest` discovers them
+(`pytest --collect-only` to confirm). New dependency → add to `pyproject.toml`. New import boundary → update the
+`import-linter` contract. New CI step → update `.github/workflows/ci.yml` (minimal, same PR).
+
+**Step 6 — Green locally:**
+```
+ruff check . && ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing
+```
+Everything passes; do **not** weaken a test or invariant to get green.
+
+**Step 7 — Update docs and the README (required every slice).** With **every commit/slice** keep these in sync as part
+of the same change — never as an afterthought:
+- **`README.md`**: update the feature summary, versioning/changelog, quickstart, and roadmap so they reflect what now
+  exists. A slice that adds/changes public behavior **must** move the README.
+- Other docs (CLI/config/usage) as usual when behavior changed.
+
+**Step 8 — Commit** (Conventional Commits; tests ship **in the same PR** as the code, ideally same commit). Use the
+plan's "Suggested commit message." Never stage `.doberman/`, `*.db`, key files, `.env*` (they're gitignored — verify
+with `git status`).
+
+**Step 9 — Push the branch** (`git push -u origin <branch>`) — tests go with it, so CI runs them.
+
+**Step 10 — Open a PR to `main`**; fill the PR template. Confirm CI turns **green**. Red CI → fix on the branch and
+push again; never merge red.
+
+**Step 11 — Post the Slice Completion Report (§10) and STOP.** Don't start the next slice until approved/merged or told to continue.
+
+**Step 12 — If this was the last slice of a feature**, after merge post the Feature Review Checkpoint (§10) and STOP. Review checkpoints are mandatory pauses.
+
+---
+
+## 6. Slice 0 — Bootstrap (only if scaffolding is missing)
+
+Scaffold the repo + working CI + a trivial smoke test, committed on `chore/bootstrap-scaffolding` with
+`chore(repo): bootstrap project scaffolding and CI`.
+
+### `pyproject.toml`
+```toml
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.importlinter]
+root_package = "doberman"
+
+# Decoupling: the policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+```
+
+### `.github/workflows/ci.yml`
+```yaml
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+```
+> `--cov-fail-under=80` is a starting bar — raise it over time, never lower it to pass a PR.
+
+### `.gitignore`
+```gitignore
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+```
+
+### `.github/pull_request_template.md`
+```markdown
+## Slice
+- Feature / Slice: <id> — <title>
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-
+```
+
+> The authoritative scaffolding is the actual `pyproject.toml`, `.github/workflows/ci.yml`, and
+> `.github/pull_request_template.md` in the repo — the blocks above are the starting shape.
+
+---
+
+## 7. Architecture enforcement (summary)
+
+The decoupling is guaranteed in CI:
+1. **`import-linter` forbidden contract**: the policy core must not import `doberman.proxy`.
+2. **Plugin inversion**: extensible features connect through core-defined interfaces + entry-point discovery, so the
+   core holds no static reference to any plugin package.
+
+---
+
+## 8. Version control hygiene
+
+- **One slice = one branch = one PR.**
+- Branches: `feat/<feature-slug>/<slice-slug>` (or `fix/...`, `chore/...`).
+- Conventional Commits; small, building commits; **tests travel with code**.
+- **Never commit** secrets, keys, `.doberman/`, `*.db`, `.env*`. If you do by accident → STOP, tell a human, treat the value as leaked (rotate it).
+- Rebase (don't merge) to update a branch: `git fetch && git rebase origin/main`.
+
+---
+
+## 9. Security & explainability rules (every slice)
+
+- **Default deny:** wrap risky ops so exceptions yield `BLOCK` (or `AUTH` only where the plan says "fail upward").
+- **Redaction mandatory:** strip raw secrets/large payloads before logging/persisting; keep path **classes**, reason codes, verdicts, **HMAC fingerprints**. Test that a synthetic secret never appears.
+- **Keyed fingerprints:** HMAC-SHA256 with a local `0600`/keyring key (never committed) — plain hashes of low-entropy secrets are brute-forceable.
+- **Explainability first:** every `BLOCK`/`AUTH` carries `reason_codes` **and** a one-line human `explanation`. Reason codes are shared constants in `models.py`.
+- **Auth is action-bound:** approvals single-use + tied to one action id; elevations narrow + time-limited + (destructive) single-use; elevation never relaxes a hard block.
+- **Canonicalize before matching** paths (resolve `.`/`..`/symlinks, confine to repo root) via one shared helper.
+- **Logging never alters/blocks a decision** and never crashes the execution path.
+- **Don't oversell:** never claim secret detection (or any single rule) is airtight — it is defense-in-depth.
+
+---
+
+## 10. Reporting formats
+
+### Slice Completion Report (after every slice, then STOP)
+```
+SLICE COMPLETE — <feature> / <slice id> (<title>)
+Branch: <branch>    PR: #<n>    CI: <green | red+why>
+What I built: <2–3 lines>
+Tests added (run in CI): <files> — <what they cover>
+Security checks verified: <redaction / fail-closed / raise-only / etc.>
+Edge cases covered: <list>
+Decisions / assumptions: <or "none">
+Deviations from the plan: <none | what & why>
+Risks / tech debt introduced: <or "none">
+Next slice: <id — title>  (awaiting go-ahead)
+```
+
+### Feature Review Checkpoint (after the last slice of a feature, then STOP)
+```
+REVIEW CHECKPOINT — <Feature N: name>
+Built: ...
+Needs human testing: ...
+Decisions to review: ...
+Risks / shortcuts / tech debt: ...
+>> Paused. I will not start the next feature until told to proceed.
+```
+
+---
+
+## 11. Never do this
+
+- ❌ Do work outside the current slice's scope.
+- ❌ Skip a review checkpoint or start the next feature without a go-ahead.
+- ❌ Mark a slice "done" with missing/failing tests or red CI.
+- ❌ Weaken/stub a test or invariant to make CI pass.
+- ❌ Auto-loosen Doberman (all loosening goes through the human-approved policy-drift path).
+- ❌ Commit or log a secret, key, full private file, unredacted prompt, or `.doberman/` content.
+- ❌ Let `doberman.proxy` be imported by the policy core.
+- ❌ Add any path by which a protected agent could reach a real tool without going through the decision engine.
+- ❌ Invent requirements. Unclear plan or wrong-looking slice → STOP and ask.
+
+---
+
+## 12. Quick reference
+
+| You want to… | Do this |
+|---|---|
+| Know **what** to build | the development plan (slice detail) + `README.md` (public roadmap) |
+| Know **how** to build it | this file |
+| Start a slice | branch `feat/<feature>/<slice>` → follow §5 |
+| Finish a slice | tests added + pushed, CI green, decoupling check passes, **README updated** (§5 Step 7), Slice Completion Report, STOP |
+| Run checks | `ruff check . && ruff format --check . && lint-imports && pytest --cov=doberman` |
+| Hit ambiguity | STOP and ask |
+
+**Remember:** small safe commits · tests with every slice · CI green before "done" · the policy core stays decoupled from the proxy · when in doubt, **fail closed and ask.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,374 @@
+# CLAUDE.md — Doberman Operating Manual
+
+> This is the init file for this repository. It governs any AI agent (Claude Code, Codex, Cursor, etc.) working here.
+> It is the **HOW**. The **WHAT** — the feature roadmap and per-slice detail — lives in `README.md` (public summary)
+> and, if present in your working tree, the project development plan you keep alongside it.
+> Content is identical to `AGENTS.md`; keep the two in sync (or symlink one to the other).
+> If this file conflicts with a casual prompt instruction, **this file wins** unless a human overrides it in writing.
+
+---
+
+## 0. On startup (every session)
+
+1. Read this entire file, then skim `README.md` for the current feature set, versioning, and roadmap. If you keep a
+   local development plan alongside the repo, read the relevant slice there for the extra detail (objective, files,
+   edge cases, suggested tests, suggested commit message).
+2. `git status` + `git log --oneline -5`.
+3. Pick the **next slice** (the lowest-numbered unmerged slice in the planned order).
+4. If the repo lacks scaffolding (`pyproject.toml` / `.github/workflows/ci.yml`), do **Slice 0 (Bootstrap)** first (§6).
+5. Execute exactly **one slice** via **The Slice Loop** (§5), then **STOP** and report. Stop at every review checkpoint.
+
+---
+
+## 1. What this repository is
+
+**Doberman** is an adaptive authorization layer for coding agents, released publicly under **Apache-2.0**.
+
+It distributes as the `doberman` package (`src/doberman/`) and is designed to be **genuinely functional on its own** —
+schema, interfaces, the runtime harness, adapters, and the built-in rules all live here. It is **not** crippleware.
+
+Doberman is built to be **extensible**: it declares stable interfaces (`Rule` / `Detector` / `AuthProvider` /
+`AuditSink`) and a runtime registry that discovers implementations via **Python entry points**. Additional packages can
+register their own rules, detectors, auth providers, or audit sinks **without Doberman importing them by name** — the
+core never takes a static dependency on any plugin. With only `doberman` installed, it works (built-in protection);
+install a plugin package and its capabilities light up automatically.
+
+---
+
+## 2. Architecture & extension points
+
+The decision path is deliberately layered so the safety-critical core stays small, open, and auditable:
+
+- **Tool mediation (`doberman.proxy`)** — the chokepoint. Every tool call an agent makes is normalized into a
+  `SecurityObject` and routed through the decision engine. There is no path around it.
+- **Decision engine (`doberman.engine`)** — combines guardrail verdicts into a final **allow / authenticate / block**
+  decision. The execution rule and the raise-only `combine` are the safety invariants — they must stay open and
+  auditable.
+- **Objective guardrail + built-in rules (`doberman.engine.rules`)** — deterministic rules over the action: path
+  canonicalization & confinement, destructive-command detection, external-destination checks, basic secret-pattern and
+  encoded-exfil detection. New rules plug in through the `Rule` interface and the registry.
+- **Roles & boundaries (`doberman.roles`)** — the role schema and per-repo boundary matcher.
+- **Policy (`doberman.policy`)** — the default checklist and the strength modes (Light / Balanced / Strict / Paranoid).
+- **Storage & audit (`doberman.storage`)** — a local, redacted decision log plus the `AuditSink` interface so
+  additional sinks can be registered.
+- **Tiered auth (`doberman.auth`)** — local confirmation, TOTP 2FA, and narrow/temporary role elevation. Auth providers
+  plug in through the `AuthProvider` interface.
+- **Subjective guardrail & baseline (`doberman.engine`)** — the abnormality interface plus a basic local behavioral
+  baseline. Detectors plug in through the `Detector` interface.
+- **Policy-drift & poisoning defense (`doberman.learning` / `doberman.policy`)** — classifies policy changes as
+  strengthen vs weaken, gates weakening behind 2FA, and records changes in an append-only ledger. A core safety
+  invariant: nothing auto-loosens.
+
+**The plugin pattern (how to keep things decoupled):** declare the interface and registry in core; let other packages
+**register** implementations through their own `pyproject.toml` entry points (groups such as `doberman.rules`,
+`doberman.detectors`, `doberman.auth_providers`, `doberman.audit_sinks`). At runtime Doberman runs its built-in
+implementations **plus** whatever is registered. Build the interface + a built-in implementation first; an advanced
+implementation can then ship as a separate plugin package that depends on the now-merged extension point — never the
+other way around.
+
+---
+
+## 3. Prime directives (non-negotiable)
+
+These override everything. If a task would break one, **STOP and ask a human**.
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case → deny / `BLOCK`. The protected agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails/learning may auto-tighten; they may **never** silently loosen. Any weakening goes through the human-approved path (the policy-drift defense).
+3. **Never expose secrets.** Never commit/log/store raw secrets, keys, full private files, unredacted prompts, or `.doberman/` contents. Fingerprints/classifications/metadata only.
+4. **Keep the core decoupled.** The policy core (`doberman.engine`/`roles`/`policy`/`storage`/`learning`) must not import `doberman.proxy`. Enforced by `import-linter`.
+5. **No slice is "done" without tests + green CI.**
+6. **One slice = one PR.** Keep changes scoped to the slice.
+
+If you feel pressure to violate one of these to "make progress," that pressure is the bug. Stop.
+
+---
+
+## 4. Project snapshot
+
+- **What:** Doberman sits between a coding agent and its tools and turns every meaningful action into a risk-based **allow / authenticate / block** decision.
+- **Package:** distributes as `doberman` (`src/doberman/`).
+- **Stack:** Python 3.11+, MCP proxy (`mcp` SDK), local-first **SQLite** (`aiosqlite`), YAML policy in `.doberman/`, Pydantic v2, `pyotp`, a `doberman` CLI (Typer), `pytest`.
+- **Runtime data** (`.doberman/`, the DB, key files) is **never** committed.
+
+---
+
+## 5. The Slice Loop (run for every slice)
+
+**Step 1 — Read the slice.** Read its objective, files, changes, security considerations, edge cases, expected output,
+suggested tests, and suggested commit message (from your local development plan, with `README.md` as the public
+roadmap). Ambiguity or a Prime-Directive conflict → STOP and ask.
+
+**Step 2 — Branch:**
+```
+git checkout main && git pull
+git checkout -b feat/<feature-slug>/<slice-slug>
+```
+
+**Step 3 — Implement** the smallest change that satisfies the Objective, strictly inside the slice's scope. For
+extensible features, implement against the **interface** and register built-ins through the registry — never make the
+policy core reach sideways into the proxy adapter.
+
+**Step 4 — Write this slice's tests (required).** In `tests/unit/` or `tests/integration/`, create
+`test_<slice_topic>.py` covering at minimum: every item in the slice's **"Suggested tests"**, every **edge case**, and
+every behavioral **security consideration** (e.g. *"a `BLOCK` means the fake downstream server recorded nothing"*,
+*"a synthetic secret never appears in any log/output"*, *"`combine` never returns a verdict lower than either input"*).
+Prefer TDD; tests must be deterministic (no real network/clock/secrets — inject/fixture them).
+
+**Step 5 — Make sure GitHub Actions runs these tests.** Tests live under `tests/` so CI's `pytest` discovers them
+(`pytest --collect-only` to confirm). New dependency → add to `pyproject.toml`. New import boundary → update the
+`import-linter` contract. New CI step → update `.github/workflows/ci.yml` (minimal, same PR).
+
+**Step 6 — Green locally:**
+```
+ruff check . && ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing
+```
+Everything passes; do **not** weaken a test or invariant to get green.
+
+**Step 7 — Update docs and the README (required every slice).** With **every commit/slice** keep these in sync as part
+of the same change — never as an afterthought:
+- **`README.md`**: update the feature summary, versioning/changelog, quickstart, and roadmap so they reflect what now
+  exists. A slice that adds/changes public behavior **must** move the README.
+- Other docs (CLI/config/usage) as usual when behavior changed.
+
+**Step 8 — Commit** (Conventional Commits; tests ship **in the same PR** as the code, ideally same commit). Use the
+plan's "Suggested commit message." Never stage `.doberman/`, `*.db`, key files, `.env*` (they're gitignored — verify
+with `git status`).
+
+**Step 9 — Push the branch** (`git push -u origin <branch>`) — tests go with it, so CI runs them.
+
+**Step 10 — Open a PR to `main`**; fill the PR template. Confirm CI turns **green**. Red CI → fix on the branch and
+push again; never merge red.
+
+**Step 11 — Post the Slice Completion Report (§10) and STOP.** Don't start the next slice until approved/merged or told to continue.
+
+**Step 12 — If this was the last slice of a feature**, after merge post the Feature Review Checkpoint (§10) and STOP. Review checkpoints are mandatory pauses.
+
+---
+
+## 6. Slice 0 — Bootstrap (only if scaffolding is missing)
+
+Scaffold the repo + working CI + a trivial smoke test, committed on `chore/bootstrap-scaffolding` with
+`chore(repo): bootstrap project scaffolding and CI`.
+
+### `pyproject.toml`
+```toml
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.importlinter]
+root_package = "doberman"
+
+# Decoupling: the policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+```
+
+### `.github/workflows/ci.yml`
+```yaml
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+```
+> `--cov-fail-under=80` is a starting bar — raise it over time, never lower it to pass a PR.
+
+### `.gitignore`
+```gitignore
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+```
+
+### `.github/pull_request_template.md`
+```markdown
+## Slice
+- Feature / Slice: <id> — <title>
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-
+```
+
+> The authoritative scaffolding is the actual `pyproject.toml`, `.github/workflows/ci.yml`, and
+> `.github/pull_request_template.md` in the repo — the blocks above are the starting shape.
+
+---
+
+## 7. Architecture enforcement (summary)
+
+The decoupling is guaranteed in CI:
+1. **`import-linter` forbidden contract**: the policy core must not import `doberman.proxy`.
+2. **Plugin inversion**: extensible features connect through core-defined interfaces + entry-point discovery, so the
+   core holds no static reference to any plugin package.
+
+---
+
+## 8. Version control hygiene
+
+- **One slice = one branch = one PR.**
+- Branches: `feat/<feature-slug>/<slice-slug>` (or `fix/...`, `chore/...`).
+- Conventional Commits; small, building commits; **tests travel with code**.
+- **Never commit** secrets, keys, `.doberman/`, `*.db`, `.env*`. If you do by accident → STOP, tell a human, treat the value as leaked (rotate it).
+- Rebase (don't merge) to update a branch: `git fetch && git rebase origin/main`.
+
+---
+
+## 9. Security & explainability rules (every slice)
+
+- **Default deny:** wrap risky ops so exceptions yield `BLOCK` (or `AUTH` only where the plan says "fail upward").
+- **Redaction mandatory:** strip raw secrets/large payloads before logging/persisting; keep path **classes**, reason codes, verdicts, **HMAC fingerprints**. Test that a synthetic secret never appears.
+- **Keyed fingerprints:** HMAC-SHA256 with a local `0600`/keyring key (never committed) — plain hashes of low-entropy secrets are brute-forceable.
+- **Explainability first:** every `BLOCK`/`AUTH` carries `reason_codes` **and** a one-line human `explanation`. Reason codes are shared constants in `models.py`.
+- **Auth is action-bound:** approvals single-use + tied to one action id; elevations narrow + time-limited + (destructive) single-use; elevation never relaxes a hard block.
+- **Canonicalize before matching** paths (resolve `.`/`..`/symlinks, confine to repo root) via one shared helper.
+- **Logging never alters/blocks a decision** and never crashes the execution path.
+- **Don't oversell:** never claim secret detection (or any single rule) is airtight — it is defense-in-depth.
+
+---
+
+## 10. Reporting formats
+
+### Slice Completion Report (after every slice, then STOP)
+```
+SLICE COMPLETE — <feature> / <slice id> (<title>)
+Branch: <branch>    PR: #<n>    CI: <green | red+why>
+What I built: <2–3 lines>
+Tests added (run in CI): <files> — <what they cover>
+Security checks verified: <redaction / fail-closed / raise-only / etc.>
+Edge cases covered: <list>
+Decisions / assumptions: <or "none">
+Deviations from the plan: <none | what & why>
+Risks / tech debt introduced: <or "none">
+Next slice: <id — title>  (awaiting go-ahead)
+```
+
+### Feature Review Checkpoint (after the last slice of a feature, then STOP)
+```
+REVIEW CHECKPOINT — <Feature N: name>
+Built: ...
+Needs human testing: ...
+Decisions to review: ...
+Risks / shortcuts / tech debt: ...
+>> Paused. I will not start the next feature until told to proceed.
+```
+
+---
+
+## 11. Never do this
+
+- ❌ Do work outside the current slice's scope.
+- ❌ Skip a review checkpoint or start the next feature without a go-ahead.
+- ❌ Mark a slice "done" with missing/failing tests or red CI.
+- ❌ Weaken/stub a test or invariant to make CI pass.
+- ❌ Auto-loosen Doberman (all loosening goes through the human-approved policy-drift path).
+- ❌ Commit or log a secret, key, full private file, unredacted prompt, or `.doberman/` content.
+- ❌ Let `doberman.proxy` be imported by the policy core.
+- ❌ Add any path by which a protected agent could reach a real tool without going through the decision engine.
+- ❌ Invent requirements. Unclear plan or wrong-looking slice → STOP and ask.
+
+---
+
+## 12. Quick reference
+
+| You want to… | Do this |
+|---|---|
+| Know **what** to build | the development plan (slice detail) + `README.md` (public roadmap) |
+| Know **how** to build it | this file |
+| Start a slice | branch `feat/<feature>/<slice>` → follow §5 |
+| Finish a slice | tests added + pushed, CI green, decoupling check passes, **README updated** (§5 Step 7), Slice Completion Report, STOP |
+| Run checks | `ruff check . && ruff format --check . && lint-imports && pytest --cov=doberman` |
+| Hit ambiguity | STOP and ask |
+
+**Remember:** small safe commits · tests with every slice · CI green before "done" · the policy core stays decoupled from the proxy · when in doubt, **fail closed and ask.**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Doberman is a security layer for AI coding agents. It sits **on the tool-execution path** — the agent talks to Doberman, and Doberman talks to the real tools (filesystem, shell, git, network, package managers) over the [Model Context Protocol](https://modelcontextprotocol.io). Every meaningful action is intercepted, normalized into a redacted, structured **security object**, and run through a risk-based decision engine that returns one of three verdicts — **allow**, **authenticate**, or **block** — before the action is ever forwarded. The guiding principle is simple: *if Doberman isn't on the execution path, it's advisory, not protective.* Doberman is built to **fail closed** (any error or uncertainty denies the action) and to be **raise-only** (guardrails may automatically tighten, never silently loosen), so an agent can never reach a tool around it and a buggy rule can never make the system less safe.
 
 > ### Project status
-> **Alpha — pre-1.0, API unstable.** The interception layer (Feature 1), the decision engine (Feature 2), the **objective guardrail** (Feature 3 — basic rules + the plugin seam), **agent role policy** (Feature 4 — role boundaries + the policy-source seam), **capability discovery** (Feature 5 — `doberman scan`), and **policy checklist + strength modes** (Feature 6) are implemented: Doberman now actively blocks the headline disasters (secret exfiltration, protected-path writes, catastrophic commands), steps up authentication on sensitive or unknown actions, escalates actions that cross the agent's role boundary, reports the agent's blast radius, and offers one Light/Balanced/Strict/Paranoid dial over good defaults. The subjective guardrail and the remaining surfaces around the engine (real authentication, audit log) arrive in upcoming versions (see the [Roadmap](#roadmap)). This is the open-source **core**; advanced/hosted capabilities live in a separate commercial edition.
+> **Alpha — pre-1.0, API unstable.** The interception layer (Feature 1), the decision engine (Feature 2), the **objective guardrail** (Feature 3 — basic rules + the plugin seam), **agent role policy** (Feature 4 — role boundaries + the policy-source seam), **capability discovery** (Feature 5 — `doberman scan`), **policy checklist + strength modes** (Feature 6), and **tiered authentication** (Feature 7 — action-specific confirm/2FA challenges, narrow/temporary role elevation, and the auth-provider seam) are implemented: Doberman now actively blocks the headline disasters (secret exfiltration, protected-path writes, catastrophic commands), turns an `AUTH` verdict into a real, action-bound challenge that releases the call only on success, escalates actions that cross the agent's role boundary, reports the agent's blast radius, and offers one Light/Balanced/Strict/Paranoid dial over good defaults. The subjective guardrail and the remaining surfaces around the engine (audit log, drift defense) arrive in upcoming versions (see the [Roadmap](#roadmap)). This is the open-source **core**; advanced/hosted capabilities live in a separate commercial edition.
 
 ---
 
@@ -54,7 +54,7 @@ Doberman is a security layer for AI coding agents. It sits **on the tool-executi
 1. **Intercept** — Doberman is an MCP *server* to the agent and an MCP *client* to the downstream tool servers. It re-exposes the downstream tools unchanged, so every `tools/call` flows through a single chokepoint.
 2. **Normalize** — each call becomes an immutable, redacted `SecurityObject` (action type, target, risk, redacted arguments, fingerprints). Normalization never raises; on bad input it produces a conservative high-risk object.
 3. **Decide** — the engine runs the objective guardrail first, then (if it passes) the subjective guardrail, combining results **raise-only** into a single explainable `Decision`.
-4. **Enforce** — `PASS` forwards the call; `AUTH` returns an "authentication required" error; `BLOCK` returns a "blocked by policy" error and the call is **never** forwarded. Any engine failure is itself a `BLOCK`.
+4. **Enforce** — `PASS` forwards the call; `AUTH` runs a tiered, action-specific challenge (confirm / 2FA / role elevation) and forwards only on success — after a TOCTOU re-decision — otherwise nothing is forwarded; `BLOCK` returns a "blocked by policy" error and the call is **never** forwarded. Any engine failure is itself a `BLOCK`.
 5. **Log** — every action is recorded as one redacted JSON line, correlated by a stable action id.
 
 ---
@@ -168,6 +168,16 @@ Good defaults as the product: a pre-checked policy generated from role + discove
 - **Strength modes** — `doberman mode <light|balanced|strict|paranoid>` (default **Balanced**) tunes step-up thresholds: stricter modes step up to AUTH sooner (e.g. the bulk-delete threshold drops from 100 → 25 → 10 → 3). Modes **only move step-ups** — the hard-block **floor is identical across every mode**, and even Light keeps all core BLOCKs. An unknown mode is rejected; a corrupt stored mode fails to the strictest.
 - **`doberman status`** — shows the active role, mode, and policy summary.
 
+### Feature 7 — Tiered Authentication & Role Elevation · `v0.7.0` _(in review)_
+
+Turns an `AUTH` verdict into a real, **action-bound** challenge whose strength scales with risk, and lets a satisfied role challenge grant a narrow, temporary permission — plus the seam for SSO/hosted approvals.
+
+- **Auth tiers** — `select_tier` derives one of `soft_confirm → local_auth → two_factor → role_elevation` from the **already-final** risk and reason codes (strongest-wins), so a sensitive delete demands 2FA while a minor unusual edit only needs a confirm. A hard `BLOCK` is never turned into a challenge.
+- **Action-specific challenge** — the prompt names the **exact** role, target, and reason ("approve THIS file", never a generic "enter 2FA"); any timeout, input error, or denial fails closed. TOTP 2FA (`doberman 2fa setup`) uses standard authenticator apps, with a ±1-step skew window, constant-time comparison, and a consecutive-failure rate limit; the secret is stored locally `0600` and never committed or logged.
+- **Narrow, temporary, single-use elevation** — a satisfied `role_elevation` grants permission for **one canonical path** (never `**`), time-limited (default 15 min), and **single-use for destructive scopes**. It satisfies only the role-boundary `AUTH` for that exact target — every other rule still runs, and it **never** relaxes a hard block. Elevations persist in a local SQLite store (`.doberman/doberman.db`, `0600`, never committed); `doberman status` lists them and `doberman revoke <id>` ends one early.
+- **Release after auth** — approval is bound to **one action id** (no replay), the action is **re-decided** before forwarding (TOCTOU — a flip to `BLOCK` still blocks), and only then does the call reach the tool.
+- **`AuthProvider` seam (extension point)** — alternative backends (SSO/RBAC, hosted/push approvals) register via the `doberman.auth_providers` entry-point group and replace the local provider without core importing them. A provider can only **grant or deny** — never change the verdict or required tier — and if it fails, the action is denied. With nothing installed, the local provider runs and behavior is unchanged.
+
 ---
 
 ## Design invariants
@@ -196,6 +206,15 @@ The version line maps to the development roadmap:
 ## Changelog
 
 This project keeps a changelog in the spirit of [Keep a Changelog](https://keepachangelog.com/).
+
+### `v0.7.0` — Tiered Authentication & Role Elevation — _Unreleased (in review)_
+
+- **Slice 7.1** — auth-tier selection from the final decision (risk + reasons, strongest-wins; a hard block never maps to a challenge).
+- **Slice 7.2** — TOTP 2FA (`doberman 2fa setup`; ±1-step skew, constant-time compare, failure rate-limit, `0600` secret, fail-closed when not enrolled).
+- **Slice 7.3** — the action-specific challenge (names the exact role/target/reason; timeout/error/denial → deny).
+- **Slice 7.4** — narrow/temporary/single-use role elevation persisted in local SQLite (`doberman status`/`revoke`; never lifts a hard block).
+- **Slice 7.5** — release after auth: approval bound to one action id, re-decided (TOCTOU) before forwarding.
+- **Slice 7.6** — the pluggable `AuthProvider` interface (the enterprise seam; discovered via `doberman.auth_providers`, defaulting to local; a provider can only grant or deny).
 
 ### `v0.6.0` — Policy Checklist & Security Strength Modes — _Unreleased (in review)_
 
@@ -252,7 +271,6 @@ Upcoming versions add the guardrail *content* and the surfaces around the engine
 
 | Version | Theme |
 |---------|-------|
-| `v0.7.0` | **Tiered authentication** — local confirmation, TOTP 2FA, narrow/temporary elevation. |
 | `v0.8.0` | **Decision log & audit** — local redacted decision log + storage interface. |
 | `v0.9.0` | **Subjective guardrail** — abnormality interface + a basic local baseline. |
 | `v0.10.0` | **Policy-drift & poisoning defense** — strengthen/weaken classification, gated approvals, append-only ledger. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doberman"
-version = "0.6.0"
+version = "0.7.0"
 description = "Adaptive authorization layer for coding agents (open core)"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"
@@ -46,7 +46,7 @@ include_external_packages = true
 [[tool.importlinter.contracts]]
 name = "Policy core must not depend on the proxy adapter"
 type = "forbidden"
-source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning", "doberman.auth"]
 forbidden_modules = ["doberman.proxy"]
 
 # Cross-repo boundary: the public core must never import the private enterprise package.

--- a/src/doberman/__init__.py
+++ b/src/doberman/__init__.py
@@ -1,3 +1,3 @@
 """Doberman — adaptive authorization layer for coding agents (open core)."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/src/doberman/auth/__init__.py
+++ b/src/doberman/auth/__init__.py
@@ -1,0 +1,11 @@
+"""Tiered authentication and role elevation (Feature 7).
+
+Turns an ``AUTH`` verdict from the decision engine into a real, action-specific
+challenge (soft confirm → local auth → 2FA → role elevation) and grants narrow,
+temporary, single-use role elevations. The active auth backend is pluggable via
+the :class:`~doberman.auth.provider.AuthProvider` seam so SSO / hosted approvals
+can attach later — core ships only the local provider.
+
+This subpackage is policy-core-adjacent: it must never import ``doberman.proxy``
+(enforced by import-linter). The proxy is the orchestrator that *uses* it.
+"""

--- a/src/doberman/auth/challenge.py
+++ b/src/doberman/auth/challenge.py
@@ -1,0 +1,144 @@
+"""Auth-tier selection and the action-specific challenge (Feature 7, slices 7.1, 7.3).
+
+When the engine returns ``AUTH``, Doberman must prove the action is *deliberate*.
+The proof required scales with risk:
+
+* ``soft_confirm`` — a yes/no acknowledgement (minor, unusual-but-allowed).
+* ``local_auth`` — local human presence at the CLI.
+* ``two_factor`` — local presence **plus** a TOTP code (sensitive / high risk).
+* ``role_elevation`` — the action crosses the agent's role boundary; satisfying
+  it grants a narrow, temporary elevation (slice 7.4) for that one target.
+
+:func:`select_tier` derives the tier from the **already-final** risk and reason
+codes (so a subjective/role escalation correctly bumps the proof required), and
+:func:`run_auth_challenge` presents the *specific* action and collects the proof
+through the active :class:`~doberman.auth.provider.AuthProvider`.
+
+SECURITY: the challenge always names the exact action and reason — never a
+generic "enter 2FA". Any timeout, input error, or denial yields a non-approved
+:class:`AuthResult` (fail closed). A hard block (``BLOCK``) never reaches here:
+:func:`select_tier` rejects a non-``AUTH`` decision.
+"""
+
+from enum import StrEnum
+from typing import Protocol
+
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
+
+from doberman.models import Decision, ReasonCode, Risk, SecurityObject, Verdict
+
+
+class AuthTier(StrEnum):
+    """The proof an ``AUTH`` requires, weakest → strongest."""
+
+    soft_confirm = "soft_confirm"
+    local_auth = "local_auth"
+    two_factor = "two_factor"
+    role_elevation = "role_elevation"
+
+
+#: Strength order so "strongest tier wins" is a simple max.
+_TIER_ORDER: dict[AuthTier, int] = {
+    AuthTier.soft_confirm: 0,
+    AuthTier.local_auth: 1,
+    AuthTier.two_factor: 2,
+    AuthTier.role_elevation: 3,
+}
+
+#: Base tier implied by the final risk alone (before reason-specific bumps).
+_RISK_TIER: dict[Risk, AuthTier] = {
+    Risk.low: AuthTier.soft_confirm,
+    Risk.medium: AuthTier.local_auth,
+    Risk.high: AuthTier.two_factor,
+    Risk.critical: AuthTier.two_factor,
+}
+
+#: Minimum tier each reason code warrants. A reason absent here imposes no floor
+#: of its own (the risk-derived base still applies). ``role_out_of_scope`` is the
+#: one reason that routes to the elevation flow — it is satisfiable by a grant.
+_REASON_TIER: dict[ReasonCode, AuthTier] = {
+    ReasonCode.role_out_of_scope: AuthTier.role_elevation,
+    ReasonCode.policy_source_sensitive: AuthTier.two_factor,
+    ReasonCode.sensitive_secret_access: AuthTier.two_factor,
+    ReasonCode.opaque_command: AuthTier.two_factor,
+    ReasonCode.encoded_exfiltration: AuthTier.two_factor,
+    ReasonCode.unknown_external_destination: AuthTier.local_auth,
+    ReasonCode.sensitive_path_access: AuthTier.local_auth,
+    ReasonCode.bulk_operation: AuthTier.local_auth,
+}
+
+
+def _stronger(a: AuthTier, b: AuthTier) -> AuthTier:
+    return a if _TIER_ORDER[a] >= _TIER_ORDER[b] else b
+
+
+def select_tier(decision: Decision) -> AuthTier:
+    """Pick the authentication tier an ``AUTH`` decision requires.
+
+    Strongest-wins across the risk-derived base tier and every reason code's
+    minimum, so the result is never weaker than any single signal warrants.
+
+    Raises ``ValueError`` if ``decision`` is not an ``AUTH`` — a ``PASS`` needs
+    no challenge and a hard ``BLOCK`` must never be turned into one (the proof
+    flow can only *grant*; it can never lift a block).
+    """
+    if decision.final_verdict is not Verdict.AUTH:
+        raise ValueError(f"select_tier requires an AUTH decision, got {decision.final_verdict}")
+    tier = _RISK_TIER.get(decision.final_risk, AuthTier.two_factor)
+    for reason in decision.reason_codes:
+        floor = _REASON_TIER.get(reason)
+        if floor is not None:
+            tier = _stronger(tier, floor)
+    return tier
+
+
+class Prompter(Protocol):
+    """Collects human input for a challenge (injected so tests stay headless).
+
+    Implementations must raise on timeout / no-input so the provider can treat
+    it as a denial (fail closed). The default CLI implementation lives in
+    :mod:`doberman.auth.provider`.
+    """
+
+    def confirm(self, message: str) -> bool: ...
+
+    def read_code(self, message: str) -> str: ...
+
+
+class AuthResult(BaseModel):
+    """The outcome of one challenge (immutable, audit-friendly).
+
+    ``action_id`` ties the approval to exactly one action (no replay onto a
+    different call). ``elevation_id`` is set only when a ``role_elevation`` tier
+    produced a grant.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    approved: bool
+    tier: AuthTier
+    method: str
+    at: AwareDatetime
+    action_id: str = Field(min_length=1)
+    elevation_id: str | None = None
+
+
+def run_auth_challenge(
+    decision: Decision,
+    action: SecurityObject,
+    *,
+    prompter: Prompter | None = None,
+    at: AwareDatetime | None = None,
+) -> AuthResult:
+    """Select the tier and run the challenge through the active provider.
+
+    ``action`` carries the role/target/tool the challenge names to the human
+    (the ``Decision`` alone does not). The provider can only *grant or deny* —
+    it never alters the decision's verdict or the required tier. With nothing
+    installed, the local provider runs (CLI confirm + TOTP). Lazy-imports the
+    provider to avoid an import cycle (challenge defines the types it consumes).
+    """
+    from doberman.auth.provider import active_provider
+
+    tier = select_tier(decision)
+    return active_provider().authenticate(decision, action, tier, prompter=prompter, at=at)

--- a/src/doberman/auth/elevation.py
+++ b/src/doberman/auth/elevation.py
@@ -1,0 +1,115 @@
+"""Narrow, temporary role elevation (Feature 7, slice 7.4).
+
+A satisfied ``role_elevation`` challenge grants a *tight* permission: it covers
+one specific path glob (not ``**``), for a short time (a TTL), and — for
+destructive scopes — for a single use. An elevation only ever satisfies a
+**role** out-of-scope ``AUTH``; it never relaxes a hard block, and the other
+objective rules (secrets, protected paths, destructive commands) still apply.
+
+This module is a deliberate **leaf**: it imports only the stdlib and the shared
+:func:`doberman.canonical.canonicalize` helper, never ``doberman.models`` or
+``doberman.proxy``. That lets the role-boundary rule consult elevations without
+an import cycle, and lets the storage layer persist :class:`ElevationGrant`
+rows. Persistence and the active-grant query live in ``doberman.storage.db``;
+the *matching* logic lives here so the engine can stay decoupled from the DB.
+
+SECURITY: matching is a pure glob test against the **canonical** target. The
+caller (the role rule) hands an already-active grant set — expiry, revocation,
+and single-use consumption are enforced at the storage layer (which excludes
+spent/expired grants) and at the proxy (which marks single-use grants used after
+a forward), never softened here.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from fnmatch import fnmatch
+
+from doberman.canonical import canonicalize
+
+#: Default elevation lifetime: long enough to finish one approved edit, short
+#: enough that a stale grant cannot be reused hours later.
+DEFAULT_TTL_SECONDS = 15 * 60
+
+#: Globs that would widen an elevation to (nearly) everything. A grant whose
+#: canonical scope is empty or whole-tree is refused — elevation must be narrow.
+_WHOLE_TREE = {"", "*", "**", "**/*", "/**"}
+
+
+@dataclass(frozen=True)
+class ElevationGrant:
+    """One granted role elevation (immutable).
+
+    Attributes:
+        id: opaque unique id (also the audit/revocation handle).
+        scope_glob: the canonical, lower-cased, root-relative path glob this
+            grant covers. Narrow by construction (a single file in the MVP).
+        task_id: the task/action this elevation was granted for (audit only).
+        granted_at / expires_at: timezone-aware UTC bounds.
+        revoked: explicitly revoked by the user (``doberman revoke``).
+        single_use: destructive scopes are consumed after one forward.
+        used: whether a single-use grant has already been spent.
+    """
+
+    id: str
+    scope_glob: str
+    task_id: str | None
+    granted_at: datetime
+    expires_at: datetime
+    revoked: bool = False
+    single_use: bool = False
+    used: bool = False
+
+    def is_active(self, now: datetime) -> bool:
+        """True if this grant is currently usable (not expired/revoked/spent)."""
+        if self.revoked:
+            return False
+        if self.single_use and self.used:
+            return False
+        return now < self.expires_at
+
+    def covers(self, target_relposix: str) -> bool:
+        """True if ``target_relposix`` (a canonical path) falls in this grant's scope."""
+        if not target_relposix or self.scope_glob in _WHOLE_TREE:
+            return False
+        return fnmatch(target_relposix, self.scope_glob)
+
+
+def scope_for_target(target: str | None, *, root: str = ".") -> str | None:
+    """Build a narrow scope glob from an action target, or ``None`` if unsafe.
+
+    The scope is the canonical, root-relative form of the exact target path, so
+    the grant covers *that one file* and nothing else. Returns ``None`` for a
+    non-path target, a path that escapes the repo root, or a whole-tree result —
+    none of which may ever be elevated (fail toward refusing the grant).
+    """
+    if not target:
+        return None
+    canonical = canonicalize(target, root=root)
+    if canonical.escapes_root or canonical.relposix in _WHOLE_TREE:
+        return None
+    return canonical.relposix
+
+
+def find_cover(
+    target: str | None,
+    grants: tuple[ElevationGrant, ...] | list[ElevationGrant],
+    *,
+    root: str = ".",
+) -> ElevationGrant | None:
+    """Return the first grant in ``grants`` whose scope covers ``target``.
+
+    ``grants`` are assumed already-active (the storage layer filters expired /
+    revoked / spent grants). Matching canonicalizes ``target`` through the one
+    shared helper so traversal/symlink/case bypasses cannot dodge or forge
+    coverage. Returns ``None`` when nothing covers it (the role AUTH stands).
+    """
+    if not target:
+        return None
+    canonical = canonicalize(target, root=root)
+    if canonical.escapes_root:
+        return None
+    rel = canonical.relposix
+    for grant in grants:
+        if grant.covers(rel):
+            return grant
+    return None

--- a/src/doberman/auth/elicitation_prompter.py
+++ b/src/doberman/auth/elicitation_prompter.py
@@ -1,0 +1,131 @@
+"""Render confirm-tier AUTH challenges inside the agent client via MCP elicitation.
+
+The first channel in the serve-mode chain: when the agent client (Claude Code,
+Codex, Cursor, …) declares the ``elicitation`` capability, Doberman sends an
+``elicitation/create`` request over the live agent session and the client renders
+the challenge natively in its own UI — the human answers right where they are
+working, with no OS dialog and no terminal contention. Clients route elicitation
+to the *user*, not the model, so the agent cannot approve its own action.
+
+Two hard rules shape this module:
+
+* **No sensitive data.** The MCP spec forbids requesting sensitive information
+  via elicitation, so :meth:`ElicitationPrompter.read_code` always raises
+  :class:`~doberman.auth.gui_prompter.PrompterUnavailableError` — one-time codes
+  stay on the out-of-band channels (GUI dialog / terminal). The approval itself
+  requests **zero** form fields: the accept/decline buttons are the answer, so
+  nothing transits the client.
+* **Never block the event loop.** The challenge answer arrives over the same MCP
+  session this server runs on; waiting for it on the loop thread would deadlock.
+  The executor runs challenges in a worker thread and this prompter bridges back
+  with ``run_coroutine_threadsafe`` — and refuses (channel-unavailable) if it
+  ever finds itself on the loop thread.
+
+Failure taxonomy: missing capability / no active request / method-not-found →
+``PrompterUnavailableError`` (the chain falls through to the GUI). A human
+``decline``/``cancel`` is a FINAL denial, a timeout raises (deny), and any other
+protocol error propagates (deny). Silence never approves.
+"""
+
+import asyncio
+import concurrent.futures
+import logging
+from typing import Any
+
+from mcp import types
+from mcp.shared.exceptions import McpError
+from mcp.types import METHOD_NOT_FOUND
+
+from doberman.auth.gui_prompter import PrompterUnavailableError
+
+logger = logging.getLogger("doberman.auth.elicitation")
+
+#: Approval is expressed through the client's accept/decline buttons alone — no
+#: form fields are requested, so no data (sensitive or otherwise) transits the client.
+_APPROVAL_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}, "required": []}
+
+#: How long to wait for the human's answer. Sized for a person, not a protocol RTT;
+#: on expiry the challenge denies (module-level so tests can shrink it).
+ANSWER_TIMEOUT_S = 300.0
+
+
+class ElicitationPrompter:
+    """Collect a confirm through the agent client's native elicitation UI.
+
+    Holds the proxy ``Server`` (to resolve the per-request session) and the serve
+    event loop (to schedule the request from the challenge worker thread). Only
+    ``confirm`` is offered on this channel — see the module docstring.
+    """
+
+    def __init__(self, server: Any, loop: asyncio.AbstractEventLoop) -> None:
+        self._server = server
+        self._loop = loop
+
+    def confirm(self, message: str) -> bool:
+        """Ask the human via the client UI. Only an explicit ``accept`` approves.
+
+        ``decline`` and ``cancel`` (dismissed without choosing) both deny — and the
+        denial is final: this raises nothing, so a fallback chain never re-asks.
+        """
+        return self._elicit_action(message) == "accept"
+
+    def read_code(self, message: str) -> str:
+        """One-time codes never transit the agent client — always unavailable."""
+        raise PrompterUnavailableError(
+            "one-time codes are sensitive and never requested via MCP elicitation; "
+            "use the out-of-band channel"
+        )
+
+    def _elicit_action(self, message: str) -> str:
+        """Send the elicitation and block (off-loop) for the human's action."""
+        self._refuse_loop_thread()
+        session = self._active_session()
+        if not self._supports_elicitation(session):
+            raise PrompterUnavailableError("agent client does not support MCP elicitation")
+
+        future = asyncio.run_coroutine_threadsafe(
+            session.elicit_form(message, requestedSchema=_APPROVAL_SCHEMA), self._loop
+        )
+        try:
+            result = future.result(timeout=ANSWER_TIMEOUT_S)
+        except concurrent.futures.TimeoutError as exc:
+            future.cancel()  # best-effort: withdraw the stale request
+            raise EOFError("no elicitation answer from the agent client") from exc
+        except McpError as exc:
+            if exc.error.code == METHOD_NOT_FOUND:
+                # The client advertised the capability but cannot serve it.
+                raise PrompterUnavailableError(
+                    "agent client rejected the elicitation request"
+                ) from exc
+            raise  # any other protocol failure → the provider denies
+        return result.action
+
+    def _refuse_loop_thread(self) -> None:
+        """Refuse to block the loop that must carry the answer (it would deadlock)."""
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # a worker thread — exactly where we want to be
+        if running is self._loop:
+            logger.warning("elicitation prompter invoked on the event-loop thread; refusing")
+            raise PrompterUnavailableError("elicitation cannot run on the serve event-loop thread")
+
+    def _active_session(self) -> Any:
+        """The agent session of the request being decided. Unavailable outside one."""
+        try:
+            return self._server.request_context.session
+        except LookupError as exc:
+            raise PrompterUnavailableError("no active MCP request context") from exc
+
+    @staticmethod
+    def _supports_elicitation(session: Any) -> bool:
+        """True when the client declared the elicitation capability (else fall through)."""
+        try:
+            return bool(
+                session.check_client_capability(
+                    types.ClientCapabilities(elicitation=types.ElicitationCapability())
+                )
+            )
+        except Exception:  # malformed capability state — treat as unsupported
+            logger.warning("could not determine client elicitation capability; skipping")
+            return False

--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -8,17 +8,22 @@ the Feature 7 challenge. The challenge must therefore surface **out-of-band** as
 a topmost dialog window; the terminal remains only a fallback for headless/SSH
 sessions where no display exists.
 
+The dialogs are custom-built tkinter windows (dark, black-and-orange theme) —
+not the stock ``messagebox``/``simpledialog`` chrome — but the security contract
+is unchanged: closing/cancelling a dialog denies, the code entry is masked, and
+the safe action (Deny) holds the initial keyboard focus so a stray Enter can
+never approve.
+
 :class:`PrompterUnavailableError` separates "this channel cannot open at all"
 (fall through to the next channel) from a human answer or a human-channel error
 (EOF/timeout — FINAL, the provider denies). A denial on one channel must never
 be re-asked on another — that would be answer-shopping.
 
 SECURITY: nothing here reads ``sys.stdin`` or writes ``sys.stdout`` (the agent's
-MCP channel). Cancelling/closing a dialog raises or returns ``False`` so the
-provider denies — there is no silent "yes". The 2FA code entry is masked.
-tkinter is stdlib; no new dependency.
+MCP channel). tkinter is stdlib; no new dependency.
 """
 
+import sys
 from collections.abc import Iterable
 from typing import Any
 
@@ -26,6 +31,22 @@ from doberman.auth.challenge import Prompter
 
 #: Window title for every challenge dialog.
 _TITLE = "Doberman — authorization required"
+
+# --- palette: dark, black and orange (no purple, no neon) ---------------------------
+_BG = "#101010"  # window base
+_PANEL = "#1b1b1b"  # message panel
+_FG = "#f2f2f2"  # primary text
+_MUTED = "#9b9b9b"  # secondary text
+_ACCENT = "#ff7a1a"  # orange — brand + the Approve action
+_ACCENT_ACTIVE = "#ff9447"  # orange hover/active
+_DENY_BG = "#262626"  # neutral dark button
+_DENY_ACTIVE = "#383838"
+
+_BODY_FONT = ("Segoe UI", 10)
+_BRAND_FONT = ("Segoe UI Semibold", 13)
+_SUB_FONT = ("Segoe UI", 9)
+_MONO_FONT = ("Consolas", 10)
+_BUTTON_FONT = ("Segoe UI Semibold", 10)
 
 
 class PrompterUnavailableError(RuntimeError):
@@ -38,7 +59,7 @@ class PrompterUnavailableError(RuntimeError):
 
 
 def _open_root() -> Any:
-    """Create a hidden, topmost Tk root for one dialog. Raises when no GUI exists.
+    """Create a Tk root for one dialog. Raises when no GUI exists.
 
     A fresh root per challenge (never cached): Tk objects are not thread-safe to
     share and a display that was missing earlier may be available now. The caller
@@ -49,41 +70,203 @@ def _open_root() -> Any:
     except Exception as exc:  # pragma: no cover — needs a tkinter-less interpreter
         raise PrompterUnavailableError("tkinter is not available") from exc
     try:
-        root = tkinter.Tk()
+        return tkinter.Tk()
     except Exception as exc:  # tkinter.TclError — no display / no window station
         raise PrompterUnavailableError("no display available for a GUI auth dialog") from exc
-    return root
 
 
-def _prepare_root(root: Any) -> None:
-    """Hide the empty main window and force the dialog above the agent's terminal."""
-    root.withdraw()  # never flash an empty main window
+def _configure_window(root: Any) -> None:
+    """Apply the window-level theme: topmost, dark base, fixed size, dark title bar."""
+    root.title(_TITLE)
+    root.configure(bg=_BG)
+    root.resizable(False, False)
     root.attributes("-topmost", True)  # the dialog must pop OVER the agent's terminal
-    root.update()
+    _apply_dark_title_bar(root)
+
+
+def _apply_dark_title_bar(root: Any) -> None:
+    """Best-effort dark title bar on Windows 11/10; purely cosmetic, never fatal."""
+    if sys.platform != "win32":
+        return
+    try:  # pragma: no cover — needs a real native window handle
+        import ctypes
+
+        root.update_idletasks()
+        hwnd = ctypes.windll.user32.GetParent(root.winfo_id())
+        use_dark = ctypes.c_int(1)
+        DWMWA_USE_IMMERSIVE_DARK_MODE = 20
+        ctypes.windll.dwmapi.DwmSetWindowAttribute(
+            hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, ctypes.byref(use_dark), ctypes.sizeof(use_dark)
+        )
+    except Exception:  # noqa: S110 — cosmetic only; the challenge must still show
+        pass
+
+
+def _center_on_screen(root: Any) -> None:
+    """Center the (now-populated) dialog so it lands where the human is looking."""
+    root.update_idletasks()
+    width, height = root.winfo_reqwidth(), root.winfo_reqheight()
+    x = max((root.winfo_screenwidth() - width) // 2, 0)
+    y = max((root.winfo_screenheight() - height) // 3, 0)  # slightly above center
+    root.geometry(f"+{x}+{y}")
+
+
+def _styled_button(parent: Any, text: str, command: Any, *, accent: bool) -> Any:
+    """A flat, hover-aware button: orange for the approve action, neutral for deny."""
+    import tkinter as tk
+
+    base = _ACCENT if accent else _DENY_BG
+    active = _ACCENT_ACTIVE if accent else _DENY_ACTIVE
+    fg = "#1a1208" if accent else _FG
+    button = tk.Button(
+        parent,
+        text=text,
+        command=command,
+        font=_BUTTON_FONT,
+        bg=base,
+        fg=fg,
+        activebackground=active,
+        activeforeground=fg,
+        relief="flat",
+        bd=0,
+        padx=18,
+        pady=7,
+        cursor="hand2",
+        highlightthickness=1,
+        highlightbackground=_BG,
+        highlightcolor=_ACCENT,
+    )
+    button.bind("<Enter>", lambda _e: button.configure(bg=active))
+    button.bind("<Leave>", lambda _e: button.configure(bg=base))
+    return button
+
+
+def _build_header_and_message(root: Any, message: str) -> None:
+    """The shared top of both dialogs: brand row + the exact challenge text."""
+    import tkinter as tk
+
+    header = tk.Frame(root, bg=_BG)
+    header.pack(fill="x", padx=18, pady=(16, 8))
+    tk.Label(header, text="🐕 DOBERMAN", font=_BRAND_FONT, fg=_ACCENT, bg=_BG).pack(anchor="w")
+    tk.Label(
+        header,
+        text="An agent action needs your decision",
+        font=_SUB_FONT,
+        fg=_MUTED,
+        bg=_BG,
+    ).pack(anchor="w", pady=(2, 0))
+
+    panel = tk.Frame(root, bg=_PANEL, highlightthickness=1, highlightbackground="#2c2c2c")
+    panel.pack(fill="both", expand=True, padx=18, pady=(6, 4))
+    tk.Label(
+        panel,
+        text=message,
+        font=_MONO_FONT,
+        fg=_FG,
+        bg=_PANEL,
+        justify="left",
+        anchor="w",
+        wraplength=480,
+        padx=12,
+        pady=10,
+    ).pack(fill="both", expand=True)
+
+
+def _populate_confirm(root: Any, message: str, answer: dict) -> None:
+    """Yes/no challenge body. Deny keeps initial focus — Enter can never stray-approve."""
+    import tkinter as tk
+
+    _build_header_and_message(root, message)
+
+    def _decide(value: bool) -> None:
+        answer["value"] = value
+        root.quit()
+
+    buttons = tk.Frame(root, bg=_BG)
+    buttons.pack(fill="x", padx=18, pady=(6, 16))
+    deny = _styled_button(buttons, "Deny", lambda: _decide(False), accent=False)
+    approve = _styled_button(buttons, "Approve", lambda: _decide(True), accent=True)
+    deny.pack(side="right", padx=(8, 0))
+    approve.pack(side="right")
+
+    root.bind("<Escape>", lambda _e: _decide(False))
+    root.bind(
+        "<Return>",
+        lambda _e: root.focus_get().invoke() if hasattr(root.focus_get(), "invoke") else None,
+    )
+    deny.focus_set()  # the safe action owns the keyboard by default
+
+
+def _populate_code(root: Any, message: str, answer: dict) -> None:
+    """Masked one-time-code entry body. Cancel/Escape/close all mean deny."""
+    import tkinter as tk
+
+    _build_header_and_message(root, message)
+
+    entry_row = tk.Frame(root, bg=_BG)
+    entry_row.pack(fill="x", padx=18, pady=(4, 4))
+    entry = tk.Entry(
+        entry_row,
+        show="*",  # the code must never echo on screen
+        font=("Consolas", 13),
+        fg=_FG,
+        bg=_PANEL,
+        insertbackground=_ACCENT,
+        relief="flat",
+        highlightthickness=1,
+        highlightbackground="#2c2c2c",
+        highlightcolor=_ACCENT,
+    )
+    entry.pack(fill="x", ipady=6)
+
+    def _submit() -> None:
+        answer["value"] = entry.get()
+        root.quit()
+
+    def _cancel() -> None:
+        answer["value"] = None
+        root.quit()
+
+    buttons = tk.Frame(root, bg=_BG)
+    buttons.pack(fill="x", padx=18, pady=(6, 16))
+    cancel = _styled_button(buttons, "Cancel", _cancel, accent=False)
+    submit = _styled_button(buttons, "Submit code", _submit, accent=True)
+    cancel.pack(side="right", padx=(8, 0))
+    submit.pack(side="right")
+
+    root.bind("<Escape>", lambda _e: _cancel())
+    entry.bind("<Return>", lambda _e: _submit())
+    entry.focus_set()
+
+
+def _run_dialog(message: str, *, want_code: bool) -> Any:
+    """Open one themed dialog, block until the human decides, and clean up.
+
+    Closing the window (WM_DELETE_WINDOW) leaves the answer unset, which resolves
+    to the deny default — there is no path where silence approves.
+    """
+    root = _open_root()
+    try:
+        _configure_window(root)
+        answer: dict = {}
+        populate = _populate_code if want_code else _populate_confirm
+        populate(root, message, answer)
+        root.protocol("WM_DELETE_WINDOW", root.quit)
+        _center_on_screen(root)
+        root.mainloop()
+        return answer.get("value", None if want_code else False)
+    finally:
+        root.destroy()
 
 
 def _confirm_dialog(message: str) -> bool:
-    """Show a yes/no challenge dialog. Closing the window is "no" (deny)."""
-    root = _open_root()
-    try:
-        from tkinter import messagebox
-
-        _prepare_root(root)
-        return bool(messagebox.askyesno(_TITLE, message, parent=root))
-    finally:
-        root.destroy()
+    """Show the yes/no challenge dialog. Closing the window is "no" (deny)."""
+    return bool(_run_dialog(message, want_code=False))
 
 
 def _code_dialog(message: str) -> str | None:
-    """Show a masked one-time-code entry dialog. Cancel/close returns ``None``."""
-    root = _open_root()
-    try:
-        from tkinter import simpledialog
-
-        _prepare_root(root)
-        return simpledialog.askstring(_TITLE, message, show="*", parent=root)
-    finally:
-        root.destroy()
+    """Show the masked one-time-code dialog. Cancel/close returns ``None``."""
+    return _run_dialog(message, want_code=True)
 
 
 class GuiPrompter:

--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -1,0 +1,142 @@
+"""GUI auth prompter + the GUI→TTY fallback chain (the serve-mode AUTH channel).
+
+When an MCP agent (Claude Code, Codex, Cursor, …) spawns ``doberman serve``, the
+controlling terminal *still exists* but is owned by the agent's TUI: a prompt
+written to ``CONOUT$``/``/dev/tty`` opens successfully yet is painted over
+(invisible), and keystrokes go to the agent — the human can never see or answer
+the Feature 7 challenge. The challenge must therefore surface **out-of-band** as
+a topmost dialog window; the terminal remains only a fallback for headless/SSH
+sessions where no display exists.
+
+:class:`PrompterUnavailableError` separates "this channel cannot open at all"
+(fall through to the next channel) from a human answer or a human-channel error
+(EOF/timeout — FINAL, the provider denies). A denial on one channel must never
+be re-asked on another — that would be answer-shopping.
+
+SECURITY: nothing here reads ``sys.stdin`` or writes ``sys.stdout`` (the agent's
+MCP channel). Cancelling/closing a dialog raises or returns ``False`` so the
+provider denies — there is no silent "yes". The 2FA code entry is masked.
+tkinter is stdlib; no new dependency.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+
+from doberman.auth.challenge import Prompter
+
+#: Window title for every challenge dialog.
+_TITLE = "Doberman — authorization required"
+
+
+class PrompterUnavailableError(RuntimeError):
+    """The prompter's human channel cannot be opened at all (no display, no GUI).
+
+    Distinct from a denial or an EOF on an *open* channel: only this error lets a
+    :class:`FallbackPrompter` consult the next channel. Reaching the provider, it
+    is treated like any other challenge failure — the action is denied.
+    """
+
+
+def _open_root() -> Any:
+    """Create a hidden, topmost Tk root for one dialog. Raises when no GUI exists.
+
+    A fresh root per challenge (never cached): Tk objects are not thread-safe to
+    share and a display that was missing earlier may be available now. The caller
+    must destroy it.
+    """
+    try:
+        import tkinter
+    except Exception as exc:  # pragma: no cover — needs a tkinter-less interpreter
+        raise PrompterUnavailableError("tkinter is not available") from exc
+    try:
+        root = tkinter.Tk()
+    except Exception as exc:  # tkinter.TclError — no display / no window station
+        raise PrompterUnavailableError("no display available for a GUI auth dialog") from exc
+    return root
+
+
+def _prepare_root(root: Any) -> None:
+    """Hide the empty main window and force the dialog above the agent's terminal."""
+    root.withdraw()  # never flash an empty main window
+    root.attributes("-topmost", True)  # the dialog must pop OVER the agent's terminal
+    root.update()
+
+
+def _confirm_dialog(message: str) -> bool:
+    """Show a yes/no challenge dialog. Closing the window is "no" (deny)."""
+    root = _open_root()
+    try:
+        from tkinter import messagebox
+
+        _prepare_root(root)
+        return bool(messagebox.askyesno(_TITLE, message, parent=root))
+    finally:
+        root.destroy()
+
+
+def _code_dialog(message: str) -> str | None:
+    """Show a masked one-time-code entry dialog. Cancel/close returns ``None``."""
+    root = _open_root()
+    try:
+        from tkinter import simpledialog
+
+        _prepare_root(root)
+        return simpledialog.askstring(_TITLE, message, show="*", parent=root)
+    finally:
+        root.destroy()
+
+
+class GuiPrompter:
+    """Collect a challenge response through a topmost dialog window.
+
+    Raises :class:`PrompterUnavailableError` when no display exists so a fallback
+    chain can try the terminal instead; any other failure (cancel, blank code)
+    raises and the provider denies (fail closed).
+    """
+
+    def confirm(self, message: str) -> bool:
+        return _confirm_dialog(message)
+
+    def read_code(self, message: str) -> str:
+        """Read a one-time code via a masked dialog. Cancel/blank → raise (deny).
+
+        An empty code must never reach the verifier, so cancel and whitespace-only
+        entries raise instead of returning ``""``.
+        """
+        code = _code_dialog(message)
+        if code is None or not code.strip():
+            raise EOFError("no code entered in the auth dialog")
+        return code.strip()
+
+
+class FallbackPrompter:
+    """Try each prompter in order; fall through ONLY when a channel is unavailable.
+
+    A human answer (including "no") is final, and a human-channel error (EOF,
+    timeout) propagates — the next channel is consulted only on
+    :class:`PrompterUnavailableError`. With every channel unavailable it raises,
+    so the provider denies (fail closed).
+    """
+
+    def __init__(self, prompters: Iterable[Prompter]) -> None:
+        self._prompters: tuple[Prompter, ...] = tuple(prompters)
+
+    @property
+    def prompters(self) -> tuple[Prompter, ...]:
+        """The chain, in consultation order (read-only — for wiring assertions)."""
+        return self._prompters
+
+    def confirm(self, message: str) -> bool:
+        return self._first_open_channel("confirm", message)
+
+    def read_code(self, message: str) -> str:
+        return self._first_open_channel("read_code", message)
+
+    def _first_open_channel(self, method: str, message: str) -> Any:
+        last: PrompterUnavailableError | None = None
+        for prompter in self._prompters:
+            try:
+                return getattr(prompter, method)(message)
+            except PrompterUnavailableError as exc:
+                last = exc
+        raise PrompterUnavailableError("no auth prompter channel is available") from last

--- a/src/doberman/auth/provider.py
+++ b/src/doberman/auth/provider.py
@@ -1,0 +1,156 @@
+"""The ``AuthProvider`` seam + the local provider (Feature 7, slice 7.6).
+
+Core ships exactly one auth backend — the **local** provider (CLI confirm +
+TOTP, slices 7.1–7.3). Alternative backends (SSO/RBAC, hosted/push approvals)
+live in separately-installed packages that register an :class:`AuthProvider`
+through the ``doberman.auth_providers`` entry-point group — so core never
+imports them by name (the repo-boundary rule).
+
+SECURITY: a provider can only **grant or deny**. It cannot change the decision's
+verdict or the required :class:`~doberman.auth.challenge.AuthTier`, and it
+receives only the already-final :class:`~doberman.models.Decision` plus the
+redacted action. If a provider raises, times out, or returns a non-approval, the
+action is **denied** (fail closed). With nothing registered, the local provider
+runs and behavior is identical to core-only.
+
+This module imports the F3 entry-point registry for discovery but never imports
+``doberman.proxy``.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Protocol, runtime_checkable
+
+from doberman.auth import totp
+from doberman.auth.challenge import AuthResult, AuthTier, Prompter
+from doberman.models import Decision, SecurityObject
+
+logger = logging.getLogger("doberman.auth.provider")
+
+
+@runtime_checkable
+class AuthProvider(Protocol):
+    """A backend that turns a challenge into an :class:`AuthResult`.
+
+    Implementations live in core (the local provider) or in installed packages
+    registered via ``doberman.auth_providers``. ``authenticate`` must never
+    raise into the caller — failure is expressed as a non-approved result.
+    """
+
+    def authenticate(
+        self,
+        decision: Decision,
+        action: SecurityObject,
+        tier: AuthTier,
+        *,
+        prompter: Prompter | None = None,
+        at: datetime | None = None,
+    ) -> AuthResult: ...
+
+
+class CliPrompter:
+    """The default :class:`Prompter`: ask the local human at the terminal.
+
+    Backed by Typer/Click. On EOF/abort it raises (Click's ``Abort``), which the
+    provider treats as a denial — there is no silent default-yes.
+    """
+
+    def confirm(self, message: str) -> bool:
+        import typer
+
+        return bool(typer.confirm(message))
+
+    def read_code(self, message: str) -> str:
+        import typer
+
+        return str(typer.prompt(message, hide_input=True))
+
+
+def _challenge_message(decision: Decision, action: SecurityObject, tier: AuthTier) -> str:
+    """Build a prompt that names the EXACT action, target, and reason.
+
+    Shown only to the local human approving the action (never logged), so it may
+    include the concrete target — that is the whole point of an action-specific
+    challenge ("approve THIS file", not a generic "enter 2FA").
+    """
+    reasons = ", ".join(decision.reason_codes) or "unspecified"
+    target = action.target or "(no target)"
+    return (
+        f"Doberman authentication required [{tier.value}]\n"
+        f"  role:   {action.agent_role}\n"
+        f"  action: {action.tool_name} → {target}\n"
+        f"  reason: {reasons} — {decision.explanation.strip() or 'no further detail'}\n"
+        f"Approve THIS exact action?"
+    )
+
+
+class LocalAuthProvider:
+    """Local CLI + TOTP provider. The default when no other is registered."""
+
+    name = "local"
+
+    def authenticate(
+        self,
+        decision: Decision,
+        action: SecurityObject,
+        tier: AuthTier,
+        *,
+        prompter: Prompter | None = None,
+        at: datetime | None = None,
+    ) -> AuthResult:
+        prompter = prompter or CliPrompter()
+        when = at or datetime.now(timezone.utc)
+        message = _challenge_message(decision, action, tier)
+
+        try:
+            approved, method = self._run_tier(tier, message, prompter)
+        except Exception:  # noqa: BLE001 — any input/timeout error is a denial
+            logger.info("local auth challenge failed for action %s; denying", action.id)
+            approved, method = False, "error"
+
+        return AuthResult(
+            approved=approved,
+            tier=tier,
+            method=method,
+            at=when,
+            action_id=action.id,
+        )
+
+    @staticmethod
+    def _run_tier(tier: AuthTier, message: str, prompter: Prompter) -> tuple[bool, str]:
+        """Collect tier-appropriate proof. Returns (approved, method)."""
+        if tier in (AuthTier.soft_confirm, AuthTier.local_auth):
+            return prompter.confirm(message), tier.value
+
+        # two_factor and role_elevation both require presence AND a TOTP code.
+        if not prompter.confirm(message):
+            return False, "denied"
+        code = prompter.read_code("Enter your 2FA code")
+        return totp.verify(code), "totp" if tier is AuthTier.two_factor else "totp+elevation"
+
+
+#: The single built-in provider, constructed once.
+LOCAL_PROVIDER = LocalAuthProvider()
+
+
+def _looks_like_auth_provider(obj: object) -> bool:
+    """Structural check (the Protocol's isinstance is method-name only)."""
+    return callable(getattr(obj, "authenticate", None))
+
+
+def active_provider() -> AuthProvider:
+    """Return the active provider: the first registered one, else local.
+
+    Discovery uses the F3 entry-point registry (group
+    ``doberman.auth_providers``); a registered provider that is not
+    auth-provider-shaped is skipped. With nothing installed, returns the local
+    provider — standalone behavior is unchanged.
+    """
+    # Lazy import: the registry lives in the engine layer.
+    from doberman.engine.registry import discover_auth_providers
+
+    for candidate in discover_auth_providers():
+        if _looks_like_auth_provider(candidate):
+            return candidate  # type: ignore[return-value]
+        logger.warning("skipping auth provider %r: not auth-provider-shaped", candidate)
+    return LOCAL_PROVIDER

--- a/src/doberman/auth/totp.py
+++ b/src/doberman/auth/totp.py
@@ -1,0 +1,144 @@
+"""TOTP-based two-factor verification (Feature 7, slice 7.2).
+
+The 2FA tier proves a *human* is present for a high-risk action. We use standard
+TOTP (RFC 6238) via ``pyotp`` so any authenticator app works. The shared secret
+is generated once at enrollment and stored locally, **never** in the repo, a
+log, or any returned value — exactly like the HMAC fingerprint key
+(:mod:`doberman.storage.fingerprint`), and for the same reason.
+
+Secret handling (SECURITY):
+
+* Location is ``$DOBERMAN_TOTP_FILE`` if set, else a per-user config dir
+  (``%LOCALAPPDATA%`` / ``$XDG_CONFIG_HOME`` / ``~/.config``) — outside any repo.
+* Written ``0600`` in a ``0700`` dir; the directory and file mirror the
+  fingerprint key's restrictive permissions.
+* Verification is **constant-time** (``pyotp`` uses ``hmac.compare_digest``),
+  allows a ±1 step skew, and is **rate-limited**: too many consecutive failures
+  locks further attempts until a reset, blunting online brute force.
+* If 2FA is **not enrolled**, :func:`verify` returns ``False`` — there is no
+  "no-auth fallback". A challenge that needs 2FA fails closed when none exists.
+
+Codes and the secret are never logged. The provisioning URI returned by
+:func:`enroll` necessarily embeds the secret; it is shown to the enrolling user
+once (their own machine, their own secret) and must not be logged or persisted
+by callers.
+"""
+
+import os
+from pathlib import Path
+
+import pyotp
+
+#: Env var overriding the secret-file location (tests inject a temp path).
+TOTP_FILE_ENV = "DOBERMAN_TOTP_FILE"
+
+#: Accept the current code plus one step on either side (±30s) for clock skew.
+_VALID_WINDOW = 1
+
+#: Consecutive failed verifications before further attempts are locked out
+#: (until :func:`reset_attempts` or a successful verify). A deliberately small
+#: bound — online TOTP guessing needs many tries to matter.
+_MAX_CONSECUTIVE_FAILURES = 5
+
+#: Per-secret-file consecutive-failure counters (isolated by path so distinct
+#: enrollments — and distinct tests — never share rate-limit state).
+_failures: dict[str, int] = {}
+
+
+def _default_secret_path() -> Path:
+    """Per-user secret path OUTSIDE any repository (never committed)."""
+    if os.name == "nt":
+        base = os.environ.get("LOCALAPPDATA") or os.path.join(
+            os.path.expanduser("~"), "AppData", "Local"
+        )
+    else:
+        base = os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
+    return Path(base) / "doberman" / "totp.secret"
+
+
+def _secret_path() -> Path:
+    override = os.environ.get(TOTP_FILE_ENV)
+    return Path(override) if override else _default_secret_path()
+
+
+def _read_secret() -> str | None:
+    """Return the stored base32 secret, or ``None`` if not enrolled/unreadable."""
+    path = _secret_path()
+    try:
+        if not path.exists():
+            return None
+        secret = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return secret or None
+
+
+def is_enrolled() -> bool:
+    """True if a TOTP secret is present and readable."""
+    return _read_secret() is not None
+
+
+def enroll(*, issuer: str = "Doberman", account: str = "local", force: bool = False) -> str:
+    """Generate and store a new TOTP secret; return its provisioning URI.
+
+    Refuses to overwrite an existing enrollment unless ``force=True`` (so a
+    second ``2fa setup`` cannot silently rotate the secret out from under an
+    authenticator app). The returned URI embeds the secret for QR/manual entry
+    and MUST NOT be logged by the caller.
+    """
+    path = _secret_path()
+    if path.exists() and not force:
+        raise RuntimeError(
+            "TOTP is already enrolled; pass force=True to deliberately rotate the secret"
+        )
+
+    secret = pyotp.random_base32()
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    # Write the secret with restrictive perms from creation. base32 text has no
+    # newline/control bytes, so text-mode translation cannot corrupt it.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(str(path), flags, 0o600)
+    try:
+        os.write(fd, secret.encode("ascii"))
+    finally:
+        os.close(fd)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+    _failures.pop(str(path), None)
+    return pyotp.TOTP(secret).provisioning_uri(name=account, issuer_name=issuer)
+
+
+def reset_attempts() -> None:
+    """Clear the consecutive-failure counter for the active secret file."""
+    _failures.pop(str(_secret_path()), None)
+
+
+def verify(code: str, *, at: int | None = None) -> bool:
+    """Verify a TOTP ``code``; return ``True`` only on a valid, in-window code.
+
+    Fails closed: not enrolled, a non-numeric/garbage code, or a rate-limit
+    lockout all return ``False`` without ever raising into the decision path.
+    ``at`` (integer epoch seconds) is injectable so tests are deterministic;
+    production uses the current time. A successful verify resets the counter.
+    """
+    secret = _read_secret()
+    if secret is None:
+        return False
+
+    key = str(_secret_path())
+    if _failures.get(key, 0) >= _MAX_CONSECUTIVE_FAILURES:
+        return False
+
+    try:
+        ok = pyotp.TOTP(secret).verify(str(code), valid_window=_VALID_WINDOW, for_time=at)
+    except Exception:  # noqa: BLE001 — any verify error is a failed auth, never a pass
+        ok = False
+
+    if ok:
+        _failures.pop(key, None)
+    else:
+        _failures[key] = _failures.get(key, 0) + 1
+    return ok

--- a/src/doberman/auth/tty_prompter.py
+++ b/src/doberman/auth/tty_prompter.py
@@ -1,0 +1,82 @@
+"""A :class:`~doberman.auth.challenge.Prompter` that talks to the controlling terminal.
+
+Used when Doberman runs as a stdio MCP proxy (``doberman serve``): the agent owns
+this process's stdin/stdout, so an ``AUTH`` challenge must reach the human through the
+controlling terminal directly — ``/dev/tty`` (POSIX) or ``CONIN$``/``CONOUT$`` (Windows).
+If no terminal is attached (a headless, agent-spawned subprocess), opening it raises →
+the provider treats the challenge as failed → the action is **denied** (fail closed).
+
+SECURITY: this never reads ``sys.stdin`` or writes ``sys.stdout`` — those are the agent's
+MCP channel, and a stray byte there corrupts the protocol. Any no-input/EOF condition
+raises so the provider denies rather than defaulting to "yes".
+"""
+
+import sys
+from typing import TextIO
+
+#: Replies that count as approval for a yes/no confirm (case-insensitive).
+_AFFIRMATIVE = frozenset({"y", "yes"})
+
+
+def _open_tty() -> tuple[TextIO, TextIO]:
+    """Open ``(read, write)`` handles to the controlling terminal.
+
+    On POSIX both are the same bidirectional ``/dev/tty`` handle; on Windows they are
+    the distinct console devices. Raises ``OSError`` when no terminal is attached — the
+    caller turns that into a denial.
+    """
+    if sys.platform == "win32":
+        return (
+            open("CONIN$", encoding="utf-8"),  # noqa: SIM115 — closed by the caller's finally
+            open("CONOUT$", "w", encoding="utf-8"),  # noqa: SIM115 — closed by the caller's finally
+        )
+    tty = open("/dev/tty", "r+", encoding="utf-8")  # noqa: SIM115 — closed by the caller's finally
+    return tty, tty
+
+
+class TtyPrompter:
+    """Collect a challenge response from the controlling terminal (see module docstring)."""
+
+    def confirm(self, message: str) -> bool:
+        """Ask a yes/no question on the terminal.
+
+        A blank line (Enter with no input) is a non-affirmative reply → ``False`` (deny);
+        EOF / a closed terminal raises (the provider also treats that as a denial). Either
+        way the answer is never silently "yes".
+        """
+        answer = self._ask(f"\n{message} [y/N] ")
+        return answer.strip().lower() in _AFFIRMATIVE
+
+    def read_code(self, message: str) -> str:
+        """Read a one-time code from the terminal. Blank/EOF input → raise (deny).
+
+        An empty code must never be returned to the verifier, so a blank line raises rather
+        than passing ``""`` through. The code may echo on the local terminal — acceptable for
+        a single-use TOTP seen only by the local human; it never touches the agent's stream or a log.
+        """
+        code = self._ask(f"\n{message}: ").strip()
+        if not code:
+            raise EOFError("no code entered on the controlling terminal")
+        return code
+
+    @staticmethod
+    def _ask(prompt: str) -> str:
+        # Open a fresh handle per prompt (don't cache): a terminal that was unavailable or
+        # closed earlier may be usable now, and per-call opens keep concurrent challenges
+        # independent. AUTH challenges are effectively serialized by the human anyway.
+        read_handle, write_handle = _open_tty()
+        try:
+            write_handle.write(prompt)
+            write_handle.flush()
+            line = read_handle.readline()
+        finally:
+            # Nested so a failure closing the write handle still closes the (distinct, on
+            # Windows) read handle — never leak a console handle.
+            try:
+                write_handle.close()
+            finally:
+                if read_handle is not write_handle:
+                    read_handle.close()
+        if not line:  # EOF / closed terminal — never silently approve
+            raise EOFError("no input available on the controlling terminal")
+        return line

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -7,9 +7,12 @@ lists currently-active elevations.
 """
 
 import asyncio
+import logging
+import sys
 from datetime import datetime, timezone
 
 import typer
+from mcp import StdioServerParameters
 
 from doberman import __version__
 from doberman.auth import totp
@@ -17,6 +20,7 @@ from doberman.config import load_active_role, load_mode, load_policy, save_mode,
 from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, render_risk_map
 from doberman.policy.checklist import recommend_policy
 from doberman.policy.modes import SecurityMode
+from doberman.proxy.serve import serve_stdio
 from doberman.storage.db import active_elevations, revoke_elevation
 
 app = typer.Typer(
@@ -27,6 +31,66 @@ app = typer.Typer(
 
 twofa_app = typer.Typer(help="Two-factor (TOTP) enrollment.", no_args_is_help=True)
 app.add_typer(twofa_app, name="2fa")
+
+
+def _configure_stderr_logging(level: int = logging.INFO) -> None:
+    """Send Doberman logs to STDERR only.
+
+    In ``serve`` mode this process's stdout IS the agent's MCP channel, so any log written
+    there would corrupt the protocol. Pin every ``doberman.*`` logger to stderr and stop
+    propagation, and — defense in depth — strip any stdout handler from the root logger so a
+    library (mcp/asyncio) or host-configured logger cannot leak a record onto stdout either.
+    """
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("doberman: %(message)s"))
+    doberman_logger = logging.getLogger("doberman")
+    for existing in doberman_logger.handlers[:]:
+        doberman_logger.removeHandler(existing)
+    doberman_logger.addHandler(handler)
+    doberman_logger.setLevel(level)
+    doberman_logger.propagate = False
+
+    root = logging.getLogger()
+    for existing in root.handlers[:]:
+        if (
+            isinstance(existing, logging.StreamHandler)
+            and getattr(existing, "stream", None) is sys.stdout
+        ):
+            root.removeHandler(existing)
+    if not root.handlers:  # keep a stderr fallback so non-doberman logs aren't silently dropped
+        root.addHandler(logging.StreamHandler(sys.stderr))
+
+
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    help="Run Doberman as an MCP proxy in front of a downstream MCP tool server.",
+)
+def serve(
+    ctx: typer.Context,
+    path: str = typer.Option(
+        ".", "--path", "-p", help="Repo root whose .doberman/ policy governs decisions."
+    ),
+) -> None:
+    """Run Doberman as an MCP proxy in front of a downstream MCP server.
+
+    Everything after `--` is the downstream server command, for example:
+
+        doberman serve -- npx -y @modelcontextprotocol/server-filesystem /path/to/repo
+
+    Point your agent's MCP config at this instead of the real server. AUTH prompts appear on
+    your terminal; with no terminal attached (headless) an AUTH action is denied (fail closed).
+    """
+    downstream_argv = list(ctx.args)
+    if not downstream_argv:
+        typer.echo("error: provide the downstream server command after `--`", err=True)
+        raise typer.Exit(code=2)
+    params = StdioServerParameters(command=downstream_argv[0], args=downstream_argv[1:])
+    _configure_stderr_logging()
+    try:
+        asyncio.run(serve_stdio(params, repo_root=path))
+    except Exception as exc:  # noqa: BLE001 — surface a clean stderr error, never a raw traceback
+        typer.echo(f"error: doberman serve failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
 
 
 @app.command()

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1,23 +1,32 @@
-"""The ``doberman`` CLI entry point (Feature 5).
+"""The ``doberman`` CLI entry point (Features 5–7).
 
-Currently exposes ``doberman scan`` — a read-only capability/risk-map report for
-the current repository. More commands (status, init, policy) arrive with later
-features.
+Exposes ``doberman scan`` (risk map), ``review`` / ``mode`` / ``status``
+(policy), and the Feature 7 auth surface: ``doberman 2fa setup`` (TOTP
+enrollment) and ``doberman revoke`` (revoke a role elevation). ``status`` also
+lists currently-active elevations.
 """
+
+import asyncio
+from datetime import datetime, timezone
 
 import typer
 
 from doberman import __version__
+from doberman.auth import totp
 from doberman.config import load_active_role, load_mode, load_policy, save_mode, save_policy
 from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, render_risk_map
 from doberman.policy.checklist import recommend_policy
 from doberman.policy.modes import SecurityMode
+from doberman.storage.db import active_elevations, revoke_elevation
 
 app = typer.Typer(
     help="Doberman — adaptive authorization layer for coding agents.",
     no_args_is_help=True,
     add_completion=False,
 )
+
+twofa_app = typer.Typer(help="Two-factor (TOTP) enrollment.", no_args_is_help=True)
+app.add_typer(twofa_app, name="2fa")
 
 
 @app.command()
@@ -102,6 +111,52 @@ def status(
     else:
         enabled = sum(1 for it in doc.items if it.enabled)
         typer.echo(f"Policy: {enabled}/{len(doc.items)} items enabled")
+
+    enrolled = "yes" if totp.is_enrolled() else "no (run `doberman 2fa setup`)"
+    typer.echo(f"2FA:    {enrolled}")
+
+    grants = asyncio.run(active_elevations(path, datetime.now(timezone.utc)))
+    if not grants:
+        typer.echo("Elevations: (none active)")
+    else:
+        typer.echo(f"Elevations: {len(grants)} active")
+        for grant in grants:
+            kind = "single-use" if grant.single_use else "reusable"
+            typer.echo(
+                f"  {grant.id}  {grant.scope_glob}  "
+                f"(expires {grant.expires_at.isoformat()}; {kind})"
+            )
+
+
+@twofa_app.command("setup")
+def twofa_setup(
+    force: bool = typer.Option(
+        False, "--force", help="Rotate an existing secret (invalidates the old one)."
+    ),
+) -> None:
+    """Enroll TOTP two-factor and print the provisioning URI for your authenticator."""
+    try:
+        uri = totp.enroll(force=force)
+    except RuntimeError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo("2FA enrolled. Add this to your authenticator app (or scan it as a QR):")
+    typer.echo(uri)
+    typer.echo("This secret is stored locally with owner-only permissions and is never committed.")
+
+
+@app.command()
+def revoke(
+    elevation_id: str = typer.Argument(..., help="Id of the elevation to revoke."),
+    path: str = typer.Option(".", "--path", "-p", help="Repository root."),
+) -> None:
+    """Revoke an active role elevation by id (see `doberman status`)."""
+    revoked = asyncio.run(revoke_elevation(path, elevation_id))
+    if revoked:
+        typer.echo(f"revoked elevation {elevation_id}")
+    else:
+        typer.echo(f"no elevation with id {elevation_id}", err=True)
+        raise typer.Exit(code=1)
 
 
 @app.command()

--- a/src/doberman/engine/registry.py
+++ b/src/doberman/engine/registry.py
@@ -38,6 +38,8 @@ RULE_GROUP = "doberman.rules"
 DETECTOR_GROUP = "doberman.detectors"
 #: Policy sources (Feature 4.4) register here; resolved by the policy layer.
 POLICY_SOURCE_GROUP = "doberman.policy_sources"
+#: Auth providers (Feature 7.6) register here; resolved by the auth layer.
+AUTH_PROVIDER_GROUP = "doberman.auth_providers"
 
 
 def _iter_entry_points(group: str) -> Iterator[EntryPoint]:
@@ -153,3 +155,35 @@ def discover_policy_sources() -> list[object]:
             continue
         sources.append(candidate)
     return sources
+
+
+def discover_auth_providers() -> list[object]:
+    """Discover registered auth providers (Feature 7.6, group ``doberman.auth_providers``).
+
+    Loaded defensively like rules/sources: an import/constructor failure, or an
+    object that is not auth-provider-shaped (no callable ``authenticate``), is
+    logged and skipped. Returns ``[]`` when nothing is installed — the auth
+    layer then falls back to the built-in local provider. Core never imports a
+    provider by name.
+    """
+    # Local import avoids an engine<->auth import cycle at module load.
+    from doberman.auth.provider import _looks_like_auth_provider
+
+    providers: list[object] = []
+    seen: set[str] = set()
+    for entry_point in _iter_entry_points(AUTH_PROVIDER_GROUP):
+        key = f"{AUTH_PROVIDER_GROUP}:{getattr(entry_point, 'name', id(entry_point))}"
+        if key in seen:
+            continue
+        seen.add(key)
+        candidate = _load_and_construct(entry_point)
+        if candidate is None:
+            continue
+        if not _looks_like_auth_provider(candidate):
+            logger.warning(
+                "skipping auth provider %r: not auth-provider-shaped",
+                getattr(entry_point, "name", "?"),
+            )
+            continue
+        providers.append(candidate)
+    return providers

--- a/src/doberman/engine/rules/role_boundary.py
+++ b/src/doberman/engine/rules/role_boundary.py
@@ -17,8 +17,16 @@ rules):
 SECURITY: the explanation names the role and the boundary class only — never
 the raw path. With ``ctx.role is None`` the rule abstains, so role enforcement
 is strictly opt-in and never silently blocks a repo that has not set a role.
+
+Role elevation (Feature 7.4): an active, narrow elevation grant (passed in via
+``ctx.metadata['elevations']``) satisfies a ``suspicious`` (out-of-scope) target
+for exactly that path — turning its AUTH into a PASS *for the role rule only*.
+A ``blocked`` target is NEVER softened by an elevation, and every other
+objective rule still runs and combines, so elevation can only ever lift the role
+boundary's own escalation, nothing else.
 """
 
+from doberman.auth.elevation import ElevationGrant, find_cover
 from doberman.models import (
     ActionType,
     EvalContext,
@@ -48,6 +56,21 @@ _SEVERITY = {
 }
 
 
+def _active_elevations(ctx: EvalContext) -> tuple[ElevationGrant, ...]:
+    """Read the already-active elevation grants the proxy loaded into context.
+
+    The proxy queries the storage layer (which filters expired/revoked/spent
+    grants) and hands the survivors in via ``ctx.metadata['elevations']`` — so
+    the rule never touches the database and time/expiry are decided upstream.
+    """
+    if not isinstance(ctx.metadata, dict):
+        return ()
+    raw = ctx.metadata.get("elevations")
+    if not isinstance(raw, (list, tuple)):
+        return ()
+    return tuple(g for g in raw if isinstance(g, ElevationGrant))
+
+
 def _candidate_paths(action: SecurityObject) -> list[str]:
     raw_paths = action.metadata.get("raw_paths") if isinstance(action.metadata, dict) else None
     if isinstance(raw_paths, (list, tuple)) and raw_paths:
@@ -74,10 +97,19 @@ class RoleBoundaryRule:
         root = _DEFAULT_ROOT
         if isinstance(ctx.metadata, dict):
             root = str(ctx.metadata.get("repo_root") or _DEFAULT_ROOT)
+        grants = _active_elevations(ctx)
 
         worst = RoleBoundary.allowed
         for raw_path in paths:
             boundary = classify(role, raw_path, root=root)
+            # A narrow, temporary elevation can satisfy a suspicious (out-of-
+            # scope) target for exactly that path — but never a blocked one.
+            if (
+                boundary is RoleBoundary.suspicious
+                and grants
+                and find_cover(raw_path, grants, root=root) is not None
+            ):
+                boundary = RoleBoundary.allowed
             if _SEVERITY[boundary] > _SEVERITY[worst]:
                 worst = boundary
             if worst is RoleBoundary.blocked:

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -17,6 +17,7 @@ Any engine failure is itself a ``BLOCK`` (fail closed). The approval is bound to
 exactly one action id (no replay onto a different call).
 """
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 
@@ -199,7 +200,12 @@ async def _handle_auth(
     now: datetime,
 ) -> CallToolResult:
     """Run the tiered challenge for an AUTH decision and act on the outcome."""
-    auth_result = run_auth_challenge(decision, action, prompter=AUTH_PROMPTER)
+    # Off the event loop: the challenge blocks for a human, and an elicitation
+    # answer arrives over the very session this loop services — waiting in-loop
+    # would deadlock it (and freeze the proxy during GUI/TTY prompts too).
+    auth_result = await asyncio.to_thread(
+        run_auth_challenge, decision, action, prompter=AUTH_PROMPTER
+    )
     # Approval is bound to THIS action id — never honor a result for another call.
     if not auth_result.approved or auth_result.action_id != action.id:
         return _verdict_result(decision)

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -1,11 +1,20 @@
 """The single execution chokepoint between the agent and downstream tools.
 
 Every tool call intercepted by the proxy MUST flow through
-:func:`decide_and_execute` — there is no other route to a downstream tool.
-The decision engine (Feature 2) judges every normalized action: ``PASS``
-forwards, ``AUTH`` returns an authentication-required error (real auth
-arrives with Feature 7), ``BLOCK`` returns a policy error and the call is
-NEVER forwarded. Any engine failure is itself a ``BLOCK`` (fail closed).
+:func:`decide_and_execute` — there is no other route to a downstream tool. The
+decision engine (Feature 2) judges every normalized action; Feature 7 turns an
+``AUTH`` into a real, action-specific challenge:
+
+* ``PASS`` forwards the call.
+* ``AUTH`` runs a tiered challenge (confirm / 2FA / role elevation). On approval
+  the action is **re-decided** (TOCTOU guard) and, unless it now ``BLOCK``s,
+  forwarded; a satisfied ``role_elevation`` grants a narrow, temporary, (for
+  destructive scopes) single-use elevation first. Denial/timeout forwards
+  nothing.
+* ``BLOCK`` returns a policy error and is NEVER forwarded.
+
+Any engine failure is itself a ``BLOCK`` (fail closed). The approval is bound to
+exactly one action id (no replay onto a different call).
 """
 
 import logging
@@ -14,10 +23,13 @@ from datetime import datetime, timezone
 from mcp.client.session import ClientSession
 from mcp.types import CallToolResult, TextContent
 
+from doberman.auth.challenge import AuthTier, run_auth_challenge
+from doberman.auth.elevation import find_cover, scope_for_target
 from doberman.config import load_active_role, load_mode
 from doberman.engine.decision_engine import PASS_STUB, Guardrail, decide
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.models import (
+    ActionType,
     Decision,
     EvalContext,
     GuardrailResult,
@@ -28,15 +40,24 @@ from doberman.models import (
 )
 from doberman.proxy.interception_log import log_action
 from doberman.proxy.normalize import normalize
+from doberman.storage.db import active_elevations, grant_elevation, mark_used
 
 _engine_logger = logging.getLogger("doberman.proxy.engine")
 
-# Guardrail implementations used by the proxy. The objective guardrail is now
-# the real Feature 3 rule set; the subjective guardrail stays a PASS stub until
+#: Repo root used for config + the elevation store. Module-level so tests can
+#: point it at an isolated temp dir (the DB/config must never touch the repo).
+REPO_ROOT = "."
+
+# Guardrail implementations used by the proxy. The objective guardrail is the
+# real Feature 3 rule set; the subjective guardrail stays a PASS stub until
 # Feature 9 lands. Module-level so tests can monkeypatch the policy without
 # touching the routing.
 DEFAULT_OBJECTIVE: Guardrail = ObjectiveGuardrail()
 DEFAULT_SUBJECTIVE: Guardrail = PASS_STUB
+
+#: Action types whose elevations are single-use (a destructive op should not be
+#: silently repeatable on one approval).
+_DESTRUCTIVE_ACTIONS = frozenset({ActionType.file_delete})
 
 _DENIED_TEMPLATE = (
     "doberman: downstream call failed; action denied "
@@ -107,6 +128,108 @@ def _engine_failure_decision(action: SecurityObject) -> Decision:
     )
 
 
+def _build_ctx(arguments: dict | None, grants: tuple) -> EvalContext:
+    """Assemble the EvalContext for one decision.
+
+    The objective rules (Feature 3) inspect the UN-redacted call content via
+    ``metadata['raw_arguments']`` (in-memory only, never logged/persisted). The
+    active role (F4), mode (F6), and active elevations (F7) ride along too.
+    """
+    return EvalContext(
+        role=load_active_role(REPO_ROOT),
+        mode=load_mode(REPO_ROOT),
+        metadata={
+            "raw_arguments": dict(arguments or {}),
+            "repo_root": REPO_ROOT,
+            "elevations": grants,
+        },
+    )
+
+
+def _safe_decide(action: SecurityObject, ctx: EvalContext) -> Decision:
+    """Run the engine; any failure becomes a fail-closed BLOCK (never crashes)."""
+    try:
+        return decide(action, DEFAULT_OBJECTIVE, DEFAULT_SUBJECTIVE, ctx)
+    except Exception:  # noqa: BLE001 — engine failure must fail closed, not crash
+        # BaseException (CancelledError, SystemExit) propagates on purpose — an
+        # unwind is fail-closed by construction (no forward is reached).
+        _engine_logger.exception("decision engine raised; failing closed (action %s)", action.id)
+        return _engine_failure_decision(action)
+
+
+def _is_destructive(action: SecurityObject) -> bool:
+    return action.action_type in _DESTRUCTIVE_ACTIONS
+
+
+async def _forward(
+    downstream: ClientSession,
+    tool_name: str,
+    arguments: dict | None,
+    action: SecurityObject,
+) -> CallToolResult:
+    """Forward an approved call downstream, failing closed on any error."""
+    try:
+        return await downstream.call_tool(tool_name, arguments or {})
+    except Exception as exc:  # noqa: BLE001 — fail closed on ANY failure mode
+        # Never re-raise into the serving path and never echo arguments.
+        # Deliberately `Exception`, not `BaseException`: cancellation and
+        # interpreter shutdown must propagate (they carry no payload to leak).
+        return _denied_result(ReasonCode.downstream_error, type(exc).__name__, action.id)
+
+
+async def _consume_single_use(action: SecurityObject, grants: tuple, now: datetime) -> None:
+    """Mark a single-use elevation spent after it released a forward (best-effort)."""
+    grant = find_cover(action.target, grants, root=REPO_ROOT)
+    if grant is not None and grant.single_use:
+        await mark_used(REPO_ROOT, grant.id)
+
+
+async def _handle_auth(
+    downstream: ClientSession,
+    tool_name: str,
+    arguments: dict | None,
+    action: SecurityObject,
+    decision: Decision,
+    now: datetime,
+) -> CallToolResult:
+    """Run the tiered challenge for an AUTH decision and act on the outcome."""
+    auth_result = run_auth_challenge(decision, action)
+    # Approval is bound to THIS action id — never honor a result for another call.
+    if not auth_result.approved or auth_result.action_id != action.id:
+        return _verdict_result(decision)
+
+    # A satisfied role elevation grants a narrow, temporary permission first.
+    if auth_result.tier is AuthTier.role_elevation:
+        scope = scope_for_target(action.target, root=REPO_ROOT)
+        if scope is None:
+            # No narrow scope can be formed (non-path / escapes root): refuse.
+            return _verdict_result(decision)
+        try:
+            await grant_elevation(
+                REPO_ROOT,
+                scope,
+                action.id,
+                now=now,
+                single_use=_is_destructive(action),
+            )
+        except Exception:  # noqa: BLE001 — a failed grant must fail closed
+            _engine_logger.warning("elevation grant failed (action %s); denying", action.id)
+            return _verdict_result(decision)
+
+    # TOCTOU guard: re-decide with refreshed elevations. A change to BLOCK must
+    # block even post-approval; otherwise the human-approved action is released.
+    grants = tuple(await active_elevations(REPO_ROOT, now))
+    redecision = _safe_decide(action, _build_ctx(arguments, grants))
+    if redecision.final_verdict is Verdict.BLOCK:
+        log_action(action, redecision.final_verdict)
+        return _verdict_result(redecision)
+
+    result = await _forward(downstream, tool_name, arguments, action)
+    if not result.isError:
+        await _consume_single_use(action, grants, now)
+    return result
+
+
 async def decide_and_execute(
     downstream: ClientSession,
     tool_name: str,
@@ -114,51 +237,30 @@ async def decide_and_execute(
 ) -> CallToolResult:
     """Decide whether to execute a tool call, then act on the verdict.
 
-    This is THE chokepoint: normalize → decide → enforce. The downstream
-    forward happens in exactly one place, reachable only on a PASS decision.
+    This is THE chokepoint: normalize → decide → enforce. The downstream forward
+    happens only on a PASS decision or a successfully-authenticated AUTH.
     """
     action: SecurityObject = normalize(tool_name, arguments)
+    now = datetime.now(timezone.utc)
 
-    # The objective rules (Feature 3) need to inspect the UN-redacted call
-    # content to detect secrets / parse commands. We hand it to them through
-    # EvalContext.metadata, which is in-memory only and never logged or
-    # persisted — the SecurityObject itself stays redacted for the audit log.
-    # The active agent role (Feature 4) is loaded from .doberman/role.yaml; it
-    # is None when no role is configured, in which case the role rule abstains.
-    ctx = EvalContext(
-        role=load_active_role("."),
-        mode=load_mode("."),
-        metadata={"raw_arguments": dict(arguments or {})},
-    )
+    # Active elevations (F7) may satisfy a role-boundary AUTH for the exact
+    # covered target, so they are loaded BEFORE the first decision.
+    grants = tuple(await active_elevations(REPO_ROOT, now))
+    decision = _safe_decide(action, _build_ctx(arguments, grants))
 
-    try:
-        decision = decide(action, DEFAULT_OBJECTIVE, DEFAULT_SUBJECTIVE, ctx)
-    except Exception:  # noqa: BLE001 — engine failure must fail closed, not crash
-        # BaseException (CancelledError, SystemExit) propagates on purpose —
-        # an unwind is fail-closed by construction (the forward below is
-        # never reached). Log the failure server-side for forensics; the
-        # exception text never reaches the agent.
-        _engine_logger.exception("decision engine raised; failing closed (action %s)", action.id)
-        decision = _engine_failure_decision(action)
-
-    # Record every intercepted action with its REAL verdict. Logged BEFORE
-    # the verdict gate — safe because log_action can never bypass the gate
-    # (it swallows its own failures and forwards nothing).
+    # Record every intercepted action with its REAL verdict. Logged before the
+    # gate — safe because log_action swallows its own failures and forwards
+    # nothing.
     log_action(action, decision.final_verdict)
 
-    if decision.final_verdict is not Verdict.PASS:
-        # AUTH (F7 adds the real challenge) and BLOCK both stop here:
-        # the downstream call below is never reached.
+    if decision.final_verdict is Verdict.BLOCK:
         return _verdict_result(decision)
 
-    try:
-        return await downstream.call_tool(tool_name, arguments or {})
-    except Exception as exc:  # noqa: BLE001 — fail closed on ANY failure mode
-        # Never re-raise into the serving path and never echo arguments:
-        # the agent gets a generic denial carrying a stable reason code and
-        # the action id for correlation with the interception log.
-        # Deliberately `Exception`, not `BaseException`: cancellation
-        # (asyncio.CancelledError) and interpreter shutdown must propagate —
-        # swallowing them would break structured concurrency, and they carry
-        # no payload to leak.
-        return _denied_result(ReasonCode.downstream_error, type(exc).__name__, action.id)
+    if decision.final_verdict is Verdict.AUTH:
+        return await _handle_auth(downstream, tool_name, arguments, action, decision, now)
+
+    # PASS — forward, then consume any single-use elevation that released it.
+    result = await _forward(downstream, tool_name, arguments, action)
+    if not result.isError:
+        await _consume_single_use(action, grants, now)
+    return result

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 from mcp.client.session import ClientSession
 from mcp.types import CallToolResult, TextContent
 
-from doberman.auth.challenge import AuthTier, run_auth_challenge
+from doberman.auth.challenge import AuthTier, Prompter, run_auth_challenge
 from doberman.auth.elevation import find_cover, scope_for_target
 from doberman.config import load_active_role, load_mode
 from doberman.engine.decision_engine import PASS_STUB, Guardrail, decide
@@ -47,6 +47,12 @@ _engine_logger = logging.getLogger("doberman.proxy.engine")
 #: Repo root used for config + the elevation store. Module-level so tests can
 #: point it at an isolated temp dir (the DB/config must never touch the repo).
 REPO_ROOT = "."
+
+#: Prompter for AUTH challenges. None ⇒ the provider's default CLI prompter
+#: (stdin/stdout). The stdio ``serve`` path sets this to a controlling-terminal
+#: prompter so a challenge never reads/writes the agent's MCP stream. Module-level
+#: so tests can inject a headless fake.
+AUTH_PROMPTER: Prompter | None = None
 
 # Guardrail implementations used by the proxy. The objective guardrail is the
 # real Feature 3 rule set; the subjective guardrail stays a PASS stub until
@@ -193,7 +199,7 @@ async def _handle_auth(
     now: datetime,
 ) -> CallToolResult:
     """Run the tiered challenge for an AUTH decision and act on the outcome."""
-    auth_result = run_auth_challenge(decision, action)
+    auth_result = run_auth_challenge(decision, action, prompter=AUTH_PROMPTER)
     # Approval is bound to THIS action id — never honor a result for another call.
     if not auth_result.approved or auth_result.action_id != action.id:
         return _verdict_result(decision)

--- a/src/doberman/proxy/serve.py
+++ b/src/doberman/proxy/serve.py
@@ -1,0 +1,43 @@
+"""Run Doberman as a real MCP proxy over stdio in front of one downstream tool server.
+
+Doberman is an MCP *server* to the agent (over this process's stdin/stdout) and an MCP
+*client* to the downstream server (which it spawns). Every ``tools/call`` flows through the
+single chokepoint (:func:`doberman.proxy.executor.decide_and_execute`) — there is no path
+around it. This is the deployable counterpart to :func:`doberman.proxy.mcp_proxy.build_proxy_server`,
+which builds the proxy object; this module gives it a transport.
+
+SECURITY: nothing here writes this process's stdout (that is the agent's MCP channel). AUTH
+challenges are routed to the controlling terminal via :class:`~doberman.auth.tty_prompter.TtyPrompter`
+so a prompt never touches the agent stream; with no terminal the challenge denies (fail closed).
+"""
+
+import logging
+
+from mcp import ClientSession, StdioServerParameters, stdio_client
+from mcp.server.stdio import stdio_server
+
+from doberman.auth.tty_prompter import TtyPrompter
+from doberman.proxy import executor
+from doberman.proxy.mcp_proxy import build_proxy_server
+
+logger = logging.getLogger("doberman.proxy.serve")
+
+
+async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = ".") -> None:
+    """Spawn ``downstream``, then serve the Doberman proxy to the agent over stdio.
+
+    Points the engine at ``repo_root`` (its ``.doberman/`` holds the active role, policy,
+    decision log, and elevation store) and installs the controlling-terminal prompter so an
+    ``AUTH`` challenge never reads/writes the agent's stdin/stdout. Returns when the agent
+    disconnects; any transport failure propagates (the caller exits non-zero, forwarding nothing).
+    """
+    executor.REPO_ROOT = repo_root
+    executor.AUTH_PROMPTER = TtyPrompter()
+    logger.info("starting downstream: %s", downstream.command)
+    async with stdio_client(downstream) as (downstream_read, downstream_write):
+        async with ClientSession(downstream_read, downstream_write) as session:
+            await session.initialize()
+            proxy = build_proxy_server(session)
+            async with stdio_server() as (agent_read, agent_write):
+                logger.info("ready — proxying tool calls to the agent over stdio")
+                await proxy.run(agent_read, agent_write, proxy.create_initialization_options())

--- a/src/doberman/proxy/serve.py
+++ b/src/doberman/proxy/serve.py
@@ -7,8 +7,12 @@ around it. This is the deployable counterpart to :func:`doberman.proxy.mcp_proxy
 which builds the proxy object; this module gives it a transport.
 
 SECURITY: nothing here writes this process's stdout (that is the agent's MCP channel). AUTH
-challenges are routed to the controlling terminal via :class:`~doberman.auth.tty_prompter.TtyPrompter`
-so a prompt never touches the agent stream; with no terminal the challenge denies (fail closed).
+challenges surface as a topmost GUI dialog (:class:`~doberman.auth.gui_prompter.GuiPrompter`)
+first — when an agent's TUI owns the console, a terminal prompt opens "successfully" but is
+invisible and its input is contested, so the dialog is the only channel the human can actually
+see. With no display the chain falls back to the controlling terminal
+(:class:`~doberman.auth.tty_prompter.TtyPrompter`); with neither, the challenge denies (fail
+closed). A prompt never touches the agent stream.
 """
 
 import logging
@@ -16,6 +20,7 @@ import logging
 from mcp import ClientSession, StdioServerParameters, stdio_client
 from mcp.server.stdio import stdio_server
 
+from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
 from doberman.auth.tty_prompter import TtyPrompter
 from doberman.proxy import executor
 from doberman.proxy.mcp_proxy import build_proxy_server
@@ -27,12 +32,13 @@ async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = "."
     """Spawn ``downstream``, then serve the Doberman proxy to the agent over stdio.
 
     Points the engine at ``repo_root`` (its ``.doberman/`` holds the active role, policy,
-    decision log, and elevation store) and installs the controlling-terminal prompter so an
-    ``AUTH`` challenge never reads/writes the agent's stdin/stdout. Returns when the agent
-    disconnects; any transport failure propagates (the caller exits non-zero, forwarding nothing).
+    decision log, and elevation store) and installs the GUI-first prompter chain so an
+    ``AUTH`` challenge never reads/writes the agent's stdin/stdout — and is actually
+    *visible* when the agent's TUI owns the console. Returns when the agent disconnects;
+    any transport failure propagates (the caller exits non-zero, forwarding nothing).
     """
     executor.REPO_ROOT = repo_root
-    executor.AUTH_PROMPTER = TtyPrompter()
+    executor.AUTH_PROMPTER = FallbackPrompter([GuiPrompter(), TtyPrompter()])
     logger.info("starting downstream: %s", downstream.command)
     async with stdio_client(downstream) as (downstream_read, downstream_write):
         async with ClientSession(downstream_read, downstream_write) as session:

--- a/src/doberman/proxy/serve.py
+++ b/src/doberman/proxy/serve.py
@@ -7,19 +7,23 @@ around it. This is the deployable counterpart to :func:`doberman.proxy.mcp_proxy
 which builds the proxy object; this module gives it a transport.
 
 SECURITY: nothing here writes this process's stdout (that is the agent's MCP channel). AUTH
-challenges surface as a topmost GUI dialog (:class:`~doberman.auth.gui_prompter.GuiPrompter`)
-first — when an agent's TUI owns the console, a terminal prompt opens "successfully" but is
-invisible and its input is contested, so the dialog is the only channel the human can actually
-see. With no display the chain falls back to the controlling terminal
-(:class:`~doberman.auth.tty_prompter.TtyPrompter`); with neither, the challenge denies (fail
-closed). A prompt never touches the agent stream.
+challenges try three channels in order: MCP **elicitation** first
+(:class:`~doberman.auth.elicitation_prompter.ElicitationPrompter` — rendered natively inside
+the agent client, for clients that support it; never used for 2FA codes), then a topmost GUI
+dialog (:class:`~doberman.auth.gui_prompter.GuiPrompter` — when an agent's TUI owns the
+console, a terminal prompt opens "successfully" but is invisible, so the dialog is the channel
+the human can actually see), then the controlling terminal
+(:class:`~doberman.auth.tty_prompter.TtyPrompter`) for headless/SSH sessions. With no channel
+available the challenge denies (fail closed). A prompt never touches the agent stream.
 """
 
+import asyncio
 import logging
 
 from mcp import ClientSession, StdioServerParameters, stdio_client
 from mcp.server.stdio import stdio_server
 
+from doberman.auth.elicitation_prompter import ElicitationPrompter
 from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
 from doberman.auth.tty_prompter import TtyPrompter
 from doberman.proxy import executor
@@ -32,18 +36,27 @@ async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = "."
     """Spawn ``downstream``, then serve the Doberman proxy to the agent over stdio.
 
     Points the engine at ``repo_root`` (its ``.doberman/`` holds the active role, policy,
-    decision log, and elevation store) and installs the GUI-first prompter chain so an
-    ``AUTH`` challenge never reads/writes the agent's stdin/stdout — and is actually
-    *visible* when the agent's TUI owns the console. Returns when the agent disconnects;
-    any transport failure propagates (the caller exits non-zero, forwarding nothing).
+    decision log, and elevation store) and installs the elicitation→GUI→terminal prompter
+    chain so an ``AUTH`` challenge never reads/writes the agent's stdin/stdout — and is
+    actually *visible* when the agent's TUI owns the console. Returns when the agent
+    disconnects; any transport failure propagates (the caller exits non-zero, forwarding
+    nothing).
     """
     executor.REPO_ROOT = repo_root
-    executor.AUTH_PROMPTER = FallbackPrompter([GuiPrompter(), TtyPrompter()])
     logger.info("starting downstream: %s", downstream.command)
     async with stdio_client(downstream) as (downstream_read, downstream_write):
         async with ClientSession(downstream_read, downstream_write) as session:
             await session.initialize()
             proxy = build_proxy_server(session)
+            # The elicitation channel needs the proxy (to resolve the per-request agent
+            # session) and this loop (challenges run in a worker thread and bridge back).
+            executor.AUTH_PROMPTER = FallbackPrompter(
+                [
+                    ElicitationPrompter(proxy, asyncio.get_running_loop()),
+                    GuiPrompter(),
+                    TtyPrompter(),
+                ]
+            )
             async with stdio_server() as (agent_read, agent_write):
                 logger.info("ready — proxying tool calls to the agent over stdio")
                 await proxy.run(agent_read, agent_write, proxy.create_initialization_options())

--- a/src/doberman/storage/db.py
+++ b/src/doberman/storage/db.py
@@ -1,0 +1,200 @@
+"""Local SQLite storage (Feature 7; extended by Feature 8).
+
+Doberman is local-first: persistent state lives in ``.doberman/doberman.db`` —
+a per-repo SQLite database that is **never committed** (``.doberman/`` is
+gitignored). Feature 7 introduces it to persist **role elevations** (slice 7.4);
+Feature 8 extends the same schema with the decision log and fingerprint store.
+
+This module owns schema creation and the elevation queries. The *matching* logic
+(which grant covers which target) lives in :mod:`doberman.auth.elevation` so the
+decision engine can reason about elevations without depending on the database.
+
+SECURITY / resilience:
+
+* The DB file is created ``0600`` inside a ``0700`` directory (best-effort;
+  Windows ACLs make ``chmod`` a no-op). No elevation row holds a raw secret —
+  only a path **glob**, ids, and timestamps.
+* Reads **fail closed toward no-elevation**: any error querying active grants
+  returns an empty list, so a corrupt/locked DB can only ever cause an action to
+  *stay* at ``AUTH`` — never to be silently elevated. Writes surface errors to
+  the caller (the proxy treats a failed grant as "not authorized").
+* ``busy_timeout`` lets a momentarily-locked DB retry rather than erroring.
+"""
+
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import aiosqlite
+
+from doberman.auth.elevation import DEFAULT_TTL_SECONDS, ElevationGrant
+
+CONFIG_DIR = ".doberman"
+DB_FILE = "doberman.db"
+
+#: Current schema version. Feature 8 bumps this when it adds its tables.
+SCHEMA_VERSION = 1
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+
+CREATE TABLE IF NOT EXISTS elevations (
+    id          TEXT PRIMARY KEY,
+    scope_glob  TEXT NOT NULL,
+    task_id     TEXT,
+    granted_at  TEXT NOT NULL,
+    expires_at  TEXT NOT NULL,
+    revoked     INTEGER NOT NULL DEFAULT 0,
+    single_use  INTEGER NOT NULL DEFAULT 0,
+    used        INTEGER NOT NULL DEFAULT 0
+);
+"""
+
+
+def db_path(repo_root: str = ".") -> Path:
+    """Path to the per-repo SQLite database (never committed)."""
+    return Path(repo_root) / CONFIG_DIR / DB_FILE
+
+
+def _restrict_permissions(path: Path) -> None:
+    """Best-effort tighten the DB dir/file to owner-only (no-op on Windows ACLs)."""
+    try:
+        os.chmod(path.parent, 0o700)
+        if path.exists():
+            os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+async def _ensure_schema(conn: aiosqlite.Connection) -> None:
+    await conn.executescript(_SCHEMA)
+    async with conn.execute("SELECT COUNT(*) FROM schema_version") as cur:
+        row = await cur.fetchone()
+    if row is not None and row[0] == 0:
+        await conn.execute("INSERT INTO schema_version (version) VALUES (?)", (SCHEMA_VERSION,))
+    await conn.commit()
+
+
+@asynccontextmanager
+async def open_db(repo_root: str = ".") -> AsyncIterator[aiosqlite.Connection]:
+    """Open (creating if needed) the repo DB with the schema ensured.
+
+    Creates ``.doberman/`` ``0700`` and the DB file ``0600`` on first use.
+    """
+    path = db_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    conn = await aiosqlite.connect(str(path))
+    try:
+        await conn.execute("PRAGMA busy_timeout = 3000")
+        await _ensure_schema(conn)
+        _restrict_permissions(path)
+        yield conn
+    finally:
+        await conn.close()
+
+
+def _parse_dt(value: str) -> datetime:
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _row_to_grant(row: aiosqlite.Row | tuple) -> ElevationGrant:
+    return ElevationGrant(
+        id=row[0],
+        scope_glob=row[1],
+        task_id=row[2],
+        granted_at=_parse_dt(row[3]),
+        expires_at=_parse_dt(row[4]),
+        revoked=bool(row[5]),
+        single_use=bool(row[6]),
+        used=bool(row[7]),
+    )
+
+
+_SELECT_ALL = (
+    "SELECT id, scope_glob, task_id, granted_at, expires_at, revoked, single_use, used "
+    "FROM elevations"
+)
+
+
+async def grant_elevation(
+    repo_root: str,
+    scope_glob: str,
+    task_id: str | None,
+    *,
+    now: datetime,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    single_use: bool = False,
+) -> ElevationGrant:
+    """Persist and return a new narrow, time-limited elevation grant.
+
+    The caller is responsible for ensuring ``scope_glob`` is narrow (a canonical
+    single-path glob from :func:`doberman.auth.elevation.scope_for_target`);
+    this layer only persists what it is given.
+    """
+    grant = ElevationGrant(
+        id=uuid4().hex,
+        scope_glob=scope_glob,
+        task_id=task_id,
+        granted_at=now,
+        expires_at=now + timedelta(seconds=ttl_seconds),
+        single_use=single_use,
+    )
+    async with open_db(repo_root) as conn:
+        await conn.execute(
+            "INSERT INTO elevations "
+            "(id, scope_glob, task_id, granted_at, expires_at, revoked, single_use, used) "
+            "VALUES (?, ?, ?, ?, ?, 0, ?, 0)",
+            (
+                grant.id,
+                grant.scope_glob,
+                grant.task_id,
+                grant.granted_at.isoformat(),
+                grant.expires_at.isoformat(),
+                int(grant.single_use),
+            ),
+        )
+        await conn.commit()
+    return grant
+
+
+async def active_elevations(repo_root: str, now: datetime) -> list[ElevationGrant]:
+    """Return all currently-usable grants (not expired/revoked/spent).
+
+    Fails closed: any storage error returns ``[]`` — no DB problem can ever add
+    an elevation, only remove one. Short-circuits (no DB creation) when no
+    database exists yet — the overwhelmingly common no-elevation case.
+    """
+    if not db_path(repo_root).exists():
+        return []
+    try:
+        async with open_db(repo_root) as conn:
+            async with conn.execute(_SELECT_ALL) as cur:
+                rows = await cur.fetchall()
+    except (aiosqlite.Error, OSError, ValueError):
+        return []
+    grants = [_row_to_grant(row) for row in rows]
+    return [g for g in grants if g.is_active(now)]
+
+
+async def revoke_elevation(repo_root: str, elevation_id: str) -> bool:
+    """Mark an elevation revoked. Returns ``True`` if a row was updated."""
+    async with open_db(repo_root) as conn:
+        cur = await conn.execute("UPDATE elevations SET revoked = 1 WHERE id = ?", (elevation_id,))
+        await conn.commit()
+        return cur.rowcount > 0
+
+
+async def mark_used(repo_root: str, elevation_id: str) -> None:
+    """Mark a single-use elevation spent (best-effort; never raises into forward)."""
+    try:
+        async with open_db(repo_root) as conn:
+            await conn.execute("UPDATE elevations SET used = 1 WHERE id = ?", (elevation_id,))
+            await conn.commit()
+    except (aiosqlite.Error, OSError):
+        return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ need to exercise key generation/rotation override this with their own
 
 import pytest
 
+from doberman.auth.totp import TOTP_FILE_ENV
 from doberman.storage.fingerprint import KEY_FILE_ENV
 
 
@@ -25,3 +26,34 @@ def isolated_fingerprint_key(tmp_path, monkeypatch):
     key_path = tmp_path / "doberman-fingerprint.key"
     monkeypatch.setenv(KEY_FILE_ENV, str(key_path))
     return key_path
+
+
+@pytest.fixture(autouse=True)
+def isolated_totp_secret(tmp_path, monkeypatch):
+    """Point the TOTP secret at a per-test temp file (Feature 7).
+
+    Tests must never touch the real per-user 2FA secret, and the
+    consecutive-failure rate-limit state is keyed by this path, so a fresh path
+    per test isolates rate-limit state too. Returns the path for tests that
+    enroll/verify directly.
+    """
+    secret_path = tmp_path / "doberman-totp.secret"
+    monkeypatch.setenv(TOTP_FILE_ENV, str(secret_path))
+    return secret_path
+
+
+@pytest.fixture(autouse=True)
+def isolated_executor_repo_root(tmp_path, monkeypatch):
+    """Point the proxy's repo root (config + elevation DB) at a temp dir.
+
+    Feature 7 persists elevations to ``<repo_root>/.doberman/doberman.db``; this
+    keeps every test's DB/config inside its own tmp dir so nothing is ever
+    written into the working tree, and elevation state never leaks across tests.
+    Returns the isolated repo root for tests that grant/read elevations.
+    """
+    from doberman.proxy import executor
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    monkeypatch.setattr(executor, "REPO_ROOT", str(repo_root))
+    return repo_root

--- a/tests/fixtures/stdio_tool_server.py
+++ b/tests/fixtures/stdio_tool_server.py
@@ -1,0 +1,109 @@
+"""A runnable downstream MCP tool server over stdio, for the serve end-to-end test.
+
+Mirrors the tool surface of :mod:`tests.fixtures.fake_tool_server` (fs_write / fs_delete /
+shell_exec / net_get) but runs as a real subprocess so ``doberman serve`` can spawn it. Every
+*executed* call is appended as one JSON line ``[tool_name, arguments]`` to the file named by the
+``DOBERMAN_TEST_CALLLOG`` environment variable, so the test can assert exactly what reached a tool
+(the chokepoint property: a blocked call must leave no line behind).
+
+Run as: ``python tests/fixtures/stdio_tool_server.py``  (stdout is its MCP channel — never printed to).
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+
+SERVER_NAME = "stdio-downstream"
+
+_TOOLS: list[Tool] = [
+    Tool(
+        name="fs_write",
+        description="Write content to a file.",
+        inputSchema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+            "required": ["path", "content"],
+        },
+    ),
+    Tool(
+        name="fs_delete",
+        description="Delete a file.",
+        inputSchema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    ),
+    Tool(
+        name="shell_exec",
+        description="Run a shell command.",
+        inputSchema={
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"],
+        },
+    ),
+    Tool(
+        name="net_get",
+        description="HTTP GET a URL.",
+        inputSchema={
+            "type": "object",
+            "properties": {"url": {"type": "string"}},
+            "required": ["url"],
+        },
+    ),
+]
+
+KNOWN_TOOL_NAMES = {tool.name for tool in _TOOLS}
+
+
+def _call_log_path() -> str | None:
+    """Where to record executed calls: argv[1] (robust — flows through `serve --`) or the
+    DOBERMAN_TEST_CALLLOG env var as a fallback."""
+    if len(sys.argv) > 1 and sys.argv[1]:
+        return sys.argv[1]
+    return os.environ.get("DOBERMAN_TEST_CALLLOG")
+
+
+def _record(tool_name: str, arguments: dict) -> None:
+    """Append one executed call to the call-log file (never to stdout)."""
+    call_log = _call_log_path()
+    if not call_log:
+        return
+    with open(call_log, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps([tool_name, arguments]) + "\n")
+
+
+def build() -> Server:
+    server: Server = Server(SERVER_NAME)
+
+    @server.list_tools()
+    async def _list_tools() -> list[Tool]:
+        return _TOOLS
+
+    @server.call_tool()
+    async def _call_tool(tool_name: str, arguments: dict) -> list[TextContent]:
+        if tool_name not in KNOWN_TOOL_NAMES:
+            raise ValueError(f"unknown tool: {tool_name}")  # error before recording
+        _record(tool_name, arguments)
+        return [TextContent(type="text", text=f"ok: {tool_name} executed")]
+
+    return server
+
+
+async def main() -> None:
+    server = build()
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised as a subprocess by the e2e test
+    try:
+        asyncio.run(main())
+    except (KeyboardInterrupt, EOFError):
+        sys.exit(0)

--- a/tests/integration/test_auth_release.py
+++ b/tests/integration/test_auth_release.py
@@ -1,0 +1,182 @@
+"""Slice 7.5 — actions are released only after a successful, bound auth."""
+
+from datetime import datetime, timezone
+
+from doberman.auth.challenge import AuthResult, AuthTier
+from doberman.engine.decision_engine import StaticGuardrail
+from doberman.models import GuardrailResult, ReasonCode, Risk, Verdict
+from doberman.proxy import executor
+
+from .test_proxy_passthrough import proxied_session
+
+_AUTHING = StaticGuardrail(
+    GuardrailResult(
+        verdict=Verdict.AUTH,
+        risk=Risk.high,
+        reason_codes=[ReasonCode.sensitive_path_access],
+        explanation="Stub objective requires authentication.",
+    )
+)
+
+
+def _approve(tier=AuthTier.local_auth):
+    def challenge(decision, action, *, prompter=None, at=None):
+        return AuthResult(
+            approved=True,
+            tier=tier,
+            method="test",
+            at=datetime.now(timezone.utc),
+            action_id=action.id,
+        )
+
+    return challenge
+
+
+def _deny(decision, action, *, prompter=None, at=None):
+    return AuthResult(
+        approved=False,
+        tier=AuthTier.local_auth,
+        method="denied",
+        at=datetime.now(timezone.utc),
+        action_id=action.id,
+    )
+
+
+def _approve_for_wrong_action(decision, action, *, prompter=None, at=None):
+    return AuthResult(
+        approved=True,
+        tier=AuthTier.local_auth,
+        method="test",
+        at=datetime.now(timezone.utc),
+        action_id="some-other-action",
+    )
+
+
+def _write_role(repo_root):
+    cfg = repo_root / ".doberman"
+    cfg.mkdir(parents=True, exist_ok=True)
+    (cfg / "role.yaml").write_text(
+        'name: webdev\nallowed:\n  - "frontend/**"\nsuspicious:\n  - "backend/**"\n',
+        encoding="utf-8",
+    )
+
+
+async def test_approved_auth_forwards_and_records(monkeypatch):
+    monkeypatch.setattr(executor, "DEFAULT_OBJECTIVE", _AUTHING)
+    monkeypatch.setattr(executor, "run_auth_challenge", _approve())
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("fs_write", {"path": "a.txt", "content": "x"})
+        assert not result.isError
+        assert fake.calls == [("fs_write", {"path": "a.txt", "content": "x"})]
+
+
+async def test_denied_auth_forwards_nothing(monkeypatch):
+    monkeypatch.setattr(executor, "DEFAULT_OBJECTIVE", _AUTHING)
+    monkeypatch.setattr(executor, "run_auth_challenge", _deny)
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("fs_write", {"path": "a.txt", "content": "x"})
+        assert result.isError
+        assert "authentication required" in result.content[0].text
+        assert fake.calls == []
+
+
+async def test_approval_must_be_bound_to_this_action_id(monkeypatch):
+    monkeypatch.setattr(executor, "DEFAULT_OBJECTIVE", _AUTHING)
+    monkeypatch.setattr(executor, "run_auth_challenge", _approve_for_wrong_action)
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("fs_write", {"path": "a.txt", "content": "x"})
+        # Approval for a different action id must not release THIS one.
+        assert result.isError
+        assert fake.calls == []
+
+
+async def test_toctou_redecision_to_block_is_honored(monkeypatch):
+    class FlipToBlock:
+        """AUTH on the first evaluation, BLOCK on every one after (a TOCTOU change)."""
+
+        def __init__(self):
+            self._seen = 0
+
+        def evaluate(self, action, ctx):
+            self._seen += 1
+            if self._seen == 1:
+                return GuardrailResult(
+                    verdict=Verdict.AUTH,
+                    risk=Risk.high,
+                    reason_codes=[ReasonCode.sensitive_path_access],
+                    explanation="first look: auth",
+                )
+            return GuardrailResult(
+                verdict=Verdict.BLOCK,
+                risk=Risk.critical,
+                reason_codes=[ReasonCode.protected_path_blocked],
+                explanation="second look: blocked",
+            )
+
+    monkeypatch.setattr(executor, "DEFAULT_OBJECTIVE", FlipToBlock())
+    monkeypatch.setattr(executor, "run_auth_challenge", _approve())
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("fs_write", {"path": "a.txt", "content": "x"})
+        # Approved, but the re-decision flipped to BLOCK → never forwarded.
+        assert result.isError
+        assert "blocked by policy" in result.content[0].text
+        assert fake.calls == []
+
+
+async def test_role_elevation_grants_then_covered_file_passes(
+    monkeypatch, isolated_executor_repo_root
+):
+    _write_role(isolated_executor_repo_root)
+    calls = {"n": 0}
+
+    def approve_elev(decision, action, *, prompter=None, at=None):
+        calls["n"] += 1
+        return AuthResult(
+            approved=True,
+            tier=AuthTier.role_elevation,
+            method="test",
+            at=datetime.now(timezone.utc),
+            action_id=action.id,
+        )
+
+    monkeypatch.setattr(executor, "run_auth_challenge", approve_elev)
+    async with proxied_session() as (fake, agent):
+        # 1) out-of-scope backend file → AUTH → elevation granted → forwards.
+        r1 = await agent.call_tool("fs_write", {"path": "backend/api.ts", "content": "x"})
+        assert not r1.isError
+        assert calls["n"] == 1
+        # 2) SAME file again → covered by the (reusable) elevation → no new challenge.
+        r2 = await agent.call_tool("fs_write", {"path": "backend/api.ts", "content": "y"})
+        assert not r2.isError
+        assert calls["n"] == 1
+        # 3) a DIFFERENT backend file is NOT covered → a fresh challenge.
+        r3 = await agent.call_tool("fs_write", {"path": "backend/other.ts", "content": "z"})
+        assert not r3.isError
+        assert calls["n"] == 2
+        assert [name for name, _ in fake.calls] == ["fs_write", "fs_write", "fs_write"]
+
+
+async def test_destructive_elevation_is_single_use(monkeypatch, isolated_executor_repo_root):
+    _write_role(isolated_executor_repo_root)
+    calls = {"n": 0}
+
+    def approve_elev(decision, action, *, prompter=None, at=None):
+        calls["n"] += 1
+        return AuthResult(
+            approved=True,
+            tier=AuthTier.role_elevation,
+            method="test",
+            at=datetime.now(timezone.utc),
+            action_id=action.id,
+        )
+
+    monkeypatch.setattr(executor, "run_auth_challenge", approve_elev)
+    async with proxied_session() as (fake, agent):
+        r1 = await agent.call_tool("fs_delete", {"path": "backend/api.ts"})
+        assert not r1.isError
+        assert calls["n"] == 1
+        # The single-use grant was consumed by the delete → a second delete of
+        # the SAME file challenges again.
+        r2 = await agent.call_tool("fs_delete", {"path": "backend/api.ts"})
+        assert not r2.isError
+        assert calls["n"] == 2

--- a/tests/integration/test_challenge_flow.py
+++ b/tests/integration/test_challenge_flow.py
@@ -1,0 +1,113 @@
+"""Slice 7.3 — the action-specific challenge, end-to-end through run_auth_challenge."""
+
+from datetime import datetime, timezone
+
+import pyotp
+
+from doberman.auth import totp
+from doberman.auth.challenge import run_auth_challenge
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+
+_NOW = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+
+class ScriptedPrompter:
+    def __init__(self, *, confirm=True, code="", raises=None):
+        self._confirm, self._code, self._raises = confirm, code, raises
+        self.messages: list[str] = []
+
+    def confirm(self, message):
+        self.messages.append(message)
+        if self._raises is not None:
+            raise self._raises
+        return self._confirm
+
+    def read_code(self, message):
+        return self._code
+
+
+def _action(target="backend/api.ts"):
+    return SecurityObject(
+        id="act-1",
+        ts=_NOW,
+        agent_role="webdev",
+        action_type=ActionType.file_write,
+        tool_name="fs_write",
+        target=target,
+    )
+
+
+def _auth_decision(reasons, risk=Risk.low):
+    objective = GuardrailResult(
+        verdict=Verdict.AUTH, risk=risk, reason_codes=list(reasons), explanation="why"
+    )
+    return Decision(
+        action_id="act-1",
+        final_verdict=Verdict.AUTH,
+        final_risk=risk,
+        objective=objective,
+        reason_codes=list(reasons),
+        explanation="why",
+        decided_at=_NOW,
+    )
+
+
+def test_prompt_names_the_specific_target_and_reason():
+    prompter = ScriptedPrompter(confirm=False)
+    run_auth_challenge(
+        _auth_decision([ReasonCode.unknown_tool]), _action("backend/api.ts"), prompter=prompter
+    )
+    msg = prompter.messages[0]
+    assert "backend/api.ts" in msg
+    assert "unknown_tool" in msg
+
+
+def test_soft_confirm_approval():
+    result = run_auth_challenge(
+        _auth_decision([ReasonCode.unknown_tool]),
+        _action(),
+        prompter=ScriptedPrompter(confirm=True),
+    )
+    assert result.approved is True
+    assert result.action_id == "act-1"
+
+
+def test_denial_is_not_approved():
+    result = run_auth_challenge(
+        _auth_decision([ReasonCode.unknown_tool]),
+        _action(),
+        prompter=ScriptedPrompter(confirm=False),
+    )
+    assert result.approved is False
+
+
+def test_timeout_denies_fail_closed():
+    result = run_auth_challenge(
+        _auth_decision([ReasonCode.unknown_tool]),
+        _action(),
+        prompter=ScriptedPrompter(raises=TimeoutError("walked away")),
+    )
+    assert result.approved is False
+
+
+def test_two_factor_decision_requires_a_valid_code():
+    totp.enroll()
+    code = pyotp.TOTP(totp._read_secret()).now()
+    # sensitive_secret_access selects the two_factor tier.
+    decision = _auth_decision([ReasonCode.sensitive_secret_access])
+    ok = run_auth_challenge(decision, _action(), prompter=ScriptedPrompter(confirm=True, code=code))
+    assert ok.tier.value == "two_factor"
+    assert ok.approved is True
+
+    bad = run_auth_challenge(
+        decision, _action(), prompter=ScriptedPrompter(confirm=True, code="000000")
+    )
+    assert bad.approved is False

--- a/tests/integration/test_cli_auth.py
+++ b/tests/integration/test_cli_auth.py
@@ -1,0 +1,63 @@
+"""Feature 7 CLI surface — `doberman 2fa setup`, `revoke`, and `status`.
+
+These tests are synchronous on purpose: the CLI calls ``asyncio.run`` internally,
+which cannot nest inside a running event loop. Seeding async state uses
+``asyncio.run`` directly.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+
+from typer.testing import CliRunner
+
+from doberman.auth import totp
+from doberman.cli.main import app
+from doberman.storage.db import grant_elevation
+
+runner = CliRunner()
+
+
+def test_2fa_setup_enrolls_and_guards_overwrite():
+    assert totp.is_enrolled() is False
+    result = runner.invoke(app, ["2fa", "setup"])
+    assert result.exit_code == 0
+    assert "otpauth://" in result.stdout
+    assert totp.is_enrolled() is True
+
+    again = runner.invoke(app, ["2fa", "setup"])
+    assert again.exit_code == 1  # refuses to silently overwrite
+
+    forced = runner.invoke(app, ["2fa", "setup", "--force"])
+    assert forced.exit_code == 0
+
+
+def test_status_reports_2fa_and_no_elevations(tmp_path):
+    result = runner.invoke(app, ["status", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "2FA:" in result.stdout
+    assert "Elevations: (none active)" in result.stdout
+
+
+def test_status_lists_then_revoke_removes_an_elevation(tmp_path):
+    root = str(tmp_path)
+    # Seed with real "now" — `doberman status` evaluates activity against the
+    # wall clock, so a fixed past timestamp would read as already-expired.
+    grant = asyncio.run(
+        grant_elevation(root, "backend/api.ts", "task", now=datetime.now(timezone.utc))
+    )
+
+    listed = runner.invoke(app, ["status", "--path", root])
+    assert grant.id in listed.stdout
+    assert "backend/api.ts" in listed.stdout
+
+    revoked = runner.invoke(app, ["revoke", grant.id, "--path", root])
+    assert revoked.exit_code == 0
+    assert "revoked" in revoked.stdout
+
+    after = runner.invoke(app, ["status", "--path", root])
+    assert "none active" in after.stdout
+
+
+def test_revoke_unknown_id_errors(tmp_path):
+    result = runner.invoke(app, ["revoke", "no-such-id", "--path", str(tmp_path)])
+    assert result.exit_code == 1

--- a/tests/integration/test_engine_blocks_reach_no_tool.py
+++ b/tests/integration/test_engine_blocks_reach_no_tool.py
@@ -1,14 +1,33 @@
-"""Slice 2.4 — verdicts are enforced: a BLOCK means the tool NEVER runs."""
+"""Slice 2.4 — verdicts are enforced: a BLOCK means the tool NEVER runs.
+
+Feature 7 makes an ``AUTH`` run a challenge; these tests pin the challenge to a
+deterministic *denial* (no real stdin) so they keep asserting the F2 behavior:
+an un-approved AUTH forwards nothing.
+"""
 
 import json
 import logging
+from datetime import datetime, timezone
 
+from doberman.auth.challenge import AuthResult, AuthTier
 from doberman.engine.decision_engine import StaticGuardrail
 from doberman.models import GuardrailResult, ReasonCode, Risk, Verdict
 from doberman.proxy import executor
 from doberman.proxy.interception_log import LOGGER_NAME
 
 from .test_proxy_passthrough import proxied_session
+
+
+def _deny_challenge(decision, action, *, prompter=None, at=None):
+    """A deterministic denied AuthResult (stands in for confirm/2FA failure)."""
+    return AuthResult(
+        approved=False,
+        tier=AuthTier.local_auth,
+        method="denied",
+        at=datetime.now(timezone.utc),
+        action_id=action.id,
+    )
+
 
 BLOCKING = StaticGuardrail(
     GuardrailResult(
@@ -60,6 +79,7 @@ async def test_block_returns_error_and_nothing_recorded(monkeypatch):
 
 async def test_auth_returns_error_and_nothing_recorded(monkeypatch):
     monkeypatch.setattr(executor, "DEFAULT_OBJECTIVE", AUTHING)
+    monkeypatch.setattr(executor, "run_auth_challenge", _deny_challenge)
     async with proxied_session() as (fake, agent):
         result = await agent.call_tool("shell_exec", {"command": "echo hi"})
         assert result.isError
@@ -84,6 +104,7 @@ async def test_engine_exception_fails_closed(monkeypatch):
 
 async def test_subjective_block_clamps_to_auth_end_to_end(monkeypatch):
     monkeypatch.setattr(executor, "DEFAULT_SUBJECTIVE", SUBJECTIVE_BLOCKING)
+    monkeypatch.setattr(executor, "run_auth_challenge", _deny_challenge)
     async with proxied_session() as (fake, agent):
         # A fetch to a TRUSTED host so the real objective guardrail (F3) PASSes
         # and the subjective guardrail actually runs (and is then clamped). With

--- a/tests/integration/test_serve_end_to_end.py
+++ b/tests/integration/test_serve_end_to_end.py
@@ -1,0 +1,84 @@
+"""End-to-end test of `doberman serve`: a real agent ⇄ doberman ⇄ downstream chain.
+
+Spawns `python -m doberman.cli.main serve -- python <stdio_tool_server> <calllog>` as a subprocess and
+connects to it with a real MCP client (the "agent"). Proves the deployable wiring works over stdio AND
+the chokepoint property end-to-end: a PASS reaches the tool (a line in the call-log); a BLOCK does not.
+
+This is the heavier test (it launches processes); a short timeout guards against a hung child.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters, stdio_client
+
+_FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "stdio_tool_server.py"
+_TIMEOUT_S = 30.0
+
+
+@asynccontextmanager
+async def _agent_through_doberman(repo_root: Path, call_log: Path) -> AsyncIterator[ClientSession]:
+    """An MCP client connected to `doberman serve`, which fronts the stdio fixture downstream."""
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=[
+            "-m",
+            "doberman.cli.main",
+            "serve",
+            "--path",
+            str(repo_root),
+            "--",
+            sys.executable,
+            str(_FIXTURE),
+            str(call_log),
+        ],
+        # Full env so the child can import doberman (venv) and find the interpreter.
+        env={**os.environ},
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as agent:
+            await agent.initialize()
+            yield agent
+
+
+def _logged_tools(call_log: Path) -> list[str]:
+    if not call_log.exists():
+        return []
+    return [
+        json.loads(line)[0] for line in call_log.read_text(encoding="utf-8").splitlines() if line
+    ]
+
+
+async def test_downstream_tools_are_re_exposed(tmp_path):
+    call_log = tmp_path / "calls.log"
+    async with asyncio.timeout(_TIMEOUT_S):
+        async with _agent_through_doberman(tmp_path, call_log) as agent:
+            result = await agent.list_tools()
+    names = {tool.name for tool in result.tools}
+    assert {"fs_write", "fs_delete", "shell_exec", "net_get"} <= names
+
+
+async def test_pass_decision_reaches_the_tool(tmp_path):
+    call_log = tmp_path / "calls.log"
+    async with asyncio.timeout(_TIMEOUT_S):
+        async with _agent_through_doberman(tmp_path, call_log) as agent:
+            # A fetch to a trusted host PASSes (mirrors test_proxy_passthrough.py).
+            result = await agent.call_tool("net_get", {"url": "https://github.com/owner/repo"})
+    assert not result.isError
+    assert "net_get" in _logged_tools(call_log)
+
+
+async def test_block_decision_reaches_no_tool(tmp_path):
+    call_log = tmp_path / "calls.log"
+    async with asyncio.timeout(_TIMEOUT_S):
+        async with _agent_through_doberman(tmp_path, call_log) as agent:
+            # A catastrophic command is BLOCKed by the objective guardrail.
+            result = await agent.call_tool("shell_exec", {"command": "rm -rf /"})
+    assert result.isError
+    # The chokepoint property: the blocked call never reached the downstream tool.
+    assert "shell_exec" not in _logged_tools(call_log)

--- a/tests/unit/test_auth_provider.py
+++ b/tests/unit/test_auth_provider.py
@@ -1,0 +1,155 @@
+"""Slices 7.3 / 7.6 — the local provider and the AuthProvider seam."""
+
+from datetime import datetime, timezone
+
+import pyotp
+
+from doberman.auth import totp
+from doberman.auth.challenge import AuthResult, AuthTier
+from doberman.auth.provider import LocalAuthProvider, active_provider
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+
+_NOW = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+
+class FakePrompter:
+    """Canned answers; records the message shown so tests can inspect it."""
+
+    def __init__(self, *, confirm=True, code="", raises=None):
+        self._confirm = confirm
+        self._code = code
+        self._raises = raises
+        self.messages: list[str] = []
+
+    def confirm(self, message: str) -> bool:
+        self.messages.append(message)
+        if self._raises is not None:
+            raise self._raises
+        return self._confirm
+
+    def read_code(self, message: str) -> str:
+        return self._code
+
+
+def _action(target="backend/api.ts"):
+    return SecurityObject(
+        id="act-7",
+        ts=_NOW,
+        agent_role="webdev",
+        action_type=ActionType.file_write,
+        tool_name="fs_write",
+        target=target,
+    )
+
+
+def _auth_decision(reasons=(ReasonCode.role_out_of_scope,)):
+    objective = GuardrailResult(
+        verdict=Verdict.AUTH, risk=Risk.medium, reason_codes=list(reasons), explanation="why"
+    )
+    return Decision(
+        action_id="act-7",
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.medium,
+        objective=objective,
+        reason_codes=list(reasons),
+        explanation="why",
+        decided_at=_NOW,
+    )
+
+
+def test_default_provider_is_local():
+    assert isinstance(active_provider(), LocalAuthProvider)
+
+
+def test_soft_confirm_approves_on_yes():
+    result = LocalAuthProvider().authenticate(
+        _auth_decision(), _action(), AuthTier.soft_confirm, prompter=FakePrompter(confirm=True)
+    )
+    assert isinstance(result, AuthResult)
+    assert result.approved is True
+    assert result.tier is AuthTier.soft_confirm
+    assert result.action_id == "act-7"  # bound to the action
+
+
+def test_soft_confirm_denies_on_no():
+    result = LocalAuthProvider().authenticate(
+        _auth_decision(), _action(), AuthTier.soft_confirm, prompter=FakePrompter(confirm=False)
+    )
+    assert result.approved is False
+    assert result.tier is AuthTier.soft_confirm  # provider never changes the tier
+
+
+def test_two_factor_requires_confirm_and_valid_code():
+    totp.enroll()
+    secret = totp._read_secret()
+    code = pyotp.TOTP(secret).now()
+    ok = LocalAuthProvider().authenticate(
+        _auth_decision(),
+        _action(),
+        AuthTier.two_factor,
+        prompter=FakePrompter(confirm=True, code=code),
+    )
+    assert ok.approved is True
+
+    bad = LocalAuthProvider().authenticate(
+        _auth_decision(),
+        _action(),
+        AuthTier.two_factor,
+        prompter=FakePrompter(confirm=True, code="000000"),
+    )
+    assert bad.approved is False
+
+
+def test_two_factor_denied_when_presence_refused():
+    totp.enroll()
+    result = LocalAuthProvider().authenticate(
+        _auth_decision(), _action(), AuthTier.two_factor, prompter=FakePrompter(confirm=False)
+    )
+    assert result.approved is False
+
+
+def test_prompter_failure_denies_fail_closed():
+    result = LocalAuthProvider().authenticate(
+        _auth_decision(),
+        _action(),
+        AuthTier.local_auth,
+        prompter=FakePrompter(raises=TimeoutError("walked away")),
+    )
+    assert result.approved is False
+
+
+def test_challenge_message_names_target_and_reason():
+    prompter = FakePrompter(confirm=False)
+    LocalAuthProvider().authenticate(
+        _auth_decision(), _action("backend/api.ts"), AuthTier.soft_confirm, prompter=prompter
+    )
+    message = prompter.messages[0]
+    assert "backend/api.ts" in message  # the EXACT target
+    assert "role_out_of_scope" in message  # the reason
+    assert "webdev" in message  # the role
+
+
+def test_registered_provider_is_preferred(monkeypatch):
+    sentinel = object()
+
+    class StubProvider:
+        def authenticate(self, decision, action, tier, *, prompter=None, at=None):
+            return sentinel
+
+    monkeypatch.setattr(
+        "doberman.engine.registry.discover_auth_providers", lambda: [StubProvider()]
+    )
+    assert isinstance(active_provider(), StubProvider)
+
+
+def test_non_provider_shaped_registration_is_skipped(monkeypatch):
+    monkeypatch.setattr("doberman.engine.registry.discover_auth_providers", lambda: [object()])
+    assert isinstance(active_provider(), LocalAuthProvider)

--- a/tests/unit/test_auth_tier.py
+++ b/tests/unit/test_auth_tier.py
@@ -1,0 +1,89 @@
+"""Slice 7.1 — auth-tier selection from the final decision."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from doberman.auth.challenge import AuthTier, select_tier
+from doberman.models import Decision, GuardrailResult, ReasonCode, Risk, Verdict
+
+
+def _decision(verdict, risk, reasons):
+    objective = GuardrailResult(
+        verdict=verdict, risk=risk, reason_codes=list(reasons), explanation="x"
+    )
+    return Decision(
+        action_id="a1",
+        final_verdict=verdict,
+        final_risk=risk,
+        objective=objective,
+        reason_codes=list(reasons),
+        explanation="x",
+        decided_at=datetime.now(timezone.utc),
+    )
+
+
+def _auth(risk, reasons):
+    return _decision(Verdict.AUTH, risk, reasons)
+
+
+def test_low_risk_minor_reason_is_soft_confirm():
+    assert select_tier(_auth(Risk.low, [ReasonCode.unknown_tool])) is AuthTier.soft_confirm
+
+
+def test_unknown_destination_maps_to_local_auth():
+    tier = select_tier(_auth(Risk.low, [ReasonCode.unknown_external_destination]))
+    assert tier is AuthTier.local_auth
+
+
+def test_sensitive_secret_access_maps_to_two_factor():
+    tier = select_tier(_auth(Risk.low, [ReasonCode.sensitive_secret_access]))
+    assert tier is AuthTier.two_factor
+
+
+def test_role_out_of_scope_routes_to_role_elevation():
+    tier = select_tier(_auth(Risk.medium, [ReasonCode.role_out_of_scope]))
+    assert tier is AuthTier.role_elevation
+
+
+def test_high_risk_base_is_two_factor():
+    # A sensitive delete: high risk + sensitive_path_access → two_factor.
+    tier = select_tier(_auth(Risk.high, [ReasonCode.sensitive_path_access]))
+    assert tier is AuthTier.two_factor
+
+
+def test_strongest_reason_wins():
+    tier = select_tier(
+        _auth(
+            Risk.low,
+            [ReasonCode.unknown_external_destination, ReasonCode.sensitive_secret_access],
+        )
+    )
+    assert tier is AuthTier.two_factor
+
+
+def test_role_elevation_outranks_two_factor():
+    tier = select_tier(
+        _auth(Risk.high, [ReasonCode.sensitive_secret_access, ReasonCode.role_out_of_scope])
+    )
+    assert tier is AuthTier.role_elevation
+
+
+def test_hard_block_never_maps_to_a_challenge():
+    block = _decision(Verdict.BLOCK, Risk.critical, [ReasonCode.secret_exfiltration])
+    with pytest.raises(ValueError, match="AUTH"):
+        select_tier(block)
+
+
+def test_pass_never_maps_to_a_challenge():
+    # A PASS carries no reasons; build it directly (the validator allows that).
+    objective = GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+    decision = Decision(
+        action_id="a1",
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=objective,
+        decided_at=datetime.now(timezone.utc),
+    )
+    with pytest.raises(ValueError, match="AUTH"):
+        select_tier(decision)

--- a/tests/unit/test_core_is_standalone.py
+++ b/tests/unit/test_core_is_standalone.py
@@ -13,7 +13,7 @@ def test_core_imports_with_no_enterprise_installed():
 def test_version_is_exposed():
     import doberman
 
-    assert doberman.__version__ == "0.6.0"
+    assert doberman.__version__ == "0.7.0"
 
 
 def test_policy_core_packages_import_cleanly():
@@ -38,6 +38,16 @@ def test_default_plugin_registry_has_no_enterprise_plugins():
     assert plugins == []
     # And none of whatever (if anything) is installed comes from enterprise.
     assert all("enterprise" not in type(p).__module__ for p in plugins)
+
+
+def test_default_auth_provider_is_local_with_no_enterprise():
+    # Slice 7.6 standalone guarantee: with no enterprise package installed, the
+    # auth-provider registry discovers nothing and the local provider is active.
+    from doberman.auth.provider import LocalAuthProvider, active_provider
+    from doberman.engine.registry import discover_auth_providers
+
+    assert discover_auth_providers() == []
+    assert isinstance(active_provider(), LocalAuthProvider)
 
 
 def test_objective_guardrail_runs_with_only_builtins():

--- a/tests/unit/test_elevation.py
+++ b/tests/unit/test_elevation.py
@@ -1,0 +1,112 @@
+"""Slice 7.4 — narrow/temporary/single-use elevation model + storage."""
+
+from datetime import datetime, timedelta, timezone
+
+from doberman.auth.elevation import (
+    ElevationGrant,
+    find_cover,
+    scope_for_target,
+)
+from doberman.storage.db import (
+    active_elevations,
+    db_path,
+    grant_elevation,
+    mark_used,
+    revoke_elevation,
+)
+
+_NOW = datetime(2026, 6, 8, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _grant(scope, *, ttl=900, single_use=False, used=False, revoked=False):
+    return ElevationGrant(
+        id="g1",
+        scope_glob=scope,
+        task_id="t1",
+        granted_at=_NOW,
+        expires_at=_NOW + timedelta(seconds=ttl),
+        single_use=single_use,
+        used=used,
+        revoked=revoked,
+    )
+
+
+# --- pure model -----------------------------------------------------------
+
+
+def test_scope_for_target_is_narrow_and_canonical():
+    assert scope_for_target("backend/api.ts", root=".") == "backend/api.ts"
+    assert scope_for_target("BACKEND/API.ts", root=".") == "backend/api.ts"
+
+
+def test_scope_refuses_non_path_and_escapes_and_whole_tree():
+    assert scope_for_target(None, root=".") is None
+    assert scope_for_target("../../etc/passwd", root=".") is None
+    assert scope_for_target(".", root=".") is None
+
+
+def test_grant_is_active_window():
+    g = _grant("backend/api.ts")
+    assert g.is_active(_NOW) is True
+    assert g.is_active(_NOW + timedelta(seconds=1000)) is False  # past TTL
+
+
+def test_revoked_and_spent_grants_are_inactive():
+    assert _grant("x", revoked=True).is_active(_NOW) is False
+    assert _grant("x", single_use=True, used=True).is_active(_NOW) is False
+    assert _grant("x", single_use=True, used=False).is_active(_NOW) is True
+
+
+def test_covers_matches_exact_path_only_and_never_whole_tree():
+    g = _grant("backend/api.ts")
+    assert g.covers("backend/api.ts") is True
+    assert g.covers("backend/other.ts") is False
+    assert _grant("**").covers("anything") is False  # whole-tree never covers
+
+
+def test_find_cover_canonicalizes_target():
+    grants = (_grant("backend/api.ts"),)
+    assert find_cover("backend/api.ts", grants, root=".") is not None
+    assert find_cover("backend/../backend/api.ts", grants, root=".") is not None
+    assert find_cover("backend/other.ts", grants, root=".") is None
+
+
+# --- storage --------------------------------------------------------------
+
+
+async def test_grant_then_active(tmp_path):
+    root = str(tmp_path)
+    grant = await grant_elevation(root, "backend/api.ts", "task-1", now=_NOW)
+    active = await active_elevations(root, _NOW)
+    assert [g.id for g in active] == [grant.id]
+    assert active[0].scope_glob == "backend/api.ts"
+
+
+async def test_active_excludes_expired(tmp_path):
+    root = str(tmp_path)
+    await grant_elevation(root, "backend/api.ts", "t", now=_NOW, ttl_seconds=60)
+    assert await active_elevations(root, _NOW + timedelta(seconds=120)) == []
+
+
+async def test_revoke_makes_inactive(tmp_path):
+    root = str(tmp_path)
+    grant = await grant_elevation(root, "backend/api.ts", "t", now=_NOW)
+    assert await revoke_elevation(root, grant.id) is True
+    assert await active_elevations(root, _NOW) == []
+    # Revoking an unknown id reports no row changed.
+    assert await revoke_elevation(root, "nope") is False
+
+
+async def test_single_use_consumed_by_mark_used(tmp_path):
+    root = str(tmp_path)
+    grant = await grant_elevation(root, "backend/api.ts", "t", now=_NOW, single_use=True)
+    assert len(await active_elevations(root, _NOW)) == 1
+    await mark_used(root, grant.id)
+    assert await active_elevations(root, _NOW) == []
+
+
+async def test_active_short_circuits_without_a_db(tmp_path):
+    root = str(tmp_path)
+    assert not db_path(root).exists()
+    assert await active_elevations(root, _NOW) == []
+    assert not db_path(root).exists()  # no DB created by a read

--- a/tests/unit/test_elicitation_prompter.py
+++ b/tests/unit/test_elicitation_prompter.py
@@ -1,0 +1,265 @@
+"""Unit tests for the MCP elicitation prompter — the challenge rendered IN the agent client.
+
+When the agent client (Claude Code, etc.) supports MCP elicitation, a confirm-tier AUTH
+challenge should render natively inside the client UI instead of an OS dialog. Contracts:
+
+* ``accept`` approves; ``decline``/``cancel`` deny — and a denial is FINAL (the chain
+  must never re-ask on another channel).
+* A client without the elicitation capability, no active request context, or a
+  method-not-found error → :class:`PrompterUnavailableError` (fall through to the GUI).
+* ``read_code`` ALWAYS raises ``PrompterUnavailableError``: the MCP spec forbids
+  requesting sensitive information via elicitation, so one-time codes never transit
+  the agent client — they stay on the out-of-band channels.
+* The prompter must refuse to run on the event-loop thread (it would deadlock the
+  session that has to carry the elicitation answer), and the executor must therefore
+  run challenges OFF the loop.
+* No schema fields are requested (buttons only) — no data transits the client.
+"""
+
+import asyncio
+import threading
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from mcp import types
+from mcp.shared.exceptions import McpError
+from mcp.types import INTERNAL_ERROR, METHOD_NOT_FOUND, ErrorData
+
+from doberman.auth import elicitation_prompter as ep_mod
+from doberman.auth.elicitation_prompter import ElicitationPrompter
+from doberman.auth.gui_prompter import FallbackPrompter, PrompterUnavailableError
+
+_CHALLENGE = "Doberman authentication required [local_auth]\nApprove THIS exact action?"
+
+
+class _FakeSession:
+    """Scripted ServerSession stand-in; records the elicitation traffic."""
+
+    def __init__(self, *, supports=True, action="accept", error=None, hang=False):
+        self._supports = supports
+        self._action = action
+        self._error = error
+        self._hang = hang
+        self.messages: list[str] = []
+        self.schemas: list[dict] = []
+
+    def check_client_capability(self, capability) -> bool:
+        assert capability.elicitation is not None  # we must ask for the right capability
+        return self._supports
+
+    async def elicit_form(self, message, requestedSchema, related_request_id=None):
+        self.messages.append(message)
+        self.schemas.append(requestedSchema)
+        if self._hang:
+            await asyncio.Event().wait()
+        if self._error is not None:
+            raise self._error
+        return types.ElicitResult(action=self._action)
+
+
+class _FakeServer:
+    """Exposes ``request_context.session`` the way ``mcp.server.lowlevel.Server`` does."""
+
+    def __init__(self, session: _FakeSession | None):
+        self._session = session
+
+    @property
+    def request_context(self):
+        if self._session is None:
+            raise LookupError("called outside of a request context")
+        return SimpleNamespace(session=self._session)
+
+
+@pytest.fixture
+def loop() -> Iterator[asyncio.AbstractEventLoop]:
+    """A real event loop on a background thread — the bridge under test is threading."""
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5)
+    loop.close()
+
+
+def _prompter(session: _FakeSession | None, loop) -> ElicitationPrompter:
+    return ElicitationPrompter(_FakeServer(session), loop)
+
+
+# --- answers ------------------------------------------------------------------------
+
+
+def test_accept_approves(loop):
+    session = _FakeSession(action="accept")
+    assert _prompter(session, loop).confirm(_CHALLENGE) is True
+    assert session.messages == [_CHALLENGE]  # the exact challenge text reaches the human
+
+
+@pytest.mark.parametrize("action", ["decline", "cancel"])
+def test_decline_and_cancel_deny(loop, action):
+    session = _FakeSession(action=action)
+    assert _prompter(session, loop).confirm(_CHALLENGE) is False
+
+
+def test_no_form_fields_are_requested(loop):
+    """Buttons only: the schema must request zero properties — nothing transits the client."""
+    session = _FakeSession(action="accept")
+    _prompter(session, loop).confirm(_CHALLENGE)
+    assert session.schemas[0].get("properties") == {}
+
+
+# --- the sensitive-data rule ---------------------------------------------------------
+
+
+def test_read_code_is_never_offered_via_elicitation(loop):
+    """The MCP spec forbids sensitive info via elicitation — codes skip this channel."""
+    session = _FakeSession(action="accept")
+    with pytest.raises(PrompterUnavailableError):
+        _prompter(session, loop).read_code("Enter your 2FA code")
+    assert session.messages == []  # the session was never even consulted
+
+
+# --- channel availability ------------------------------------------------------------
+
+
+def test_client_without_capability_is_unavailable(loop):
+    session = _FakeSession(supports=False)
+    with pytest.raises(PrompterUnavailableError):
+        _prompter(session, loop).confirm(_CHALLENGE)
+    assert session.messages == []
+
+
+def test_no_active_request_context_is_unavailable(loop):
+    with pytest.raises(PrompterUnavailableError):
+        _prompter(None, loop).confirm(_CHALLENGE)
+
+
+def test_method_not_found_is_unavailable(loop):
+    session = _FakeSession(error=McpError(ErrorData(code=METHOD_NOT_FOUND, message="nope")))
+    with pytest.raises(PrompterUnavailableError):
+        _prompter(session, loop).confirm(_CHALLENGE)
+
+
+def test_other_protocol_errors_propagate_so_provider_denies(loop):
+    session = _FakeSession(error=McpError(ErrorData(code=INTERNAL_ERROR, message="boom")))
+    with pytest.raises(McpError):
+        _prompter(session, loop).confirm(_CHALLENGE)
+
+
+def test_unanswered_challenge_times_out_to_a_denial(loop, monkeypatch):
+    monkeypatch.setattr(ep_mod, "ANSWER_TIMEOUT_S", 0.05)
+    session = _FakeSession(hang=True)
+    with pytest.raises(EOFError):
+        _prompter(session, loop).confirm(_CHALLENGE)
+
+
+def test_refuses_to_run_on_the_event_loop_thread(loop):
+    """Blocking the loop would deadlock the very session carrying the answer."""
+    session = _FakeSession(action="accept")
+    prompter = _prompter(session, loop)
+
+    async def _on_loop():
+        return prompter.confirm(_CHALLENGE)
+
+    with pytest.raises(PrompterUnavailableError):
+        asyncio.run_coroutine_threadsafe(_on_loop(), loop).result(timeout=5)
+    assert session.messages == []
+
+
+# --- chain behavior ------------------------------------------------------------------
+
+
+class _RecorderPrompter:
+    def __init__(self, *, confirm=True):
+        self._confirm = confirm
+        self.calls: list[str] = []
+
+    def confirm(self, message: str) -> bool:
+        self.calls.append(message)
+        return self._confirm
+
+    def read_code(self, message: str) -> str:
+        self.calls.append(message)
+        return "123456"
+
+
+def test_unsupported_client_falls_through_to_the_next_channel(loop):
+    gui = _RecorderPrompter(confirm=True)
+    chain = FallbackPrompter([_prompter(_FakeSession(supports=False), loop), gui])
+    assert chain.confirm(_CHALLENGE) is True
+    assert gui.calls == [_CHALLENGE]
+
+
+def test_an_elicitation_denial_is_final_in_the_chain(loop):
+    gui = _RecorderPrompter(confirm=True)  # would approve — must never be consulted
+    chain = FallbackPrompter([_prompter(_FakeSession(action="decline"), loop), gui])
+    assert chain.confirm(_CHALLENGE) is False
+    assert gui.calls == []
+
+
+def test_code_requests_skip_elicitation_and_reach_the_next_channel(loop):
+    gui = _RecorderPrompter()
+    chain = FallbackPrompter([_prompter(_FakeSession(), loop), gui])
+    assert chain.read_code("Enter your 2FA code") == "123456"
+    assert gui.calls == ["Enter your 2FA code"]
+
+
+# --- the executor must run challenges OFF the event loop ------------------------------
+
+
+async def test_executor_runs_the_challenge_off_the_event_loop(monkeypatch):
+    """An in-loop challenge would deadlock elicitation; the prompter must see a worker thread."""
+    from doberman.models import (
+        ActionType,
+        Decision,
+        GuardrailResult,
+        ReasonCode,
+        Risk,
+        SecurityObject,
+        Verdict,
+    )
+    from doberman.proxy import executor
+
+    loop_thread = threading.current_thread()
+    seen: dict = {}
+
+    class _ThreadRecorder:
+        def confirm(self, message: str) -> bool:
+            seen["thread"] = threading.current_thread()
+            return False  # deny — the downstream must never be needed
+
+        def read_code(self, message: str) -> str:  # pragma: no cover — never reached
+            raise AssertionError("code requested for a confirm-tier challenge")
+
+    monkeypatch.setattr(executor, "AUTH_PROMPTER", _ThreadRecorder())
+    now = datetime(2026, 6, 10, tzinfo=timezone.utc)
+    action = SecurityObject(
+        id="act-thread-1",
+        ts=now,
+        agent_role="webdev",
+        action_type=ActionType.file_write,
+        tool_name="fs_write",
+        target="backend/api.ts",
+    )
+    objective = GuardrailResult(
+        verdict=Verdict.AUTH,
+        risk=Risk.medium,
+        reason_codes=[ReasonCode.sensitive_path_access],
+        explanation="why",
+    )
+    decision = Decision(
+        action_id="act-thread-1",
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.medium,
+        objective=objective,
+        reason_codes=[ReasonCode.sensitive_path_access],
+        explanation="why",
+        decided_at=now,
+    )
+
+    result = await executor._handle_auth(None, "fs_write", {}, action, decision, now)
+
+    assert result.isError  # denied — nothing forwarded
+    assert seen["thread"] is not loop_thread

--- a/tests/unit/test_elicitation_prompter.py
+++ b/tests/unit/test_elicitation_prompter.py
@@ -209,8 +209,10 @@ def test_code_requests_skip_elicitation_and_reach_the_next_channel(loop):
 # --- the executor must run challenges OFF the event loop ------------------------------
 
 
-async def test_executor_runs_the_challenge_off_the_event_loop(monkeypatch):
+async def test_executor_runs_the_challenge_off_the_event_loop(monkeypatch, tmp_path):
     """An in-loop challenge would deadlock elicitation; the prompter must see a worker thread."""
+    import inspect
+
     from doberman.models import (
         ActionType,
         Decision,
@@ -234,6 +236,8 @@ async def test_executor_runs_the_challenge_off_the_event_loop(monkeypatch):
             raise AssertionError("code requested for a confirm-tier challenge")
 
     monkeypatch.setattr(executor, "AUTH_PROMPTER", _ThreadRecorder())
+    # Isolate any denied-path persistence (later features record challenge outcomes).
+    monkeypatch.setattr(executor, "REPO_ROOT", str(tmp_path))
     now = datetime(2026, 6, 10, tzinfo=timezone.utc)
     action = SecurityObject(
         id="act-thread-1",
@@ -259,7 +263,14 @@ async def test_executor_runs_the_challenge_off_the_event_loop(monkeypatch):
         decided_at=now,
     )
 
-    result = await executor._handle_auth(None, "fs_write", {}, action, decision, now)
+    # The signature gains feature-specific scores on later branches — fill any
+    # extras neutrally so this contract test holds across the whole stack.
+    extras: dict = {}
+    defaults = {"abnormality_score": 0.0, "surprise_score": 0.0, "eid": "entity-test"}
+    for name in inspect.signature(executor._handle_auth).parameters:
+        if name in defaults:
+            extras[name] = defaults[name]
+    result = await executor._handle_auth(None, "fs_write", {}, action, decision, now, **extras)
 
     assert result.isError  # denied — nothing forwarded
     assert seen["thread"] is not loop_thread

--- a/tests/unit/test_gui_prompter.py
+++ b/tests/unit/test_gui_prompter.py
@@ -105,81 +105,161 @@ def test_open_root_raises_prompter_unavailable_when_tk_init_fails(monkeypatch):
         gui_prompter._open_root()
 
 
-# --- GuiPrompter: real dialog internals (faked root + faked tkinter dialogs) -------
+# --- GuiPrompter: custom dialog internals (faked root + faked widget builders) -----
 
 
 class _FakeRoot:
+    """Duck-typed stand-in for a Tk root so the dialog plumbing runs headless."""
+
     def __init__(self):
         self.destroyed = False
-        self.withdrawn = False
         self.attrs: dict = {}
-
-    def withdraw(self):
-        self.withdrawn = True
+        self.config: dict = {}
+        self.titles: list[str] = []
+        self.resizable_args: tuple | None = None
+        self.protocols: dict = {}
+        self.bindings: dict = {}
+        self.geometries: list[str] = []
+        self.close_on_mainloop = False
 
     def attributes(self, name, value):
         self.attrs[name] = value
 
-    def update(self):
+    def configure(self, **kwargs):
+        self.config.update(kwargs)
+
+    def title(self, text):
+        self.titles.append(text)
+
+    def resizable(self, w, h):
+        self.resizable_args = (w, h)
+
+    def protocol(self, name, callback):
+        self.protocols[name] = callback
+
+    def bind(self, sequence, callback):
+        self.bindings[sequence] = callback
+
+    def geometry(self, spec):
+        self.geometries.append(spec)
+
+    def update_idletasks(self):
+        pass
+
+    def winfo_reqwidth(self):
+        return 420
+
+    def winfo_reqheight(self):
+        return 220
+
+    def winfo_screenwidth(self):
+        return 1920
+
+    def winfo_screenheight(self):
+        return 1080
+
+    def winfo_id(self):
+        return 0
+
+    def mainloop(self):
+        # Simulate the human closing the window instead of answering.
+        if self.close_on_mainloop:
+            self.protocols["WM_DELETE_WINDOW"]()
+
+    def quit(self):
         pass
 
     def destroy(self):
         self.destroyed = True
 
 
-def test_confirm_dialog_uses_hidden_topmost_root_and_destroys_it(monkeypatch):
-    pytest.importorskip("tkinter")
-    from tkinter import messagebox
-
+@pytest.fixture
+def fake_root(monkeypatch):
     root = _FakeRoot()
-    seen: dict = {}
     monkeypatch.setattr(gui_prompter, "_open_root", lambda: root)
+    return root
 
-    def _fake_askyesno(title, message, parent=None):
-        seen["title"], seen["message"], seen["parent"] = title, message, parent
-        return True
 
-    monkeypatch.setattr(messagebox, "askyesno", _fake_askyesno)
+def test_run_dialog_returns_the_populated_answer_and_destroys_root(monkeypatch, fake_root):
+    def _fake_populate(root, message, answer):
+        assert message == "Approve THIS exact action?"
+        answer["value"] = True
+
+    monkeypatch.setattr(gui_prompter, "_populate_confirm", _fake_populate)
     assert gui_prompter._confirm_dialog("Approve THIS exact action?") is True
-    assert seen["message"] == "Approve THIS exact action?"
-    assert seen["parent"] is root
-    assert root.withdrawn is True
-    assert root.attrs.get("-topmost") is True
-    assert root.destroyed is True  # never leak a Tk root
+    assert fake_root.destroyed is True  # never leak a Tk root
 
 
-def test_code_dialog_masks_input_and_destroys_root(monkeypatch):
-    pytest.importorskip("tkinter")
-    from tkinter import simpledialog
-
-    root = _FakeRoot()
-    seen: dict = {}
-    monkeypatch.setattr(gui_prompter, "_open_root", lambda: root)
-
-    def _fake_askstring(title, message, *, show=None, parent=None):
-        seen["show"], seen["parent"] = show, parent
-        return "123456"
-
-    monkeypatch.setattr(simpledialog, "askstring", _fake_askstring)
-    assert gui_prompter._code_dialog("Enter your 2FA code") == "123456"
-    assert seen["show"] == "*"  # the code must be masked on screen
-    assert root.destroyed is True
+def test_closing_the_window_is_a_denial_never_an_approval(monkeypatch, fake_root):
+    fake_root.close_on_mainloop = True
+    monkeypatch.setattr(gui_prompter, "_populate_confirm", lambda *_a: None)
+    monkeypatch.setattr(gui_prompter, "_populate_code", lambda *_a: None)
+    assert gui_prompter._confirm_dialog("Approve?") is False
+    assert gui_prompter._code_dialog("Enter your 2FA code") is None
 
 
-def test_dialog_root_destroyed_even_when_dialog_raises(monkeypatch):
-    pytest.importorskip("tkinter")
-    from tkinter import messagebox
-
-    root = _FakeRoot()
-    monkeypatch.setattr(gui_prompter, "_open_root", lambda: root)
-
-    def _boom(*_a, **_k):
+def test_root_destroyed_even_when_the_widget_builder_raises(monkeypatch, fake_root):
+    def _boom(*_a):
         raise RuntimeError("dialog exploded")
 
-    monkeypatch.setattr(messagebox, "askyesno", _boom)
+    monkeypatch.setattr(gui_prompter, "_populate_confirm", _boom)
     with pytest.raises(RuntimeError, match="dialog exploded"):
         gui_prompter._confirm_dialog("Approve?")
-    assert root.destroyed is True
+    assert fake_root.destroyed is True
+
+
+def test_window_is_topmost_dark_and_fixed_size(monkeypatch, fake_root):
+    """The dialog must pop OVER the agent terminal and use the dark theme base."""
+    monkeypatch.setattr(gui_prompter, "_populate_confirm", lambda *_a: None)
+    gui_prompter._confirm_dialog("Approve?")
+    assert fake_root.attrs.get("-topmost") is True
+    assert fake_root.titles and fake_root.titles[0] == gui_prompter._TITLE
+    assert fake_root.config.get("bg") == gui_prompter._BG
+    assert fake_root.resizable_args == (False, False)
+
+
+def test_palette_is_dark_black_and_orange():
+    """Design contract: dark/black surfaces, orange accent — no purple, no neon."""
+
+    def _rgb(color: str) -> tuple[int, int, int]:
+        return int(color[1:3], 16), int(color[3:5], 16), int(color[5:7], 16)
+
+    for surface in (gui_prompter._BG, gui_prompter._PANEL):
+        assert max(_rgb(surface)) < 48  # near-black surfaces
+    r, g, b = _rgb(gui_prompter._ACCENT)
+    assert r > 200 and r > g > b  # orange: red-dominant, green mid, low blue
+    assert b < 80  # nothing purple/neon-blue about the accent
+
+
+def test_real_dialog_widgets_dark_theme_and_masked_entry(monkeypatch):
+    """With a real display: the code entry is masked and surfaces use the dark palette.
+
+    Skipped where Tk cannot open (headless CI) — the contract above still covers the
+    plumbing; this verifies the actual widget construction when a display exists.
+    """
+    tkinter = pytest.importorskip("tkinter")
+    try:
+        root = tkinter.Tk()
+    except tkinter.TclError:
+        pytest.skip("no display available")
+    try:
+        root.withdraw()
+        answer: dict = {}
+        gui_prompter._configure_window(root)
+        gui_prompter._populate_code(root, "Enter your 2FA code", answer)
+
+        def _walk(widget):
+            yield widget
+            for child in widget.winfo_children():
+                yield from _walk(child)
+
+        widgets = list(_walk(root))
+        entries = [w for w in widgets if isinstance(w, tkinter.Entry)]
+        assert entries, "code dialog must contain an entry field"
+        assert entries[0].cget("show") == "*"  # the code must be masked on screen
+        assert root.cget("bg") == gui_prompter._BG
+    finally:
+        root.destroy()
 
 
 # --- FallbackPrompter ---------------------------------------------------------------

--- a/tests/unit/test_gui_prompter.py
+++ b/tests/unit/test_gui_prompter.py
@@ -1,0 +1,314 @@
+"""Unit tests for the GUI auth prompter and the GUI→TTY fallback chain.
+
+When an MCP agent (Claude Code, Codex, Cursor, …) spawns ``doberman serve``, the
+*controlling terminal still exists* but is owned by the agent's TUI: a prompt written
+to it is painted over (invisible) and keystrokes go to the agent, not Doberman. The
+challenge must therefore surface OUT-OF-BAND as a GUI dialog, with the terminal only
+as a fallback when no display is available.
+
+Contracts under test:
+* ``GuiPrompter`` collects a confirm/code via a topmost dialog window; cancel/blank
+  raise so the provider denies (fail closed); never touches sys.stdin/sys.stdout.
+* A GUI channel that cannot open at all raises ``PrompterUnavailableError`` — a
+  *channel* failure, distinct from a human denial.
+* ``FallbackPrompter`` consults the next channel ONLY on ``PrompterUnavailableError``.
+  A human answer (including "no") and any human-channel error (EOF, timeout) are
+  FINAL — a denial must never trigger answer-shopping on another channel.
+
+The tkinter machinery is monkeypatched at module seams (mirroring how the TTY tests
+fake ``_open_tty``) so everything here runs headless and deterministically.
+"""
+
+import pytest
+
+from doberman.auth import gui_prompter
+from doberman.auth.gui_prompter import (
+    FallbackPrompter,
+    GuiPrompter,
+    PrompterUnavailableError,
+)
+
+# --- GuiPrompter: answers ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("answer", [True, False])
+def test_confirm_returns_the_dialog_answer(monkeypatch, answer):
+    monkeypatch.setattr(gui_prompter, "_confirm_dialog", lambda _msg: answer)
+    assert GuiPrompter().confirm("Approve THIS exact action?") is answer
+
+
+def test_confirm_passes_the_exact_challenge_message(monkeypatch):
+    seen: list[str] = []
+
+    def _dialog(message: str) -> bool:
+        seen.append(message)
+        return True
+
+    monkeypatch.setattr(gui_prompter, "_confirm_dialog", _dialog)
+    GuiPrompter().confirm("Approve THIS exact action?")
+    assert seen == ["Approve THIS exact action?"]
+
+
+def test_read_code_returns_stripped_code(monkeypatch):
+    monkeypatch.setattr(gui_prompter, "_code_dialog", lambda _msg: "  123456 \n")
+    assert GuiPrompter().read_code("Enter your 2FA code") == "123456"
+
+
+def test_read_code_raises_on_cancel_so_provider_denies(monkeypatch):
+    # Cancelling / closing the dialog returns None — never pass "" to the verifier.
+    monkeypatch.setattr(gui_prompter, "_code_dialog", lambda _msg: None)
+    with pytest.raises(EOFError):
+        GuiPrompter().read_code("Enter your 2FA code")
+
+
+def test_read_code_raises_on_blank_entry(monkeypatch):
+    monkeypatch.setattr(gui_prompter, "_code_dialog", lambda _msg: "   ")
+    with pytest.raises(EOFError):
+        GuiPrompter().read_code("Enter your 2FA code")
+
+
+def test_never_touches_std_streams(monkeypatch):
+    """A GUI challenge must not read stdin or write stdout (the agent's MCP channel)."""
+
+    class _Explode:
+        def __getattr__(self, _name):
+            raise AssertionError("prompter touched a std stream")
+
+    monkeypatch.setattr("sys.stdin", _Explode())
+    monkeypatch.setattr("sys.stdout", _Explode())
+    monkeypatch.setattr(gui_prompter, "_confirm_dialog", lambda _msg: True)
+    assert GuiPrompter().confirm("Approve?") is True
+
+
+# --- GuiPrompter: unavailable channel ----------------------------------------------
+
+
+def test_no_gui_raises_prompter_unavailable(monkeypatch):
+    def _no_root():
+        raise PrompterUnavailableError("no display")
+
+    monkeypatch.setattr(gui_prompter, "_open_root", _no_root)
+    with pytest.raises(PrompterUnavailableError):
+        GuiPrompter().confirm("Approve?")
+    with pytest.raises(PrompterUnavailableError):
+        GuiPrompter().read_code("Enter your 2FA code")
+
+
+def test_open_root_raises_prompter_unavailable_when_tk_init_fails(monkeypatch):
+    tkinter = pytest.importorskip("tkinter")
+
+    def _boom(*_a, **_k):
+        raise tkinter.TclError("no display name and no $DISPLAY")
+
+    monkeypatch.setattr(tkinter, "Tk", _boom)
+    with pytest.raises(PrompterUnavailableError):
+        gui_prompter._open_root()
+
+
+# --- GuiPrompter: real dialog internals (faked root + faked tkinter dialogs) -------
+
+
+class _FakeRoot:
+    def __init__(self):
+        self.destroyed = False
+        self.withdrawn = False
+        self.attrs: dict = {}
+
+    def withdraw(self):
+        self.withdrawn = True
+
+    def attributes(self, name, value):
+        self.attrs[name] = value
+
+    def update(self):
+        pass
+
+    def destroy(self):
+        self.destroyed = True
+
+
+def test_confirm_dialog_uses_hidden_topmost_root_and_destroys_it(monkeypatch):
+    pytest.importorskip("tkinter")
+    from tkinter import messagebox
+
+    root = _FakeRoot()
+    seen: dict = {}
+    monkeypatch.setattr(gui_prompter, "_open_root", lambda: root)
+
+    def _fake_askyesno(title, message, parent=None):
+        seen["title"], seen["message"], seen["parent"] = title, message, parent
+        return True
+
+    monkeypatch.setattr(messagebox, "askyesno", _fake_askyesno)
+    assert gui_prompter._confirm_dialog("Approve THIS exact action?") is True
+    assert seen["message"] == "Approve THIS exact action?"
+    assert seen["parent"] is root
+    assert root.withdrawn is True
+    assert root.attrs.get("-topmost") is True
+    assert root.destroyed is True  # never leak a Tk root
+
+
+def test_code_dialog_masks_input_and_destroys_root(monkeypatch):
+    pytest.importorskip("tkinter")
+    from tkinter import simpledialog
+
+    root = _FakeRoot()
+    seen: dict = {}
+    monkeypatch.setattr(gui_prompter, "_open_root", lambda: root)
+
+    def _fake_askstring(title, message, *, show=None, parent=None):
+        seen["show"], seen["parent"] = show, parent
+        return "123456"
+
+    monkeypatch.setattr(simpledialog, "askstring", _fake_askstring)
+    assert gui_prompter._code_dialog("Enter your 2FA code") == "123456"
+    assert seen["show"] == "*"  # the code must be masked on screen
+    assert root.destroyed is True
+
+
+def test_dialog_root_destroyed_even_when_dialog_raises(monkeypatch):
+    pytest.importorskip("tkinter")
+    from tkinter import messagebox
+
+    root = _FakeRoot()
+    monkeypatch.setattr(gui_prompter, "_open_root", lambda: root)
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("dialog exploded")
+
+    monkeypatch.setattr(messagebox, "askyesno", _boom)
+    with pytest.raises(RuntimeError, match="dialog exploded"):
+        gui_prompter._confirm_dialog("Approve?")
+    assert root.destroyed is True
+
+
+# --- FallbackPrompter ---------------------------------------------------------------
+
+
+class _Recorder:
+    """A scripted prompter that records which methods were consulted."""
+
+    def __init__(self, *, confirm=None, code=None, raises=None):
+        self._confirm = confirm
+        self._code = code
+        self._raises = raises
+        self.calls: list[str] = []
+
+    def confirm(self, message: str) -> bool:
+        self.calls.append("confirm")
+        if self._raises is not None:
+            raise self._raises
+        return self._confirm
+
+    def read_code(self, message: str) -> str:
+        self.calls.append("read_code")
+        if self._raises is not None:
+            raise self._raises
+        return self._code
+
+
+def test_first_available_answer_wins():
+    first = _Recorder(confirm=True)
+    second = _Recorder(confirm=False)
+    assert FallbackPrompter([first, second]).confirm("Approve?") is True
+    assert second.calls == []
+
+
+def test_a_denial_is_final_never_answer_shopping():
+    """A human "no" on the first channel must NOT be retried on the next channel."""
+    first = _Recorder(confirm=False)
+    second = _Recorder(confirm=True)  # would approve — must never be consulted
+    assert FallbackPrompter([first, second]).confirm("Approve?") is False
+    assert second.calls == []
+
+
+def test_unavailable_channel_falls_through_to_the_next():
+    first = _Recorder(raises=PrompterUnavailableError("no display"))
+    second = _Recorder(confirm=True)
+    assert FallbackPrompter([first, second]).confirm("Approve?") is True
+    assert first.calls == ["confirm"]
+    assert second.calls == ["confirm"]
+
+
+def test_human_channel_error_propagates_without_fallthrough():
+    """EOF/timeout on an OPEN channel is a denial signal, not a reason to re-ask."""
+    first = _Recorder(raises=EOFError("walked away"))
+    second = _Recorder(confirm=True)
+    with pytest.raises(EOFError):
+        FallbackPrompter([first, second]).confirm("Approve?")
+    assert second.calls == []
+
+
+def test_all_channels_unavailable_raises_so_provider_denies():
+    first = _Recorder(raises=PrompterUnavailableError("no display"))
+    second = _Recorder(raises=PrompterUnavailableError("no terminal"))
+    with pytest.raises(PrompterUnavailableError):
+        FallbackPrompter([first, second]).confirm("Approve?")
+
+
+def test_read_code_follows_the_same_fallback_rules():
+    first = _Recorder(raises=PrompterUnavailableError("no display"))
+    second = _Recorder(code="123456")
+    assert FallbackPrompter([first, second]).read_code("Enter your 2FA code") == "123456"
+    assert second.calls == ["read_code"]
+
+
+def test_chain_is_introspectable_for_wiring_assertions():
+    first, second = _Recorder(confirm=True), _Recorder(confirm=True)
+    chain = FallbackPrompter([first, second])
+    assert list(chain.prompters) == [first, second]
+
+
+# --- fail-closed through the provider ----------------------------------------------
+
+
+def test_provider_denies_when_every_channel_is_unavailable():
+    """End to end: no GUI + no terminal ⇒ the AUTH challenge is DENIED, never approved."""
+    from datetime import datetime, timezone
+
+    from doberman.auth.challenge import AuthTier
+    from doberman.auth.provider import LocalAuthProvider
+    from doberman.models import (
+        ActionType,
+        Decision,
+        GuardrailResult,
+        ReasonCode,
+        Risk,
+        SecurityObject,
+        Verdict,
+    )
+
+    now = datetime(2026, 6, 10, tzinfo=timezone.utc)
+    action = SecurityObject(
+        id="act-gui-1",
+        ts=now,
+        agent_role="webdev",
+        action_type=ActionType.file_write,
+        tool_name="fs_write",
+        target="backend/api.ts",
+    )
+    objective = GuardrailResult(
+        verdict=Verdict.AUTH,
+        risk=Risk.medium,
+        reason_codes=[ReasonCode.sensitive_path_access],
+        explanation="why",
+    )
+    decision = Decision(
+        action_id="act-gui-1",
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.medium,
+        objective=objective,
+        reason_codes=[ReasonCode.sensitive_path_access],
+        explanation="why",
+        decided_at=now,
+    )
+    chain = FallbackPrompter(
+        [
+            _Recorder(raises=PrompterUnavailableError("no display")),
+            _Recorder(raises=PrompterUnavailableError("no terminal")),
+        ]
+    )
+    result = LocalAuthProvider().authenticate(
+        decision, action, AuthTier.local_auth, prompter=chain, at=now
+    )
+    assert result.approved is False

--- a/tests/unit/test_role_elevation_satisfies.py
+++ b/tests/unit/test_role_elevation_satisfies.py
@@ -1,0 +1,67 @@
+"""Slice 7.4 — an active elevation satisfies a role AUTH (never a role BLOCK)."""
+
+from datetime import datetime, timedelta, timezone
+
+from doberman.auth.elevation import ElevationGrant
+from doberman.engine.rules.role_boundary import RoleBoundaryRule
+from doberman.models import ActionType, EvalContext, ReasonCode, SecurityObject, Verdict
+from doberman.roles.roles import RoleDefinition
+
+_NOW = datetime(2026, 6, 8, tzinfo=timezone.utc)
+_ROLE = RoleDefinition(
+    name="webdev",
+    allowed=("frontend/**",),
+    suspicious=("backend/**",),
+    blocked=("secrets/**",),
+)
+
+
+def _action(target, action_type=ActionType.file_write):
+    return SecurityObject(
+        id="a1",
+        ts=_NOW,
+        agent_role="webdev",
+        action_type=action_type,
+        tool_name="fs_write",
+        target=target,
+    )
+
+
+def _grant(scope):
+    return ElevationGrant(
+        id="g1",
+        scope_glob=scope,
+        task_id="t",
+        granted_at=_NOW,
+        expires_at=_NOW + timedelta(seconds=900),
+    )
+
+
+def _ctx(grants=()):
+    return EvalContext(role=_ROLE, metadata={"repo_root": ".", "elevations": grants})
+
+
+def test_out_of_scope_auths_without_elevation():
+    result = RoleBoundaryRule().evaluate(_action("backend/api.ts"), _ctx())
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.role_out_of_scope in result.reason_codes
+
+
+def test_matching_elevation_satisfies_the_role_auth():
+    ctx = _ctx((_grant("backend/api.ts"),))
+    result = RoleBoundaryRule().evaluate(_action("backend/api.ts"), ctx)
+    assert result.verdict is Verdict.PASS
+
+
+def test_elevation_for_a_different_file_does_not_satisfy():
+    ctx = _ctx((_grant("backend/other.ts"),))
+    result = RoleBoundaryRule().evaluate(_action("backend/api.ts"), ctx)
+    assert result.verdict is Verdict.AUTH
+
+
+def test_elevation_never_lifts_a_role_block():
+    # Even an elevation whose glob covers a BLOCKED path must not downgrade it.
+    ctx = _ctx((_grant("secrets/key"),))
+    result = RoleBoundaryRule().evaluate(_action("secrets/key"), ctx)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.role_blocked_target in result.reason_codes

--- a/tests/unit/test_serve.py
+++ b/tests/unit/test_serve.py
@@ -1,0 +1,169 @@
+"""Unit tests for the `doberman serve` command and the `serve_stdio` launcher.
+
+Covers CLI argument parsing (downstream command after `--`, `--path`, the missing-command error)
+and that `serve_stdio` sets the executor's repo root + a non-stdio AUTH prompter and runs the proxy
+over stdio. The real stdio transports are faked so these stay headless and deterministic; the full
+agent⇄serve⇄downstream chain is covered by the integration test.
+"""
+
+import logging
+import sys
+from contextlib import asynccontextmanager
+
+import pytest
+from mcp import StdioServerParameters
+from typer.testing import CliRunner
+
+import doberman.cli.main as cli
+from doberman.auth.tty_prompter import TtyPrompter
+from doberman.proxy import executor
+from doberman.proxy import serve as serve_mod
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _restore_executor_globals():
+    """The serve path mutates module-level executor globals — restore them after each test."""
+    repo_root, prompter = executor.REPO_ROOT, executor.AUTH_PROMPTER
+    try:
+        yield
+    finally:
+        executor.REPO_ROOT = repo_root
+        executor.AUTH_PROMPTER = prompter
+
+
+@pytest.fixture
+def _no_logging_mutation(monkeypatch):
+    """Stub out stderr-logging setup so CLI-parse tests don't reconfigure global logging."""
+    monkeypatch.setattr(cli, "_configure_stderr_logging", lambda *a, **k: None)
+
+
+# --- CLI parsing -----------------------------------------------------------------
+
+
+def test_missing_downstream_command_exits_2(monkeypatch):
+    called = False
+
+    async def _spy(*_a, **_k):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(cli, "serve_stdio", _spy)
+    result = runner.invoke(cli.app, ["serve"])
+    assert result.exit_code == 2
+    assert not called
+
+
+def test_builds_stdio_params_from_argv(monkeypatch, _no_logging_mutation):
+    seen: dict = {}
+
+    async def _spy(params, *, repo_root):
+        seen["params"] = params
+        seen["repo_root"] = repo_root
+
+    monkeypatch.setattr(cli, "serve_stdio", _spy)
+    result = runner.invoke(cli.app, ["serve", "--", "mytool", "a", "b"])
+    assert result.exit_code == 0
+    assert result.output == ""  # nothing on stdout — that is the agent's MCP channel
+    assert seen["params"].command == "mytool"
+    assert seen["params"].args == ["a", "b"]
+    assert seen["repo_root"] == "."
+
+
+def test_path_option_threads_repo_root(monkeypatch, _no_logging_mutation):
+    seen: dict = {}
+
+    async def _spy(params, *, repo_root):
+        seen["repo_root"] = repo_root
+
+    monkeypatch.setattr(cli, "serve_stdio", _spy)
+    result = runner.invoke(cli.app, ["serve", "-p", "/repo", "--", "mytool"])
+    assert result.exit_code == 0
+    assert seen["repo_root"] == "/repo"
+
+
+def test_serve_reports_downstream_failure_cleanly(monkeypatch, _no_logging_mutation):
+    """A failure to start/serve becomes a clean stderr error + exit 1, never a raw traceback."""
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("downstream boom")
+
+    monkeypatch.setattr(cli, "serve_stdio", _boom)
+    result = runner.invoke(cli.app, ["serve", "--", "mytool"])
+    assert result.exit_code == 1
+    assert "doberman serve failed" in result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_stderr_logging_keeps_stdout_clean():
+    """_configure_stderr_logging pins doberman logs to stderr and scrubs stdout from root."""
+    root = logging.getLogger()
+    doberman_logger = logging.getLogger("doberman")
+    saved_root, saved_dob = root.handlers[:], doberman_logger.handlers[:]
+    saved_prop = doberman_logger.propagate
+    hostile = logging.StreamHandler(sys.stdout)  # pretend a host config logs to stdout
+    root.addHandler(hostile)
+    try:
+        cli._configure_stderr_logging()
+        assert doberman_logger.propagate is False
+        assert doberman_logger.handlers
+        assert all(getattr(h, "stream", None) is sys.stderr for h in doberman_logger.handlers)
+        assert not any(
+            isinstance(h, logging.StreamHandler) and getattr(h, "stream", None) is sys.stdout
+            for h in root.handlers
+        )
+    finally:
+        root.handlers[:] = saved_root
+        doberman_logger.handlers[:] = saved_dob
+        doberman_logger.propagate = saved_prop
+
+
+# --- serve_stdio wiring ----------------------------------------------------------
+
+
+async def test_serve_stdio_sets_repo_root_and_tty_prompter(monkeypatch):
+    """serve_stdio points the engine at repo_root and installs a non-stdio prompter, then runs."""
+    ran: dict = {}
+
+    @asynccontextmanager
+    async def _fake_stdio_client(_params):
+        yield ("d_read", "d_write")
+
+    class _FakeSession:
+        def __init__(self, read, write):
+            ran["session_args"] = (read, write)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def initialize(self):
+            ran["initialized"] = True
+
+    @asynccontextmanager
+    async def _fake_stdio_server():
+        yield ("a_read", "a_write")
+
+    class _FakeProxy:
+        def create_initialization_options(self):
+            return "init-opts"
+
+        async def run(self, read, write, opts):
+            ran["run"] = (read, write, opts)
+
+    monkeypatch.setattr(serve_mod, "stdio_client", _fake_stdio_client)
+    monkeypatch.setattr(serve_mod, "ClientSession", _FakeSession)
+    monkeypatch.setattr(serve_mod, "stdio_server", _fake_stdio_server)
+    monkeypatch.setattr(serve_mod, "build_proxy_server", lambda _session: _FakeProxy())
+
+    params = StdioServerParameters(command="mytool", args=[])
+    await serve_mod.serve_stdio(params, repo_root="/some/repo")
+
+    assert executor.REPO_ROOT == "/some/repo"
+    assert isinstance(executor.AUTH_PROMPTER, TtyPrompter)
+    assert ran["session_args"] == ("d_read", "d_write")  # downstream streams wired into the session
+    assert ran["initialized"] is True
+    assert ran["run"] == ("a_read", "a_write", "init-opts")

--- a/tests/unit/test_serve.py
+++ b/tests/unit/test_serve.py
@@ -15,6 +15,7 @@ from mcp import StdioServerParameters
 from typer.testing import CliRunner
 
 import doberman.cli.main as cli
+from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
 from doberman.auth.tty_prompter import TtyPrompter
 from doberman.proxy import executor
 from doberman.proxy import serve as serve_mod
@@ -122,8 +123,14 @@ def test_stderr_logging_keeps_stdout_clean():
 # --- serve_stdio wiring ----------------------------------------------------------
 
 
-async def test_serve_stdio_sets_repo_root_and_tty_prompter(monkeypatch):
-    """serve_stdio points the engine at repo_root and installs a non-stdio prompter, then runs."""
+async def test_serve_stdio_sets_repo_root_and_gui_first_prompter(monkeypatch):
+    """serve_stdio points the engine at repo_root and installs a GUI-first prompter, then runs.
+
+    GUI first is load-bearing: when an agent's TUI (Claude Code etc.) owns the console,
+    CONIN$/CONOUT$ still OPEN successfully but the prompt is invisible and input is
+    contested — so a TTY-first chain would never reach the dialog the human can see.
+    The terminal is only the fallback for headless/SSH sessions with no display.
+    """
     ran: dict = {}
 
     @asynccontextmanager
@@ -163,7 +170,8 @@ async def test_serve_stdio_sets_repo_root_and_tty_prompter(monkeypatch):
     await serve_mod.serve_stdio(params, repo_root="/some/repo")
 
     assert executor.REPO_ROOT == "/some/repo"
-    assert isinstance(executor.AUTH_PROMPTER, TtyPrompter)
+    assert isinstance(executor.AUTH_PROMPTER, FallbackPrompter)
+    assert [type(p) for p in executor.AUTH_PROMPTER.prompters] == [GuiPrompter, TtyPrompter]
     assert ran["session_args"] == ("d_read", "d_write")  # downstream streams wired into the session
     assert ran["initialized"] is True
     assert ran["run"] == ("a_read", "a_write", "init-opts")

--- a/tests/unit/test_serve.py
+++ b/tests/unit/test_serve.py
@@ -15,6 +15,7 @@ from mcp import StdioServerParameters
 from typer.testing import CliRunner
 
 import doberman.cli.main as cli
+from doberman.auth.elicitation_prompter import ElicitationPrompter
 from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
 from doberman.auth.tty_prompter import TtyPrompter
 from doberman.proxy import executor
@@ -123,13 +124,15 @@ def test_stderr_logging_keeps_stdout_clean():
 # --- serve_stdio wiring ----------------------------------------------------------
 
 
-async def test_serve_stdio_sets_repo_root_and_gui_first_prompter(monkeypatch):
-    """serve_stdio points the engine at repo_root and installs a GUI-first prompter, then runs.
+async def test_serve_stdio_sets_repo_root_and_elicitation_first_prompter(monkeypatch):
+    """serve_stdio points the engine at repo_root and installs the challenge chain, then runs.
 
-    GUI first is load-bearing: when an agent's TUI (Claude Code etc.) owns the console,
-    CONIN$/CONOUT$ still OPEN successfully but the prompt is invisible and input is
-    contested — so a TTY-first chain would never reach the dialog the human can see.
-    The terminal is only the fallback for headless/SSH sessions with no display.
+    The order is load-bearing: elicitation renders the challenge INSIDE the agent client
+    (best UX, works remotely) but only for clients that support it; the GUI dialog covers
+    desktop sessions (and is the only 2FA-code channel — the MCP spec forbids sensitive
+    data via elicitation); the terminal is the last resort for headless/SSH sessions.
+    A TTY-first chain would never fall through: the agent-owned console OPENS successfully
+    even though its prompt is invisible.
     """
     ran: dict = {}
 
@@ -171,7 +174,11 @@ async def test_serve_stdio_sets_repo_root_and_gui_first_prompter(monkeypatch):
 
     assert executor.REPO_ROOT == "/some/repo"
     assert isinstance(executor.AUTH_PROMPTER, FallbackPrompter)
-    assert [type(p) for p in executor.AUTH_PROMPTER.prompters] == [GuiPrompter, TtyPrompter]
+    assert [type(p) for p in executor.AUTH_PROMPTER.prompters] == [
+        ElicitationPrompter,
+        GuiPrompter,
+        TtyPrompter,
+    ]
     assert ran["session_args"] == ("d_read", "d_write")  # downstream streams wired into the session
     assert ran["initialized"] is True
     assert ran["run"] == ("a_read", "a_write", "init-opts")

--- a/tests/unit/test_totp.py
+++ b/tests/unit/test_totp.py
@@ -1,0 +1,71 @@
+"""Slice 7.2 — TOTP enrollment and verification (deterministic, no real time)."""
+
+import pyotp
+import pytest
+
+from doberman.auth import totp
+
+#: A fixed reference time (epoch seconds) so code generation is deterministic.
+_T0 = 1_700_000_000
+
+
+def _current_code(at: int = _T0) -> str:
+    secret = totp._read_secret()
+    assert secret is not None
+    return pyotp.TOTP(secret).at(at)
+
+
+def test_not_enrolled_verify_fails_closed():
+    assert totp.is_enrolled() is False
+    assert totp.verify("000000") is False  # no enrollment → no no-auth fallback
+
+
+def test_enroll_then_verify_current_code():
+    uri = totp.enroll()
+    assert uri.startswith("otpauth://")
+    assert totp.is_enrolled() is True
+    assert totp.verify(_current_code(), at=_T0) is True
+
+
+def test_skew_window_accepts_adjacent_step_rejects_far():
+    totp.enroll()
+    code = _current_code(_T0)
+    assert totp.verify(code, at=_T0 + 30) is True  # ±1 step tolerated
+    assert totp.verify(code, at=_T0 - 30) is True
+    totp.reset_attempts()
+    assert totp.verify(code, at=_T0 + 90) is False  # 3 steps away → rejected
+
+
+def test_wrong_code_rejected():
+    totp.enroll()
+    assert totp.verify("000000", at=_T0) is False
+
+
+def test_rate_limited_after_repeated_failures():
+    totp.enroll()
+    for _ in range(5):
+        assert totp.verify("000000", at=_T0) is False
+    # Even a CORRECT code is now refused until the counter is reset.
+    assert totp.verify(_current_code(_T0), at=_T0) is False
+    totp.reset_attempts()
+    assert totp.verify(_current_code(_T0), at=_T0) is True
+
+
+def test_enroll_refuses_silent_overwrite():
+    totp.enroll()
+    first = totp._read_secret()
+    with pytest.raises(RuntimeError):
+        totp.enroll()
+    assert totp._read_secret() == first  # unchanged
+    totp.enroll(force=True)
+    assert totp._read_secret() != first  # rotated only with force
+
+
+def test_secret_file_is_owner_only(isolated_totp_secret):
+    import os
+    import stat
+
+    totp.enroll()
+    if os.name != "nt":  # POSIX permission bits are meaningful
+        mode = stat.S_IMODE(isolated_totp_secret.stat().st_mode)
+        assert mode == 0o600

--- a/tests/unit/test_tty_prompter.py
+++ b/tests/unit/test_tty_prompter.py
@@ -1,0 +1,157 @@
+"""Unit tests for the controlling-terminal prompter (serve-mode AUTH channel).
+
+The prompter must (a) collect a confirm/code from the terminal, (b) raise on EOF/no-terminal so
+the provider denies (fail closed), and (c) NEVER touch sys.stdin/sys.stdout (the agent's MCP stream).
+``_open_tty`` is monkeypatched so these stay headless and deterministic.
+
+Note on fakes: a real ``/dev/tty`` opened ``r+`` does NOT share a buffer between read and write
+(write goes to the screen, read comes from the keyboard). ``io.StringIO`` does share one, so the
+fakes below keep the input and the captured output separate.
+"""
+
+import io
+
+import pytest
+
+from doberman.auth import tty_prompter
+from doberman.auth.tty_prompter import TtyPrompter
+
+
+class _FakeWrite:
+    """A terminal-output handle: records what was written; close() is a no-op so the test
+    can still inspect it after the prompter closes its handles."""
+
+    def __init__(self) -> None:
+        self.text = ""
+
+    def write(self, s: str) -> int:
+        self.text += s
+        return len(s)
+
+    def flush(self) -> None:  # pragma: no cover — trivial
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def _fake_tty(input_text: str) -> tuple[io.StringIO, _FakeWrite]:
+    """Distinct (read, write) handles, mirroring a real bidirectional tty."""
+    return io.StringIO(input_text), _FakeWrite()
+
+
+@pytest.mark.parametrize(
+    ("reply", "expected"),
+    [("y\n", True), ("yes\n", True), ("Y\n", True), ("YES\n", True), ("n\n", False), ("\n", False)],
+)
+def test_confirm_maps_reply_to_bool(monkeypatch, reply, expected):
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty(reply))
+    assert TtyPrompter().confirm("Approve THIS exact action?") is expected
+
+
+def test_confirm_writes_prompt_to_terminal(monkeypatch):
+    captured = _fake_tty("y\n")
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: captured)
+    TtyPrompter().confirm("Approve THIS exact action?")
+    assert "Approve THIS exact action?" in captured[1].text
+
+
+def test_read_code_returns_stripped_code(monkeypatch):
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty("123456\n"))
+    assert TtyPrompter().read_code("Enter your 2FA code") == "123456"
+
+
+def test_confirm_raises_on_eof_so_provider_denies(monkeypatch):
+    # Empty string = EOF / closed terminal. Must raise (never silently approve).
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty(""))
+    with pytest.raises(EOFError):
+        TtyPrompter().confirm("Approve?")
+
+
+def test_read_code_raises_on_eof(monkeypatch):
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty(""))
+    with pytest.raises(EOFError):
+        TtyPrompter().read_code("Enter your 2FA code")
+
+
+def test_read_code_raises_on_blank_line(monkeypatch):
+    # A blank line (Enter with no code) must NOT return "" to the TOTP verifier — it denies.
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty("\n"))
+    with pytest.raises(EOFError):
+        TtyPrompter().read_code("Enter your 2FA code")
+
+
+def test_read_handle_closed_even_if_write_close_raises(monkeypatch):
+    """On Windows read/write are distinct handles — a failure closing one must not leak the other."""
+    closed = {"read": False}
+
+    class _Write:
+        def write(self, s: str) -> int:
+            return len(s)
+
+        def flush(self) -> None:
+            pass
+
+        def close(self) -> None:
+            raise OSError("flush failed on close")
+
+    class _Read(io.StringIO):
+        def close(self) -> None:
+            closed["read"] = True
+            super().close()
+
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: (_Read("y\n"), _Write()))
+    with pytest.raises(OSError, match="flush failed on close"):
+        TtyPrompter().confirm("Approve?")
+    assert closed["read"] is True
+
+
+def test_no_terminal_raises_so_auth_fails_closed(monkeypatch):
+    def _no_tty():
+        raise OSError("no controlling terminal")
+
+    monkeypatch.setattr(tty_prompter, "_open_tty", _no_tty)
+    with pytest.raises(OSError, match="no controlling terminal"):
+        TtyPrompter().confirm("Approve?")
+    with pytest.raises(OSError, match="no controlling terminal"):
+        TtyPrompter().read_code("Enter your 2FA code")
+
+
+def test_never_touches_std_streams(monkeypatch):
+    """A challenge must not read stdin or write stdout (that is the agent's MCP channel)."""
+
+    class _Explode:
+        def __getattr__(self, _name):
+            raise AssertionError("prompter touched a std stream")
+
+    monkeypatch.setattr("sys.stdin", _Explode())
+    monkeypatch.setattr("sys.stdout", _Explode())
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty("y\n"))
+    assert TtyPrompter().confirm("Approve?") is True
+
+
+def test_posix_shared_handle_closed_once(monkeypatch):
+    """On POSIX read and write are the SAME object — it must be closed exactly once."""
+
+    class _Bidi:
+        def __init__(self, input_text: str) -> None:
+            self._in = io.StringIO(input_text)
+            self.out = io.StringIO()
+            self.closes = 0
+
+        def write(self, s: str) -> int:
+            return self.out.write(s)
+
+        def flush(self) -> None:
+            pass
+
+        def readline(self) -> str:
+            return self._in.readline()
+
+        def close(self) -> None:
+            self.closes += 1
+
+    handle = _Bidi("y\n")
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: (handle, handle))
+    assert TtyPrompter().confirm("Approve?") is True
+    assert handle.closes == 1


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: Feature 7 — Tiered Authentication & Role Elevation (slices 7.1–7.6)
- Plan reference: doberman_core_plan.md

## What this PR does
Turns an `AUTH` verdict into a real, **action-bound** challenge whose strength scales with risk, grants narrow/temporary/single-use **role elevations**, and adds the pluggable **`AuthProvider`** enterprise seam.

- **7.1 `select_tier`** — risk + reason codes → `soft_confirm`/`local_auth`/`two_factor`/`role_elevation` (strongest-wins). A hard `BLOCK` never maps to a challenge.
- **7.2 TOTP 2FA** (`doberman 2fa setup`) — ±1-step skew, constant-time compare, consecutive-failure rate limit, `0600` secret stored outside the repo, fail-closed when not enrolled.
- **7.3 action-specific challenge** — names the exact role/target/reason; any timeout/error/denial fails closed.
- **7.4 narrow/temporary/single-use elevation** — persisted in local SQLite (`.doberman/doberman.db`, `0600`, gitignored); satisfies **only** the role-boundary `AUTH` for the exact covered path and **never** lifts a hard block. `doberman status` lists, `doberman revoke <id>` ends one early.
- **7.5 release after auth** — approval bound to **one action id** (no replay); the action is **re-decided** (TOCTOU — a flip to `BLOCK` still blocks) before forwarding.
- **7.6 `AuthProvider` seam** — discovered via the `doberman.auth_providers` entry-point group, defaulting to local; a provider can only **grant or deny**, never change the verdict/tier. Standalone behavior unchanged.

Extends the policy-core import boundary to cover `doberman.auth`; bumps to `0.7.0`.

## Tests added (run in CI)
- `tests/unit/test_auth_tier.py` — tier mapping, strongest-wins, hard-block/PASS never map to a challenge.
- `tests/unit/test_totp.py` — enroll/verify, skew window, not-enrolled fail-closed, rate-limit lockout, `0600`, overwrite guard.
- `tests/unit/test_elevation.py` — grant model (active/covers/whole-tree refusal), scope canonicalization, storage grant/active/revoke/single-use, DB-existence short-circuit.
- `tests/unit/test_role_elevation_satisfies.py` — elevation satisfies a role AUTH for the exact path; different file still AUTHs; never lifts a role BLOCK.
- `tests/unit/test_auth_provider.py` — local default, tier/verdict immutable, fail-closed on prompter error, 2FA flow, registered-provider preference + shape skip.
- `tests/integration/test_challenge_flow.py` — prompt names target+reason; approve/deny/timeout; 2FA tier requires a valid code.
- `tests/integration/test_auth_release.py` — approved forwards+records, denied/wrong-action-id forward nothing, TOCTOU→BLOCK honored, elevation grants then covered file passes without a fresh challenge, destructive elevation is single-use.
- `tests/integration/test_cli_auth.py` — `2fa setup` (+ overwrite guard), `status` 2FA/elevation reporting, `revoke`.
- Updated `test_core_is_standalone.py` (default provider is local; version 0.7.0) and the two F2 AUTH tests (now deterministically denied).

426 passed, 3 skipped; coverage 91.6% (gate 80%). `ruff` + `ruff format` + `lint-imports` all clean.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (challenge timeout/error → deny; failed grant → deny; corrupt/locked DB → no elevation)
- [x] No secret, full file, or unredacted prompt logged or committed (TOTP secret `0600` outside repo; only path globs/ids/timestamps persisted)
- [x] Any guardrail/learning change is raise-only (elevation only satisfies the role AUTH for an exact path; never lifts a hard block; never lowers a verdict)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Edge cases: not-enrolled 2FA, rate-limit lockout, whole-tree/escaping elevation scopes refused, single-use consumption + TTL expiry, TOCTOU re-decision, approval bound to one action id, registered-but-malformed provider skipped.
- Deviations: elevations are threaded to the engine via `EvalContext.metadata['elevations']` (proxy loads already-active grants) rather than a new typed field — keeps the engine decoupled from the DB and time. Real cross-platform input *timeouts* are modeled as a denying prompter error (synchronous MVP); noted as future work.
- Risks/tech debt: synchronous/blocking challenge model (MVP); local secret storage relies on filesystem perms.
