### PR TITLE
feat(proxy): `doberman serve` runtime so agents can connect directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,21 +92,50 @@ A green run means the core engine, proxy, and guardrail wiring all behave as spe
 
 ## Quickstart
 
-At this stage Doberman is a **library**, not a standalone binary — you embed the proxy in front of a downstream MCP tool server. The proxy is created from an active downstream client session:
+Doberman ships a **`doberman serve`** runtime: it runs as an MCP server to your agent and an MCP client to your
+real tool server, so it sits *on* the execution path with no code changes on either side. The pattern is one line —
+**instead of pointing your agent at the real MCP server, point it at `doberman serve -- <that server>`.**
 
-```python
-from doberman.proxy.mcp_proxy import build_proxy_server
+```bash
+# Run Doberman in front of any MCP tool server (everything after `--` is the downstream command):
+doberman serve -- npx -y @modelcontextprotocol/server-filesystem /path/to/repo
 
-# `downstream` is an mcp.client.session.ClientSession connected to your
-# real tool server. The returned MCP server re-exposes its tools and routes
-# every tools/call through Doberman's decision chokepoint.
-proxy = build_proxy_server(downstream)
-# ...serve `proxy` to the agent over your preferred MCP transport.
+# Policy, decision log, and elevations live in <repo>/.doberman — choose the repo with --path:
+doberman serve --path /path/to/repo -- npx -y @modelcontextprotocol/server-filesystem /path/to/repo
 ```
 
-For a complete, runnable wiring (an in-process downstream + proxy + agent client),
-see [`tests/integration/test_proxy_passthrough.py`](./tests/integration/test_proxy_passthrough.py)
-and [`tests/integration/test_engine_blocks_reach_no_tool.py`](./tests/integration/test_engine_blocks_reach_no_tool.py).
+### Connect your agent
+
+Swap the agent's MCP server entry to launch Doberman, which then spawns the real server. The decision happens in
+between; `AUTH` prompts appear on **your terminal** (with no terminal attached, an `AUTH` action is denied — fail
+closed), and every decision is recorded — inspect it with `doberman log` and `doberman status`.
+
+**Claude Code**
+
+```bash
+claude mcp add doberman -- doberman serve -- npx -y @modelcontextprotocol/server-filesystem ~/repo
+```
+
+**Claude Desktop / Cursor / Codex** (`mcpServers` block in the client's config, e.g. `claude_desktop_config.json`)
+
+```jsonc
+{
+  "mcpServers": {
+    "doberman": {
+      "command": "doberman",
+      "args": ["serve", "--",
+               "npx", "-y", "@modelcontextprotocol/server-filesystem", "~/repo"]
+    }
+  }
+}
+```
+
+That's it — your agent sees exactly the same tools, now mediated by Doberman.
+
+For the embeddable form (build the proxy yourself and serve it over your own transport), use
+[`build_proxy_server`](./src/doberman/proxy/mcp_proxy.py); for runnable wiring examples see
+[`tests/integration/test_serve_end_to_end.py`](./tests/integration/test_serve_end_to_end.py) and
+[`tests/integration/test_proxy_passthrough.py`](./tests/integration/test_proxy_passthrough.py).
 
 ---
 
@@ -233,6 +262,12 @@ The version line maps to the development roadmap:
 ## Changelog
 
 This project keeps a changelog in the spirit of [Keep a Changelog](https://keepachangelog.com/).
+
+### `v0.11.0` — Agent Integration: `doberman serve` — _Unreleased (in review)_
+
+- **`doberman serve -- <downstream cmd>`** — a runnable stdio MCP proxy that fronts any downstream MCP tool server (MCP server to the agent, MCP client to the downstream); makes Doberman usable from Claude Code, Codex, Claude Desktop, Cursor, and any MCP client with a one-line config swap.
+- **Controlling-terminal AUTH** — in serve mode an `AUTH` challenge is routed to the local terminal (`/dev/tty` / `CONIN$`/`CONOUT$`) so it never touches the agent's stdin/stdout MCP stream; with no terminal attached the action is denied (fail closed).
+- Logs are pinned to **stderr** (stdout is the agent's protocol channel); the engine's repo root (`.doberman/`) is selectable with `--path`.
 
 ### `v0.10.0` — Policy-Drift Detection & Poisoning Defense — _Unreleased (in review)_
 

--- a/src/doberman/__init__.py
+++ b/src/doberman/__init__.py
@@ -1,3 +1,3 @@
 """Doberman — adaptive authorization layer for coding agents (open core)."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/src/doberman/auth/tty_prompter.py
+++ b/src/doberman/auth/tty_prompter.py
@@ -1,0 +1,82 @@
+"""A :class:`~doberman.auth.challenge.Prompter` that talks to the controlling terminal.
+
+Used when Doberman runs as a stdio MCP proxy (``doberman serve``): the agent owns
+this process's stdin/stdout, so an ``AUTH`` challenge must reach the human through the
+controlling terminal directly — ``/dev/tty`` (POSIX) or ``CONIN$``/``CONOUT$`` (Windows).
+If no terminal is attached (a headless, agent-spawned subprocess), opening it raises →
+the provider treats the challenge as failed → the action is **denied** (fail closed).
+
+SECURITY: this never reads ``sys.stdin`` or writes ``sys.stdout`` — those are the agent's
+MCP channel, and a stray byte there corrupts the protocol. Any no-input/EOF condition
+raises so the provider denies rather than defaulting to "yes".
+"""
+
+import sys
+from typing import TextIO
+
+#: Replies that count as approval for a yes/no confirm (case-insensitive).
+_AFFIRMATIVE = frozenset({"y", "yes"})
+
+
+def _open_tty() -> tuple[TextIO, TextIO]:
+    """Open ``(read, write)`` handles to the controlling terminal.
+
+    On POSIX both are the same bidirectional ``/dev/tty`` handle; on Windows they are
+    the distinct console devices. Raises ``OSError`` when no terminal is attached — the
+    caller turns that into a denial.
+    """
+    if sys.platform == "win32":
+        return (
+            open("CONIN$", encoding="utf-8"),  # noqa: SIM115 — closed by the caller's finally
+            open("CONOUT$", "w", encoding="utf-8"),  # noqa: SIM115 — closed by the caller's finally
+        )
+    tty = open("/dev/tty", "r+", encoding="utf-8")  # noqa: SIM115 — closed by the caller's finally
+    return tty, tty
+
+
+class TtyPrompter:
+    """Collect a challenge response from the controlling terminal (see module docstring)."""
+
+    def confirm(self, message: str) -> bool:
+        """Ask a yes/no question on the terminal.
+
+        A blank line (Enter with no input) is a non-affirmative reply → ``False`` (deny);
+        EOF / a closed terminal raises (the provider also treats that as a denial). Either
+        way the answer is never silently "yes".
+        """
+        answer = self._ask(f"\n{message} [y/N] ")
+        return answer.strip().lower() in _AFFIRMATIVE
+
+    def read_code(self, message: str) -> str:
+        """Read a one-time code from the terminal. Blank/EOF input → raise (deny).
+
+        An empty code must never be returned to the verifier, so a blank line raises rather
+        than passing ``""`` through. The code may echo on the local terminal — acceptable for
+        a single-use TOTP seen only by the local human; it never touches the agent's stream or a log.
+        """
+        code = self._ask(f"\n{message}: ").strip()
+        if not code:
+            raise EOFError("no code entered on the controlling terminal")
+        return code
+
+    @staticmethod
+    def _ask(prompt: str) -> str:
+        # Open a fresh handle per prompt (don't cache): a terminal that was unavailable or
+        # closed earlier may be usable now, and per-call opens keep concurrent challenges
+        # independent. AUTH challenges are effectively serialized by the human anyway.
+        read_handle, write_handle = _open_tty()
+        try:
+            write_handle.write(prompt)
+            write_handle.flush()
+            line = read_handle.readline()
+        finally:
+            # Nested so a failure closing the write handle still closes the (distinct, on
+            # Windows) read handle — never leak a console handle.
+            try:
+                write_handle.close()
+            finally:
+                if read_handle is not write_handle:
+                    read_handle.close()
+        if not line:  # EOF / closed terminal — never silently approve
+            raise EOFError("no input available on the controlling terminal")
+        return line

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -8,9 +8,12 @@ lists currently-active elevations.
 
 import asyncio
 import json
+import logging
+import sys
 from datetime import datetime, timezone
 
 import typer
+from mcp import StdioServerParameters
 
 from doberman import __version__
 from doberman.auth import totp
@@ -19,6 +22,7 @@ from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, r
 from doberman.policy.checklist import recommend_policy
 from doberman.policy.drift import read_policy_changes
 from doberman.policy.modes import SecurityMode
+from doberman.proxy.serve import serve_stdio
 from doberman.storage.db import active_elevations, revoke_elevation
 from doberman.storage.log import memory_summary, read_decisions
 
@@ -30,6 +34,66 @@ app = typer.Typer(
 
 twofa_app = typer.Typer(help="Two-factor (TOTP) enrollment.", no_args_is_help=True)
 app.add_typer(twofa_app, name="2fa")
+
+
+def _configure_stderr_logging(level: int = logging.INFO) -> None:
+    """Send Doberman logs to STDERR only.
+
+    In ``serve`` mode this process's stdout IS the agent's MCP channel, so any log written
+    there would corrupt the protocol. Pin every ``doberman.*`` logger to stderr and stop
+    propagation, and — defense in depth — strip any stdout handler from the root logger so a
+    library (mcp/asyncio) or host-configured logger cannot leak a record onto stdout either.
+    """
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("doberman: %(message)s"))
+    doberman_logger = logging.getLogger("doberman")
+    for existing in doberman_logger.handlers[:]:
+        doberman_logger.removeHandler(existing)
+    doberman_logger.addHandler(handler)
+    doberman_logger.setLevel(level)
+    doberman_logger.propagate = False
+
+    root = logging.getLogger()
+    for existing in root.handlers[:]:
+        if (
+            isinstance(existing, logging.StreamHandler)
+            and getattr(existing, "stream", None) is sys.stdout
+        ):
+            root.removeHandler(existing)
+    if not root.handlers:  # keep a stderr fallback so non-doberman logs aren't silently dropped
+        root.addHandler(logging.StreamHandler(sys.stderr))
+
+
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    help="Run Doberman as an MCP proxy in front of a downstream MCP tool server.",
+)
+def serve(
+    ctx: typer.Context,
+    path: str = typer.Option(
+        ".", "--path", "-p", help="Repo root whose .doberman/ policy governs decisions."
+    ),
+) -> None:
+    """Run Doberman as an MCP proxy in front of a downstream MCP server.
+
+    Everything after `--` is the downstream server command, for example:
+
+        doberman serve -- npx -y @modelcontextprotocol/server-filesystem /path/to/repo
+
+    Point your agent's MCP config at this instead of the real server. AUTH prompts appear on
+    your terminal; with no terminal attached (headless) an AUTH action is denied (fail closed).
+    """
+    downstream_argv = list(ctx.args)
+    if not downstream_argv:
+        typer.echo("error: provide the downstream server command after `--`", err=True)
+        raise typer.Exit(code=2)
+    params = StdioServerParameters(command=downstream_argv[0], args=downstream_argv[1:])
+    _configure_stderr_logging()
+    try:
+        asyncio.run(serve_stdio(params, repo_root=path))
+    except Exception as exc:  # noqa: BLE001 — surface a clean stderr error, never a raw traceback
+        typer.echo(f"error: doberman serve failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
 
 
 @app.command()

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 from mcp.client.session import ClientSession
 from mcp.types import CallToolResult, TextContent
 
-from doberman.auth.challenge import AuthTier, run_auth_challenge
+from doberman.auth.challenge import AuthTier, Prompter, run_auth_challenge
 from doberman.auth.elevation import find_cover, scope_for_target
 from doberman.config import load_active_role, load_mode
 from doberman.engine.decision_engine import Guardrail, decide
@@ -50,6 +50,12 @@ _engine_logger = logging.getLogger("doberman.proxy.engine")
 #: Repo root used for config + the elevation store. Module-level so tests can
 #: point it at an isolated temp dir (the DB/config must never touch the repo).
 REPO_ROOT = "."
+
+#: Prompter for AUTH challenges. None ⇒ the provider's default CLI prompter
+#: (stdin/stdout). The stdio ``serve`` path sets this to a controlling-terminal
+#: prompter so a challenge never reads/writes the agent's MCP stream. Module-level
+#: so tests can inject a headless fake.
+AUTH_PROMPTER: Prompter | None = None
 
 # Guardrail implementations used by the proxy: the real Feature 3 objective rule
 # set and the real Feature 9 subjective (workflow-baseline) guardrail. Module-
@@ -236,7 +242,7 @@ async def _handle_auth(
     abnormality_score: float,
 ) -> CallToolResult:
     """Run the tiered challenge for an AUTH decision and act on the outcome."""
-    auth_result = run_auth_challenge(decision, action)
+    auth_result = run_auth_challenge(decision, action, prompter=AUTH_PROMPTER)
     # Approval is bound to THIS action id — never honor a result for another call.
     if not auth_result.approved or auth_result.action_id != action.id:
         await _persist(decision, action, auth_result="denied")

--- a/src/doberman/proxy/serve.py
+++ b/src/doberman/proxy/serve.py
@@ -1,0 +1,43 @@
+"""Run Doberman as a real MCP proxy over stdio in front of one downstream tool server.
+
+Doberman is an MCP *server* to the agent (over this process's stdin/stdout) and an MCP
+*client* to the downstream server (which it spawns). Every ``tools/call`` flows through the
+single chokepoint (:func:`doberman.proxy.executor.decide_and_execute`) — there is no path
+around it. This is the deployable counterpart to :func:`doberman.proxy.mcp_proxy.build_proxy_server`,
+which builds the proxy object; this module gives it a transport.
+
+SECURITY: nothing here writes this process's stdout (that is the agent's MCP channel). AUTH
+challenges are routed to the controlling terminal via :class:`~doberman.auth.tty_prompter.TtyPrompter`
+so a prompt never touches the agent stream; with no terminal the challenge denies (fail closed).
+"""
+
+import logging
+
+from mcp import ClientSession, StdioServerParameters, stdio_client
+from mcp.server.stdio import stdio_server
+
+from doberman.auth.tty_prompter import TtyPrompter
+from doberman.proxy import executor
+from doberman.proxy.mcp_proxy import build_proxy_server
+
+logger = logging.getLogger("doberman.proxy.serve")
+
+
+async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = ".") -> None:
+    """Spawn ``downstream``, then serve the Doberman proxy to the agent over stdio.
+
+    Points the engine at ``repo_root`` (its ``.doberman/`` holds the active role, policy,
+    decision log, and elevation store) and installs the controlling-terminal prompter so an
+    ``AUTH`` challenge never reads/writes the agent's stdin/stdout. Returns when the agent
+    disconnects; any transport failure propagates (the caller exits non-zero, forwarding nothing).
+    """
+    executor.REPO_ROOT = repo_root
+    executor.AUTH_PROMPTER = TtyPrompter()
+    logger.info("starting downstream: %s", downstream.command)
+    async with stdio_client(downstream) as (downstream_read, downstream_write):
+        async with ClientSession(downstream_read, downstream_write) as session:
+            await session.initialize()
+            proxy = build_proxy_server(session)
+            async with stdio_server() as (agent_read, agent_write):
+                logger.info("ready — proxying tool calls to the agent over stdio")
+                await proxy.run(agent_read, agent_write, proxy.create_initialization_options())

--- a/tests/fixtures/stdio_tool_server.py
+++ b/tests/fixtures/stdio_tool_server.py
@@ -1,0 +1,109 @@
+"""A runnable downstream MCP tool server over stdio, for the serve end-to-end test.
+
+Mirrors the tool surface of :mod:`tests.fixtures.fake_tool_server` (fs_write / fs_delete /
+shell_exec / net_get) but runs as a real subprocess so ``doberman serve`` can spawn it. Every
+*executed* call is appended as one JSON line ``[tool_name, arguments]`` to the file named by the
+``DOBERMAN_TEST_CALLLOG`` environment variable, so the test can assert exactly what reached a tool
+(the chokepoint property: a blocked call must leave no line behind).
+
+Run as: ``python tests/fixtures/stdio_tool_server.py``  (stdout is its MCP channel — never printed to).
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+
+SERVER_NAME = "stdio-downstream"
+
+_TOOLS: list[Tool] = [
+    Tool(
+        name="fs_write",
+        description="Write content to a file.",
+        inputSchema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+            "required": ["path", "content"],
+        },
+    ),
+    Tool(
+        name="fs_delete",
+        description="Delete a file.",
+        inputSchema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    ),
+    Tool(
+        name="shell_exec",
+        description="Run a shell command.",
+        inputSchema={
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"],
+        },
+    ),
+    Tool(
+        name="net_get",
+        description="HTTP GET a URL.",
+        inputSchema={
+            "type": "object",
+            "properties": {"url": {"type": "string"}},
+            "required": ["url"],
+        },
+    ),
+]
+
+KNOWN_TOOL_NAMES = {tool.name for tool in _TOOLS}
+
+
+def _call_log_path() -> str | None:
+    """Where to record executed calls: argv[1] (robust — flows through `serve --`) or the
+    DOBERMAN_TEST_CALLLOG env var as a fallback."""
+    if len(sys.argv) > 1 and sys.argv[1]:
+        return sys.argv[1]
+    return os.environ.get("DOBERMAN_TEST_CALLLOG")
+
+
+def _record(tool_name: str, arguments: dict) -> None:
+    """Append one executed call to the call-log file (never to stdout)."""
+    call_log = _call_log_path()
+    if not call_log:
+        return
+    with open(call_log, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps([tool_name, arguments]) + "\n")
+
+
+def build() -> Server:
+    server: Server = Server(SERVER_NAME)
+
+    @server.list_tools()
+    async def _list_tools() -> list[Tool]:
+        return _TOOLS
+
+    @server.call_tool()
+    async def _call_tool(tool_name: str, arguments: dict) -> list[TextContent]:
+        if tool_name not in KNOWN_TOOL_NAMES:
+            raise ValueError(f"unknown tool: {tool_name}")  # error before recording
+        _record(tool_name, arguments)
+        return [TextContent(type="text", text=f"ok: {tool_name} executed")]
+
+    return server
+
+
+async def main() -> None:
+    server = build()
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised as a subprocess by the e2e test
+    try:
+        asyncio.run(main())
+    except (KeyboardInterrupt, EOFError):
+        sys.exit(0)

--- a/tests/integration/test_serve_end_to_end.py
+++ b/tests/integration/test_serve_end_to_end.py
@@ -1,0 +1,84 @@
+"""End-to-end test of `doberman serve`: a real agent ⇄ doberman ⇄ downstream chain.
+
+Spawns `python -m doberman.cli.main serve -- python <stdio_tool_server> <calllog>` as a subprocess and
+connects to it with a real MCP client (the "agent"). Proves the deployable wiring works over stdio AND
+the chokepoint property end-to-end: a PASS reaches the tool (a line in the call-log); a BLOCK does not.
+
+This is the heavier test (it launches processes); a short timeout guards against a hung child.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters, stdio_client
+
+_FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "stdio_tool_server.py"
+_TIMEOUT_S = 30.0
+
+
+@asynccontextmanager
+async def _agent_through_doberman(repo_root: Path, call_log: Path) -> AsyncIterator[ClientSession]:
+    """An MCP client connected to `doberman serve`, which fronts the stdio fixture downstream."""
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=[
+            "-m",
+            "doberman.cli.main",
+            "serve",
+            "--path",
+            str(repo_root),
+            "--",
+            sys.executable,
+            str(_FIXTURE),
+            str(call_log),
+        ],
+        # Full env so the child can import doberman (venv) and find the interpreter.
+        env={**os.environ},
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as agent:
+            await agent.initialize()
+            yield agent
+
+
+def _logged_tools(call_log: Path) -> list[str]:
+    if not call_log.exists():
+        return []
+    return [
+        json.loads(line)[0] for line in call_log.read_text(encoding="utf-8").splitlines() if line
+    ]
+
+
+async def test_downstream_tools_are_re_exposed(tmp_path):
+    call_log = tmp_path / "calls.log"
+    async with asyncio.timeout(_TIMEOUT_S):
+        async with _agent_through_doberman(tmp_path, call_log) as agent:
+            result = await agent.list_tools()
+    names = {tool.name for tool in result.tools}
+    assert {"fs_write", "fs_delete", "shell_exec", "net_get"} <= names
+
+
+async def test_pass_decision_reaches_the_tool(tmp_path):
+    call_log = tmp_path / "calls.log"
+    async with asyncio.timeout(_TIMEOUT_S):
+        async with _agent_through_doberman(tmp_path, call_log) as agent:
+            # A fetch to a trusted host PASSes (mirrors test_proxy_passthrough.py).
+            result = await agent.call_tool("net_get", {"url": "https://github.com/owner/repo"})
+    assert not result.isError
+    assert "net_get" in _logged_tools(call_log)
+
+
+async def test_block_decision_reaches_no_tool(tmp_path):
+    call_log = tmp_path / "calls.log"
+    async with asyncio.timeout(_TIMEOUT_S):
+        async with _agent_through_doberman(tmp_path, call_log) as agent:
+            # A catastrophic command is BLOCKed by the objective guardrail.
+            result = await agent.call_tool("shell_exec", {"command": "rm -rf /"})
+    assert result.isError
+    # The chokepoint property: the blocked call never reached the downstream tool.
+    assert "shell_exec" not in _logged_tools(call_log)

--- a/tests/unit/test_core_is_standalone.py
+++ b/tests/unit/test_core_is_standalone.py
@@ -13,7 +13,7 @@ def test_core_imports_with_no_enterprise_installed():
 def test_version_is_exposed():
     import doberman
 
-    assert doberman.__version__ == "0.10.0"
+    assert doberman.__version__ == "0.11.0"
 
 
 def test_policy_core_packages_import_cleanly():

--- a/tests/unit/test_serve.py
+++ b/tests/unit/test_serve.py
@@ -1,0 +1,169 @@
+"""Unit tests for the `doberman serve` command and the `serve_stdio` launcher.
+
+Covers CLI argument parsing (downstream command after `--`, `--path`, the missing-command error)
+and that `serve_stdio` sets the executor's repo root + a non-stdio AUTH prompter and runs the proxy
+over stdio. The real stdio transports are faked so these stay headless and deterministic; the full
+agent⇄serve⇄downstream chain is covered by the integration test.
+"""
+
+import logging
+import sys
+from contextlib import asynccontextmanager
+
+import pytest
+from mcp import StdioServerParameters
+from typer.testing import CliRunner
+
+import doberman.cli.main as cli
+from doberman.auth.tty_prompter import TtyPrompter
+from doberman.proxy import executor
+from doberman.proxy import serve as serve_mod
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _restore_executor_globals():
+    """The serve path mutates module-level executor globals — restore them after each test."""
+    repo_root, prompter = executor.REPO_ROOT, executor.AUTH_PROMPTER
+    try:
+        yield
+    finally:
+        executor.REPO_ROOT = repo_root
+        executor.AUTH_PROMPTER = prompter
+
+
+@pytest.fixture
+def _no_logging_mutation(monkeypatch):
+    """Stub out stderr-logging setup so CLI-parse tests don't reconfigure global logging."""
+    monkeypatch.setattr(cli, "_configure_stderr_logging", lambda *a, **k: None)
+
+
+# --- CLI parsing -----------------------------------------------------------------
+
+
+def test_missing_downstream_command_exits_2(monkeypatch):
+    called = False
+
+    async def _spy(*_a, **_k):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(cli, "serve_stdio", _spy)
+    result = runner.invoke(cli.app, ["serve"])
+    assert result.exit_code == 2
+    assert not called
+
+
+def test_builds_stdio_params_from_argv(monkeypatch, _no_logging_mutation):
+    seen: dict = {}
+
+    async def _spy(params, *, repo_root):
+        seen["params"] = params
+        seen["repo_root"] = repo_root
+
+    monkeypatch.setattr(cli, "serve_stdio", _spy)
+    result = runner.invoke(cli.app, ["serve", "--", "mytool", "a", "b"])
+    assert result.exit_code == 0
+    assert result.output == ""  # nothing on stdout — that is the agent's MCP channel
+    assert seen["params"].command == "mytool"
+    assert seen["params"].args == ["a", "b"]
+    assert seen["repo_root"] == "."
+
+
+def test_path_option_threads_repo_root(monkeypatch, _no_logging_mutation):
+    seen: dict = {}
+
+    async def _spy(params, *, repo_root):
+        seen["repo_root"] = repo_root
+
+    monkeypatch.setattr(cli, "serve_stdio", _spy)
+    result = runner.invoke(cli.app, ["serve", "-p", "/repo", "--", "mytool"])
+    assert result.exit_code == 0
+    assert seen["repo_root"] == "/repo"
+
+
+def test_serve_reports_downstream_failure_cleanly(monkeypatch, _no_logging_mutation):
+    """A failure to start/serve becomes a clean stderr error + exit 1, never a raw traceback."""
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("downstream boom")
+
+    monkeypatch.setattr(cli, "serve_stdio", _boom)
+    result = runner.invoke(cli.app, ["serve", "--", "mytool"])
+    assert result.exit_code == 1
+    assert "doberman serve failed" in result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_stderr_logging_keeps_stdout_clean():
+    """_configure_stderr_logging pins doberman logs to stderr and scrubs stdout from root."""
+    root = logging.getLogger()
+    doberman_logger = logging.getLogger("doberman")
+    saved_root, saved_dob = root.handlers[:], doberman_logger.handlers[:]
+    saved_prop = doberman_logger.propagate
+    hostile = logging.StreamHandler(sys.stdout)  # pretend a host config logs to stdout
+    root.addHandler(hostile)
+    try:
+        cli._configure_stderr_logging()
+        assert doberman_logger.propagate is False
+        assert doberman_logger.handlers
+        assert all(getattr(h, "stream", None) is sys.stderr for h in doberman_logger.handlers)
+        assert not any(
+            isinstance(h, logging.StreamHandler) and getattr(h, "stream", None) is sys.stdout
+            for h in root.handlers
+        )
+    finally:
+        root.handlers[:] = saved_root
+        doberman_logger.handlers[:] = saved_dob
+        doberman_logger.propagate = saved_prop
+
+
+# --- serve_stdio wiring ----------------------------------------------------------
+
+
+async def test_serve_stdio_sets_repo_root_and_tty_prompter(monkeypatch):
+    """serve_stdio points the engine at repo_root and installs a non-stdio prompter, then runs."""
+    ran: dict = {}
+
+    @asynccontextmanager
+    async def _fake_stdio_client(_params):
+        yield ("d_read", "d_write")
+
+    class _FakeSession:
+        def __init__(self, read, write):
+            ran["session_args"] = (read, write)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def initialize(self):
+            ran["initialized"] = True
+
+    @asynccontextmanager
+    async def _fake_stdio_server():
+        yield ("a_read", "a_write")
+
+    class _FakeProxy:
+        def create_initialization_options(self):
+            return "init-opts"
+
+        async def run(self, read, write, opts):
+            ran["run"] = (read, write, opts)
+
+    monkeypatch.setattr(serve_mod, "stdio_client", _fake_stdio_client)
+    monkeypatch.setattr(serve_mod, "ClientSession", _FakeSession)
+    monkeypatch.setattr(serve_mod, "stdio_server", _fake_stdio_server)
+    monkeypatch.setattr(serve_mod, "build_proxy_server", lambda _session: _FakeProxy())
+
+    params = StdioServerParameters(command="mytool", args=[])
+    await serve_mod.serve_stdio(params, repo_root="/some/repo")
+
+    assert executor.REPO_ROOT == "/some/repo"
+    assert isinstance(executor.AUTH_PROMPTER, TtyPrompter)
+    assert ran["session_args"] == ("d_read", "d_write")  # downstream streams wired into the session
+    assert ran["initialized"] is True
+    assert ran["run"] == ("a_read", "a_write", "init-opts")

--- a/tests/unit/test_tty_prompter.py
+++ b/tests/unit/test_tty_prompter.py
@@ -1,0 +1,157 @@
+"""Unit tests for the controlling-terminal prompter (serve-mode AUTH channel).
+
+The prompter must (a) collect a confirm/code from the terminal, (b) raise on EOF/no-terminal so
+the provider denies (fail closed), and (c) NEVER touch sys.stdin/sys.stdout (the agent's MCP stream).
+``_open_tty`` is monkeypatched so these stay headless and deterministic.
+
+Note on fakes: a real ``/dev/tty`` opened ``r+`` does NOT share a buffer between read and write
+(write goes to the screen, read comes from the keyboard). ``io.StringIO`` does share one, so the
+fakes below keep the input and the captured output separate.
+"""
+
+import io
+
+import pytest
+
+from doberman.auth import tty_prompter
+from doberman.auth.tty_prompter import TtyPrompter
+
+
+class _FakeWrite:
+    """A terminal-output handle: records what was written; close() is a no-op so the test
+    can still inspect it after the prompter closes its handles."""
+
+    def __init__(self) -> None:
+        self.text = ""
+
+    def write(self, s: str) -> int:
+        self.text += s
+        return len(s)
+
+    def flush(self) -> None:  # pragma: no cover — trivial
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def _fake_tty(input_text: str) -> tuple[io.StringIO, _FakeWrite]:
+    """Distinct (read, write) handles, mirroring a real bidirectional tty."""
+    return io.StringIO(input_text), _FakeWrite()
+
+
+@pytest.mark.parametrize(
+    ("reply", "expected"),
+    [("y\n", True), ("yes\n", True), ("Y\n", True), ("YES\n", True), ("n\n", False), ("\n", False)],
+)
+def test_confirm_maps_reply_to_bool(monkeypatch, reply, expected):
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty(reply))
+    assert TtyPrompter().confirm("Approve THIS exact action?") is expected
+
+
+def test_confirm_writes_prompt_to_terminal(monkeypatch):
+    captured = _fake_tty("y\n")
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: captured)
+    TtyPrompter().confirm("Approve THIS exact action?")
+    assert "Approve THIS exact action?" in captured[1].text
+
+
+def test_read_code_returns_stripped_code(monkeypatch):
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty("123456\n"))
+    assert TtyPrompter().read_code("Enter your 2FA code") == "123456"
+
+
+def test_confirm_raises_on_eof_so_provider_denies(monkeypatch):
+    # Empty string = EOF / closed terminal. Must raise (never silently approve).
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty(""))
+    with pytest.raises(EOFError):
+        TtyPrompter().confirm("Approve?")
+
+
+def test_read_code_raises_on_eof(monkeypatch):
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty(""))
+    with pytest.raises(EOFError):
+        TtyPrompter().read_code("Enter your 2FA code")
+
+
+def test_read_code_raises_on_blank_line(monkeypatch):
+    # A blank line (Enter with no code) must NOT return "" to the TOTP verifier — it denies.
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty("\n"))
+    with pytest.raises(EOFError):
+        TtyPrompter().read_code("Enter your 2FA code")
+
+
+def test_read_handle_closed_even_if_write_close_raises(monkeypatch):
+    """On Windows read/write are distinct handles — a failure closing one must not leak the other."""
+    closed = {"read": False}
+
+    class _Write:
+        def write(self, s: str) -> int:
+            return len(s)
+
+        def flush(self) -> None:
+            pass
+
+        def close(self) -> None:
+            raise OSError("flush failed on close")
+
+    class _Read(io.StringIO):
+        def close(self) -> None:
+            closed["read"] = True
+            super().close()
+
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: (_Read("y\n"), _Write()))
+    with pytest.raises(OSError, match="flush failed on close"):
+        TtyPrompter().confirm("Approve?")
+    assert closed["read"] is True
+
+
+def test_no_terminal_raises_so_auth_fails_closed(monkeypatch):
+    def _no_tty():
+        raise OSError("no controlling terminal")
+
+    monkeypatch.setattr(tty_prompter, "_open_tty", _no_tty)
+    with pytest.raises(OSError, match="no controlling terminal"):
+        TtyPrompter().confirm("Approve?")
+    with pytest.raises(OSError, match="no controlling terminal"):
+        TtyPrompter().read_code("Enter your 2FA code")
+
+
+def test_never_touches_std_streams(monkeypatch):
+    """A challenge must not read stdin or write stdout (that is the agent's MCP channel)."""
+
+    class _Explode:
+        def __getattr__(self, _name):
+            raise AssertionError("prompter touched a std stream")
+
+    monkeypatch.setattr("sys.stdin", _Explode())
+    monkeypatch.setattr("sys.stdout", _Explode())
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: _fake_tty("y\n"))
+    assert TtyPrompter().confirm("Approve?") is True
+
+
+def test_posix_shared_handle_closed_once(monkeypatch):
+    """On POSIX read and write are the SAME object — it must be closed exactly once."""
+
+    class _Bidi:
+        def __init__(self, input_text: str) -> None:
+            self._in = io.StringIO(input_text)
+            self.out = io.StringIO()
+            self.closes = 0
+
+        def write(self, s: str) -> int:
+            return self.out.write(s)
+
+        def flush(self) -> None:
+            pass
+
+        def readline(self) -> str:
+            return self._in.readline()
+
+        def close(self) -> None:
+            self.closes += 1
+
+    handle = _Bidi("y\n")
+    monkeypatch.setattr(tty_prompter, "_open_tty", lambda: (handle, handle))
+    assert TtyPrompter().confirm("Approve?") is True
+    assert handle.closes == 1


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: serve wrapper — agent integration (runtime `doberman serve`); net-new core slice beyond F1–F10, pure core (no enterprise)
- Plan reference: `.claude/PRPs/plans/completed/doberman-serve-wrapper.plan.md`
- Base: `feat/f10-policy-drift` (the stack tip — has proxy + CLI + auth; `main` has only F1)

## What this PR does
Turns Doberman from a library into a runnable MCP proxy an agent can connect to with one config line.

- **`doberman serve -- <downstream cmd>`** — stdio MCP proxy (MCP server to the agent, MCP client to the downstream it spawns). Works with Claude Code, Codex, Claude Desktop, Cursor.
- **Controlling-terminal AUTH** (`TtyPrompter`) — confirm/2FA go to `/dev/tty` (POSIX) or `CONIN$`/`CONOUT$` (Windows) so a challenge never touches the agent's stdin/stdout MCP stream; no terminal ⇒ deny (fail closed); blank/EOF input ⇒ raise (deny).
- **`executor.AUTH_PROMPTER` seam** — `None` ⇒ unchanged default behavior (existing tests untouched).
- **stdout safety** — logs pinned to stderr + root stdout-handler scrub; clean stderr error + exit 1 on startup failure.
- **README** — runnable quickstart + per-agent MCP configs; version → 0.11.0.

## Tests added (run in CI)
- `tests/unit/test_tty_prompter.py` — terminal confirm/code, EOF/blank ⇒ raise, no-tty ⇒ raise, never touches std streams, handle-close safety.
- `tests/unit/test_serve.py` — CLI arg parsing (downstream after `--`, `--path`, missing-cmd exit 2), `serve_stdio` wiring (REPO_ROOT + TtyPrompter + stream wiring), stderr-logging keeps stdout clean, clean failure ⇒ exit 1.
- `tests/integration/test_serve_end_to_end.py` — real subprocess agent ⇄ `doberman serve` ⇄ stdio fixture: tools re-exposed, PASS reaches the tool, **BLOCK reaches no tool** (chokepoint property end-to-end).

## Public-release safety (doberman-core only)
- [x] No enterprise/hosted/proprietary/commercial code; no customer data; no secrets
- [x] Core still builds/tests/runs with NO enterprise package installed (standalone test green)

## Security checklist
- [x] Fails closed on error / uncertainty (no terminal / EOF / startup failure ⇒ deny / exit 1)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no loosening; `AUTH_PROMPTER=None` is a no-op)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged engine path)
- [x] doberman-core does not import doberman_enterprise
- [x] Reviewed by security-reviewer + python-reviewer; their HIGH/MEDIUM findings fixed (read_code blank-line deny, Windows handle-close, root-logger stdout scrub, clean error handling, test wiring assertions)

## Validation
`ruff check` ✓ · `ruff format --check` ✓ · `lint-imports` (2 kept, 0 broken) ✓ · `pytest --cov=doberman` → 517 passed, 3 skipped, 90.7% (gate 80%) ✓

## Distribution (per plan — after this merges)
Cherry-pick the wrapper onto `feat/f9`, `feat/f8`, `feat/f7` (full); a transport-only variant onto `feat/f6`, `feat/f5`; skip `feat/f2–f4` (no CLI/auth).

## Edge cases covered / Deviations / Risks
- Deviations: factored a shared `_ask` helper in TtyPrompter (DRY); e2e timeout uses stdlib `asyncio.timeout` (not transitive `anyio`); passes downstream call-log path as an argv (robust) instead of env.
- Risks: e2e is a subprocess test (30s timeout, deselectable); real `_open_tty` device-open branch is uncovered by design (needs a physical terminal).