### PR TITLE
feat(policy): policy-drift detection & poisoning defense (Feature 10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,8 @@ dist/
 build/
 *.egg-info/
 
-# Operating manual + implementation plans: local-only, never published
-CLAUDE.md
-AGENTS.md
+# Development plans: local-only, never published.
+# (The operating manual — CLAUDE.md / AGENTS.md — is published; these detailed plans are not.)
 doberman_core_plan.md
 doberman_enterprise_plan.md
 doberman_implementation_plan.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,374 @@
+# CLAUDE.md — Doberman Operating Manual
+
+> This is the init file for this repository. It governs any AI agent (Claude Code, Codex, Cursor, etc.) working here.
+> It is the **HOW**. The **WHAT** — the feature roadmap and per-slice detail — lives in `README.md` (public summary)
+> and, if present in your working tree, the project development plan you keep alongside it.
+> Content is identical to `AGENTS.md`; keep the two in sync (or symlink one to the other).
+> If this file conflicts with a casual prompt instruction, **this file wins** unless a human overrides it in writing.
+
+---
+
+## 0. On startup (every session)
+
+1. Read this entire file, then skim `README.md` for the current feature set, versioning, and roadmap. If you keep a
+   local development plan alongside the repo, read the relevant slice there for the extra detail (objective, files,
+   edge cases, suggested tests, suggested commit message).
+2. `git status` + `git log --oneline -5`.
+3. Pick the **next slice** (the lowest-numbered unmerged slice in the planned order).
+4. If the repo lacks scaffolding (`pyproject.toml` / `.github/workflows/ci.yml`), do **Slice 0 (Bootstrap)** first (§6).
+5. Execute exactly **one slice** via **The Slice Loop** (§5), then **STOP** and report. Stop at every review checkpoint.
+
+---
+
+## 1. What this repository is
+
+**Doberman** is an adaptive authorization layer for coding agents, released publicly under **Apache-2.0**.
+
+It distributes as the `doberman` package (`src/doberman/`) and is designed to be **genuinely functional on its own** —
+schema, interfaces, the runtime harness, adapters, and the built-in rules all live here. It is **not** crippleware.
+
+Doberman is built to be **extensible**: it declares stable interfaces (`Rule` / `Detector` / `AuthProvider` /
+`AuditSink`) and a runtime registry that discovers implementations via **Python entry points**. Additional packages can
+register their own rules, detectors, auth providers, or audit sinks **without Doberman importing them by name** — the
+core never takes a static dependency on any plugin. With only `doberman` installed, it works (built-in protection);
+install a plugin package and its capabilities light up automatically.
+
+---
+
+## 2. Architecture & extension points
+
+The decision path is deliberately layered so the safety-critical core stays small, open, and auditable:
+
+- **Tool mediation (`doberman.proxy`)** — the chokepoint. Every tool call an agent makes is normalized into a
+  `SecurityObject` and routed through the decision engine. There is no path around it.
+- **Decision engine (`doberman.engine`)** — combines guardrail verdicts into a final **allow / authenticate / block**
+  decision. The execution rule and the raise-only `combine` are the safety invariants — they must stay open and
+  auditable.
+- **Objective guardrail + built-in rules (`doberman.engine.rules`)** — deterministic rules over the action: path
+  canonicalization & confinement, destructive-command detection, external-destination checks, basic secret-pattern and
+  encoded-exfil detection. New rules plug in through the `Rule` interface and the registry.
+- **Roles & boundaries (`doberman.roles`)** — the role schema and per-repo boundary matcher.
+- **Policy (`doberman.policy`)** — the default checklist and the strength modes (Light / Balanced / Strict / Paranoid).
+- **Storage & audit (`doberman.storage`)** — a local, redacted decision log plus the `AuditSink` interface so
+  additional sinks can be registered.
+- **Tiered auth (`doberman.auth`)** — local confirmation, TOTP 2FA, and narrow/temporary role elevation. Auth providers
+  plug in through the `AuthProvider` interface.
+- **Subjective guardrail & baseline (`doberman.engine`)** — the abnormality interface plus a basic local behavioral
+  baseline. Detectors plug in through the `Detector` interface.
+- **Policy-drift & poisoning defense (`doberman.learning` / `doberman.policy`)** — classifies policy changes as
+  strengthen vs weaken, gates weakening behind 2FA, and records changes in an append-only ledger. A core safety
+  invariant: nothing auto-loosens.
+
+**The plugin pattern (how to keep things decoupled):** declare the interface and registry in core; let other packages
+**register** implementations through their own `pyproject.toml` entry points (groups such as `doberman.rules`,
+`doberman.detectors`, `doberman.auth_providers`, `doberman.audit_sinks`). At runtime Doberman runs its built-in
+implementations **plus** whatever is registered. Build the interface + a built-in implementation first; an advanced
+implementation can then ship as a separate plugin package that depends on the now-merged extension point — never the
+other way around.
+
+---
+
+## 3. Prime directives (non-negotiable)
+
+These override everything. If a task would break one, **STOP and ask a human**.
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case → deny / `BLOCK`. The protected agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails/learning may auto-tighten; they may **never** silently loosen. Any weakening goes through the human-approved path (the policy-drift defense).
+3. **Never expose secrets.** Never commit/log/store raw secrets, keys, full private files, unredacted prompts, or `.doberman/` contents. Fingerprints/classifications/metadata only.
+4. **Keep the core decoupled.** The policy core (`doberman.engine`/`roles`/`policy`/`storage`/`learning`) must not import `doberman.proxy`. Enforced by `import-linter`.
+5. **No slice is "done" without tests + green CI.**
+6. **One slice = one PR.** Keep changes scoped to the slice.
+
+If you feel pressure to violate one of these to "make progress," that pressure is the bug. Stop.
+
+---
+
+## 4. Project snapshot
+
+- **What:** Doberman sits between a coding agent and its tools and turns every meaningful action into a risk-based **allow / authenticate / block** decision.
+- **Package:** distributes as `doberman` (`src/doberman/`).
+- **Stack:** Python 3.11+, MCP proxy (`mcp` SDK), local-first **SQLite** (`aiosqlite`), YAML policy in `.doberman/`, Pydantic v2, `pyotp`, a `doberman` CLI (Typer), `pytest`.
+- **Runtime data** (`.doberman/`, the DB, key files) is **never** committed.
+
+---
+
+## 5. The Slice Loop (run for every slice)
+
+**Step 1 — Read the slice.** Read its objective, files, changes, security considerations, edge cases, expected output,
+suggested tests, and suggested commit message (from your local development plan, with `README.md` as the public
+roadmap). Ambiguity or a Prime-Directive conflict → STOP and ask.
+
+**Step 2 — Branch:**
+```
+git checkout main && git pull
+git checkout -b feat/<feature-slug>/<slice-slug>
+```
+
+**Step 3 — Implement** the smallest change that satisfies the Objective, strictly inside the slice's scope. For
+extensible features, implement against the **interface** and register built-ins through the registry — never make the
+policy core reach sideways into the proxy adapter.
+
+**Step 4 — Write this slice's tests (required).** In `tests/unit/` or `tests/integration/`, create
+`test_<slice_topic>.py` covering at minimum: every item in the slice's **"Suggested tests"**, every **edge case**, and
+every behavioral **security consideration** (e.g. *"a `BLOCK` means the fake downstream server recorded nothing"*,
+*"a synthetic secret never appears in any log/output"*, *"`combine` never returns a verdict lower than either input"*).
+Prefer TDD; tests must be deterministic (no real network/clock/secrets — inject/fixture them).
+
+**Step 5 — Make sure GitHub Actions runs these tests.** Tests live under `tests/` so CI's `pytest` discovers them
+(`pytest --collect-only` to confirm). New dependency → add to `pyproject.toml`. New import boundary → update the
+`import-linter` contract. New CI step → update `.github/workflows/ci.yml` (minimal, same PR).
+
+**Step 6 — Green locally:**
+```
+ruff check . && ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing
+```
+Everything passes; do **not** weaken a test or invariant to get green.
+
+**Step 7 — Update docs and the README (required every slice).** With **every commit/slice** keep these in sync as part
+of the same change — never as an afterthought:
+- **`README.md`**: update the feature summary, versioning/changelog, quickstart, and roadmap so they reflect what now
+  exists. A slice that adds/changes public behavior **must** move the README.
+- Other docs (CLI/config/usage) as usual when behavior changed.
+
+**Step 8 — Commit** (Conventional Commits; tests ship **in the same PR** as the code, ideally same commit). Use the
+plan's "Suggested commit message." Never stage `.doberman/`, `*.db`, key files, `.env*` (they're gitignored — verify
+with `git status`).
+
+**Step 9 — Push the branch** (`git push -u origin <branch>`) — tests go with it, so CI runs them.
+
+**Step 10 — Open a PR to `main`**; fill the PR template. Confirm CI turns **green**. Red CI → fix on the branch and
+push again; never merge red.
+
+**Step 11 — Post the Slice Completion Report (§10) and STOP.** Don't start the next slice until approved/merged or told to continue.
+
+**Step 12 — If this was the last slice of a feature**, after merge post the Feature Review Checkpoint (§10) and STOP. Review checkpoints are mandatory pauses.
+
+---
+
+## 6. Slice 0 — Bootstrap (only if scaffolding is missing)
+
+Scaffold the repo + working CI + a trivial smoke test, committed on `chore/bootstrap-scaffolding` with
+`chore(repo): bootstrap project scaffolding and CI`.
+
+### `pyproject.toml`
+```toml
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.importlinter]
+root_package = "doberman"
+
+# Decoupling: the policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+```
+
+### `.github/workflows/ci.yml`
+```yaml
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+```
+> `--cov-fail-under=80` is a starting bar — raise it over time, never lower it to pass a PR.
+
+### `.gitignore`
+```gitignore
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+```
+
+### `.github/pull_request_template.md`
+```markdown
+## Slice
+- Feature / Slice: <id> — <title>
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-
+```
+
+> The authoritative scaffolding is the actual `pyproject.toml`, `.github/workflows/ci.yml`, and
+> `.github/pull_request_template.md` in the repo — the blocks above are the starting shape.
+
+---
+
+## 7. Architecture enforcement (summary)
+
+The decoupling is guaranteed in CI:
+1. **`import-linter` forbidden contract**: the policy core must not import `doberman.proxy`.
+2. **Plugin inversion**: extensible features connect through core-defined interfaces + entry-point discovery, so the
+   core holds no static reference to any plugin package.
+
+---
+
+## 8. Version control hygiene
+
+- **One slice = one branch = one PR.**
+- Branches: `feat/<feature-slug>/<slice-slug>` (or `fix/...`, `chore/...`).
+- Conventional Commits; small, building commits; **tests travel with code**.
+- **Never commit** secrets, keys, `.doberman/`, `*.db`, `.env*`. If you do by accident → STOP, tell a human, treat the value as leaked (rotate it).
+- Rebase (don't merge) to update a branch: `git fetch && git rebase origin/main`.
+
+---
+
+## 9. Security & explainability rules (every slice)
+
+- **Default deny:** wrap risky ops so exceptions yield `BLOCK` (or `AUTH` only where the plan says "fail upward").
+- **Redaction mandatory:** strip raw secrets/large payloads before logging/persisting; keep path **classes**, reason codes, verdicts, **HMAC fingerprints**. Test that a synthetic secret never appears.
+- **Keyed fingerprints:** HMAC-SHA256 with a local `0600`/keyring key (never committed) — plain hashes of low-entropy secrets are brute-forceable.
+- **Explainability first:** every `BLOCK`/`AUTH` carries `reason_codes` **and** a one-line human `explanation`. Reason codes are shared constants in `models.py`.
+- **Auth is action-bound:** approvals single-use + tied to one action id; elevations narrow + time-limited + (destructive) single-use; elevation never relaxes a hard block.
+- **Canonicalize before matching** paths (resolve `.`/`..`/symlinks, confine to repo root) via one shared helper.
+- **Logging never alters/blocks a decision** and never crashes the execution path.
+- **Don't oversell:** never claim secret detection (or any single rule) is airtight — it is defense-in-depth.
+
+---
+
+## 10. Reporting formats
+
+### Slice Completion Report (after every slice, then STOP)
+```
+SLICE COMPLETE — <feature> / <slice id> (<title>)
+Branch: <branch>    PR: #<n>    CI: <green | red+why>
+What I built: <2–3 lines>
+Tests added (run in CI): <files> — <what they cover>
+Security checks verified: <redaction / fail-closed / raise-only / etc.>
+Edge cases covered: <list>
+Decisions / assumptions: <or "none">
+Deviations from the plan: <none | what & why>
+Risks / tech debt introduced: <or "none">
+Next slice: <id — title>  (awaiting go-ahead)
+```
+
+### Feature Review Checkpoint (after the last slice of a feature, then STOP)
+```
+REVIEW CHECKPOINT — <Feature N: name>
+Built: ...
+Needs human testing: ...
+Decisions to review: ...
+Risks / shortcuts / tech debt: ...
+>> Paused. I will not start the next feature until told to proceed.
+```
+
+---
+
+## 11. Never do this
+
+- ❌ Do work outside the current slice's scope.
+- ❌ Skip a review checkpoint or start the next feature without a go-ahead.
+- ❌ Mark a slice "done" with missing/failing tests or red CI.
+- ❌ Weaken/stub a test or invariant to make CI pass.
+- ❌ Auto-loosen Doberman (all loosening goes through the human-approved policy-drift path).
+- ❌ Commit or log a secret, key, full private file, unredacted prompt, or `.doberman/` content.
+- ❌ Let `doberman.proxy` be imported by the policy core.
+- ❌ Add any path by which a protected agent could reach a real tool without going through the decision engine.
+- ❌ Invent requirements. Unclear plan or wrong-looking slice → STOP and ask.
+
+---
+
+## 12. Quick reference
+
+| You want to… | Do this |
+|---|---|
+| Know **what** to build | the development plan (slice detail) + `README.md` (public roadmap) |
+| Know **how** to build it | this file |
+| Start a slice | branch `feat/<feature>/<slice>` → follow §5 |
+| Finish a slice | tests added + pushed, CI green, decoupling check passes, **README updated** (§5 Step 7), Slice Completion Report, STOP |
+| Run checks | `ruff check . && ruff format --check . && lint-imports && pytest --cov=doberman` |
+| Hit ambiguity | STOP and ask |
+
+**Remember:** small safe commits · tests with every slice · CI green before "done" · the policy core stays decoupled from the proxy · when in doubt, **fail closed and ask.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,374 @@
+# CLAUDE.md — Doberman Operating Manual
+
+> This is the init file for this repository. It governs any AI agent (Claude Code, Codex, Cursor, etc.) working here.
+> It is the **HOW**. The **WHAT** — the feature roadmap and per-slice detail — lives in `README.md` (public summary)
+> and, if present in your working tree, the project development plan you keep alongside it.
+> Content is identical to `AGENTS.md`; keep the two in sync (or symlink one to the other).
+> If this file conflicts with a casual prompt instruction, **this file wins** unless a human overrides it in writing.
+
+---
+
+## 0. On startup (every session)
+
+1. Read this entire file, then skim `README.md` for the current feature set, versioning, and roadmap. If you keep a
+   local development plan alongside the repo, read the relevant slice there for the extra detail (objective, files,
+   edge cases, suggested tests, suggested commit message).
+2. `git status` + `git log --oneline -5`.
+3. Pick the **next slice** (the lowest-numbered unmerged slice in the planned order).
+4. If the repo lacks scaffolding (`pyproject.toml` / `.github/workflows/ci.yml`), do **Slice 0 (Bootstrap)** first (§6).
+5. Execute exactly **one slice** via **The Slice Loop** (§5), then **STOP** and report. Stop at every review checkpoint.
+
+---
+
+## 1. What this repository is
+
+**Doberman** is an adaptive authorization layer for coding agents, released publicly under **Apache-2.0**.
+
+It distributes as the `doberman` package (`src/doberman/`) and is designed to be **genuinely functional on its own** —
+schema, interfaces, the runtime harness, adapters, and the built-in rules all live here. It is **not** crippleware.
+
+Doberman is built to be **extensible**: it declares stable interfaces (`Rule` / `Detector` / `AuthProvider` /
+`AuditSink`) and a runtime registry that discovers implementations via **Python entry points**. Additional packages can
+register their own rules, detectors, auth providers, or audit sinks **without Doberman importing them by name** — the
+core never takes a static dependency on any plugin. With only `doberman` installed, it works (built-in protection);
+install a plugin package and its capabilities light up automatically.
+
+---
+
+## 2. Architecture & extension points
+
+The decision path is deliberately layered so the safety-critical core stays small, open, and auditable:
+
+- **Tool mediation (`doberman.proxy`)** — the chokepoint. Every tool call an agent makes is normalized into a
+  `SecurityObject` and routed through the decision engine. There is no path around it.
+- **Decision engine (`doberman.engine`)** — combines guardrail verdicts into a final **allow / authenticate / block**
+  decision. The execution rule and the raise-only `combine` are the safety invariants — they must stay open and
+  auditable.
+- **Objective guardrail + built-in rules (`doberman.engine.rules`)** — deterministic rules over the action: path
+  canonicalization & confinement, destructive-command detection, external-destination checks, basic secret-pattern and
+  encoded-exfil detection. New rules plug in through the `Rule` interface and the registry.
+- **Roles & boundaries (`doberman.roles`)** — the role schema and per-repo boundary matcher.
+- **Policy (`doberman.policy`)** — the default checklist and the strength modes (Light / Balanced / Strict / Paranoid).
+- **Storage & audit (`doberman.storage`)** — a local, redacted decision log plus the `AuditSink` interface so
+  additional sinks can be registered.
+- **Tiered auth (`doberman.auth`)** — local confirmation, TOTP 2FA, and narrow/temporary role elevation. Auth providers
+  plug in through the `AuthProvider` interface.
+- **Subjective guardrail & baseline (`doberman.engine`)** — the abnormality interface plus a basic local behavioral
+  baseline. Detectors plug in through the `Detector` interface.
+- **Policy-drift & poisoning defense (`doberman.learning` / `doberman.policy`)** — classifies policy changes as
+  strengthen vs weaken, gates weakening behind 2FA, and records changes in an append-only ledger. A core safety
+  invariant: nothing auto-loosens.
+
+**The plugin pattern (how to keep things decoupled):** declare the interface and registry in core; let other packages
+**register** implementations through their own `pyproject.toml` entry points (groups such as `doberman.rules`,
+`doberman.detectors`, `doberman.auth_providers`, `doberman.audit_sinks`). At runtime Doberman runs its built-in
+implementations **plus** whatever is registered. Build the interface + a built-in implementation first; an advanced
+implementation can then ship as a separate plugin package that depends on the now-merged extension point — never the
+other way around.
+
+---
+
+## 3. Prime directives (non-negotiable)
+
+These override everything. If a task would break one, **STOP and ask a human**.
+
+1. **Fail closed.** On any error, uncertainty, or unhandled case → deny / `BLOCK`. The protected agent must never reach a tool around Doberman.
+2. **Raise-only.** Guardrails/learning may auto-tighten; they may **never** silently loosen. Any weakening goes through the human-approved path (the policy-drift defense).
+3. **Never expose secrets.** Never commit/log/store raw secrets, keys, full private files, unredacted prompts, or `.doberman/` contents. Fingerprints/classifications/metadata only.
+4. **Keep the core decoupled.** The policy core (`doberman.engine`/`roles`/`policy`/`storage`/`learning`) must not import `doberman.proxy`. Enforced by `import-linter`.
+5. **No slice is "done" without tests + green CI.**
+6. **One slice = one PR.** Keep changes scoped to the slice.
+
+If you feel pressure to violate one of these to "make progress," that pressure is the bug. Stop.
+
+---
+
+## 4. Project snapshot
+
+- **What:** Doberman sits between a coding agent and its tools and turns every meaningful action into a risk-based **allow / authenticate / block** decision.
+- **Package:** distributes as `doberman` (`src/doberman/`).
+- **Stack:** Python 3.11+, MCP proxy (`mcp` SDK), local-first **SQLite** (`aiosqlite`), YAML policy in `.doberman/`, Pydantic v2, `pyotp`, a `doberman` CLI (Typer), `pytest`.
+- **Runtime data** (`.doberman/`, the DB, key files) is **never** committed.
+
+---
+
+## 5. The Slice Loop (run for every slice)
+
+**Step 1 — Read the slice.** Read its objective, files, changes, security considerations, edge cases, expected output,
+suggested tests, and suggested commit message (from your local development plan, with `README.md` as the public
+roadmap). Ambiguity or a Prime-Directive conflict → STOP and ask.
+
+**Step 2 — Branch:**
+```
+git checkout main && git pull
+git checkout -b feat/<feature-slug>/<slice-slug>
+```
+
+**Step 3 — Implement** the smallest change that satisfies the Objective, strictly inside the slice's scope. For
+extensible features, implement against the **interface** and register built-ins through the registry — never make the
+policy core reach sideways into the proxy adapter.
+
+**Step 4 — Write this slice's tests (required).** In `tests/unit/` or `tests/integration/`, create
+`test_<slice_topic>.py` covering at minimum: every item in the slice's **"Suggested tests"**, every **edge case**, and
+every behavioral **security consideration** (e.g. *"a `BLOCK` means the fake downstream server recorded nothing"*,
+*"a synthetic secret never appears in any log/output"*, *"`combine` never returns a verdict lower than either input"*).
+Prefer TDD; tests must be deterministic (no real network/clock/secrets — inject/fixture them).
+
+**Step 5 — Make sure GitHub Actions runs these tests.** Tests live under `tests/` so CI's `pytest` discovers them
+(`pytest --collect-only` to confirm). New dependency → add to `pyproject.toml`. New import boundary → update the
+`import-linter` contract. New CI step → update `.github/workflows/ci.yml` (minimal, same PR).
+
+**Step 6 — Green locally:**
+```
+ruff check . && ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing
+```
+Everything passes; do **not** weaken a test or invariant to get green.
+
+**Step 7 — Update docs and the README (required every slice).** With **every commit/slice** keep these in sync as part
+of the same change — never as an afterthought:
+- **`README.md`**: update the feature summary, versioning/changelog, quickstart, and roadmap so they reflect what now
+  exists. A slice that adds/changes public behavior **must** move the README.
+- Other docs (CLI/config/usage) as usual when behavior changed.
+
+**Step 8 — Commit** (Conventional Commits; tests ship **in the same PR** as the code, ideally same commit). Use the
+plan's "Suggested commit message." Never stage `.doberman/`, `*.db`, key files, `.env*` (they're gitignored — verify
+with `git status`).
+
+**Step 9 — Push the branch** (`git push -u origin <branch>`) — tests go with it, so CI runs them.
+
+**Step 10 — Open a PR to `main`**; fill the PR template. Confirm CI turns **green**. Red CI → fix on the branch and
+push again; never merge red.
+
+**Step 11 — Post the Slice Completion Report (§10) and STOP.** Don't start the next slice until approved/merged or told to continue.
+
+**Step 12 — If this was the last slice of a feature**, after merge post the Feature Review Checkpoint (§10) and STOP. Review checkpoints are mandatory pauses.
+
+---
+
+## 6. Slice 0 — Bootstrap (only if scaffolding is missing)
+
+Scaffold the repo + working CI + a trivial smoke test, committed on `chore/bootstrap-scaffolding` with
+`chore(repo): bootstrap project scaffolding and CI`.
+
+### `pyproject.toml`
+```toml
+[project]
+name = "doberman"
+version = "0.0.0"
+description = "Adaptive authorization layer for coding agents (open core)"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.11"
+dependencies = ["pydantic>=2", "mcp", "aiosqlite", "pyotp", "pyyaml", "typer"]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/doberman"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["doberman"]
+branch = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]   # imports, bugbear, security
+
+[tool.importlinter]
+root_package = "doberman"
+
+# Decoupling: the policy core must not import the proxy adapter.
+[[tool.importlinter.contracts]]
+name = "Policy core must not depend on the proxy adapter"
+type = "forbidden"
+source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.learning"]
+forbidden_modules = ["doberman.proxy"]
+```
+
+### `.github/workflows/ci.yml`
+```yaml
+name: CI
+on:
+  push:
+    branches: ["feat/**", "fix/**", "chore/**", "main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Architecture boundaries
+        run: lint-imports
+      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+```
+> `--cov-fail-under=80` is a starting bar — raise it over time, never lower it to pass a PR.
+
+### `.gitignore`
+```gitignore
+.doberman/
+*.db
+*.sqlite
+*.sqlite3
+*.key
+.env
+.env.*
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+```
+
+### `.github/pull_request_template.md`
+```markdown
+## Slice
+- Feature / Slice: <id> — <title>
+
+## What this PR does
+
+## Tests added (run in CI)
+-
+
+## Security checklist
+- [ ] Fails closed on error / uncertainty
+- [ ] No secret, full file, or unredacted prompt logged or committed
+- [ ] Any guardrail/learning change is raise-only (no silent loosening)
+- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
+
+## Edge cases covered / Deviations from plan / Risks introduced
+-
+```
+
+> The authoritative scaffolding is the actual `pyproject.toml`, `.github/workflows/ci.yml`, and
+> `.github/pull_request_template.md` in the repo — the blocks above are the starting shape.
+
+---
+
+## 7. Architecture enforcement (summary)
+
+The decoupling is guaranteed in CI:
+1. **`import-linter` forbidden contract**: the policy core must not import `doberman.proxy`.
+2. **Plugin inversion**: extensible features connect through core-defined interfaces + entry-point discovery, so the
+   core holds no static reference to any plugin package.
+
+---
+
+## 8. Version control hygiene
+
+- **One slice = one branch = one PR.**
+- Branches: `feat/<feature-slug>/<slice-slug>` (or `fix/...`, `chore/...`).
+- Conventional Commits; small, building commits; **tests travel with code**.
+- **Never commit** secrets, keys, `.doberman/`, `*.db`, `.env*`. If you do by accident → STOP, tell a human, treat the value as leaked (rotate it).
+- Rebase (don't merge) to update a branch: `git fetch && git rebase origin/main`.
+
+---
+
+## 9. Security & explainability rules (every slice)
+
+- **Default deny:** wrap risky ops so exceptions yield `BLOCK` (or `AUTH` only where the plan says "fail upward").
+- **Redaction mandatory:** strip raw secrets/large payloads before logging/persisting; keep path **classes**, reason codes, verdicts, **HMAC fingerprints**. Test that a synthetic secret never appears.
+- **Keyed fingerprints:** HMAC-SHA256 with a local `0600`/keyring key (never committed) — plain hashes of low-entropy secrets are brute-forceable.
+- **Explainability first:** every `BLOCK`/`AUTH` carries `reason_codes` **and** a one-line human `explanation`. Reason codes are shared constants in `models.py`.
+- **Auth is action-bound:** approvals single-use + tied to one action id; elevations narrow + time-limited + (destructive) single-use; elevation never relaxes a hard block.
+- **Canonicalize before matching** paths (resolve `.`/`..`/symlinks, confine to repo root) via one shared helper.
+- **Logging never alters/blocks a decision** and never crashes the execution path.
+- **Don't oversell:** never claim secret detection (or any single rule) is airtight — it is defense-in-depth.
+
+---
+
+## 10. Reporting formats
+
+### Slice Completion Report (after every slice, then STOP)
+```
+SLICE COMPLETE — <feature> / <slice id> (<title>)
+Branch: <branch>    PR: #<n>    CI: <green | red+why>
+What I built: <2–3 lines>
+Tests added (run in CI): <files> — <what they cover>
+Security checks verified: <redaction / fail-closed / raise-only / etc.>
+Edge cases covered: <list>
+Decisions / assumptions: <or "none">
+Deviations from the plan: <none | what & why>
+Risks / tech debt introduced: <or "none">
+Next slice: <id — title>  (awaiting go-ahead)
+```
+
+### Feature Review Checkpoint (after the last slice of a feature, then STOP)
+```
+REVIEW CHECKPOINT — <Feature N: name>
+Built: ...
+Needs human testing: ...
+Decisions to review: ...
+Risks / shortcuts / tech debt: ...
+>> Paused. I will not start the next feature until told to proceed.
+```
+
+---
+
+## 11. Never do this
+
+- ❌ Do work outside the current slice's scope.
+- ❌ Skip a review checkpoint or start the next feature without a go-ahead.
+- ❌ Mark a slice "done" with missing/failing tests or red CI.
+- ❌ Weaken/stub a test or invariant to make CI pass.
+- ❌ Auto-loosen Doberman (all loosening goes through the human-approved policy-drift path).
+- ❌ Commit or log a secret, key, full private file, unredacted prompt, or `.doberman/` content.
+- ❌ Let `doberman.proxy` be imported by the policy core.
+- ❌ Add any path by which a protected agent could reach a real tool without going through the decision engine.
+- ❌ Invent requirements. Unclear plan or wrong-looking slice → STOP and ask.
+
+---
+
+## 12. Quick reference
+
+| You want to… | Do this |
+|---|---|
+| Know **what** to build | the development plan (slice detail) + `README.md` (public roadmap) |
+| Know **how** to build it | this file |
+| Start a slice | branch `feat/<feature>/<slice>` → follow §5 |
+| Finish a slice | tests added + pushed, CI green, decoupling check passes, **README updated** (§5 Step 7), Slice Completion Report, STOP |
+| Run checks | `ruff check . && ruff format --check . && lint-imports && pytest --cov=doberman` |
+| Hit ambiguity | STOP and ask |
+
+**Remember:** small safe commits · tests with every slice · CI green before "done" · the policy core stays decoupled from the proxy · when in doubt, **fail closed and ask.**

--- a/README.md
+++ b/README.md
@@ -92,21 +92,50 @@ A green run means the core engine, proxy, and guardrail wiring all behave as spe
 
 ## Quickstart
 
-At this stage Doberman is a **library**, not a standalone binary — you embed the proxy in front of a downstream MCP tool server. The proxy is created from an active downstream client session:
+Doberman ships a **`doberman serve`** runtime: it runs as an MCP server to your agent and an MCP client to your
+real tool server, so it sits *on* the execution path with no code changes on either side. The pattern is one line —
+**instead of pointing your agent at the real MCP server, point it at `doberman serve -- <that server>`.**
 
-```python
-from doberman.proxy.mcp_proxy import build_proxy_server
+```bash
+# Run Doberman in front of any MCP tool server (everything after `--` is the downstream command):
+doberman serve -- npx -y @modelcontextprotocol/server-filesystem /path/to/repo
 
-# `downstream` is an mcp.client.session.ClientSession connected to your
-# real tool server. The returned MCP server re-exposes its tools and routes
-# every tools/call through Doberman's decision chokepoint.
-proxy = build_proxy_server(downstream)
-# ...serve `proxy` to the agent over your preferred MCP transport.
+# Policy, decision log, and elevations live in <repo>/.doberman — choose the repo with --path:
+doberman serve --path /path/to/repo -- npx -y @modelcontextprotocol/server-filesystem /path/to/repo
 ```
 
-For a complete, runnable wiring (an in-process downstream + proxy + agent client),
-see [`tests/integration/test_proxy_passthrough.py`](./tests/integration/test_proxy_passthrough.py)
-and [`tests/integration/test_engine_blocks_reach_no_tool.py`](./tests/integration/test_engine_blocks_reach_no_tool.py).
+### Connect your agent
+
+Swap the agent's MCP server entry to launch Doberman, which then spawns the real server. The decision happens in
+between; `AUTH` prompts appear on **your terminal** (with no terminal attached, an `AUTH` action is denied — fail
+closed), and every decision is recorded — inspect it with `doberman log` and `doberman status`.
+
+**Claude Code**
+
+```bash
+claude mcp add doberman -- doberman serve -- npx -y @modelcontextprotocol/server-filesystem ~/repo
+```
+
+**Claude Desktop / Cursor / Codex** (`mcpServers` block in the client's config, e.g. `claude_desktop_config.json`)
+
+```jsonc
+{
+  "mcpServers": {
+    "doberman": {
+      "command": "doberman",
+      "args": ["serve", "--",
+               "npx", "-y", "@modelcontextprotocol/server-filesystem", "~/repo"]
+    }
+  }
+}
+```
+
+That's it — your agent sees exactly the same tools, now mediated by Doberman.
+
+For the embeddable form (build the proxy yourself and serve it over your own transport), use
+[`build_proxy_server`](./src/doberman/proxy/mcp_proxy.py); for runnable wiring examples see
+[`tests/integration/test_serve_end_to_end.py`](./tests/integration/test_serve_end_to_end.py) and
+[`tests/integration/test_proxy_passthrough.py`](./tests/integration/test_proxy_passthrough.py).
 
 ---
 
@@ -233,6 +262,12 @@ The version line maps to the development roadmap:
 ## Changelog
 
 This project keeps a changelog in the spirit of [Keep a Changelog](https://keepachangelog.com/).
+
+### `v0.11.0` — Agent Integration: `doberman serve` — _Unreleased (in review)_
+
+- **`doberman serve -- <downstream cmd>`** — a runnable stdio MCP proxy that fronts any downstream MCP tool server (MCP server to the agent, MCP client to the downstream); makes Doberman usable from Claude Code, Codex, Claude Desktop, Cursor, and any MCP client with a one-line config swap.
+- **Controlling-terminal AUTH** — in serve mode an `AUTH` challenge is routed to the local terminal (`/dev/tty` / `CONIN$`/`CONOUT$`) so it never touches the agent's stdin/stdout MCP stream; with no terminal attached the action is denied (fail closed).
+- Logs are pinned to **stderr** (stdout is the agent's protocol channel); the engine's repo root (`.doberman/`) is selectable with `--path`.
 
 ### `v0.10.0` — Policy-Drift Detection & Poisoning Defense — _Unreleased (in review)_
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ doberman serve --path /path/to/repo -- npx -y @modelcontextprotocol/server-files
 ### Connect your agent
 
 Swap the agent's MCP server entry to launch Doberman, which then spawns the real server. The decision happens in
-between; `AUTH` challenges **pop up as a dialog window** above your agent's terminal (agent TUIs like Claude Code own
-the console, so a terminal prompt would be invisible there). With no display, the prompt falls back to **your
-terminal**; with neither, the `AUTH` action is denied — fail closed. Every decision is recorded — inspect it with
-`doberman log` and `doberman status`.
+between; an `AUTH` challenge reaches you on the first available channel: rendered **natively inside your agent's UI**
+(MCP elicitation, for clients that support it — confirmations only, never 2FA codes), else **a dialog window** above
+your agent's terminal (agent TUIs like Claude Code own the console, so a terminal prompt would be invisible there),
+else **your terminal** (headless/SSH). With no channel available, the `AUTH` action is denied — fail closed. Every
+decision is recorded — inspect it with `doberman log` and `doberman status`.
 
 **Claude Code**
 
@@ -268,7 +269,7 @@ This project keeps a changelog in the spirit of [Keep a Changelog](https://keepa
 ### `v0.11.0` — Agent Integration: `doberman serve` — _Unreleased (in review)_
 
 - **`doberman serve -- <downstream cmd>`** — a runnable stdio MCP proxy that fronts any downstream MCP tool server (MCP server to the agent, MCP client to the downstream); makes Doberman usable from Claude Code, Codex, Claude Desktop, Cursor, and any MCP client with a one-line config swap.
-- **Out-of-band AUTH** — in serve mode an `AUTH` challenge pops up as a **topmost GUI dialog** (stdlib tkinter; masked 2FA entry), so it is visible even when an agent TUI such as Claude Code owns the console; it never touches the agent's stdin/stdout MCP stream. With no display it falls back to the controlling terminal (`/dev/tty` / `CONIN$`/`CONOUT$`); with neither channel available the action is denied (fail closed). A denial on one channel is final — it is never re-asked on another.
+- **Out-of-band AUTH** — in serve mode an `AUTH` challenge tries three channels in order: **MCP elicitation** (rendered natively inside the agent client's UI, for clients that declare the capability — confirmations only; the spec forbids sensitive data, so 2FA codes never transit the agent client), a **topmost GUI dialog** (stdlib tkinter, dark themed, masked 2FA entry — visible even when an agent TUI such as Claude Code owns the console), then the controlling terminal (`/dev/tty` / `CONIN$`/`CONOUT$`). None of these touch the agent's stdin/stdout MCP stream; with no channel available the action is denied (fail closed). A denial on one channel is final — it is never re-asked on another. Challenges run off the event loop, so the proxy stays responsive while a prompt is open.
 - Logs are pinned to **stderr** (stdout is the agent's protocol channel); the engine's repo root (`.doberman/`) is selectable with `--path`.
 
 ### `v0.10.0` — Policy-Drift Detection & Poisoning Defense — _Unreleased (in review)_

--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ doberman serve --path /path/to/repo -- npx -y @modelcontextprotocol/server-files
 ### Connect your agent
 
 Swap the agent's MCP server entry to launch Doberman, which then spawns the real server. The decision happens in
-between; `AUTH` prompts appear on **your terminal** (with no terminal attached, an `AUTH` action is denied — fail
-closed), and every decision is recorded — inspect it with `doberman log` and `doberman status`.
+between; `AUTH` challenges **pop up as a dialog window** above your agent's terminal (agent TUIs like Claude Code own
+the console, so a terminal prompt would be invisible there). With no display, the prompt falls back to **your
+terminal**; with neither, the `AUTH` action is denied — fail closed. Every decision is recorded — inspect it with
+`doberman log` and `doberman status`.
 
 **Claude Code**
 
@@ -266,7 +268,7 @@ This project keeps a changelog in the spirit of [Keep a Changelog](https://keepa
 ### `v0.11.0` — Agent Integration: `doberman serve` — _Unreleased (in review)_
 
 - **`doberman serve -- <downstream cmd>`** — a runnable stdio MCP proxy that fronts any downstream MCP tool server (MCP server to the agent, MCP client to the downstream); makes Doberman usable from Claude Code, Codex, Claude Desktop, Cursor, and any MCP client with a one-line config swap.
-- **Controlling-terminal AUTH** — in serve mode an `AUTH` challenge is routed to the local terminal (`/dev/tty` / `CONIN$`/`CONOUT$`) so it never touches the agent's stdin/stdout MCP stream; with no terminal attached the action is denied (fail closed).
+- **Out-of-band AUTH** — in serve mode an `AUTH` challenge pops up as a **topmost GUI dialog** (stdlib tkinter; masked 2FA entry), so it is visible even when an agent TUI such as Claude Code owns the console; it never touches the agent's stdin/stdout MCP stream. With no display it falls back to the controlling terminal (`/dev/tty` / `CONIN$`/`CONOUT$`); with neither channel available the action is denied (fail closed). A denial on one channel is final — it is never re-asked on another.
 - Logs are pinned to **stderr** (stdout is the agent's protocol channel); the engine's repo root (`.doberman/`) is selectable with `--path`.
 
 ### `v0.10.0` — Policy-Drift Detection & Poisoning Defense — _Unreleased (in review)_

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Doberman is a security layer for AI coding agents. It sits **on the tool-executi
 ## How it works
 
 ```
-                ┌─────────────────────── Doberman ───────────────────────┐
+                ┌─────────────────────── Doberman ────────────────────────┐
    coding       │                                                         │     real
-   agent  ──────┼──▶  normalize  ──▶  decision engine  ──▶  enforce  ─────┼──▶  tool
-  (MCP client)  │   (SecurityObject)   (PASS/AUTH/BLOCK)    (chokepoint)   │   servers
+   agent  ──────┼──▶  normalize  ──▶  decision engine  ──▶  enforce ────┼──▶  tool
+  (MCP client)  │   (SecurityObject)   (PASS/AUTH/BLOCK)    (chokepoint)  │    servers
                 │                                              │          │
                 │                                  redacted interception  │
                 │                                       log (JSON)        │

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The deterministic, conservative rules for universal danger — the guardrail tha
 
 - **Basic rules (raise-only, fail-upward):** four pure rules run on every action and combine strongest-wins:
   - **Secret leakage** — detects credential shapes (`AKIA…`, `sk-…`, `ghp_…`, PEM keys, `.env` `KEY=value`) and base64/hex-encoded carriers; secret material bound for an external destination → **BLOCK**, local secret access → **AUTH**. Two confidence tiers mean a benign high-entropy blob (a base64 asset) is never hard-blocked on encoding alone.
-  - **Protected paths** — matches the **canonicalized** target (resolving `..`, symlinks, and case via one shared helper) against blocked/sensitive globs; traversal, symlink, and case bypasses are caught, and a path escaping the repo root is blocked.
+  - **Protected paths** — matches the **canonicalized** target (resolving `..`, symlinks, and case via one shared helper) against blocked/sensitive globs; traversal, symlink, and case bypasses are caught, and a path escaping the repo root is blocked. Doberman's own control plane (`.doberman/` — the policy doc, the active role, and the DB holding the append-only policy-change ledger, decision log, baselines, and elevations) is a **hard-blocked** path, so a proxied agent cannot rewrite policy, expand its role, or wipe the ledger on disk and sidestep the Feature 10 gate.
   - **Destructive commands** — adversarially parses shell/git command lines (`;` `&&` `|` `$()` backticks, env prefixes, `sudo`); `rm -rf /`, disk wipes, and force-pushes to a protected branch → **BLOCK**; bulk deletes and opaque `bash -c` payloads → **AUTH** (never a guessed `PASS`).
   - **External destinations** — classifies network hosts on their **registered domain** (defeating punycode/homoglyph, `user@host`, IP-literal, and substring spoofs); unknown destinations → **AUTH**, which combines with a secret to a **BLOCK**.
 - **HMAC fingerprinting** — keyed (`HMAC-SHA256`) one-way fingerprints recognize secrets without ever storing them; the local key is generated on first use, kept `0600`, and never committed or logged.
@@ -278,6 +278,7 @@ This project keeps a changelog in the spirit of [Keep a Changelog](https://keepa
 - **Slice 10.2** — `apply_change` chokepoint: a weakening requires 2FA + a rendered diff and applies only on approval; strengthen/neutral apply automatically.
 - **Slice 10.3** — append-only policy-change ledger + `doberman policy-history` (records applied changes **and** denied weakening attempts).
 - **Slice 10.4** — the pluggable `DriftObserver` interface (the enterprise seam; discovered via `doberman.drift_observers`; redacted events; can never override the gate).
+- **Hardening** — the protected-path rule now **hard-blocks** Doberman's own control plane (`.doberman/` — the policy doc, the active role, and the DB holding the ledger, decision log, baselines, and elevations). This closes a bypass where a proxied agent could rewrite policy, expand its role, or delete the ledger directly on disk without ever going through the 2FA-gated `apply_change` chokepoint. (Doberman writes `.doberman/` via direct I/O, never through the proxy, so its own operation is unaffected.)
 
 ### `v0.9.0` — Subjective Guardrail & Workflow Baseline — _Unreleased (in review)_
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Doberman is a security layer for AI coding agents. It sits **on the tool-execution path** — the agent talks to Doberman, and Doberman talks to the real tools (filesystem, shell, git, network, package managers) over the [Model Context Protocol](https://modelcontextprotocol.io). Every meaningful action is intercepted, normalized into a redacted, structured **security object**, and run through a risk-based decision engine that returns one of three verdicts — **allow**, **authenticate**, or **block** — before the action is ever forwarded. The guiding principle is simple: *if Doberman isn't on the execution path, it's advisory, not protective.* Doberman is built to **fail closed** (any error or uncertainty denies the action) and to be **raise-only** (guardrails may automatically tighten, never silently loosen), so an agent can never reach a tool around it and a buggy rule can never make the system less safe.
 
 > ### Project status
-> **Alpha — pre-1.0, API unstable.** Features 1–9 are implemented: the interception layer (1), the decision engine (2), the **objective guardrail** (3 — basic rules + the plugin seam), **agent role policy** (4 — role boundaries + the policy-source seam), **capability discovery** (5 — `doberman scan`), **policy checklist + strength modes** (6), **tiered authentication** (7 — action-specific confirm/2FA challenges, narrow/temporary role elevation, and the auth-provider seam), the **local decision log & audit** (8 — an append-only, redacted SQLite log with `doberman log`/`memory` and the audit-sink seam), and the **subjective guardrail** (9 — a local workflow baseline that escalates *unusual-for-you* actions, plus the detector seam). Doberman now actively blocks the headline disasters (secret exfiltration, protected-path writes, catastrophic commands), turns an `AUTH` verdict into a real, action-bound challenge that releases the call only on success, escalates actions that cross the agent's role boundary **or** depart from its learned workflow, reports the agent's blast radius, offers one Light/Balanced/Strict/Paranoid dial over good defaults, and records every decision to an explainable, privacy-preserving local audit trail. The policy-drift & poisoning defense (Feature 10) arrives next (see the [Roadmap](#roadmap)). This is the open-source **core**; advanced/hosted capabilities live in a separate commercial edition.
+> **Alpha — pre-1.0, API unstable.** The **complete MVP core (Features 1–10)** is implemented: the interception layer (1), the decision engine (2), the **objective guardrail** (3 — basic rules + the plugin seam), **agent role policy** (4 — role boundaries + the policy-source seam), **capability discovery** (5 — `doberman scan`), **policy checklist + strength modes** (6), **tiered authentication** (7 — action-specific confirm/2FA challenges, narrow/temporary role elevation, and the auth-provider seam), the **local decision log & audit** (8 — an append-only, redacted SQLite log with `doberman log`/`memory` and the audit-sink seam), the **subjective guardrail** (9 — a local workflow baseline that escalates *unusual-for-you* actions, plus the detector seam), and the **policy-drift & poisoning defense** (10 — strengthen/weaken classification, a 2FA-gated weakening chokepoint with a visible diff, an append-only change ledger, and the drift-observer seam). Doberman blocks the headline disasters (secret exfiltration, protected-path writes, catastrophic commands), turns an `AUTH` verdict into a real, action-bound challenge that releases the call only on success, escalates actions that cross the agent's role boundary **or** depart from its learned workflow, reports the agent's blast radius, offers one Light/Balanced/Strict/Paranoid dial over good defaults, records every decision to an explainable, privacy-preserving local audit trail, and ensures protection can only ever be *loosened* through an explicit, audited, 2FA-gated human approval. This is the open-source **core**; advanced/hosted capabilities live in a separate commercial edition (see the [Roadmap](#roadmap)).
 
 ---
 
@@ -196,6 +196,15 @@ The *second* guardrail: it learns what is normal for this repo/role/workflow and
 - **`SubjectiveGuardrail` + mode awareness** — maps the score to `PASS`/`AUTH` by the active mode's sensitivity (Strict/Paranoid step up sooner; **Light disables** the abnormality step-up). It is **raise-only** and **cannot hard-block** (the execution rule clamps a subjective block to `AUTH`) — escalation, not paternalism — so it can never weaken an objective verdict.
 - **`Detector` seam (extension point)** — advanced/behavioral (UEBA-style) detectors register via the `doberman.detectors` entry-point group and run in the subjective layer, bound by the same raise-only discipline and isolated on failure. With nothing installed, only the baseline signal runs.
 
+### Feature 10 — Policy-Drift Detection & Poisoning Defense · `v0.10.0` _(in review)_
+
+Makes the **raise-only** invariant enforceable over time: learning and edits may tighten freely, but any **weakening** of protection must be deliberate — classified, gated, and recorded — so protection cannot slowly erode (the policy-poisoning attack).
+
+- **Strengthen/weaken classifier** — `classify_change(before, after)` labels a proposed change by protection rank. **Ambiguous or mixed changes classify as *weaken*** (fail safe), so a disguised weakening cannot slip through as "neutral".
+- **2FA-gated weakening chokepoint** — `apply_change(...)` is the single path for a policy change: a weakening renders a Before/After **diff** and requires a **`two_factor`** confirmation, and is applied **only on approval**; strengthening/neutral changes apply automatically. A denial leaves protection unchanged.
+- **Append-only change ledger** — every change — **including denied weakening attempts** (the attack signal) — is recorded immutably in the `policy_changes` table; `doberman policy-history` prints the full time-ordered history (rule, before→after, classification, how it was approved).
+- **`DriftObserver` seam (extension point)** — org-wide drift monitoring / compliance tooling registers via the `doberman.drift_observers` entry-point group and receives **redacted** change events. An observer is purely observational — it can **never** approve, suppress, or alter a weakening (the 2FA gate is core and authoritative) — and a failing observer is isolated. With nothing installed, the gate and local ledger are unaffected.
+
 ---
 
 ## Design invariants
@@ -224,6 +233,13 @@ The version line maps to the development roadmap:
 ## Changelog
 
 This project keeps a changelog in the spirit of [Keep a Changelog](https://keepachangelog.com/).
+
+### `v0.10.0` — Policy-Drift Detection & Poisoning Defense — _Unreleased (in review)_
+
+- **Slice 10.1** — strengthen/weaken/neutral change classifier (ambiguous & mixed → weaken, fail safe).
+- **Slice 10.2** — `apply_change` chokepoint: a weakening requires 2FA + a rendered diff and applies only on approval; strengthen/neutral apply automatically.
+- **Slice 10.3** — append-only policy-change ledger + `doberman policy-history` (records applied changes **and** denied weakening attempts).
+- **Slice 10.4** — the pluggable `DriftObserver` interface (the enterprise seam; discovered via `doberman.drift_observers`; redacted events; can never override the gate).
 
 ### `v0.9.0` — Subjective Guardrail & Workflow Baseline — _Unreleased (in review)_
 
@@ -298,11 +314,16 @@ This project keeps a changelog in the spirit of [Keep a Changelog](https://keepa
 
 ## Roadmap
 
-Upcoming versions add the guardrail *content* and the surfaces around the engine (capability-level summary):
+The **MVP core (Features 1–10) is feature-complete** and in review. Beyond it, the planned (still open-source) directions are:
 
-| Version | Theme |
-|---------|-------|
-| `v0.10.0` | **Policy-drift & poisoning defense** — strengthen/weaken classification, gated approvals, append-only ledger. |
+| Theme | What |
+|-------|------|
+| Stronger auth tiers | passkeys / WebAuthn as a tier above TOTP. |
+| Async / remote challenges | a non-blocking approval model for hosted/remote humans. |
+| More adapters | Cursor / Claude-Code / OpenAI / LangChain / terminal / browser against the decoupled core. |
+| Hardening | signed (cryptographically tamper-evident) append-only logs; policy-as-code checked into the repo; a local web dashboard. |
+
+Advanced/hosted capabilities — premium detection, centralized audit, SSO/RBAC, org policy management, compliance — live in a separate commercial edition that attaches through the core extension points (`doberman.rules` / `detectors` / `auth_providers` / `audit_sinks` / `policy_sources` / `drift_observers`) **without core ever depending on it**.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doberman"
-version = "0.9.0"
+version = "0.10.0"
 description = "Adaptive authorization layer for coding agents (open core)"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"

--- a/src/doberman/__init__.py
+++ b/src/doberman/__init__.py
@@ -1,3 +1,3 @@
 """Doberman — adaptive authorization layer for coding agents (open core)."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/src/doberman/__init__.py
+++ b/src/doberman/__init__.py
@@ -1,3 +1,3 @@
 """Doberman — adaptive authorization layer for coding agents (open core)."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/src/doberman/auth/elicitation_prompter.py
+++ b/src/doberman/auth/elicitation_prompter.py
@@ -1,0 +1,131 @@
+"""Render confirm-tier AUTH challenges inside the agent client via MCP elicitation.
+
+The first channel in the serve-mode chain: when the agent client (Claude Code,
+Codex, Cursor, …) declares the ``elicitation`` capability, Doberman sends an
+``elicitation/create`` request over the live agent session and the client renders
+the challenge natively in its own UI — the human answers right where they are
+working, with no OS dialog and no terminal contention. Clients route elicitation
+to the *user*, not the model, so the agent cannot approve its own action.
+
+Two hard rules shape this module:
+
+* **No sensitive data.** The MCP spec forbids requesting sensitive information
+  via elicitation, so :meth:`ElicitationPrompter.read_code` always raises
+  :class:`~doberman.auth.gui_prompter.PrompterUnavailableError` — one-time codes
+  stay on the out-of-band channels (GUI dialog / terminal). The approval itself
+  requests **zero** form fields: the accept/decline buttons are the answer, so
+  nothing transits the client.
+* **Never block the event loop.** The challenge answer arrives over the same MCP
+  session this server runs on; waiting for it on the loop thread would deadlock.
+  The executor runs challenges in a worker thread and this prompter bridges back
+  with ``run_coroutine_threadsafe`` — and refuses (channel-unavailable) if it
+  ever finds itself on the loop thread.
+
+Failure taxonomy: missing capability / no active request / method-not-found →
+``PrompterUnavailableError`` (the chain falls through to the GUI). A human
+``decline``/``cancel`` is a FINAL denial, a timeout raises (deny), and any other
+protocol error propagates (deny). Silence never approves.
+"""
+
+import asyncio
+import concurrent.futures
+import logging
+from typing import Any
+
+from mcp import types
+from mcp.shared.exceptions import McpError
+from mcp.types import METHOD_NOT_FOUND
+
+from doberman.auth.gui_prompter import PrompterUnavailableError
+
+logger = logging.getLogger("doberman.auth.elicitation")
+
+#: Approval is expressed through the client's accept/decline buttons alone — no
+#: form fields are requested, so no data (sensitive or otherwise) transits the client.
+_APPROVAL_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}, "required": []}
+
+#: How long to wait for the human's answer. Sized for a person, not a protocol RTT;
+#: on expiry the challenge denies (module-level so tests can shrink it).
+ANSWER_TIMEOUT_S = 300.0
+
+
+class ElicitationPrompter:
+    """Collect a confirm through the agent client's native elicitation UI.
+
+    Holds the proxy ``Server`` (to resolve the per-request session) and the serve
+    event loop (to schedule the request from the challenge worker thread). Only
+    ``confirm`` is offered on this channel — see the module docstring.
+    """
+
+    def __init__(self, server: Any, loop: asyncio.AbstractEventLoop) -> None:
+        self._server = server
+        self._loop = loop
+
+    def confirm(self, message: str) -> bool:
+        """Ask the human via the client UI. Only an explicit ``accept`` approves.
+
+        ``decline`` and ``cancel`` (dismissed without choosing) both deny — and the
+        denial is final: this raises nothing, so a fallback chain never re-asks.
+        """
+        return self._elicit_action(message) == "accept"
+
+    def read_code(self, message: str) -> str:
+        """One-time codes never transit the agent client — always unavailable."""
+        raise PrompterUnavailableError(
+            "one-time codes are sensitive and never requested via MCP elicitation; "
+            "use the out-of-band channel"
+        )
+
+    def _elicit_action(self, message: str) -> str:
+        """Send the elicitation and block (off-loop) for the human's action."""
+        self._refuse_loop_thread()
+        session = self._active_session()
+        if not self._supports_elicitation(session):
+            raise PrompterUnavailableError("agent client does not support MCP elicitation")
+
+        future = asyncio.run_coroutine_threadsafe(
+            session.elicit_form(message, requestedSchema=_APPROVAL_SCHEMA), self._loop
+        )
+        try:
+            result = future.result(timeout=ANSWER_TIMEOUT_S)
+        except concurrent.futures.TimeoutError as exc:
+            future.cancel()  # best-effort: withdraw the stale request
+            raise EOFError("no elicitation answer from the agent client") from exc
+        except McpError as exc:
+            if exc.error.code == METHOD_NOT_FOUND:
+                # The client advertised the capability but cannot serve it.
+                raise PrompterUnavailableError(
+                    "agent client rejected the elicitation request"
+                ) from exc
+            raise  # any other protocol failure → the provider denies
+        return result.action
+
+    def _refuse_loop_thread(self) -> None:
+        """Refuse to block the loop that must carry the answer (it would deadlock)."""
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # a worker thread — exactly where we want to be
+        if running is self._loop:
+            logger.warning("elicitation prompter invoked on the event-loop thread; refusing")
+            raise PrompterUnavailableError("elicitation cannot run on the serve event-loop thread")
+
+    def _active_session(self) -> Any:
+        """The agent session of the request being decided. Unavailable outside one."""
+        try:
+            return self._server.request_context.session
+        except LookupError as exc:
+            raise PrompterUnavailableError("no active MCP request context") from exc
+
+    @staticmethod
+    def _supports_elicitation(session: Any) -> bool:
+        """True when the client declared the elicitation capability (else fall through)."""
+        try:
+            return bool(
+                session.check_client_capability(
+                    types.ClientCapabilities(elicitation=types.ElicitationCapability())
+                )
+            )
+        except Exception:  # malformed capability state — treat as unsupported
+            logger.warning("could not determine client elicitation capability; skipping")
+            return False

--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -8,17 +8,22 @@ the Feature 7 challenge. The challenge must therefore surface **out-of-band** as
 a topmost dialog window; the terminal remains only a fallback for headless/SSH
 sessions where no display exists.
 
+The dialogs are custom-built tkinter windows (dark, black-and-orange theme) —
+not the stock ``messagebox``/``simpledialog`` chrome — but the security contract
+is unchanged: closing/cancelling a dialog denies, the code entry is masked, and
+the safe action (Deny) holds the initial keyboard focus so a stray Enter can
+never approve.
+
 :class:`PrompterUnavailableError` separates "this channel cannot open at all"
 (fall through to the next channel) from a human answer or a human-channel error
 (EOF/timeout — FINAL, the provider denies). A denial on one channel must never
 be re-asked on another — that would be answer-shopping.
 
 SECURITY: nothing here reads ``sys.stdin`` or writes ``sys.stdout`` (the agent's
-MCP channel). Cancelling/closing a dialog raises or returns ``False`` so the
-provider denies — there is no silent "yes". The 2FA code entry is masked.
-tkinter is stdlib; no new dependency.
+MCP channel). tkinter is stdlib; no new dependency.
 """
 
+import sys
 from collections.abc import Iterable
 from typing import Any
 
@@ -26,6 +31,22 @@ from doberman.auth.challenge import Prompter
 
 #: Window title for every challenge dialog.
 _TITLE = "Doberman — authorization required"
+
+# --- palette: dark, black and orange (no purple, no neon) ---------------------------
+_BG = "#101010"  # window base
+_PANEL = "#1b1b1b"  # message panel
+_FG = "#f2f2f2"  # primary text
+_MUTED = "#9b9b9b"  # secondary text
+_ACCENT = "#ff7a1a"  # orange — brand + the Approve action
+_ACCENT_ACTIVE = "#ff9447"  # orange hover/active
+_DENY_BG = "#262626"  # neutral dark button
+_DENY_ACTIVE = "#383838"
+
+_BODY_FONT = ("Segoe UI", 10)
+_BRAND_FONT = ("Segoe UI Semibold", 13)
+_SUB_FONT = ("Segoe UI", 9)
+_MONO_FONT = ("Consolas", 10)
+_BUTTON_FONT = ("Segoe UI Semibold", 10)
 
 
 class PrompterUnavailableError(RuntimeError):
@@ -38,7 +59,7 @@ class PrompterUnavailableError(RuntimeError):
 
 
 def _open_root() -> Any:
-    """Create a hidden, topmost Tk root for one dialog. Raises when no GUI exists.
+    """Create a Tk root for one dialog. Raises when no GUI exists.
 
     A fresh root per challenge (never cached): Tk objects are not thread-safe to
     share and a display that was missing earlier may be available now. The caller
@@ -49,41 +70,203 @@ def _open_root() -> Any:
     except Exception as exc:  # pragma: no cover — needs a tkinter-less interpreter
         raise PrompterUnavailableError("tkinter is not available") from exc
     try:
-        root = tkinter.Tk()
+        return tkinter.Tk()
     except Exception as exc:  # tkinter.TclError — no display / no window station
         raise PrompterUnavailableError("no display available for a GUI auth dialog") from exc
-    return root
 
 
-def _prepare_root(root: Any) -> None:
-    """Hide the empty main window and force the dialog above the agent's terminal."""
-    root.withdraw()  # never flash an empty main window
+def _configure_window(root: Any) -> None:
+    """Apply the window-level theme: topmost, dark base, fixed size, dark title bar."""
+    root.title(_TITLE)
+    root.configure(bg=_BG)
+    root.resizable(False, False)
     root.attributes("-topmost", True)  # the dialog must pop OVER the agent's terminal
-    root.update()
+    _apply_dark_title_bar(root)
+
+
+def _apply_dark_title_bar(root: Any) -> None:
+    """Best-effort dark title bar on Windows 11/10; purely cosmetic, never fatal."""
+    if sys.platform != "win32":
+        return
+    try:  # pragma: no cover — needs a real native window handle
+        import ctypes
+
+        root.update_idletasks()
+        hwnd = ctypes.windll.user32.GetParent(root.winfo_id())
+        use_dark = ctypes.c_int(1)
+        DWMWA_USE_IMMERSIVE_DARK_MODE = 20
+        ctypes.windll.dwmapi.DwmSetWindowAttribute(
+            hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, ctypes.byref(use_dark), ctypes.sizeof(use_dark)
+        )
+    except Exception:  # noqa: S110 — cosmetic only; the challenge must still show
+        pass
+
+
+def _center_on_screen(root: Any) -> None:
+    """Center the (now-populated) dialog so it lands where the human is looking."""
+    root.update_idletasks()
+    width, height = root.winfo_reqwidth(), root.winfo_reqheight()
+    x = max((root.winfo_screenwidth() - width) // 2, 0)
+    y = max((root.winfo_screenheight() - height) // 3, 0)  # slightly above center
+    root.geometry(f"+{x}+{y}")
+
+
+def _styled_button(parent: Any, text: str, command: Any, *, accent: bool) -> Any:
+    """A flat, hover-aware button: orange for the approve action, neutral for deny."""
+    import tkinter as tk
+
+    base = _ACCENT if accent else _DENY_BG
+    active = _ACCENT_ACTIVE if accent else _DENY_ACTIVE
+    fg = "#1a1208" if accent else _FG
+    button = tk.Button(
+        parent,
+        text=text,
+        command=command,
+        font=_BUTTON_FONT,
+        bg=base,
+        fg=fg,
+        activebackground=active,
+        activeforeground=fg,
+        relief="flat",
+        bd=0,
+        padx=18,
+        pady=7,
+        cursor="hand2",
+        highlightthickness=1,
+        highlightbackground=_BG,
+        highlightcolor=_ACCENT,
+    )
+    button.bind("<Enter>", lambda _e: button.configure(bg=active))
+    button.bind("<Leave>", lambda _e: button.configure(bg=base))
+    return button
+
+
+def _build_header_and_message(root: Any, message: str) -> None:
+    """The shared top of both dialogs: brand row + the exact challenge text."""
+    import tkinter as tk
+
+    header = tk.Frame(root, bg=_BG)
+    header.pack(fill="x", padx=18, pady=(16, 8))
+    tk.Label(header, text="🐕 DOBERMAN", font=_BRAND_FONT, fg=_ACCENT, bg=_BG).pack(anchor="w")
+    tk.Label(
+        header,
+        text="An agent action needs your decision",
+        font=_SUB_FONT,
+        fg=_MUTED,
+        bg=_BG,
+    ).pack(anchor="w", pady=(2, 0))
+
+    panel = tk.Frame(root, bg=_PANEL, highlightthickness=1, highlightbackground="#2c2c2c")
+    panel.pack(fill="both", expand=True, padx=18, pady=(6, 4))
+    tk.Label(
+        panel,
+        text=message,
+        font=_MONO_FONT,
+        fg=_FG,
+        bg=_PANEL,
+        justify="left",
+        anchor="w",
+        wraplength=480,
+        padx=12,
+        pady=10,
+    ).pack(fill="both", expand=True)
+
+
+def _populate_confirm(root: Any, message: str, answer: dict) -> None:
+    """Yes/no challenge body. Deny keeps initial focus — Enter can never stray-approve."""
+    import tkinter as tk
+
+    _build_header_and_message(root, message)
+
+    def _decide(value: bool) -> None:
+        answer["value"] = value
+        root.quit()
+
+    buttons = tk.Frame(root, bg=_BG)
+    buttons.pack(fill="x", padx=18, pady=(6, 16))
+    deny = _styled_button(buttons, "Deny", lambda: _decide(False), accent=False)
+    approve = _styled_button(buttons, "Approve", lambda: _decide(True), accent=True)
+    deny.pack(side="right", padx=(8, 0))
+    approve.pack(side="right")
+
+    root.bind("<Escape>", lambda _e: _decide(False))
+    root.bind(
+        "<Return>",
+        lambda _e: root.focus_get().invoke() if hasattr(root.focus_get(), "invoke") else None,
+    )
+    deny.focus_set()  # the safe action owns the keyboard by default
+
+
+def _populate_code(root: Any, message: str, answer: dict) -> None:
+    """Masked one-time-code entry body. Cancel/Escape/close all mean deny."""
+    import tkinter as tk
+
+    _build_header_and_message(root, message)
+
+    entry_row = tk.Frame(root, bg=_BG)
+    entry_row.pack(fill="x", padx=18, pady=(4, 4))
+    entry = tk.Entry(
+        entry_row,
+        show="*",  # the code must never echo on screen
+        font=("Consolas", 13),
+        fg=_FG,
+        bg=_PANEL,
+        insertbackground=_ACCENT,
+        relief="flat",
+        highlightthickness=1,
+        highlightbackground="#2c2c2c",
+        highlightcolor=_ACCENT,
+    )
+    entry.pack(fill="x", ipady=6)
+
+    def _submit() -> None:
+        answer["value"] = entry.get()
+        root.quit()
+
+    def _cancel() -> None:
+        answer["value"] = None
+        root.quit()
+
+    buttons = tk.Frame(root, bg=_BG)
+    buttons.pack(fill="x", padx=18, pady=(6, 16))
+    cancel = _styled_button(buttons, "Cancel", _cancel, accent=False)
+    submit = _styled_button(buttons, "Submit code", _submit, accent=True)
+    cancel.pack(side="right", padx=(8, 0))
+    submit.pack(side="right")
+
+    root.bind("<Escape>", lambda _e: _cancel())
+    entry.bind("<Return>", lambda _e: _submit())
+    entry.focus_set()
+
+
+def _run_dialog(message: str, *, want_code: bool) -> Any:
+    """Open one themed dialog, block until the human decides, and clean up.
+
+    Closing the window (WM_DELETE_WINDOW) leaves the answer unset, which resolves
+    to the deny default — there is no path where silence approves.
+    """
+    root = _open_root()
+    try:
+        _configure_window(root)
+        answer: dict = {}
+        populate = _populate_code if want_code else _populate_confirm
+        populate(root, message, answer)
+        root.protocol("WM_DELETE_WINDOW", root.quit)
+        _center_on_screen(root)
+        root.mainloop()
+        return answer.get("value", None if want_code else False)
+    finally:
+        root.destroy()
 
 
 def _confirm_dialog(message: str) -> bool:
-    """Show a yes/no challenge dialog. Closing the window is "no" (deny)."""
-    root = _open_root()
-    try:
-        from tkinter import messagebox
-
-        _prepare_root(root)
-        return bool(messagebox.askyesno(_TITLE, message, parent=root))
-    finally:
-        root.destroy()
+    """Show the yes/no challenge dialog. Closing the window is "no" (deny)."""
+    return bool(_run_dialog(message, want_code=False))
 
 
 def _code_dialog(message: str) -> str | None:
-    """Show a masked one-time-code entry dialog. Cancel/close returns ``None``."""
-    root = _open_root()
-    try:
-        from tkinter import simpledialog
-
-        _prepare_root(root)
-        return simpledialog.askstring(_TITLE, message, show="*", parent=root)
-    finally:
-        root.destroy()
+    """Show the masked one-time-code dialog. Cancel/close returns ``None``."""
+    return _run_dialog(message, want_code=True)
 
 
 class GuiPrompter:

--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -1,0 +1,142 @@
+"""GUI auth prompter + the GUI→TTY fallback chain (the serve-mode AUTH channel).
+
+When an MCP agent (Claude Code, Codex, Cursor, …) spawns ``doberman serve``, the
+controlling terminal *still exists* but is owned by the agent's TUI: a prompt
+written to ``CONOUT$``/``/dev/tty`` opens successfully yet is painted over
+(invisible), and keystrokes go to the agent — the human can never see or answer
+the Feature 7 challenge. The challenge must therefore surface **out-of-band** as
+a topmost dialog window; the terminal remains only a fallback for headless/SSH
+sessions where no display exists.
+
+:class:`PrompterUnavailableError` separates "this channel cannot open at all"
+(fall through to the next channel) from a human answer or a human-channel error
+(EOF/timeout — FINAL, the provider denies). A denial on one channel must never
+be re-asked on another — that would be answer-shopping.
+
+SECURITY: nothing here reads ``sys.stdin`` or writes ``sys.stdout`` (the agent's
+MCP channel). Cancelling/closing a dialog raises or returns ``False`` so the
+provider denies — there is no silent "yes". The 2FA code entry is masked.
+tkinter is stdlib; no new dependency.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+
+from doberman.auth.challenge import Prompter
+
+#: Window title for every challenge dialog.
+_TITLE = "Doberman — authorization required"
+
+
+class PrompterUnavailableError(RuntimeError):
+    """The prompter's human channel cannot be opened at all (no display, no GUI).
+
+    Distinct from a denial or an EOF on an *open* channel: only this error lets a
+    :class:`FallbackPrompter` consult the next channel. Reaching the provider, it
+    is treated like any other challenge failure — the action is denied.
+    """
+
+
+def _open_root() -> Any:
+    """Create a hidden, topmost Tk root for one dialog. Raises when no GUI exists.
+
+    A fresh root per challenge (never cached): Tk objects are not thread-safe to
+    share and a display that was missing earlier may be available now. The caller
+    must destroy it.
+    """
+    try:
+        import tkinter
+    except Exception as exc:  # pragma: no cover — needs a tkinter-less interpreter
+        raise PrompterUnavailableError("tkinter is not available") from exc
+    try:
+        root = tkinter.Tk()
+    except Exception as exc:  # tkinter.TclError — no display / no window station
+        raise PrompterUnavailableError("no display available for a GUI auth dialog") from exc
+    return root
+
+
+def _prepare_root(root: Any) -> None:
+    """Hide the empty main window and force the dialog above the agent's terminal."""
+    root.withdraw()  # never flash an empty main window
+    root.attributes("-topmost", True)  # the dialog must pop OVER the agent's terminal
+    root.update()
+
+
+def _confirm_dialog(message: str) -> bool:
+    """Show a yes/no challenge dialog. Closing the window is "no" (deny)."""
+    root = _open_root()
+    try:
+        from tkinter import messagebox
+
+        _prepare_root(root)
+        return bool(messagebox.askyesno(_TITLE, message, parent=root))
+    finally:
+        root.destroy()
+
+
+def _code_dialog(message: str) -> str | None:
+    """Show a masked one-time-code entry dialog. Cancel/close returns ``None``."""
+    root = _open_root()
+    try:
+        from tkinter import simpledialog
+
+        _prepare_root(root)
+        return simpledialog.askstring(_TITLE, message, show="*", parent=root)
+    finally:
+        root.destroy()
+
+
+class GuiPrompter:
+    """Collect a challenge response through a topmost dialog window.
+
+    Raises :class:`PrompterUnavailableError` when no display exists so a fallback
+    chain can try the terminal instead; any other failure (cancel, blank code)
+    raises and the provider denies (fail closed).
+    """
+
+    def confirm(self, message: str) -> bool:
+        return _confirm_dialog(message)
+
+    def read_code(self, message: str) -> str:
+        """Read a one-time code via a masked dialog. Cancel/blank → raise (deny).
+
+        An empty code must never reach the verifier, so cancel and whitespace-only
+        entries raise instead of returning ``""``.
+        """
+        code = _code_dialog(message)
+        if code is None or not code.strip():
+            raise EOFError("no code entered in the auth dialog")
+        return code.strip()
+
+
+class FallbackPrompter:
+    """Try each prompter in order; fall through ONLY when a channel is unavailable.
+
+    A human answer (including "no") is final, and a human-channel error (EOF,
+    timeout) propagates — the next channel is consulted only on
+    :class:`PrompterUnavailableError`. With every channel unavailable it raises,
+    so the provider denies (fail closed).
+    """
+
+    def __init__(self, prompters: Iterable[Prompter]) -> None:
+        self._prompters: tuple[Prompter, ...] = tuple(prompters)
+
+    @property
+    def prompters(self) -> tuple[Prompter, ...]:
+        """The chain, in consultation order (read-only — for wiring assertions)."""
+        return self._prompters
+
+    def confirm(self, message: str) -> bool:
+        return self._first_open_channel("confirm", message)
+
+    def read_code(self, message: str) -> str:
+        return self._first_open_channel("read_code", message)
+
+    def _first_open_channel(self, method: str, message: str) -> Any:
+        last: PrompterUnavailableError | None = None
+        for prompter in self._prompters:
+            try:
+                return getattr(prompter, method)(message)
+            except PrompterUnavailableError as exc:
+                last = exc
+        raise PrompterUnavailableError("no auth prompter channel is available") from last

--- a/src/doberman/auth/tty_prompter.py
+++ b/src/doberman/auth/tty_prompter.py
@@ -1,0 +1,82 @@
+"""A :class:`~doberman.auth.challenge.Prompter` that talks to the controlling terminal.
+
+Used when Doberman runs as a stdio MCP proxy (``doberman serve``): the agent owns
+this process's stdin/stdout, so an ``AUTH`` challenge must reach the human through the
+controlling terminal directly — ``/dev/tty`` (POSIX) or ``CONIN$``/``CONOUT$`` (Windows).
+If no terminal is attached (a headless, agent-spawned subprocess), opening it raises →
+the provider treats the challenge as failed → the action is **denied** (fail closed).
+
+SECURITY: this never reads ``sys.stdin`` or writes ``sys.stdout`` — those are the agent's
+MCP channel, and a stray byte there corrupts the protocol. Any no-input/EOF condition
+raises so the provider denies rather than defaulting to "yes".
+"""
+
+import sys
+from typing import TextIO
+
+#: Replies that count as approval for a yes/no confirm (case-insensitive).
+_AFFIRMATIVE = frozenset({"y", "yes"})
+
+
+def _open_tty() -> tuple[TextIO, TextIO]:
+    """Open ``(read, write)`` handles to the controlling terminal.
+
+    On POSIX both are the same bidirectional ``/dev/tty`` handle; on Windows they are
+    the distinct console devices. Raises ``OSError`` when no terminal is attached — the
+    caller turns that into a denial.
+    """
+    if sys.platform == "win32":
+        return (
+            open("CONIN$", encoding="utf-8"),  # noqa: SIM115 — closed by the caller's finally
+            open("CONOUT$", "w", encoding="utf-8"),  # noqa: SIM115 — closed by the caller's finally
+        )
+    tty = open("/dev/tty", "r+", encoding="utf-8")  # noqa: SIM115 — closed by the caller's finally
+    return tty, tty
+
+
+class TtyPrompter:
+    """Collect a challenge response from the controlling terminal (see module docstring)."""
+
+    def confirm(self, message: str) -> bool:
+        """Ask a yes/no question on the terminal.
+
+        A blank line (Enter with no input) is a non-affirmative reply → ``False`` (deny);
+        EOF / a closed terminal raises (the provider also treats that as a denial). Either
+        way the answer is never silently "yes".
+        """
+        answer = self._ask(f"\n{message} [y/N] ")
+        return answer.strip().lower() in _AFFIRMATIVE
+
+    def read_code(self, message: str) -> str:
+        """Read a one-time code from the terminal. Blank/EOF input → raise (deny).
+
+        An empty code must never be returned to the verifier, so a blank line raises rather
+        than passing ``""`` through. The code may echo on the local terminal — acceptable for
+        a single-use TOTP seen only by the local human; it never touches the agent's stream or a log.
+        """
+        code = self._ask(f"\n{message}: ").strip()
+        if not code:
+            raise EOFError("no code entered on the controlling terminal")
+        return code
+
+    @staticmethod
+    def _ask(prompt: str) -> str:
+        # Open a fresh handle per prompt (don't cache): a terminal that was unavailable or
+        # closed earlier may be usable now, and per-call opens keep concurrent challenges
+        # independent. AUTH challenges are effectively serialized by the human anyway.
+        read_handle, write_handle = _open_tty()
+        try:
+            write_handle.write(prompt)
+            write_handle.flush()
+            line = read_handle.readline()
+        finally:
+            # Nested so a failure closing the write handle still closes the (distinct, on
+            # Windows) read handle — never leak a console handle.
+            try:
+                write_handle.close()
+            finally:
+                if read_handle is not write_handle:
+                    read_handle.close()
+        if not line:  # EOF / closed terminal — never silently approve
+            raise EOFError("no input available on the controlling terminal")
+        return line

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -8,9 +8,12 @@ lists currently-active elevations.
 
 import asyncio
 import json
+import logging
+import sys
 from datetime import datetime, timezone
 
 import typer
+from mcp import StdioServerParameters
 
 from doberman import __version__
 from doberman.auth import totp
@@ -19,6 +22,7 @@ from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, r
 from doberman.policy.checklist import recommend_policy
 from doberman.policy.drift import read_policy_changes
 from doberman.policy.modes import SecurityMode
+from doberman.proxy.serve import serve_stdio
 from doberman.storage.db import active_elevations, revoke_elevation
 from doberman.storage.log import memory_summary, read_decisions
 
@@ -30,6 +34,66 @@ app = typer.Typer(
 
 twofa_app = typer.Typer(help="Two-factor (TOTP) enrollment.", no_args_is_help=True)
 app.add_typer(twofa_app, name="2fa")
+
+
+def _configure_stderr_logging(level: int = logging.INFO) -> None:
+    """Send Doberman logs to STDERR only.
+
+    In ``serve`` mode this process's stdout IS the agent's MCP channel, so any log written
+    there would corrupt the protocol. Pin every ``doberman.*`` logger to stderr and stop
+    propagation, and — defense in depth — strip any stdout handler from the root logger so a
+    library (mcp/asyncio) or host-configured logger cannot leak a record onto stdout either.
+    """
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("doberman: %(message)s"))
+    doberman_logger = logging.getLogger("doberman")
+    for existing in doberman_logger.handlers[:]:
+        doberman_logger.removeHandler(existing)
+    doberman_logger.addHandler(handler)
+    doberman_logger.setLevel(level)
+    doberman_logger.propagate = False
+
+    root = logging.getLogger()
+    for existing in root.handlers[:]:
+        if (
+            isinstance(existing, logging.StreamHandler)
+            and getattr(existing, "stream", None) is sys.stdout
+        ):
+            root.removeHandler(existing)
+    if not root.handlers:  # keep a stderr fallback so non-doberman logs aren't silently dropped
+        root.addHandler(logging.StreamHandler(sys.stderr))
+
+
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    help="Run Doberman as an MCP proxy in front of a downstream MCP tool server.",
+)
+def serve(
+    ctx: typer.Context,
+    path: str = typer.Option(
+        ".", "--path", "-p", help="Repo root whose .doberman/ policy governs decisions."
+    ),
+) -> None:
+    """Run Doberman as an MCP proxy in front of a downstream MCP server.
+
+    Everything after `--` is the downstream server command, for example:
+
+        doberman serve -- npx -y @modelcontextprotocol/server-filesystem /path/to/repo
+
+    Point your agent's MCP config at this instead of the real server. AUTH prompts appear on
+    your terminal; with no terminal attached (headless) an AUTH action is denied (fail closed).
+    """
+    downstream_argv = list(ctx.args)
+    if not downstream_argv:
+        typer.echo("error: provide the downstream server command after `--`", err=True)
+        raise typer.Exit(code=2)
+    params = StdioServerParameters(command=downstream_argv[0], args=downstream_argv[1:])
+    _configure_stderr_logging()
+    try:
+        asyncio.run(serve_stdio(params, repo_root=path))
+    except Exception as exc:  # noqa: BLE001 — surface a clean stderr error, never a raw traceback
+        typer.echo(f"error: doberman serve failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
 
 
 @app.command()

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -17,6 +17,7 @@ from doberman.auth import totp
 from doberman.config import load_active_role, load_mode, load_policy, save_mode, save_policy
 from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, render_risk_map
 from doberman.policy.checklist import recommend_policy
+from doberman.policy.drift import read_policy_changes
 from doberman.policy.modes import SecurityMode
 from doberman.storage.db import active_elevations, revoke_elevation
 from doberman.storage.log import memory_summary, read_decisions
@@ -210,6 +211,32 @@ def memory(
         for cls, count in summary["top_path_classes"]:
             typer.echo(f"  {cls}  ×{count}")
     typer.echo(f"Distinct secrets seen (count only, never stored): {summary['secrets_seen']}")
+
+
+@app.command("policy-history")
+def policy_history(
+    last: int = typer.Option(20, "--last", "-n", help="Show the most recent N changes."),
+    path: str = typer.Option(".", "--path", "-p", help="Repository root."),
+) -> None:
+    """Show the append-only policy-change ledger (newest first).
+
+    Records every classified change — strengthen / weaken / neutral — **including
+    denied weakening attempts** (the poisoning signal). Each row shows the rule,
+    the before→after states, the classification, and how it was approved.
+    """
+    rows = asyncio.run(read_policy_changes(path, limit=max(0, last)))
+    if not rows:
+        typer.echo("(no policy changes recorded yet)")
+        return
+    typer.echo("Doberman policy-change ledger")
+    typer.echo("=" * 32)
+    for row in rows:
+        status = "approved" if row["approved"] else "DENIED"
+        typer.echo(
+            f"{row['ts']}  {row['classification']:<10} {row['rule_id']}: "
+            f"{row['from_state']} → {row['to_state']}  "
+            f"[{status} via {row['approval_method']}]"
+        )
 
 
 @app.command()

--- a/src/doberman/engine/registry.py
+++ b/src/doberman/engine/registry.py
@@ -42,6 +42,8 @@ POLICY_SOURCE_GROUP = "doberman.policy_sources"
 AUTH_PROVIDER_GROUP = "doberman.auth_providers"
 #: Audit sinks (Feature 8.4) register here; resolved by the storage layer.
 AUDIT_SINK_GROUP = "doberman.audit_sinks"
+#: Drift observers (Feature 10.4) register here; resolved by the policy layer.
+DRIFT_OBSERVER_GROUP = "doberman.drift_observers"
 
 
 def _iter_entry_points(group: str) -> Iterator[EntryPoint]:
@@ -242,3 +244,34 @@ def discover_audit_sinks() -> list[object]:
             continue
         sinks.append(candidate)
     return sinks
+
+
+def discover_drift_observers() -> list[object]:
+    """Discover registered drift observers (Feature 10.4, group ``doberman.drift_observers``).
+
+    Loaded defensively like rules/sinks: an import/constructor failure, or an
+    object that is not observer-shaped (no callable ``on_change``), is logged and
+    skipped. Returns ``[]`` when nothing is installed — the 2FA gate + local
+    ledger are unaffected. Core never imports an observer by name.
+    """
+    # Local import avoids an engine<->policy import cycle at module load.
+    from doberman.policy.drift import _looks_like_drift_observer
+
+    observers: list[object] = []
+    seen: set[str] = set()
+    for entry_point in _iter_entry_points(DRIFT_OBSERVER_GROUP):
+        key = f"{DRIFT_OBSERVER_GROUP}:{getattr(entry_point, 'name', id(entry_point))}"
+        if key in seen:
+            continue
+        seen.add(key)
+        candidate = _load_and_construct(entry_point)
+        if candidate is None:
+            continue
+        if not _looks_like_drift_observer(candidate):
+            logger.warning(
+                "skipping drift observer %r: not observer-shaped",
+                getattr(entry_point, "name", "?"),
+            )
+            continue
+        observers.append(candidate)
+    return observers

--- a/src/doberman/engine/rules/paths.py
+++ b/src/doberman/engine/rules/paths.py
@@ -50,6 +50,16 @@ DEFAULT_BLOCKED_GLOBS: tuple[str, ...] = (
     "**/secrets/**",
     "**/id_rsa*",
     "**/id_ed25519*",
+    # Doberman's own control plane: the policy doc, the active role, and the DB
+    # holding the append-only policy_changes ledger / decision log / baselines /
+    # elevations. A proxied agent has no legitimate path here — Doberman writes
+    # it via direct I/O, never through the proxy — and reaching it would bypass
+    # the Feature 10 apply_change gate (policy rewrite, role expansion, ledger
+    # wipe). Block any agent-proxied read/write/delete of it.
+    ".doberman",
+    ".doberman/**",
+    "**/.doberman",
+    "**/.doberman/**",
 )
 
 #: Paths that are sensitive: allowed, but only after authentication.

--- a/src/doberman/policy/checklist.py
+++ b/src/doberman/policy/checklist.py
@@ -50,7 +50,7 @@ _CORE_HARD_BLOCKS: tuple[PolicyItem, ...] = (
     ),
     PolicyItem(
         "hard_block.protected_path",
-        "Block writes/deletes to protected paths (.env, secrets, keys).",
+        "Block writes/deletes to protected paths (.env, secrets, keys, Doberman's own .doberman/ state).",
         CATEGORY_HARD_BLOCK,
         Verdict.BLOCK,
         core=True,

--- a/src/doberman/policy/drift.py
+++ b/src/doberman/policy/drift.py
@@ -1,0 +1,310 @@
+"""Policy-drift detection & poisoning defense (Feature 10).
+
+The thesis flags **policy poisoning** — the slow erosion of protection over time
+— as a top weakness. Learning and edits may *tighten* freely, but any
+**weakening** must be deliberate: classified, gated behind strong auth with a
+visible diff, and recorded in an append-only ledger. This module is that
+mechanism (a core safety invariant):
+
+* :func:`classify_change` — labels a proposed change ``strengthen`` /
+  ``weaken`` / ``neutral``. **Ambiguous or mixed → weaken** (fail safe).
+* :func:`apply_change` — the **single chokepoint**: a weakening requires a
+  ``two_factor`` confirmation against a rendered Before/After diff and is applied
+  only on approval; strengthening/neutral changes apply (still logged). Every
+  attempt — including denials (the attack signal) — is written to the ledger and
+  fanned out to registered :class:`DriftObserver` s.
+* :class:`DriftObserver` — the enterprise seam (org-wide drift monitoring /
+  compliance). Observers receive **redacted** events and can **never** approve or
+  suppress a weakening — the 2FA gate is core and authoritative.
+
+This module is policy core: it may import ``doberman.auth`` / ``doberman.storage``
+but never ``doberman.proxy``.
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Protocol, runtime_checkable
+
+from doberman.auth import totp
+from doberman.auth.challenge import Prompter
+from doberman.storage.db import db_path, open_db
+
+logger = logging.getLogger("doberman.policy.drift")
+
+
+class Classification(StrEnum):
+    """How a proposed policy change affects protection."""
+
+    strengthen = "strengthen"
+    weaken = "weaken"
+    neutral = "neutral"
+
+
+#: Protection rank of a policy state token (higher = stronger protection). A
+#: weakening is any move DOWN this scale (or removing a protective entry). Unknown
+#: tokens rank as ``auth`` (mid) — conservative, never treated as "no protection".
+_RANK: dict[str, int] = {
+    "block": 3,
+    "hard_block": 3,
+    "blocked": 3,
+    "protected": 3,
+    "deny": 3,
+    "auth": 2,
+    "sensitive": 2,
+    "step_up": 2,
+    "unknown": 2,
+    "on": 2,
+    "enabled": 2,
+    "true": 2,
+    "allow": 1,
+    "normal": 1,
+    "trusted": 1,
+    "pass": 1,
+    "off": 0,
+    "disabled": 0,
+    "false": 0,
+    "none": 0,
+    "absent": 0,
+}
+
+#: Rank used when a key is absent from a side of the diff (no entry = no protection).
+_ABSENT_RANK = 0
+#: Rank for an unrecognized token (treat as needs-auth — never "no protection").
+_UNKNOWN_TOKEN_RANK = 2
+
+
+def _rank(value: object) -> int:
+    if value is None:
+        return _ABSENT_RANK
+    if isinstance(value, bool):
+        return 2 if value else 0
+    return _RANK.get(str(value).strip().lower(), _UNKNOWN_TOKEN_RANK)
+
+
+def classify_change(before: dict, after: dict) -> Classification:
+    """Classify a policy change as strengthen / weaken / neutral.
+
+    Compares two ``{rule_id: state}`` mappings by protection rank. **Any**
+    weakening (a rule moved to a weaker state, or a protective entry removed)
+    makes the whole change a ``weaken`` — even if other rules strengthened
+    (mixed → weaken, fail safe). Only-strengthening → ``strengthen``; identical →
+    ``neutral``.
+    """
+    weakened = False
+    strengthened = False
+    for key in set(before) | set(after):
+        before_rank = _rank(before[key]) if key in before else _ABSENT_RANK
+        after_rank = _rank(after[key]) if key in after else _ABSENT_RANK
+        if after_rank < before_rank:
+            weakened = True
+        elif after_rank > before_rank:
+            strengthened = True
+    if weakened:
+        return Classification.weaken
+    if strengthened:
+        return Classification.strengthen
+    return Classification.neutral
+
+
+@dataclass(frozen=True)
+class ChangeOutcome:
+    """The result of routing a change through :func:`apply_change`."""
+
+    classification: Classification
+    approved: bool
+    method: str
+
+
+def _changed_keys(before: dict, after: dict) -> list[str]:
+    return sorted(k for k in set(before) | set(after) if before.get(k) != after.get(k))
+
+
+def _render_diff(before: dict, after: dict, reason: str) -> str:
+    """A human-readable Before/After diff for the weaken confirmation (no secrets)."""
+    lines = ["Doberman policy WEAKENING requested — review carefully:"]
+    for key in _changed_keys(before, after):
+        lines.append(f"  {key}: {before.get(key, '(absent)')} → {after.get(key, '(absent)')}")
+    lines.append(f"Reason: {reason or '(none given)'}")
+    return "\n".join(lines)
+
+
+def _run_weaken_gate(
+    before: dict, after: dict, reason: str, prompter: Prompter
+) -> tuple[bool, str]:
+    """Require presence + a valid TOTP code to approve a weakening. Fails closed."""
+    try:
+        if not prompter.confirm(_render_diff(before, after, reason)):
+            return False, "denied"
+        code = prompter.read_code("Enter your 2FA code to authorize this policy weakening")
+        if totp.verify(code):
+            return True, "two_factor"
+        return False, "denied"
+    except Exception:  # noqa: BLE001 — any input/timeout error denies the weakening
+        return False, "denied"
+
+
+_INSERT_CHANGE = (
+    "INSERT INTO policy_changes "
+    "(ts, rule_id, from_state, to_state, classification, reason, approval_method, "
+    "approved, approved_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+)
+
+
+async def _record_change(
+    repo_root: str,
+    before: dict,
+    after: dict,
+    classification: Classification,
+    reason: str,
+    *,
+    approved: bool,
+    method: str,
+    now: datetime,
+) -> None:
+    """Append one ledger row per changed rule (best-effort; never raises)."""
+    approved_by = "local" if approved else None
+    ts = now.isoformat()
+    try:
+        async with open_db(repo_root) as conn:
+            for key in _changed_keys(before, after):
+                await conn.execute(
+                    _INSERT_CHANGE,
+                    (
+                        ts,
+                        key,
+                        str(before.get(key, "(absent)")),
+                        str(after.get(key, "(absent)")),
+                        classification.value,
+                        reason,
+                        method,
+                        int(approved),
+                        approved_by,
+                    ),
+                )
+            await conn.commit()
+    except Exception:  # noqa: BLE001 — ledger failure must not crash the edit path
+        logger.warning("policy-change ledger write failed; continuing")
+
+
+async def apply_change(
+    before: dict,
+    after: dict,
+    reason: str,
+    *,
+    repo_root: str,
+    prompter: Prompter | None = None,
+    now: datetime | None = None,
+) -> ChangeOutcome:
+    """The single chokepoint for a policy change. Returns the outcome.
+
+    A **weaken** is gated behind a 2FA confirmation of a rendered diff and is
+    approved only on success; a **strengthen**/**neutral** applies automatically.
+    Every attempt (incl. denials) is written to the append-only ledger and fanned
+    out to registered drift observers. The caller persists the new policy **only
+    when** ``outcome.approved`` is True — this function decides, records, and
+    notifies; it never weakens silently.
+    """
+    when = now or datetime.now(timezone.utc)
+    classification = classify_change(before, after)
+
+    if classification is Classification.weaken:
+        from doberman.auth.provider import CliPrompter
+
+        approved, method = _run_weaken_gate(before, after, reason, prompter or CliPrompter())
+    else:
+        approved, method = True, "auto"
+
+    await _record_change(
+        repo_root,
+        before,
+        after,
+        classification,
+        reason,
+        approved=approved,
+        method=method,
+        now=when,
+    )
+    notify_observers(
+        {
+            "ts": when.isoformat(),
+            "classification": classification.value,
+            "changed_rules": _changed_keys(before, after),
+            "reason": reason,
+            "approved": approved,
+            "method": method,
+        }
+    )
+    return ChangeOutcome(classification=classification, approved=approved, method=method)
+
+
+async def read_policy_changes(repo_root: str, *, limit: int | None = None) -> list[dict]:
+    """Read ledger rows, newest first (for ``doberman policy-history``)."""
+    if not db_path(repo_root).exists():
+        return []
+    query = (
+        "SELECT ts, rule_id, from_state, to_state, classification, reason, "
+        "approval_method, approved, approved_by FROM policy_changes ORDER BY id DESC"
+    )
+    if limit:
+        query += f" LIMIT {int(limit)}"
+    cols = [
+        "ts",
+        "rule_id",
+        "from_state",
+        "to_state",
+        "classification",
+        "reason",
+        "approval_method",
+        "approved",
+        "approved_by",
+    ]
+    try:
+        async with open_db(repo_root) as conn:
+            async with conn.execute(query) as cur:
+                rows = await cur.fetchall()
+    except Exception:  # noqa: BLE001 — a read failure must never crash the CLI
+        return []
+    return [dict(zip(cols, row, strict=True)) for row in rows]
+
+
+# --- DriftObserver seam (slice 10.4) -------------------------------------
+
+
+@runtime_checkable
+class DriftObserver(Protocol):
+    """Receives **redacted** policy-change events (org-wide monitoring seam).
+
+    Implementations live in installed packages registered via the
+    ``doberman.drift_observers`` entry-point group. ``on_change`` is purely
+    observational: it can never approve, suppress, or alter a weakening (the 2FA
+    gate is core and authoritative) and must not raise into the caller.
+    """
+
+    def on_change(self, event: dict) -> None: ...
+
+
+def _looks_like_drift_observer(obj: object) -> bool:
+    """Structural check (the Protocol's isinstance is method-name only)."""
+    return callable(getattr(obj, "on_change", None))
+
+
+def notify_observers(event: dict) -> None:
+    """Fan a **redacted** drift event out to every registered observer, isolated.
+
+    Never raises and never affects the gate: observers are notified *after* the
+    authoritative decision is made and the ledger written. A non-observer-shaped
+    or raising observer is logged and skipped. With none installed this is a
+    no-op.
+    """
+    from doberman.engine.registry import discover_drift_observers
+
+    for observer in discover_drift_observers():
+        if not _looks_like_drift_observer(observer):
+            logger.warning("skipping drift observer %r: not observer-shaped", observer)
+            continue
+        try:
+            observer.on_change(dict(event))
+        except Exception:  # noqa: BLE001 — an observer can never break the gate
+            logger.warning("drift observer %r raised; skipping", type(observer).__name__)

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -17,6 +17,7 @@ Any engine failure is itself a ``BLOCK`` (fail closed). The approval is bound to
 exactly one action id (no replay onto a different call).
 """
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 
@@ -242,7 +243,12 @@ async def _handle_auth(
     abnormality_score: float,
 ) -> CallToolResult:
     """Run the tiered challenge for an AUTH decision and act on the outcome."""
-    auth_result = run_auth_challenge(decision, action, prompter=AUTH_PROMPTER)
+    # Off the event loop: the challenge blocks for a human, and an elicitation
+    # answer arrives over the very session this loop services — waiting in-loop
+    # would deadlock it (and freeze the proxy during GUI/TTY prompts too).
+    auth_result = await asyncio.to_thread(
+        run_auth_challenge, decision, action, prompter=AUTH_PROMPTER
+    )
     # Approval is bound to THIS action id — never honor a result for another call.
     if not auth_result.approved or auth_result.action_id != action.id:
         await _persist(decision, action, auth_result="denied")

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 from mcp.client.session import ClientSession
 from mcp.types import CallToolResult, TextContent
 
-from doberman.auth.challenge import AuthTier, run_auth_challenge
+from doberman.auth.challenge import AuthTier, Prompter, run_auth_challenge
 from doberman.auth.elevation import find_cover, scope_for_target
 from doberman.config import load_active_role, load_mode
 from doberman.engine.decision_engine import Guardrail, decide
@@ -50,6 +50,12 @@ _engine_logger = logging.getLogger("doberman.proxy.engine")
 #: Repo root used for config + the elevation store. Module-level so tests can
 #: point it at an isolated temp dir (the DB/config must never touch the repo).
 REPO_ROOT = "."
+
+#: Prompter for AUTH challenges. None ⇒ the provider's default CLI prompter
+#: (stdin/stdout). The stdio ``serve`` path sets this to a controlling-terminal
+#: prompter so a challenge never reads/writes the agent's MCP stream. Module-level
+#: so tests can inject a headless fake.
+AUTH_PROMPTER: Prompter | None = None
 
 # Guardrail implementations used by the proxy: the real Feature 3 objective rule
 # set and the real Feature 9 subjective (workflow-baseline) guardrail. Module-
@@ -236,7 +242,7 @@ async def _handle_auth(
     abnormality_score: float,
 ) -> CallToolResult:
     """Run the tiered challenge for an AUTH decision and act on the outcome."""
-    auth_result = run_auth_challenge(decision, action)
+    auth_result = run_auth_challenge(decision, action, prompter=AUTH_PROMPTER)
     # Approval is bound to THIS action id — never honor a result for another call.
     if not auth_result.approved or auth_result.action_id != action.id:
         await _persist(decision, action, auth_result="denied")

--- a/src/doberman/proxy/serve.py
+++ b/src/doberman/proxy/serve.py
@@ -1,0 +1,43 @@
+"""Run Doberman as a real MCP proxy over stdio in front of one downstream tool server.
+
+Doberman is an MCP *server* to the agent (over this process's stdin/stdout) and an MCP
+*client* to the downstream server (which it spawns). Every ``tools/call`` flows through the
+single chokepoint (:func:`doberman.proxy.executor.decide_and_execute`) — there is no path
+around it. This is the deployable counterpart to :func:`doberman.proxy.mcp_proxy.build_proxy_server`,
+which builds the proxy object; this module gives it a transport.
+
+SECURITY: nothing here writes this process's stdout (that is the agent's MCP channel). AUTH
+challenges are routed to the controlling terminal via :class:`~doberman.auth.tty_prompter.TtyPrompter`
+so a prompt never touches the agent stream; with no terminal the challenge denies (fail closed).
+"""
+
+import logging
+
+from mcp import ClientSession, StdioServerParameters, stdio_client
+from mcp.server.stdio import stdio_server
+
+from doberman.auth.tty_prompter import TtyPrompter
+from doberman.proxy import executor
+from doberman.proxy.mcp_proxy import build_proxy_server
+
+logger = logging.getLogger("doberman.proxy.serve")
+
+
+async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = ".") -> None:
+    """Spawn ``downstream``, then serve the Doberman proxy to the agent over stdio.
+
+    Points the engine at ``repo_root`` (its ``.doberman/`` holds the active role, policy,
+    decision log, and elevation store) and installs the controlling-terminal prompter so an
+    ``AUTH`` challenge never reads/writes the agent's stdin/stdout. Returns when the agent
+    disconnects; any transport failure propagates (the caller exits non-zero, forwarding nothing).
+    """
+    executor.REPO_ROOT = repo_root
+    executor.AUTH_PROMPTER = TtyPrompter()
+    logger.info("starting downstream: %s", downstream.command)
+    async with stdio_client(downstream) as (downstream_read, downstream_write):
+        async with ClientSession(downstream_read, downstream_write) as session:
+            await session.initialize()
+            proxy = build_proxy_server(session)
+            async with stdio_server() as (agent_read, agent_write):
+                logger.info("ready — proxying tool calls to the agent over stdio")
+                await proxy.run(agent_read, agent_write, proxy.create_initialization_options())

--- a/src/doberman/proxy/serve.py
+++ b/src/doberman/proxy/serve.py
@@ -7,8 +7,12 @@ around it. This is the deployable counterpart to :func:`doberman.proxy.mcp_proxy
 which builds the proxy object; this module gives it a transport.
 
 SECURITY: nothing here writes this process's stdout (that is the agent's MCP channel). AUTH
-challenges are routed to the controlling terminal via :class:`~doberman.auth.tty_prompter.TtyPrompter`
-so a prompt never touches the agent stream; with no terminal the challenge denies (fail closed).
+challenges surface as a topmost GUI dialog (:class:`~doberman.auth.gui_prompter.GuiPrompter`)
+first — when an agent's TUI owns the console, a terminal prompt opens "successfully" but is
+invisible and its input is contested, so the dialog is the only channel the human can actually
+see. With no display the chain falls back to the controlling terminal
+(:class:`~doberman.auth.tty_prompter.TtyPrompter`); with neither, the challenge denies (fail
+closed). A prompt never touches the agent stream.
 """
 
 import logging
@@ -16,6 +20,7 @@ import logging
 from mcp import ClientSession, StdioServerParameters, stdio_client
 from mcp.server.stdio import stdio_server
 
+from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
 from doberman.auth.tty_prompter import TtyPrompter
 from doberman.proxy import executor
 from doberman.proxy.mcp_proxy import build_proxy_server
@@ -27,12 +32,13 @@ async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = "."
     """Spawn ``downstream``, then serve the Doberman proxy to the agent over stdio.
 
     Points the engine at ``repo_root`` (its ``.doberman/`` holds the active role, policy,
-    decision log, and elevation store) and installs the controlling-terminal prompter so an
-    ``AUTH`` challenge never reads/writes the agent's stdin/stdout. Returns when the agent
-    disconnects; any transport failure propagates (the caller exits non-zero, forwarding nothing).
+    decision log, and elevation store) and installs the GUI-first prompter chain so an
+    ``AUTH`` challenge never reads/writes the agent's stdin/stdout — and is actually
+    *visible* when the agent's TUI owns the console. Returns when the agent disconnects;
+    any transport failure propagates (the caller exits non-zero, forwarding nothing).
     """
     executor.REPO_ROOT = repo_root
-    executor.AUTH_PROMPTER = TtyPrompter()
+    executor.AUTH_PROMPTER = FallbackPrompter([GuiPrompter(), TtyPrompter()])
     logger.info("starting downstream: %s", downstream.command)
     async with stdio_client(downstream) as (downstream_read, downstream_write):
         async with ClientSession(downstream_read, downstream_write) as session:

--- a/src/doberman/proxy/serve.py
+++ b/src/doberman/proxy/serve.py
@@ -7,19 +7,23 @@ around it. This is the deployable counterpart to :func:`doberman.proxy.mcp_proxy
 which builds the proxy object; this module gives it a transport.
 
 SECURITY: nothing here writes this process's stdout (that is the agent's MCP channel). AUTH
-challenges surface as a topmost GUI dialog (:class:`~doberman.auth.gui_prompter.GuiPrompter`)
-first — when an agent's TUI owns the console, a terminal prompt opens "successfully" but is
-invisible and its input is contested, so the dialog is the only channel the human can actually
-see. With no display the chain falls back to the controlling terminal
-(:class:`~doberman.auth.tty_prompter.TtyPrompter`); with neither, the challenge denies (fail
-closed). A prompt never touches the agent stream.
+challenges try three channels in order: MCP **elicitation** first
+(:class:`~doberman.auth.elicitation_prompter.ElicitationPrompter` — rendered natively inside
+the agent client, for clients that support it; never used for 2FA codes), then a topmost GUI
+dialog (:class:`~doberman.auth.gui_prompter.GuiPrompter` — when an agent's TUI owns the
+console, a terminal prompt opens "successfully" but is invisible, so the dialog is the channel
+the human can actually see), then the controlling terminal
+(:class:`~doberman.auth.tty_prompter.TtyPrompter`) for headless/SSH sessions. With no channel
+available the challenge denies (fail closed). A prompt never touches the agent stream.
 """
 
+import asyncio
 import logging
 
 from mcp import ClientSession, StdioServerParameters, stdio_client
 from mcp.server.stdio import stdio_server
 
+from doberman.auth.elicitation_prompter import ElicitationPrompter
 from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
 from doberman.auth.tty_prompter import TtyPrompter
 from doberman.proxy import executor
@@ -32,18 +36,27 @@ async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = "."
     """Spawn ``downstream``, then serve the Doberman proxy to the agent over stdio.
 
     Points the engine at ``repo_root`` (its ``.doberman/`` holds the active role, policy,
-    decision log, and elevation store) and installs the GUI-first prompter chain so an
-    ``AUTH`` challenge never reads/writes the agent's stdin/stdout — and is actually
-    *visible* when the agent's TUI owns the console. Returns when the agent disconnects;
-    any transport failure propagates (the caller exits non-zero, forwarding nothing).
+    decision log, and elevation store) and installs the elicitation→GUI→terminal prompter
+    chain so an ``AUTH`` challenge never reads/writes the agent's stdin/stdout — and is
+    actually *visible* when the agent's TUI owns the console. Returns when the agent
+    disconnects; any transport failure propagates (the caller exits non-zero, forwarding
+    nothing).
     """
     executor.REPO_ROOT = repo_root
-    executor.AUTH_PROMPTER = FallbackPrompter([GuiPrompter(), TtyPrompter()])
     logger.info("starting downstream: %s", downstream.command)
     async with stdio_client(downstream) as (downstream_read, downstream_write):
         async with ClientSession(downstream_read, downstream_write) as session:
             await session.initialize()
             proxy = build_proxy_server(session)
+            # The elicitation channel needs the proxy (to resolve the per-request agent
+            # session) and this loop (challenges run in a worker thread and bridge back).
+            executor.AUTH_PROMPTER = FallbackPrompter(
+                [
+                    ElicitationPrompter(proxy, asyncio.get_running_loop()),
+                    GuiPrompter(),
+                    TtyPrompter(),
+                ]
+            )
             async with stdio_server() as (agent_read, agent_write):
                 logger.info("ready — proxying tool calls to the agent over stdio")
                 await proxy.run(agent_read, agent_write, proxy.create_initialization_options())

--- a/tests/fixtures/stdio_tool_server.py
+++ b/tests/fixtures/stdio_tool_server.py
@@ -1,0 +1,109 @@
+"""A runnable downstream MCP tool server over stdio, for the serve end-to-end test.
+
+Mirrors the tool surface of :mod:`tests.fixtures.fake_tool_server` (fs_write / fs_delete /
+shell_exec / net_get) but runs as a real subprocess so ``doberman serve`` can spawn it. Every
+*executed* call is appended as one JSON line ``[tool_name, arguments]`` to the file named by the
+``DOBERMAN_TEST_CALLLOG`` environment variable, so the test can assert exactly what reached a tool
+(the chokepoint property: a blocked call must leave no line behind).
+
+Run as: ``python tests/fixtures/stdio_tool_server.py``  (stdout is its MCP channel — never printed to).
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+
+SERVER_NAME = "stdio-downstream"
+
+_TOOLS: list[Tool] = [
+    Tool(
+        name="fs_write",
+        description="Write content to a file.",
+        inputSchema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+            "required": ["path", "content"],
+        },
+    ),
+    Tool(
+        name="fs_delete",
+        description="Delete a file.",
+        inputSchema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    ),
+    Tool(
+        name="shell_exec",
+        description="Run a shell command.",
+        inputSchema={
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"],
+        },
+    ),
+    Tool(
+        name="net_get",
+        description="HTTP GET a URL.",
+        inputSchema={
+            "type": "object",
+            "properties": {"url": {"type": "string"}},
+            "required": ["url"],
+        },
+    ),
+]
+
+KNOWN_TOOL_NAMES = {tool.name for tool in _TOOLS}
+
+
+def _call_log_path() -> str | None:
+    """Where to record executed calls: argv[1] (robust — flows through `serve --`) or the
+    DOBERMAN_TEST_CALLLOG env var as a fallback."""
+    if len(sys.argv) > 1 and sys.argv[1]:
+        return sys.argv[1]
+    return os.environ.get("DOBERMAN_TEST_CALLLOG")
+
+
+def _record(tool_name: str, arguments: dict) -> None:
+    """Append one executed call to the call-log file (never to stdout)."""
+    call_log = _call_log_path()
+    if not call_log:
+        return
+    with open(call_log, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps([tool_name, arguments]) + "\n")
+
+
+def build() -> Server:
+    server: Server = Server(SERVER_NAME)
+
+    @server.list_tools()
+    async def _list_tools() -> list[Tool]:
+        return _TOOLS
+
+    @server.call_tool()
+    async def _call_tool(tool_name: str, arguments: dict) -> list[TextContent]:
+        if tool_name not in KNOWN_TOOL_NAMES:
+            raise ValueError(f"unknown tool: {tool_name}")  # error before recording
+        _record(tool_name, arguments)
+        return [TextContent(type="text", text=f"ok: {tool_name} executed")]
+
+    return server
+
+
+async def main() -> None:
+    server = build()
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised as a subprocess by the e2e test
+    try:
+        asyncio.run(main())
+    except (KeyboardInterrupt, EOFError):
+        sys.exit(0)

--- a/tests/integration/test_drift_gate.py
+++ b/tests/integration/test_drift_gate.py
@@ -1,0 +1,116 @@
+"""Slice 10.2 — weakening is gated behind 2FA + a diff; strengthen/neutral apply."""
+
+import inspect
+from datetime import datetime, timezone
+
+import pyotp
+
+from doberman.auth import totp
+from doberman.policy.drift import Classification, apply_change
+
+_NOW = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+
+class ScriptedPrompter:
+    def __init__(self, *, confirm=True, code="", raises=None):
+        self._confirm, self._code, self._raises = confirm, code, raises
+        self.diffs: list[str] = []
+
+    def confirm(self, message):
+        self.diffs.append(message)
+        if self._raises is not None:
+            raise self._raises
+        return self._confirm
+
+    def read_code(self, message):
+        return self._code
+
+
+def _enrolled_code() -> str:
+    totp.enroll()
+    return pyotp.TOTP(totp._read_secret()).now()
+
+
+async def test_weaken_requires_2fa_and_shows_a_diff(tmp_path):
+    code = _enrolled_code()
+    prompter = ScriptedPrompter(confirm=True, code=code)
+    outcome = await apply_change(
+        {"r": "block"},
+        {"r": "auth"},
+        "loosen r",
+        repo_root=str(tmp_path),
+        prompter=prompter,
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.weaken
+    assert outcome.approved is True
+    assert outcome.method == "two_factor"
+    assert "WEAKENING" in prompter.diffs[0]
+    assert "block → auth" in prompter.diffs[0]  # the rendered Before/After
+
+
+async def test_weaken_denied_when_confirmation_refused(tmp_path):
+    outcome = await apply_change(
+        {"r": "block"},
+        {"r": "allow"},
+        "loosen",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=False),
+        now=_NOW,
+    )
+    assert outcome.approved is False
+    assert outcome.method == "denied"
+
+
+async def test_weaken_denied_on_wrong_2fa_code(tmp_path):
+    totp.enroll()
+    outcome = await apply_change(
+        {"r": "block"},
+        {"r": "allow"},
+        "loosen",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=True, code="000000"),
+        now=_NOW,
+    )
+    assert outcome.approved is False
+
+
+async def test_weaken_denied_on_prompter_failure(tmp_path):
+    outcome = await apply_change(
+        {"r": "block"},
+        {"r": "allow"},
+        "loosen",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(raises=TimeoutError("walked away")),
+        now=_NOW,
+    )
+    assert outcome.approved is False
+
+
+async def test_strengthen_applies_without_a_challenge(tmp_path):
+    # No prompter needed: a strengthening change is auto-approved.
+    outcome = await apply_change(
+        {"r": "auth"}, {"r": "block"}, "tighten", repo_root=str(tmp_path), now=_NOW
+    )
+    assert outcome.classification is Classification.strengthen
+    assert outcome.approved is True
+    assert outcome.method == "auto"
+
+
+async def test_neutral_applies_automatically(tmp_path):
+    outcome = await apply_change(
+        {"r": "block"}, {"r": "block"}, "no-op", repo_root=str(tmp_path), now=_NOW
+    )
+    assert outcome.classification is Classification.neutral
+    assert outcome.approved is True
+
+
+def test_policy_ledger_is_only_written_by_apply_change():
+    # The poisoning defense relies on a single write path: only the drift module
+    # ever inserts into the policy_changes ledger.
+    import doberman.policy.drift as drift_module
+
+    src = inspect.getsource(drift_module)
+    assert "INSERT INTO policy_changes" in src
+    assert "UPDATE policy_changes" not in src
+    assert "DELETE FROM policy_changes" not in src

--- a/tests/integration/test_policy_ledger.py
+++ b/tests/integration/test_policy_ledger.py
@@ -1,0 +1,66 @@
+"""Slice 10.3 — the append-only policy-change ledger (applied + denied recorded)."""
+
+import asyncio
+from datetime import datetime, timezone
+
+from typer.testing import CliRunner
+
+from doberman.cli.main import app
+from doberman.policy.drift import apply_change, read_policy_changes
+
+runner = CliRunner()
+_NOW = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+
+class DenyPrompter:
+    def confirm(self, message):
+        return False
+
+    def read_code(self, message):
+        return ""
+
+
+async def test_applied_and_denied_changes_are_both_recorded(tmp_path):
+    root = str(tmp_path)
+    # A strengthening applies; a weakening is denied — BOTH are in the ledger.
+    await apply_change({"r": "auth"}, {"r": "block"}, "tighten", repo_root=root, now=_NOW)
+    await apply_change(
+        {"r": "block"},
+        {"r": "allow"},
+        "loosen",
+        repo_root=root,
+        prompter=DenyPrompter(),
+        now=_NOW,
+    )
+    rows = await read_policy_changes(root)
+    assert len(rows) == 2
+    by_class = {r["classification"]: r for r in rows}
+    assert by_class["strengthen"]["approved"] == 1
+    assert by_class["weaken"]["approved"] == 0  # the denied attempt — the attack signal
+
+
+def test_denied_weakening_is_the_attack_signal_in_history(tmp_path):
+    # Sync test: the CLI calls asyncio.run internally, which cannot nest inside a
+    # running loop — so we seed the ledger with asyncio.run directly.
+    root = str(tmp_path)
+    asyncio.run(
+        apply_change(
+            {"r": "block"},
+            {"r": "allow"},
+            "sneaky",
+            repo_root=root,
+            prompter=DenyPrompter(),
+            now=_NOW,
+        )
+    )
+    result = runner.invoke(app, ["policy-history", "--path", root])
+    assert result.exit_code == 0
+    assert "weaken" in result.stdout
+    assert "DENIED" in result.stdout
+    assert "block → allow" in result.stdout
+
+
+def test_policy_history_empty(tmp_path):
+    result = runner.invoke(app, ["policy-history", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "no policy changes recorded yet" in result.stdout

--- a/tests/integration/test_serve_end_to_end.py
+++ b/tests/integration/test_serve_end_to_end.py
@@ -1,0 +1,84 @@
+"""End-to-end test of `doberman serve`: a real agent ⇄ doberman ⇄ downstream chain.
+
+Spawns `python -m doberman.cli.main serve -- python <stdio_tool_server> <calllog>` as a subprocess and
+connects to it with a real MCP client (the "agent"). Proves the deployable wiring works over stdio AND
+the chokepoint property end-to-end: a PASS reaches the tool (a line in the call-log); a BLOCK does not.
+
+This is the heavier test (it launches processes); a short timeout guards against a hung child.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters, stdio_client
+
+_FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "stdio_tool_server.py"
+_TIMEOUT_S = 30.0
+
+
+@asynccontextmanager
+async def _agent_through_doberman(repo_root: Path, call_log: Path) -> AsyncIterator[ClientSession]:
+    """An MCP client connected to `doberman serve`, which fronts the stdio fixture downstream."""
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=[
+            "-m",
+            "doberman.cli.main",
+            "serve",
+            "--path",
+            str(repo_root),
+            "--",
+            sys.executable,
+            str(_FIXTURE),
+            str(call_log),
+        ],
+        # Full env so the child can import doberman (venv) and find the interpreter.
+        env={**os.environ},
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as agent:
+            await agent.initialize()
+            yield agent
+
+
+def _logged_tools(call_log: Path) -> list[str]:
+    if not call_log.exists():
+        return []
+    return [
+        json.loads(line)[0] for line in call_log.read_text(encoding="utf-8").splitlines() if line
+    ]
+
+
+async def test_downstream_tools_are_re_exposed(tmp_path):
+    call_log = tmp_path / "calls.log"
+    async with asyncio.timeout(_TIMEOUT_S):
+        async with _agent_through_doberman(tmp_path, call_log) as agent:
+            result = await agent.list_tools()
+    names = {tool.name for tool in result.tools}
+    assert {"fs_write", "fs_delete", "shell_exec", "net_get"} <= names
+
+
+async def test_pass_decision_reaches_the_tool(tmp_path):
+    call_log = tmp_path / "calls.log"
+    async with asyncio.timeout(_TIMEOUT_S):
+        async with _agent_through_doberman(tmp_path, call_log) as agent:
+            # A fetch to a trusted host PASSes (mirrors test_proxy_passthrough.py).
+            result = await agent.call_tool("net_get", {"url": "https://github.com/owner/repo"})
+    assert not result.isError
+    assert "net_get" in _logged_tools(call_log)
+
+
+async def test_block_decision_reaches_no_tool(tmp_path):
+    call_log = tmp_path / "calls.log"
+    async with asyncio.timeout(_TIMEOUT_S):
+        async with _agent_through_doberman(tmp_path, call_log) as agent:
+            # A catastrophic command is BLOCKed by the objective guardrail.
+            result = await agent.call_tool("shell_exec", {"command": "rm -rf /"})
+    assert result.isError
+    # The chokepoint property: the blocked call never reached the downstream tool.
+    assert "shell_exec" not in _logged_tools(call_log)

--- a/tests/unit/test_core_is_standalone.py
+++ b/tests/unit/test_core_is_standalone.py
@@ -13,7 +13,7 @@ def test_core_imports_with_no_enterprise_installed():
 def test_version_is_exposed():
     import doberman
 
-    assert doberman.__version__ == "0.9.0"
+    assert doberman.__version__ == "0.10.0"
 
 
 def test_policy_core_packages_import_cleanly():
@@ -48,6 +48,14 @@ def test_default_auth_provider_is_local_with_no_enterprise():
 
     assert discover_auth_providers() == []
     assert isinstance(active_provider(), LocalAuthProvider)
+
+
+def test_no_drift_observers_registered_by_default():
+    # Slice 10.4 standalone guarantee: with no enterprise package installed, the
+    # drift-observer registry discovers nothing — the 2FA gate + local ledger run.
+    from doberman.engine.registry import discover_drift_observers
+
+    assert discover_drift_observers() == []
 
 
 def test_no_detectors_registered_by_default():

--- a/tests/unit/test_core_is_standalone.py
+++ b/tests/unit/test_core_is_standalone.py
@@ -13,7 +13,7 @@ def test_core_imports_with_no_enterprise_installed():
 def test_version_is_exposed():
     import doberman
 
-    assert doberman.__version__ == "0.10.0"
+    assert doberman.__version__ == "0.11.0"
 
 
 def test_policy_core_packages_import_cleanly():

--- a/tests/unit/test_drift_classify.py
+++ b/tests/unit/test_drift_classify.py
@@ -1,0 +1,46 @@
+"""Slice 10.1 — strengthen/weaken/neutral change classifier (ambiguous → weaken)."""
+
+import pytest
+
+from doberman.policy.drift import Classification, classify_change
+
+WEAKENING_TRANSITIONS = [
+    ({"r": "block"}, {"r": "auth"}),  # hard block → step-up
+    ({"r": "auth"}, {"r": "allow"}),  # step-up → allow
+    ({"r": "protected"}, {"r": "normal"}),  # protected → normal
+    ({"r": "unknown"}, {"r": "trusted"}),  # unknown dest → trusted
+    ({"r": "block"}, {}),  # protective entry removed entirely
+    ({"enabled": True}, {"enabled": False}),  # a protection toggled off
+]
+
+
+@pytest.mark.parametrize(("before", "after"), WEAKENING_TRANSITIONS)
+def test_weakening_transitions_classify_as_weaken(before, after):
+    assert classify_change(before, after) is Classification.weaken
+
+
+@pytest.mark.parametrize(("before", "after"), WEAKENING_TRANSITIONS)
+def test_reverse_transitions_classify_as_strengthen(before, after):
+    # The exact reverse of every weakening is a strengthening.
+    assert classify_change(after, before) is Classification.strengthen
+
+
+def test_mixed_change_is_weaken_fail_safe():
+    before = {"a": "block", "b": "allow"}
+    after = {"a": "auth", "b": "block"}  # a weakened, b strengthened
+    assert classify_change(before, after) is Classification.weaken
+
+
+def test_ambiguous_token_against_a_block_is_weaken():
+    # An unrecognized target state is treated conservatively (ranks below block).
+    assert classify_change({"r": "block"}, {"r": "mystery"}) is Classification.weaken
+
+
+def test_no_op_is_neutral():
+    assert classify_change({"r": "block"}, {"r": "block"}) is Classification.neutral
+    assert classify_change({}, {}) is Classification.neutral
+
+
+def test_pure_strengthen_adds_protection():
+    assert classify_change({}, {"r": "block"}) is Classification.strengthen
+    assert classify_change({"r": "allow"}, {"r": "auth"}) is Classification.strengthen

--- a/tests/unit/test_drift_observer.py
+++ b/tests/unit/test_drift_observer.py
@@ -1,0 +1,94 @@
+"""Slice 10.4 — the DriftObserver seam: redacted, isolated, never authoritative."""
+
+from datetime import datetime, timezone
+
+from doberman.policy.drift import (
+    Classification,
+    _looks_like_drift_observer,
+    apply_change,
+    notify_observers,
+)
+
+_NOW = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+
+class RecordingObserver:
+    def __init__(self):
+        self.events: list[dict] = []
+
+    def on_change(self, event):
+        self.events.append(event)
+
+
+class ExplodingObserver:
+    def on_change(self, event):
+        raise RuntimeError("observer boom")
+
+
+class SuppressingObserver:
+    """Tries (and fails) to veto a weakening by mutating the event/raising."""
+
+    def on_change(self, event):
+        event["approved"] = True  # mutating its own copy must not affect the gate
+        raise RuntimeError("I refuse to allow this")
+
+
+def test_notify_is_isolated_and_redacted(monkeypatch):
+    obs = RecordingObserver()
+    monkeypatch.setattr("doberman.engine.registry.discover_drift_observers", lambda: [obs])
+    notify_observers({"classification": "weaken", "changed_rules": ["r"], "approved": False})
+    assert obs.events[0]["classification"] == "weaken"
+    # The event is rule-id level only — it never carries before/after state values.
+    assert "from_state" not in obs.events[0]
+    assert "to_state" not in obs.events[0]
+
+
+def test_failing_observer_does_not_raise(monkeypatch):
+    good = RecordingObserver()
+    monkeypatch.setattr(
+        "doberman.engine.registry.discover_drift_observers",
+        lambda: [ExplodingObserver(), good],
+    )
+    notify_observers({"classification": "neutral"})  # must not raise
+    assert good.events  # the good observer still ran
+
+
+def test_non_observer_shaped_is_skipped(monkeypatch):
+    monkeypatch.setattr("doberman.engine.registry.discover_drift_observers", lambda: [object()])
+    notify_observers({"classification": "neutral"})  # no raise
+    assert _looks_like_drift_observer(object()) is False
+
+
+async def test_observer_cannot_alter_the_gate_outcome(tmp_path, monkeypatch):
+    # An observer that tries to approve/suppress a weakening cannot change the
+    # authoritative outcome: a denied weakening stays denied.
+    monkeypatch.setattr(
+        "doberman.engine.registry.discover_drift_observers", lambda: [SuppressingObserver()]
+    )
+
+    class DenyPrompter:
+        def confirm(self, message):
+            return False
+
+        def read_code(self, message):
+            return ""
+
+    outcome = await apply_change(
+        {"r": "block"},
+        {"r": "allow"},
+        "loosen",
+        repo_root=str(tmp_path),
+        prompter=DenyPrompter(),
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.weaken
+    assert outcome.approved is False  # the observer could not flip it
+
+
+async def test_observer_notified_for_every_change(tmp_path, monkeypatch):
+    obs = RecordingObserver()
+    monkeypatch.setattr("doberman.engine.registry.discover_drift_observers", lambda: [obs])
+    await apply_change({"r": "auth"}, {"r": "block"}, "tighten", repo_root=str(tmp_path), now=_NOW)
+    assert len(obs.events) == 1
+    assert obs.events[0]["classification"] == "strengthen"
+    assert obs.events[0]["approved"] is True

--- a/tests/unit/test_elicitation_prompter.py
+++ b/tests/unit/test_elicitation_prompter.py
@@ -1,0 +1,265 @@
+"""Unit tests for the MCP elicitation prompter — the challenge rendered IN the agent client.
+
+When the agent client (Claude Code, etc.) supports MCP elicitation, a confirm-tier AUTH
+challenge should render natively inside the client UI instead of an OS dialog. Contracts:
+
+* ``accept`` approves; ``decline``/``cancel`` deny — and a denial is FINAL (the chain
+  must never re-ask on another channel).
+* A client without the elicitation capability, no active request context, or a
+  method-not-found error → :class:`PrompterUnavailableError` (fall through to the GUI).
+* ``read_code`` ALWAYS raises ``PrompterUnavailableError``: the MCP spec forbids
+  requesting sensitive information via elicitation, so one-time codes never transit
+  the agent client — they stay on the out-of-band channels.
+* The prompter must refuse to run on the event-loop thread (it would deadlock the
+  session that has to carry the elicitation answer), and the executor must therefore
+  run challenges OFF the loop.
+* No schema fields are requested (buttons only) — no data transits the client.
+"""
+
+import asyncio
+import threading
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from mcp import types
+from mcp.shared.exceptions import McpError
+from mcp.types import INTERNAL_ERROR, METHOD_NOT_FOUND, ErrorData
+
+from doberman.auth import elicitation_prompter as ep_mod
+from doberman.auth.elicitation_prompter import ElicitationPrompter
+from doberman.auth.gui_prompter import FallbackPrompter, PrompterUnavailableError
+
+_CHALLENGE = "Doberman authentication required [local_auth]\nApprove THIS exact action?"
+
+
+class _FakeSession:
+    """Scripted ServerSession stand-in; records the elicitation traffic."""
+
+    def __init__(self, *, supports=True, action="accept", error=None, hang=False):
+        self._supports = supports
+        self._action = action
+        self._error = error
+        self._hang = hang
+        self.messages: list[str] = []
+        self.schemas: list[dict] = []
+
+    def check_client_capability(self, capability) -> bool:
+        assert capability.elicitation is not None  # we must ask for the right capability
+        return self._supports
+
+    async def elicit_form(self, message, requestedSchema, related_request_id=None):
+        self.messages.append(message)
+        self.schemas.append(requestedSchema)
+        if self._hang:
+            await asyncio.Event().wait()
+        if self._error is not None:
+            raise self._error
+        return types.ElicitResult(action=self._action)
+
+
+class _FakeServer:
+    """Exposes ``request_context.session`` the way ``mcp.server.lowlevel.Server`` does."""
+
+    def __init__(self, session: _FakeSession | None):
+        self._session = session
+
+    @property
+    def request_context(self):
+        if self._session is None:
+            raise LookupError("called outside of a request context")
+        return SimpleNamespace(session=self._session)
+
+
+@pytest.fixture
+def loop() -> Iterator[asyncio.AbstractEventLoop]:
+    """A real event loop on a background thread — the bridge under test is threading."""
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5)
+    loop.close()
+
+
+def _prompter(session: _FakeSession | None, loop) -> ElicitationPrompter:
+    return ElicitationPrompter(_FakeServer(session), loop)
+
+
+# --- answers ------------------------------------------------------------------------
+
+
+def test_accept_approves(loop):
+    session = _FakeSession(action="accept")
+    assert _prompter(session, loop).confirm(_CHALLENGE) is True
+    assert session.messages == [_CHALLENGE]  # the exact challenge text reaches the human
+
+
+@pytest.mark.parametrize("action", ["decline", "cancel"])
+def test_decline_and_cancel_deny(loop, action):
+    session = _FakeSession(action=action)
+    assert _prompter(session, loop).confirm(_CHALLENGE) is False
+
+
+def test_no_form_fields_are_requested(loop):
+    """Buttons only: the schema must request zero properties — nothing transits the client."""
+    session = _FakeSession(action="accept")
+    _prompter(session, loop).confirm(_CHALLENGE)
+    assert session.schemas[0].get("properties") == {}
+
+
+# --- the sensitive-data rule ---------------------------------------------------------
+
+
+def test_read_code_is_never_offered_via_elicitation(loop):
+    """The MCP spec forbids sensitive info via elicitation — codes skip this channel."""
+    session = _FakeSession(action="accept")
+    with pytest.raises(PrompterUnavailableError):
+        _prompter(session, loop).read_code("Enter your 2FA code")
+    assert session.messages == []  # the session was never even consulted
+
+
+# --- channel availability ------------------------------------------------------------
+
+
+def test_client_without_capability_is_unavailable(loop):
+    session = _FakeSession(supports=False)
+    with pytest.raises(PrompterUnavailableError):
+        _prompter(session, loop).confirm(_CHALLENGE)
+    assert session.messages == []
+
+
+def test_no_active_request_context_is_unavailable(loop):
+    with pytest.raises(PrompterUnavailableError):
+        _prompter(None, loop).confirm(_CHALLENGE)
+
+
+def test_method_not_found_is_unavailable(loop):
+    session = _FakeSession(error=McpError(ErrorData(code=METHOD_NOT_FOUND, message="nope")))
+    with pytest.raises(PrompterUnavailableError):
+        _prompter(session, loop).confirm(_CHALLENGE)
+
+
+def test_other_protocol_errors_propagate_so_provider_denies(loop):
+    session = _FakeSession(error=McpError(ErrorData(code=INTERNAL_ERROR, message="boom")))
+    with pytest.raises(McpError):
+        _prompter(session, loop).confirm(_CHALLENGE)
+
+
+def test_unanswered_challenge_times_out_to_a_denial(loop, monkeypatch):
+    monkeypatch.setattr(ep_mod, "ANSWER_TIMEOUT_S", 0.05)
+    session = _FakeSession(hang=True)
+    with pytest.raises(EOFError):
+        _prompter(session, loop).confirm(_CHALLENGE)
+
+
+def test_refuses_to_run_on_the_event_loop_thread(loop):
+    """Blocking the loop would deadlock the very session carrying the answer."""
+    session = _FakeSession(action="accept")
+    prompter = _prompter(session, loop)
+
+    async def _on_loop():
+        return prompter.confirm(_CHALLENGE)
+
+    with pytest.raises(PrompterUnavailableError):
+        asyncio.run_coroutine_threadsafe(_on_loop(), loop).result(timeout=5)
+    assert session.messages == []
+
+
+# --- chain behavior ------------------------------------------------------------------
+
+
+class _RecorderPrompter:
+    def __init__(self, *, confirm=True):
+        self._confirm = confirm
+        self.calls: list[str] = []
+
+    def confirm(self, message: str) -> bool:
+        self.calls.append(message)
+        return self._confirm
+
+    def read_code(self, message: str) -> str:
+        self.calls.append(message)
+        return "123456"
+
+
+def test_unsupported_client_falls_through_to_the_next_channel(loop):
+    gui = _RecorderPrompter(confirm=True)
+    chain = FallbackPrompter([_prompter(_FakeSession(supports=False), loop), gui])
+    assert chain.confirm(_CHALLENGE) is True
+    assert gui.calls == [_CHALLENGE]
+
+
+def test_an_elicitation_denial_is_final_in_the_chain(loop):
+    gui = _RecorderPrompter(confirm=True)  # would approve — must never be consulted
+    chain = FallbackPrompter([_prompter(_FakeSession(action="decline"), loop), gui])
+    assert chain.confirm(_CHALLENGE) is False
+    assert gui.calls == []
+
+
+def test_code_requests_skip_elicitation_and_reach_the_next_channel(loop):
+    gui = _RecorderPrompter()
+    chain = FallbackPrompter([_prompter(_FakeSession(), loop), gui])
+    assert chain.read_code("Enter your 2FA code") == "123456"
+    assert gui.calls == ["Enter your 2FA code"]
+
+
+# --- the executor must run challenges OFF the event loop ------------------------------
+
+
+async def test_executor_runs_the_challenge_off_the_event_loop(monkeypatch):
+    """An in-loop challenge would deadlock elicitation; the prompter must see a worker thread."""
+    from doberman.models import (
+        ActionType,
+        Decision,
+        GuardrailResult,
+        ReasonCode,
+        Risk,
+        SecurityObject,
+        Verdict,
+    )
+    from doberman.proxy import executor
+
+    loop_thread = threading.current_thread()
+    seen: dict = {}
+
+    class _ThreadRecorder:
+        def confirm(self, message: str) -> bool:
+            seen["thread"] = threading.current_thread()
+            return False  # deny — the downstream must never be needed
+
+        def read_code(self, message: str) -> str:  # pragma: no cover — never reached
+            raise AssertionError("code requested for a confirm-tier challenge")
+
+    monkeypatch.setattr(executor, "AUTH_PROMPTER", _ThreadRecorder())
+    now = datetime(2026, 6, 10, tzinfo=timezone.utc)
+    action = SecurityObject(
+        id="act-thread-1",
+        ts=now,
+        agent_role="webdev",
+        action_type=ActionType.file_write,
+        tool_name="fs_write",
+        target="backend/api.ts",
+    )
+    objective = GuardrailResult(
+        verdict=Verdict.AUTH,
+        risk=Risk.medium,
+        reason_codes=[ReasonCode.sensitive_path_access],
+        explanation="why",
+    )
+    decision = Decision(
+        action_id="act-thread-1",
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.medium,
+        objective=objective,
+        reason_codes=[ReasonCode.sensitive_path_access],
+        explanation="why",
+        decided_at=now,
+    )
+
+    result = await executor._handle_auth(None, "fs_write", {}, action, decision, now)
+
+    assert result.isError  # denied — nothing forwarded
+    assert seen["thread"] is not loop_thread

--- a/tests/unit/test_elicitation_prompter.py
+++ b/tests/unit/test_elicitation_prompter.py
@@ -209,8 +209,10 @@ def test_code_requests_skip_elicitation_and_reach_the_next_channel(loop):
 # --- the executor must run challenges OFF the event loop ------------------------------
 
 
-async def test_executor_runs_the_challenge_off_the_event_loop(monkeypatch):
+async def test_executor_runs_the_challenge_off_the_event_loop(monkeypatch, tmp_path):
     """An in-loop challenge would deadlock elicitation; the prompter must see a worker thread."""
+    import inspect
+
     from doberman.models import (
         ActionType,
         Decision,
@@ -234,6 +236,8 @@ async def test_executor_runs_the_challenge_off_the_event_loop(monkeypatch):
             raise AssertionError("code requested for a confirm-tier challenge")
 
     monkeypatch.setattr(executor, "AUTH_PROMPTER", _ThreadRecorder())
+    # Isolate any denied-path persistence (later features record challenge outcomes).
+    monkeypatch.setattr(executor, "REPO_ROOT", str(tmp_path))
     now = datetime(2026, 6, 10, tzinfo=timezone.utc)
     action = SecurityObject(
         id="act-thread-1",
@@ -259,7 +263,14 @@ async def test_executor_runs_the_challenge_off_the_event_loop(monkeypatch):
         decided_at=now,
     )
 
-    result = await executor._handle_auth(None, "fs_write", {}, action, decision, now)
+    # The signature gains feature-specific scores on later branches — fill any
+    # extras neutrally so this contract test holds across the whole stack.
+    extras: dict = {}
+    defaults = {"abnormality_score": 0.0, "surprise_score": 0.0, "eid": "entity-test"}
+    for name in inspect.signature(executor._handle_auth).parameters:
+        if name in defaults:
+            extras[name] = defaults[name]
+    result = await executor._handle_auth(None, "fs_write", {}, action, decision, now, **extras)
 
     assert result.isError  # denied — nothing forwarded
     assert seen["thread"] is not loop_thread

--- a/tests/unit/test_gui_prompter.py
+++ b/tests/unit/test_gui_prompter.py
@@ -105,81 +105,161 @@ def test_open_root_raises_prompter_unavailable_when_tk_init_fails(monkeypatch):
         gui_prompter._open_root()
 
 
-# --- GuiPrompter: real dialog internals (faked root + faked tkinter dialogs) -------
+# --- GuiPrompter: custom dialog internals (faked root + faked widget builders) -----
 
 
 class _FakeRoot:
+    """Duck-typed stand-in for a Tk root so the dialog plumbing runs headless."""
+
     def __init__(self):
         self.destroyed = False
-        self.withdrawn = False
         self.attrs: dict = {}
-
-    def withdraw(self):
-        self.withdrawn = True
+        self.config: dict = {}
+        self.titles: list[str] = []
+        self.resizable_args: tuple | None = None
+        self.protocols: dict = {}
+        self.bindings: dict = {}
+        self.geometries: list[str] = []
+        self.close_on_mainloop = False
 
     def attributes(self, name, value):
         self.attrs[name] = value
 
-    def update(self):
+    def configure(self, **kwargs):
+        self.config.update(kwargs)
+
+    def title(self, text):
+        self.titles.append(text)
+
+    def resizable(self, w, h):
+        self.resizable_args = (w, h)
+
+    def protocol(self, name, callback):
+        self.protocols[name] = callback
+
+    def bind(self, sequence, callback):
+        self.bindings[sequence] = callback
+
+    def geometry(self, spec):
+        self.geometries.append(spec)
+
+    def update_idletasks(self):
+        pass
+
+    def winfo_reqwidth(self):
+        return 420
+
+    def winfo_reqheight(self):
+        return 220
+
+    def winfo_screenwidth(self):
+        return 1920
+
+    def winfo_screenheight(self):
+        return 1080
+
+    def winfo_id(self):
+        return 0
+
+    def mainloop(self):
+        # Simulate the human closing the window instead of answering.
+        if self.close_on_mainloop:
+            self.protocols["WM_DELETE_WINDOW"]()
+
+    def quit(self):
         pass
 
     def destroy(self):
         self.destroyed = True
 
 
-def test_confirm_dialog_uses_hidden_topmost_root_and_destroys_it(monkeypatch):
-    pytest.importorskip("tkinter")
-    from tkinter import messagebox
-
+@pytest.fixture
+def fake_root(monkeypatch):
     root = _FakeRoot()
-    seen: dict = {}
     monkeypatch.setattr(gui_prompter, "_open_root", lambda: root)
+    return root
 
-    def _fake_askyesno(title, message, parent=None):
-        seen["title"], seen["message"], seen["parent"] = title, message, parent
-        return True
 
-    monkeypatch.setattr(messagebox, "askyesno", _fake_askyesno)
+def test_run_dialog_returns_the_populated_answer_and_destroys_root(monkeypatch, fake_root):
+    def _fake_populate(root, message, answer):
+        assert message == "Approve THIS exact action?"
+        answer["value"] = True
+
+    monkeypatch.setattr(gui_prompter, "_populate_confirm", _fake_populate)
     assert gui_prompter._confirm_dialog("Approve THIS exact action?") is True
-    assert seen["message"] == "Approve THIS exact action?"
-    assert seen["parent"] is root
-    assert root.withdrawn is True
-    assert root.attrs.get("-topmost") is True
-    assert root.destroyed is True  # never leak a Tk root
+    assert fake_root.destroyed is True  # never leak a Tk root
 
 
-def test_code_dialog_masks_input_and_destroys_root(monkeypatch):
-    pytest.importorskip("tkinter")
-    from tkinter import simpledialog
-
-    root = _FakeRoot()
-    seen: dict = {}
-    monkeypatch.setattr(gui_prompter, "_open_root", lambda: root)
-
-    def _fake_askstring(title, message, *, show=None, parent=None):
-        seen["show"], seen["parent"] = show, parent
-        return "123456"
-
-    monkeypatch.setattr(simpledialog, "askstring", _fake_askstring)
-    assert gui_prompter._code_dialog("Enter your 2FA code") == "123456"
-    assert seen["show"] == "*"  # the code must be masked on screen
-    assert root.destroyed is True
+def test_closing_the_window_is_a_denial_never_an_approval(monkeypatch, fake_root):
+    fake_root.close_on_mainloop = True
+    monkeypatch.setattr(gui_prompter, "_populate_confirm", lambda *_a: None)
+    monkeypatch.setattr(gui_prompter, "_populate_code", lambda *_a: None)
+    assert gui_prompter._confirm_dialog("Approve?") is False
+    assert gui_prompter._code_dialog("Enter your 2FA code") is None
 
 
-def test_dialog_root_destroyed_even_when_dialog_raises(monkeypatch):
-    pytest.importorskip("tkinter")
-    from tkinter import messagebox
-
-    root = _FakeRoot()
-    monkeypatch.setattr(gui_prompter, "_open_root", lambda: root)
-
-    def _boom(*_a, **_k):
+def test_root_destroyed_even_when_the_widget_builder_raises(monkeypatch, fake_root):
+    def _boom(*_a):
         raise RuntimeError("dialog exploded")
 
-    monkeypatch.setattr(messagebox, "askyesno", _boom)
+    monkeypatch.setattr(gui_prompter, "_populate_confirm", _boom)
     with pytest.raises(RuntimeError, match="dialog exploded"):
         gui_prompter._confirm_dialog("Approve?")
-    assert root.destroyed is True
+    assert fake_root.destroyed is True
+
+
+def test_window_is_topmost_dark_and_fixed_size(monkeypatch, fake_root):
+    """The dialog must pop OVER the agent terminal and use the dark theme base."""
+    monkeypatch.setattr(gui_prompter, "_populate_confirm", lambda *_a: None)
+    gui_prompter._confirm_dialog("Approve?")
+    assert fake_root.attrs.get("-topmost") is True
+    assert fake_root.titles and fake_root.titles[0] == gui_prompter._TITLE
+    assert fake_root.config.get("bg") == gui_prompter._BG
+    assert fake_root.resizable_args == (False, False)
+
+
+def test_palette_is_dark_black_and_orange():
+    """Design contract: dark/black surfaces, orange accent — no purple, no neon."""
+
+    def _rgb(color: str) -> tuple[int, int, int]:
+        return int(color[1:3], 16), int(color[3:5], 16), int(color[5:7], 16)
+
+    for surface in (gui_prompter._BG, gui_prompter._PANEL):
+        assert max(_rgb(surface)) < 48  # near-black surfaces
+    r, g, b = _rgb(gui_prompter._ACCENT)
+    assert r > 200 and r > g > b  # orange: red-dominant, green mid, low blue
+    assert b < 80  # nothing purple/neon-blue about the accent
+
+
+def test_real_dialog_widgets_dark_theme_and_masked_entry(monkeypatch):
+    """With a real display: the code entry is masked and surfaces use the dark palette.
+
+    Skipped where Tk cannot open (headless CI) — the contract above still covers the
+    plumbing; this verifies the actual widget construction when a display exists.
+    """
+    tkinter = pytest.importorskip("tkinter")
+    try:
+        root = tkinter.Tk()
+    except tkinter.TclError:
+        pytest.skip("no display available")
+    try:
+        root.withdraw()
+        answer: dict = {}
+        gui_prompter._configure_window(root)
+        gui_prompter._populate_code(root, "Enter your 2FA code", answer)
+
+        def _walk(widget):
+            yield widget
+            for child in widget.winfo_children():
+                yield from _walk(child)
+
+        widgets = list(_walk(root))
+        entries = [w for w in widgets if isinstance(w, tkinter.Entry)]
+        assert entries, "code dialog must contain an entry field"
+        assert entries[0].cget("show") == "*"  # the code must be masked on screen
+        assert root.cget("bg") == gui_prompter._BG
+    finally:
+        root.destroy()
 
 
 # --- FallbackPrompter ---------------------------------------------------------------

--- a/tests/unit/test_gui_prompter.py
+++ b/tests/unit/test_gui_prompter.py
@@ -1,0 +1,314 @@
+"""Unit tests for the GUI auth prompter and the GUI→TTY fallback chain.
+
+When an MCP agent (Claude Code, Codex, Cursor, …) spawns ``doberman serve``, the
+*controlling terminal still exists* but is owned by the agent's TUI: a prompt written
+to it is painted over (invisible) and keystrokes go to the agent, not Doberman. The
+challenge must therefore surface OUT-OF-BAND as a GUI dialog, with the terminal only
+as a fallback when no display is available.
+
+Contracts under test:
+* ``GuiPrompter`` collects a confirm/code via a topmost dialog window; cancel/blank
+  raise so the provider denies (fail closed); never touches sys.stdin/sys.stdout.
+* A GUI channel that cannot open at all raises ``PrompterUnavailableError`` — a
+  *channel* failure, distinct from a human denial.
+* ``FallbackPrompter`` consults the next channel ONLY on ``PrompterUnavailableError``.
+  A human answer (including "no") and any human-channel error (EOF, timeout) are
+  FINAL — a denial must never trigger answer-shopping on another channel.
+
+The tkinter machinery is monkeypatched at module seams (mirroring how the TTY tests
+fake ``_open_tty``) so everything here runs headless and deterministically.
+"""
+
+import pytest
+
+from doberman.auth import gui_prompter
+from doberman.auth.gui_prompter import (
+    FallbackPrompter,
+    GuiPrompter,
+    PrompterUnavailableError,
+)
+
+# --- GuiPrompter: answers ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("answer", [True, False])
+def test_confirm_returns_the_dialog_answer(monkeypatch, answer):
+    monkeypatch.setattr(gui_prompter, "_confirm_dialog", lambda _msg: answer)
+    assert GuiPrompter().confirm("Approve THIS exact action?") is answer
+
+
+def test_confirm_passes_the_exact_challenge_message(monkeypatch):
+    seen: list[str] = []
+
+    def _dialog(message: str) -> bool:
+        seen.append(message)
+        return True
+
+    monkeypatch.setattr(gui_prompter, "_confirm_dialog", _dialog)
+    GuiPrompter().confirm("Approve THIS exact action?")
+    assert seen == ["Approve THIS exact action?"]
+
+
+def test_read_code_returns_stripped_code(monkeypatch):
+    monkeypatch.setattr(gui_prompter, "_code_dialog", lambda _msg: "  123456 \n")
+    assert GuiPrompter().read_code("Enter your 2FA code") == "123456"
+
+
+def test_read_code_raises_on_cancel_so_provider_denies(monkeypatch):
+    # Cancelling / closing the dialog returns None — never pass "" to the verifier.
+    monkeypatch.setattr(gui_prompter, "_code_dialog", lambda _msg: None)
+    with pytest.raises(EOFError):
+        GuiPrompter().read_code("Enter your 2FA code")
+
+
+def test_read_code_raises_on_blank_entry(monkeypatch):
+    monkeypatch.setattr(gui_prompter, "_code_dialog", lambda _msg: "   ")
+    with pytest.raises(EOFError):
+        GuiPrompter().read_code("Enter your 2FA code")
+
+
+def test_never_touches_std_streams(monkeypatch):
+    """A GUI challenge must not read stdin or write stdout (the agent's MCP channel)."""
+
+    class _Explode:
+        def __getattr__(self, _name):
+            raise AssertionError("prompter touched a std stream")
+
+    monkeypatch.setattr("sys.stdin", _Explode())
+    monkeypatch.setattr("sys.stdout", _Explode())
+    monkeypatch.setattr(gui_prompter, "_confirm_dialog", lambda _msg: True)
+    assert GuiPrompter().confirm("Approve?") is True
+
+
+# --- GuiPrompter: unavailable channel ----------------------------------------------
+
+
+def test_no_gui_raises_prompter_unavailable(monkeypatch):
+    def _no_root():
+        raise PrompterUnavailableError("no display")
+
+    monkeypatch.setattr(gui_prompter, "_open_root", _no_root)
+    with pytest.raises(PrompterUnavailableError):
+        GuiPrompter().confirm("Approve?")
+    with pytest.raises(PrompterUnavailableError):
+        GuiPrompter().read_code("Enter your 2FA code")
+
+
+def test_open_root_raises_prompter_unavailable_when_tk_init_fails(monkeypatch):
+    tkinter = pytest.importorskip("tkinter")
+
+    def _boom(*_a, **_k):
+        raise tkinter.TclError("no display name and no $DISPLAY")
+
+    monkeypatch.setattr(tkinter, "Tk", _boom)
+    with pytest.raises(PrompterUnavailableError):
+        gui_prompter._open_root()
+
+
+# --- GuiPrompter: real dialog internals (faked root + faked tkinter dialogs) -------
+
+
+class _FakeRoot:
+    def __init__(self):
+        self.destroyed = False
+        self.withdrawn = False
+        self.attrs: dict = {}
+
+    def withdraw(self):
+        self.withdrawn = True
+
+    def attributes(self, name, value):
+        self.attrs[name] = value
+
+    def update(self):
+        pass
+
+    def destroy(self):
+        self.destroyed = True
+
+
+def test_confirm_dialog_uses_hidden_topmost_root_and_destroys_it(monkeypatch):
+    pytest.importorskip("tkinter")
+    from tkinter import messagebox
+
+    root = _FakeRoot()
+    seen: dict = {}
+    monkeypatch.setattr(gui_prompter, "_open_root", lambda: root)
+
+    def _fake_askyesno(title, message, parent=None):
+        seen["title"], seen["message"], seen["parent"] = title, message, parent
+        return True
+
+    monkeypatch.setattr(messagebox, "askyesno", _fake_askyesno)
+    assert gui_prompter._confirm_dialog("Approve THIS exact action?") is True
+    assert seen["message"] == "Approve THIS exact action?"
+    assert seen["parent"] is root
+    assert root.withdrawn is True
+    assert root.attrs.get("-topmost") is True
+    assert root.destroyed is True  # never leak a Tk root
+
+
+def test_code_dialog_masks_input_and_destroys_root(monkeypatch):
+    pytest.importorskip("tkinter")
+    from tkinter import simpledialog
+
+    root = _FakeRoot()
+    seen: dict = {}
+    monkeypatch.setattr(gui_prompter, "_open_root", lambda: root)
+
+    def _fake_askstring(title, message, *, show=None, parent=None):
+        seen["show"], seen["parent"] = show, parent
+        return "123456"
+
+    monkeypatch.setattr(simpledialog, "askstring", _fake_askstring)
+    assert gui_prompter._code_dialog("Enter your 2FA code") == "123456"
+    assert seen["show"] == "*"  # the code must be masked on screen
+    assert root.destroyed is True
+
+
+def test_dialog_root_destroyed_even_when_dialog_raises(monkeypatch):
+    pytest.importorskip("tkinter")
+    from tkinter import messagebox
+
+    root = _FakeRoot()
+    monkeypatch.setattr(gui_prompter, "_open_root", lambda: root)
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("dialog exploded")
+
+    monkeypatch.setattr(messagebox, "askyesno", _boom)
+    with pytest.raises(RuntimeError, match="dialog exploded"):
+        gui_prompter._confirm_dialog("Approve?")
+    assert root.destroyed is True
+
+
+# --- FallbackPrompter ---------------------------------------------------------------
+
+
+class _Recorder:
+    """A scripted prompter that records which methods were consulted."""
+
+    def __init__(self, *, confirm=None, code=None, raises=None):
+        self._confirm = confirm
+        self._code = code
+        self._raises = raises
+        self.calls: list[str] = []
+
+    def confirm(self, message: str) -> bool:
+        self.calls.append("confirm")
+        if self._raises is not None:
+            raise self._raises
+        return self._confirm
+
+    def read_code(self, message: str) -> str:
+        self.calls.append("read_code")
+        if self._raises is not None:
+            raise self._raises
+        return self._code
+
+
+def test_first_available_answer_wins():
+    first = _Recorder(confirm=True)
+    second = _Recorder(confirm=False)
+    assert FallbackPrompter([first, second]).confirm("Approve?") is True
+    assert second.calls == []
+
+
+def test_a_denial_is_final_never_answer_shopping():
+    """A human "no" on the first channel must NOT be retried on the next channel."""
+    first = _Recorder(confirm=False)
+    second = _Recorder(confirm=True)  # would approve — must never be consulted
+    assert FallbackPrompter([first, second]).confirm("Approve?") is False
+    assert second.calls == []
+
+
+def test_unavailable_channel_falls_through_to_the_next():
+    first = _Recorder(raises=PrompterUnavailableError("no display"))
+    second = _Recorder(confirm=True)
+    assert FallbackPrompter([first, second]).confirm("Approve?") is True
+    assert first.calls == ["confirm"]
+    assert second.calls == ["confirm"]
+
+
+def test_human_channel_error_propagates_without_fallthrough():
+    """EOF/timeout on an OPEN channel is a denial signal, not a reason to re-ask."""
+    first = _Recorder(raises=EOFError("walked away"))
+    second = _Recorder(confirm=True)
+    with pytest.raises(EOFError):
+        FallbackPrompter([first, second]).confirm("Approve?")
+    assert second.calls == []
+
+
+def test_all_channels_unavailable_raises_so_provider_denies():
+    first = _Recorder(raises=PrompterUnavailableError("no display"))
+    second = _Recorder(raises=PrompterUnavailableError("no terminal"))
+    with pytest.raises(PrompterUnavailableError):
+        FallbackPrompter([first, second]).confirm("Approve?")
+
+
+def test_read_code_follows_the_same_fallback_rules():
+    first = _Recorder(raises=PrompterUnavailableError("no display"))
+    second = _Recorder(code="123456")
+    assert FallbackPrompter([first, second]).read_code("Enter your 2FA code") == "123456"
+    assert second.calls == ["read_code"]
+
+
+def test_chain_is_introspectable_for_wiring_assertions():
+    first, second = _Recorder(confirm=True), _Recorder(confirm=True)
+    chain = FallbackPrompter([first, second])
+    assert list(chain.prompters) == [first, second]
+
+
+# --- fail-closed through the provider ----------------------------------------------
+
+
+def test_provider_denies_when_every_channel_is_unavailable():
+    """End to end: no GUI + no terminal ⇒ the AUTH challenge is DENIED, never approved."""
+    from datetime import datetime, timezone
+
+    from doberman.auth.challenge import AuthTier
+    from doberman.auth.provider import LocalAuthProvider
+    from doberman.models import (
+        ActionType,
+        Decision,
+        GuardrailResult,
+        ReasonCode,
+        Risk,
+        SecurityObject,
+        Verdict,
+    )
+
+    now = datetime(2026, 6, 10, tzinfo=timezone.utc)
+    action = SecurityObject(
+        id="act-gui-1",
+        ts=now,
+        agent_role="webdev",
+        action_type=ActionType.file_write,
+        tool_name="fs_write",
+        target="backend/api.ts",
+    )
+    objective = GuardrailResult(
+        verdict=Verdict.AUTH,
+        risk=Risk.medium,
+        reason_codes=[ReasonCode.sensitive_path_access],
+        explanation="why",
+    )
+    decision = Decision(
+        action_id="act-gui-1",
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.medium,
+        objective=objective,
+        reason_codes=[ReasonCode.sensitive_path_access],
+        explanation="why",
+        decided_at=now,
+    )
+    chain = FallbackPrompter(
+        [
+            _Recorder(raises=PrompterUnavailableError("no display")),
+            _Recorder(raises=PrompterUnavailableError("no terminal")),
+        ]
+    )
+    result = LocalAuthProvider().authenticate(
+        decision, action, AuthTier.local_auth, prompter=chain, at=now
+    )
+    assert result.approved is False

--- a/tests/unit/test_rule_paths_control_plane.py
+++ b/tests/unit/test_rule_paths_control_plane.py
@@ -65,9 +65,7 @@ def test_deleting_the_ledger_db_is_blocked(tmp_path):
 
 
 def test_deleting_the_whole_control_plane_dir_is_blocked(tmp_path):
-    result = RULE.evaluate(
-        _action(".doberman", action_type=ActionType.file_delete), _ctx(tmp_path)
-    )
+    result = RULE.evaluate(_action(".doberman", action_type=ActionType.file_delete), _ctx(tmp_path))
     assert result.verdict is Verdict.BLOCK
 
 
@@ -88,9 +86,7 @@ def test_reading_the_control_plane_is_blocked(tmp_path):
 
 def test_traversal_into_control_plane_is_caught(tmp_path):
     # a/b/../../.doberman/policies.yaml canonicalizes back into .doberman → BLOCK.
-    result = RULE.evaluate(
-        _action("a/b/../../.doberman/policies.yaml"), _ctx(tmp_path)
-    )
+    result = RULE.evaluate(_action("a/b/../../.doberman/policies.yaml"), _ctx(tmp_path))
     assert result.verdict is Verdict.BLOCK
 
 

--- a/tests/unit/test_rule_paths_control_plane.py
+++ b/tests/unit/test_rule_paths_control_plane.py
@@ -1,0 +1,107 @@
+"""Doberman's own control plane (``.doberman/``) is a hard-blocked path.
+
+The Feature 10 poisoning defense routes every policy **weakening** through the
+2FA-gated ``apply_change`` chokepoint and an append-only ledger. That guarantee
+is only real if a proxied agent cannot reach Doberman's own state on disk: the
+policy document (``.doberman/policies.yaml``), the active role
+(``.doberman/role.yaml``), and the SQLite DB (``.doberman/doberman.db``) that
+holds the append-only ``policy_changes`` ledger, the decision log, the
+baselines, and the elevations all live under ``<repo_root>/.doberman/``.
+Rewriting the policy file, expanding the role file, or deleting the ledger DB
+through a normal proxied tool call would each bypass the gate entirely.
+
+Doberman writes ``.doberman/`` itself via direct file I/O (never through the
+proxy), so hard-blocking *agent-proxied* access here closes the bypass without
+touching Doberman's own operation.
+"""
+
+from datetime import datetime, timezone
+
+from doberman.engine.objective import ObjectiveGuardrail
+from doberman.engine.rules.paths import DEFAULT_BLOCKED_GLOBS, ProtectedPathRule
+from doberman.models import (
+    ActionType,
+    EvalContext,
+    ReasonCode,
+    SecurityObject,
+    Verdict,
+)
+
+RULE = ProtectedPathRule()
+
+
+def _action(target, *, action_type=ActionType.file_write, metadata=None):
+    return SecurityObject(
+        id="cp-1",
+        ts=datetime(2026, 6, 8, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=action_type,
+        tool_name="t",
+        target=target,
+        metadata=metadata or {},
+    )
+
+
+def _ctx(root):
+    return EvalContext(metadata={"repo_root": str(root)})
+
+
+def test_writing_the_policy_file_is_blocked(tmp_path):
+    result = RULE.evaluate(_action(".doberman/policies.yaml"), _ctx(tmp_path))
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+def test_writing_the_role_file_is_blocked(tmp_path):
+    result = RULE.evaluate(_action(".doberman/role.yaml"), _ctx(tmp_path))
+    assert result.verdict is Verdict.BLOCK
+
+
+def test_deleting_the_ledger_db_is_blocked(tmp_path):
+    result = RULE.evaluate(
+        _action(".doberman/doberman.db", action_type=ActionType.file_delete), _ctx(tmp_path)
+    )
+    assert result.verdict is Verdict.BLOCK
+
+
+def test_deleting_the_whole_control_plane_dir_is_blocked(tmp_path):
+    result = RULE.evaluate(
+        _action(".doberman", action_type=ActionType.file_delete), _ctx(tmp_path)
+    )
+    assert result.verdict is Verdict.BLOCK
+
+
+def test_nested_control_plane_is_blocked(tmp_path):
+    # A monorepo sub-project's own .doberman/ is protected too.
+    result = RULE.evaluate(_action("packages/app/.doberman/policies.yaml"), _ctx(tmp_path))
+    assert result.verdict is Verdict.BLOCK
+
+
+def test_reading_the_control_plane_is_blocked(tmp_path):
+    # Conservative: reading the policy/baseline to plan evasion is also denied;
+    # the rule matches on the path for any file action.
+    result = RULE.evaluate(
+        _action(".doberman/policies.yaml", action_type=ActionType.file_read), _ctx(tmp_path)
+    )
+    assert result.verdict is Verdict.BLOCK
+
+
+def test_traversal_into_control_plane_is_caught(tmp_path):
+    # a/b/../../.doberman/policies.yaml canonicalizes back into .doberman → BLOCK.
+    result = RULE.evaluate(
+        _action("a/b/../../.doberman/policies.yaml"), _ctx(tmp_path)
+    )
+    assert result.verdict is Verdict.BLOCK
+
+
+def test_default_blocked_globs_include_the_control_plane():
+    assert any(".doberman" in glob for glob in DEFAULT_BLOCKED_GLOBS)
+
+
+def test_objective_guardrail_blocks_a_control_plane_write(tmp_path):
+    # The proxy uses a default-constructed ObjectiveGuardrail; prove the wired
+    # guardrail (not just the rule in isolation) hard-blocks the policy file.
+    guardrail = ObjectiveGuardrail(load_plugins=False)
+    result = guardrail.evaluate(_action(".doberman/policies.yaml"), _ctx(tmp_path))
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes

--- a/tests/unit/test_serve.py
+++ b/tests/unit/test_serve.py
@@ -1,0 +1,169 @@
+"""Unit tests for the `doberman serve` command and the `serve_stdio` launcher.
+
+Covers CLI argument parsing (downstream command after `--`, `--path`, the missing-command error)
+and that `serve_stdio` sets the executor's repo root + a non-stdio AUTH prompter and runs the proxy
+over stdio. The real stdio transports are faked so these stay headless and deterministic; the full
+agent⇄serve⇄downstream chain is covered by the integration test.
+"""
+
+import logging
+import sys
+from contextlib import asynccontextmanager
+
+import pytest
+from mcp import StdioServerParameters
+from typer.testing import CliRunner
+
+import doberman.cli.main as cli
+from doberman.auth.tty_prompter import TtyPrompter
+from doberman.proxy import executor
+from doberman.proxy import serve as serve_mod
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _restore_executor_globals():
+    """The serve path mutates module-level executor globals — restore them after each test."""
+    repo_root, prompter = executor.REPO_ROOT, executor.AUTH_PROMPTER
+    try:
+        yield
+    finally:
+        executor.REPO_ROOT = repo_root
+        executor.AUTH_PROMPTER = prompter
+
+
+@pytest.fixture
+def _no_logging_mutation(monkeypatch):
+    """Stub out stderr-logging setup so CLI-parse tests don't reconfigure global logging."""
+    monkeypatch.setattr(cli, "_configure_stderr_logging", lambda *a, **k: None)
+
+
+# --- CLI parsing -----------------------------------------------------------------
+
+
+def test_missing_downstream_command_exits_2(monkeypatch):
+    called = False
+
+    async def _spy(*_a, **_k):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(cli, "serve_stdio", _spy)
+    result = runner.invoke(cli.app, ["serve"])
+    assert result.exit_code == 2
+    assert not called
+
+
+def test_builds_stdio_params_from_argv(monkeypatch, _no_logging_mutation):
+    seen: dict = {}
+
+    async def _spy(params, *, repo_root):
+        seen["params"] = params
+        seen["repo_root"] = repo_root
+
+    monkeypatch.setattr(cli, "serve_stdio", _spy)
+    result = runner.invoke(cli.app, ["serve", "--", "mytool", "a", "b"])
+    assert result.exit_code == 0
+    assert result.output == ""  # nothing on stdout — that is the agent's MCP channel
+    assert seen["params"].command == "mytool"
+    assert seen["params"].args == ["a", "b"]
+    assert seen["repo_root"] == "."
+
+
+def test_path_option_threads_repo_root(monkeypatch, _no_logging_mutation):
+    seen: dict = {}
+
+    async def _spy(params, *, repo_root):
+        seen["repo_root"] = repo_root
+
+    monkeypatch.setattr(cli, "serve_stdio", _spy)
+    result = runner.invoke(cli.app, ["serve", "-p", "/repo", "--", "mytool"])
+    assert result.exit_code == 0
+    assert seen["repo_root"] == "/repo"
+
+
+def test_serve_reports_downstream_failure_cleanly(monkeypatch, _no_logging_mutation):
+    """A failure to start/serve becomes a clean stderr error + exit 1, never a raw traceback."""
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("downstream boom")
+
+    monkeypatch.setattr(cli, "serve_stdio", _boom)
+    result = runner.invoke(cli.app, ["serve", "--", "mytool"])
+    assert result.exit_code == 1
+    assert "doberman serve failed" in result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_stderr_logging_keeps_stdout_clean():
+    """_configure_stderr_logging pins doberman logs to stderr and scrubs stdout from root."""
+    root = logging.getLogger()
+    doberman_logger = logging.getLogger("doberman")
+    saved_root, saved_dob = root.handlers[:], doberman_logger.handlers[:]
+    saved_prop = doberman_logger.propagate
+    hostile = logging.StreamHandler(sys.stdout)  # pretend a host config logs to stdout
+    root.addHandler(hostile)
+    try:
+        cli._configure_stderr_logging()
+        assert doberman_logger.propagate is False
+        assert doberman_logger.handlers
+        assert all(getattr(h, "stream", None) is sys.stderr for h in doberman_logger.handlers)
+        assert not any(
+            isinstance(h, logging.StreamHandler) and getattr(h, "stream", None) is sys.stdout
+            for h in root.handlers
+        )
+    finally:
+        root.handlers[:] = saved_root
+        doberman_logger.handlers[:] = saved_dob
+        doberman_logger.propagate = saved_prop
+
+
+# --- serve_stdio wiring ----------------------------------------------------------
+
+
+async def test_serve_stdio_sets_repo_root_and_tty_prompter(monkeypatch):
+    """serve_stdio points the engine at repo_root and installs a non-stdio prompter, then runs."""
+    ran: dict = {}
+
+    @asynccontextmanager
+    async def _fake_stdio_client(_params):
+        yield ("d_read", "d_write")
+
+    class _FakeSession:
+        def __init__(self, read, write):
+            ran["session_args"] = (read, write)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def initialize(self):
+            ran["initialized"] = True
+
+    @asynccontextmanager
+    async def _fake_stdio_server():
+        yield ("a_read", "a_write")
+
+    class _FakeProxy:
+        def create_initialization_options(self):
+            return "init-opts"
+
+        async def run(self, read, write, opts):
+            ran["run"] = (read, write, opts)
+
+    monkeypatch.setattr(serve_mod, "stdio_client", _fake_stdio_client)
+    monkeypatch.setattr(serve_mod, "ClientSession", _FakeSession)
+    monkeypatch.setattr(serve_mod, "stdio_server", _fake_stdio_server)
+    monkeypatch.setattr(serve_mod, "build_proxy_server", lambda _session: _FakeProxy())
+
+    params = StdioServerParameters(command="mytool", args=[])
+    await serve_mod.serve_stdio(params, repo_root="/some/repo")
+
+    assert executor.REPO_ROOT == "/some/repo"
+    assert isinstance(executor.AUTH_PROMPTER, TtyPrompter)
+    assert ran["session_args"] == ("d_read", "d_write")  # downstream streams wired into the session
+    assert ran["initialized"] is True
+    assert ran["run"] == ("a_read", "a_write", "init-opts")

--- a/tests/unit/test_serve.py
+++ b/tests/unit/test_serve.py
@@ -15,6 +15,7 @@ from mcp import StdioServerParameters
 from typer.testing import CliRunner
 
 import doberman.cli.main as cli
+from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
 from doberman.auth.tty_prompter import TtyPrompter
 from doberman.proxy import executor
 from doberman.proxy import serve as serve_mod
@@ -122,8 +123,14 @@ def test_stderr_logging_keeps_stdout_clean():
 # --- serve_stdio wiring ----------------------------------------------------------
 
 
-async def test_serve_stdio_sets_repo_root_and_tty_prompter(monkeypatch):
-    """serve_stdio points the engine at repo_root and installs a non-stdio prompter, then runs."""
+async def test_serve_stdio_sets_repo_root_and_gui_first_prompter(monkeypatch):
+    """serve_stdio points the engine at repo_root and installs a GUI-first prompter, then runs.
+
+    GUI first is load-bearing: when an agent's TUI (Claude Code etc.) owns the console,
+    CONIN$/CONOUT$ still OPEN successfully but the prompt is invisible and input is
+    contested — so a TTY-first chain would never reach the dialog the human can see.
+    The terminal is only the fallback for headless/SSH sessions with no display.
+    """
     ran: dict = {}
 
     @asynccontextmanager
@@ -163,7 +170,8 @@ async def test_serve_stdio_sets_repo_root_and_tty_prompter(monkeypatch):
     await serve_mod.serve_stdio(params, repo_root="/some/repo")
 
     assert executor.REPO_ROOT == "/some/repo"
-    assert isinstance(executor.AUTH_PROMPTER, TtyPrompter)
+    assert isinstance(executor.AUTH_PROMPTER, FallbackPrompter)
+    assert [type(p) for p in executor.AUTH_PROMPTER.prompters] == [GuiPrompter, TtyPrompter]
     assert ran["session_args"] == ("d_read", "d_write")  # downstream streams wired into the session
     assert ran["initialized"] is True
     assert ran["run"] == ("a_read", "a_write", "init-opts")

--- a/tests/unit/test_serve.py
+++ b/tests/unit/test_serve.py
@@ -15,6 +15,7 @@ from mcp import StdioServerParameters
 from typer.testing import CliRunner
 
 import doberman.cli.main as cli
+from doberman.auth.elicitation_prompter import ElicitationPrompter
 from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
 from doberman.auth.tty_prompter import TtyPrompter
 from doberman.proxy import executor
@@ -123,13 +124,15 @@ def test_stderr_logging_keeps_stdout_clean():
 # --- serve_stdio wiring ----------------------------------------------------------
 
 
-async def test_serve_stdio_sets_repo_root_and_gui_first_prompter(monkeypatch):
-    """serve_stdio points the engine at repo_root and installs a GUI-first prompter, then runs.
+async def test_serve_stdio_sets_repo_root_and_elicitation_first_prompter(monkeypatch):
+    """serve_stdio points the engine at repo_root and installs the challenge chain, then runs.
 
-    GUI first is load-bearing: when an agent's TUI (Claude Code etc.) owns the console,
-    CONIN$/CONOUT$ still OPEN successfully but the prompt is invisible and input is
-    contested — so a TTY-first chain would never reach the dialog the human can see.
-    The terminal is only the fallback for headless/SSH sessions with no display.
+    The order is load-bearing: elicitation renders the challenge INSIDE the agent client
+    (best UX, works remotely) but only for clients that support it; the GUI dialog covers
+    desktop sessions (and is the only 2FA-code channel — the MCP spec forbids sensitive
+    data via elicitation); the terminal is the last resort for headless/SSH sessions.
+    A TTY-first chain would never fall through: the agent-owned console OPENS successfully
+    even though its prompt is invisible.
     """
     ran: dict = {}
 
@@ -171,7 +174,11 @@ async def test_serve_stdio_sets_repo_root_and_gui_first_prompter(monkeypatch):
 
     assert executor.REPO_ROOT == "/some/repo"
     assert isinstance(executor.AUTH_PROMPTER, FallbackPrompter)
-    assert [type(p) for p in executor.AUTH_PROMPTER.prompters] == [GuiPrompter, TtyPrompter]
+    assert [type(p) for p in executor.AUTH_PROMPTER.prompters] == [
+        ElicitationPrompter,
+        GuiPrompter,
+        TtyPrompter,
+    ]
     assert ran["session_args"] == ("d_read", "d_write")  # downstream streams wired into the session
     assert ran["initialized"] is True
     assert ran["run"] == ("a_read", "a_write", "init-opts")

--- a/tests/unit/test_tty_prompter.py
+++ b/tests/unit/test_tty_prompter.py
@@ -1,0 +1,157 @@
+"""Unit tests for the controlling-terminal prompter (serve-mode AUTH channel).
+
+The prompter must (a) collect a confirm/code from the terminal, (b) raise on EOF/no-terminal so
+the provider denies (fail closed), and (c) NEVER touch sys.stdin/sys.stdout (the agent's MCP stream).
+``_open_tty`` is monkeypatched so these stay headless and deterministic.
+
+Note on fakes: a real ``/dev/tty`` opened ``r+`` does NOT share a buffer between read and write
+(write goes to the screen, read comes from the keyboard). ``io.StringIO`` does share one, so the
+fakes below keep the input and the captured output separate.
+"""
+
+import io
+
+import pytest
+
+from doberman.auth import tty_prompter
+from doberman.auth.tty_prompter import TtyPrompter
+
+
+class _FakeWrite:
+    """A terminal-output handle: records what was written; close() is a no-op so the test
+    can still inspect it after the prompter closes its handles."""
+
+    def __init__(self) -> None:
+        self.text = ""
+
+    def write(self, s: str) -> int:
+        self.text += s
+        return len(s)
+
+    def flush(self) -> None:  # pragma: no cover — trivial
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def _fake_tty(input_text: str) -> tuple[io.StringIO, _FakeWrite]:
+    """Distinct (read, write) handles, mirroring a real bidirectional tty."""
+    return io.StringIO(input_text), _FakeWrite()
+
+
+@pytest.mark.parametrize(
+    ("reply", "expected"),
+    [("y\n", True), ("yes\n", True), ("Y\n", True), ("YES\n", True), ("n\n", False), ("\n", False)],
+)
+def test_confirm_maps_reply_to_bool(monkeypatch, reply, expected):
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty(reply))
+    assert TtyPrompter().confirm("Approve THIS exact action?") is expected
+
+
+def test_confirm_writes_prompt_to_terminal(monkeypatch):
+    captured = _fake_tty("y\n")
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: captured)
+    TtyPrompter().confirm("Approve THIS exact action?")
+    assert "Approve THIS exact action?" in captured[1].text
+
+
+def test_read_code_returns_stripped_code(monkeypatch):
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty("123456\n"))
+    assert TtyPrompter().read_code("Enter your 2FA code") == "123456"
+
+
+def test_confirm_raises_on_eof_so_provider_denies(monkeypatch):
+    # Empty string = EOF / closed terminal. Must raise (never silently approve).
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty(""))
+    with pytest.raises(EOFError):
+        TtyPrompter().confirm("Approve?")
+
+
+def test_read_code_raises_on_eof(monkeypatch):
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty(""))
+    with pytest.raises(EOFError):
+        TtyPrompter().read_code("Enter your 2FA code")
+
+
+def test_read_code_raises_on_blank_line(monkeypatch):
+    # A blank line (Enter with no code) must NOT return "" to the TOTP verifier — it denies.
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty("\n"))
+    with pytest.raises(EOFError):
+        TtyPrompter().read_code("Enter your 2FA code")
+
+
+def test_read_handle_closed_even_if_write_close_raises(monkeypatch):
+    """On Windows read/write are distinct handles — a failure closing one must not leak the other."""
+    closed = {"read": False}
+
+    class _Write:
+        def write(self, s: str) -> int:
+            return len(s)
+
+        def flush(self) -> None:
+            pass
+
+        def close(self) -> None:
+            raise OSError("flush failed on close")
+
+    class _Read(io.StringIO):
+        def close(self) -> None:
+            closed["read"] = True
+            super().close()
+
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: (_Read("y\n"), _Write()))
+    with pytest.raises(OSError, match="flush failed on close"):
+        TtyPrompter().confirm("Approve?")
+    assert closed["read"] is True
+
+
+def test_no_terminal_raises_so_auth_fails_closed(monkeypatch):
+    def _no_tty():
+        raise OSError("no controlling terminal")
+
+    monkeypatch.setattr(tty_prompter, "_open_tty", _no_tty)
+    with pytest.raises(OSError, match="no controlling terminal"):
+        TtyPrompter().confirm("Approve?")
+    with pytest.raises(OSError, match="no controlling terminal"):
+        TtyPrompter().read_code("Enter your 2FA code")
+
+
+def test_never_touches_std_streams(monkeypatch):
+    """A challenge must not read stdin or write stdout (that is the agent's MCP channel)."""
+
+    class _Explode:
+        def __getattr__(self, _name):
+            raise AssertionError("prompter touched a std stream")
+
+    monkeypatch.setattr("sys.stdin", _Explode())
+    monkeypatch.setattr("sys.stdout", _Explode())
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty("y\n"))
+    assert TtyPrompter().confirm("Approve?") is True
+
+
+def test_posix_shared_handle_closed_once(monkeypatch):
+    """On POSIX read and write are the SAME object — it must be closed exactly once."""
+
+    class _Bidi:
+        def __init__(self, input_text: str) -> None:
+            self._in = io.StringIO(input_text)
+            self.out = io.StringIO()
+            self.closes = 0
+
+        def write(self, s: str) -> int:
+            return self.out.write(s)
+
+        def flush(self) -> None:
+            pass
+
+        def readline(self) -> str:
+            return self._in.readline()
+
+        def close(self) -> None:
+            self.closes += 1
+
+    handle = _Bidi("y\n")
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: (handle, handle))
+    assert TtyPrompter().confirm("Approve?") is True
+    assert handle.closes == 1


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: Feature 10 — Policy-Drift Detection & Poisoning Defense (slices 10.1–10.4)
- Plan reference: doberman_core_plan.md

## What this PR does
Makes the **raise-only** invariant enforceable over time: learning and edits may tighten freely, but any **weakening** of protection must be deliberate — classified, gated, and recorded — so protection cannot slowly erode (the policy-poisoning attack). **Completes the MVP core (Features 1–10).**

- **10.1 classifier** — `classify_change(before, after)` labels a change `strengthen`/`weaken`/`neutral` by protection rank. **Ambiguous or mixed → weaken** (fail safe), so a disguised weakening can't pass as neutral.
- **10.2 2FA-gated chokepoint** — `apply_change(...)` is the single path: a weakening renders a Before/After **diff** and requires a **`two_factor`** confirmation, applied **only on approval**; strengthen/neutral apply automatically; a denial leaves protection unchanged.
- **10.3 append-only ledger** — every change — **including denied weakening attempts** (the attack signal) — is recorded immutably in `policy_changes`; `doberman policy-history` prints the time-ordered history.
- **10.4 `DriftObserver` seam** — org-wide monitoring registers via `doberman.drift_observers` and receives **redacted** events; an observer can **never** approve/suppress/alter a weakening (the gate is authoritative) and is isolated on failure.

Bumps to `0.10.0`.

## Tests added (run in CI)
- `tests/unit/test_drift_classify.py` — every weakening transition + its reverse, mixed → weaken, ambiguous → weaken, no-op → neutral, pure strengthen.
- `tests/integration/test_drift_gate.py` — weaken requires 2FA + shows a diff; denied on refuse/wrong-code/prompter-failure; strengthen/neutral auto-apply; **ledger is written only by `apply_change`** (no `UPDATE`/`DELETE` on `policy_changes`).
- `tests/integration/test_policy_ledger.py` — applied **and** denied changes both recorded; `policy-history` surfaces a denied weakening as the attack signal; empty history.
- `tests/unit/test_drift_observer.py` — observer notified with a **redacted** (rule-id-level, no before/after values) event; a suppressing/exploding observer can't alter the outcome and is isolated; non-observer-shaped skipped.
- Updated `test_core_is_standalone.py` (no drift observers by default; version 0.10.0).

493 passed, 3 skipped; coverage 90.7% (gate 80%). `ruff` + `ruff format` + `lint-imports` clean.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (ambiguous/mixed → weaken; gate denies on any input/2FA failure; ledger/observer failures isolated)
- [x] No secret, full file, or unredacted prompt logged or committed (ledger stores rule ids + state tokens; observer events are rule-id level only)
- [x] Any guardrail/learning change is raise-only (weakening only via the 2FA-gated, audited `apply_change`; this IS the Feature 10 human-approved path)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (N/A to the classifier; the weaken gate shows a full diff + reason)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Edge cases: mixed/ambiguous changes, added/removed protective entries, boolean toggles, denied weakenings recorded, observer isolation/suppression attempt, empty history.
- Deviations: `apply_change` decides + records + notifies and returns `approved`; the caller persists the new policy only when approved (keeps the mechanism decoupled from each policy writer's storage). Wiring the existing CLI policy editors (`review`/`mode`) through `apply_change` is noted as follow-up hardening — this PR delivers the core *mechanism* + ledger + history + observer.
- Risks/tech debt: ledger is append-only by convention + tests (cryptographic signing is future hardening); heuristic rank table for state tokens (keep ambiguous → weaken).
