### PR TITLE
chore(release): publish to PyPI as doberman-core via Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,68 @@
+name: Publish
+
+# Publishing uses PyPI Trusted Publishing (OIDC) — there are NO API tokens stored
+# in this repo. PyPI/TestPyPI are configured to trust this repo + workflow + the
+# GitHub Environments named below. See RELEASING.md for the one-time setup.
+on:
+  release:
+    types: [published]     # tag a GitHub Release -> publish to PyPI
+  workflow_dispatch: {}    # manual run -> dry-run publish to TestPyPI
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip build
+      - run: python -m build
+      - name: Check distribution metadata
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  pypi-publish:
+    name: Publish to PyPI
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/doberman-core
+    permissions:
+      id-token: write     # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  testpypi-publish:
+    name: Publish to TestPyPI (dry run)
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/doberman-core
+    permissions:
+      id-token: write     # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -121,7 +121,15 @@ Doberman: PASS
 
 ### 1. Install
 
-> ⚠️ Not yet published to PyPI (the `doberman` name there belongs to an unrelated project — do **not** `pip install doberman`). Install from source:
+```bash
+pip install doberman-core
+```
+
+> The distribution is **`doberman-core`** (the bare `doberman` name on PyPI belongs to an
+> unrelated, abandoned project). The import name and CLI are unchanged — after install you
+> still `import doberman` and run the `doberman` command.
+
+Or install the latest from source:
 
 ```bash
 pip install git+https://github.com/fu351/Doberman-Core.git
@@ -135,7 +143,7 @@ cd Doberman-Core
 pip install -e ".[dev]"
 ```
 
-Either way you get the `doberman` CLI on your PATH.
+Either way you get the `doberman` CLI on your PATH. (Maintainers: see [`RELEASING.md`](RELEASING.md).)
 
 ### 2. Wrap your tool server with Doberman
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,95 @@
+# Releasing `doberman-core`
+
+Doberman publishes to PyPI as the distribution **`doberman-core`**. The *import* name
+and CLI command stay `doberman` (`import doberman`, `doberman --help`) — only the
+`pip install` command differs.
+
+> Why not `doberman`? That name is already taken on PyPI by an unrelated, abandoned
+> 2020 project. See "Claiming the `doberman` name" at the bottom.
+
+Releasing uses **PyPI Trusted Publishing (OIDC)** via
+`.github/workflows/publish.yml` — there are **no API tokens** stored in this repo.
+
+---
+
+## One-time setup (do this once, requires your PyPI account)
+
+You configure PyPI/TestPyPI to trust this repo. Because the project doesn't exist on
+PyPI yet, you register a **pending publisher** so the very first upload works over OIDC.
+
+### 1. PyPI (production)
+1. Log in at <https://pypi.org> → **Account settings → Publishing** →
+   **Add a pending publisher**.
+2. Fill in:
+   - **PyPI project name:** `doberman-core`
+   - **Owner:** `fu351`
+   - **Repository name:** `Doberman-Core`
+   - **Workflow name:** `publish.yml`
+   - **Environment name:** `pypi`
+3. Save.
+
+### 2. TestPyPI (optional but recommended for dry-runs)
+Repeat the same at <https://test.pypi.org> with **Environment name:** `testpypi`.
+
+### 3. GitHub Environments
+In the repo: **Settings → Environments** → create `pypi` and `testpypi`
+(names must match the workflow). Optionally add protection rules / required reviewers
+to `pypi` so a human approves every production publish.
+
+---
+
+## Cut a release
+
+1. Bump `version` in `pyproject.toml` (follow semver; the changelog/README should
+   reflect what changed).
+2. Commit + merge to `main`.
+3. (Optional dry-run) GitHub → **Actions → Publish → Run workflow** on `main`.
+   This builds + uploads to **TestPyPI**. Verify:
+   ```bash
+   pip install -i https://test.pypi.org/simple/ \
+       --extra-index-url https://pypi.org/simple/ doberman-core
+   ```
+4. Create a **GitHub Release** with tag `vX.Y.Z` (matching the version).
+   Publishing the release triggers the workflow's `pypi-publish` job → uploads to PyPI.
+5. Verify from a clean environment:
+   ```bash
+   python -m venv /tmp/dob && /tmp/dob/bin/pip install doberman-core
+   /tmp/dob/bin/doberman --help
+   ```
+
+---
+
+## Local build / inspect (sanity check before tagging)
+
+```bash
+python -m pip install --upgrade build twine
+python -m build                 # -> dist/doberman_core-X.Y.Z-py3-none-any.whl + .tar.gz
+twine check dist/*
+# Public-release safety: confirm NOTHING local leaks into the artifacts.
+unzip -l dist/*.whl
+tar tzf dist/*.tar.gz
+```
+The sdist file list is pinned in `pyproject.toml`
+(`[tool.hatch.build.targets.sdist]`) to `src/doberman`, `tests`, `README.md`,
+`LICENSE`, `pyproject.toml` — so `graphify-out/`, `.doberman/`, DBs, keys, and dev
+plan files can never be shipped.
+
+---
+
+## Claiming the `doberman` name (PEP 541)
+
+To eventually offer `pip install doberman`, the abandoned PyPI name must be
+transferred to you. It's a manual, human-reviewed process and not guaranteed.
+
+1. **Contact the current owner first.** Email the maintainer listed on
+   <https://pypi.org/project/doberman/> and ask if they'll transfer the name.
+   Keep the message for your records.
+2. **If no response / they agree,** file a name request under PEP 541 at
+   <https://github.com/pypi/support/issues> (choose the project-name-related
+   template). Note the project is abandoned (last release 0.0.4, Sept 2020),
+   link this repo as evidence of active intended use, and reference any prior
+   contact attempt.
+3. If granted, add `doberman` as the distribution name (or publish a thin
+   `doberman` package that depends on `doberman-core`) and update install docs.
+
+Until then, `doberman-core` is the canonical install name.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,31 @@
 [project]
-name = "doberman"
+name = "doberman-core"
 version = "0.11.0"
 description = "Adaptive authorization layer for coding agents (open core)"
-license = { text = "Apache-2.0" }
+readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.11"
+authors = [{ name = "fu351" }]
+keywords = [
+    "security",
+    "authorization",
+    "ai-agents",
+    "llm",
+    "mcp",
+    "guardrails",
+    "agent-security",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security",
+    "Topic :: Software Development :: Quality Assurance",
+]
 dependencies = ["pydantic>=2", "mcp>=1.27,<2", "aiosqlite", "pyotp", "pyyaml", "typer"]
 
 [project.optional-dependencies]
@@ -12,12 +34,28 @@ dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter"]
 [project.scripts]
 doberman = "doberman.cli.main:app"
 
+[project.urls]
+Homepage = "https://github.com/fu351/Doberman-Core"
+Repository = "https://github.com/fu351/Doberman-Core"
+Issues = "https://github.com/fu351/Doberman-Core/issues"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/doberman"]
+
+# Lock down exactly what ships in the sdist so no local/runtime files (graphify-out,
+# .doberman/, *.db, key files, dev plans) can ever leak into a published artifact.
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/doberman",
+    "tests",
+    "README.md",
+    "LICENSE",
+    "pyproject.toml",
+]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Slice
- Feature / Slice: chore — PyPI publishing setup
- Plan reference: ad-hoc release chore (no F* slice)

## What this PR does
Makes the package installable from PyPI. The bare `doberman` name on PyPI is taken by an unrelated, abandoned 2020 project, so the distribution publishes as **`doberman-core`** — the import name (`import doberman`) and CLI command (`doberman`) are unchanged.

- **pyproject.toml**: rename distribution `doberman` → `doberman-core`; add `readme`, `authors`, `[project.urls]`, `keywords`, `classifiers`; modernize license to SPDX (`license = "Apache-2.0"` + `license-files`); pin the sdist file list (`[tool.hatch.build.targets.sdist]`) to `src/doberman`, `tests`, `README.md`, `LICENSE`, `pyproject.toml`.
- **.github/workflows/publish.yml**: PyPI **Trusted Publishing** (OIDC, no stored tokens) — publishes to PyPI on a GitHub Release, and to TestPyPI on manual `workflow_dispatch` for dry runs.
- **RELEASING.md**: one-time pending-publisher setup, release steps, local build/inspect, and the PEP 541 playbook for claiming the `doberman` name.
- **README.md**: real `pip install doberman-core` instructions.

## Tests added (run in CI)
- None (packaging-only change; no runtime behavior). Verified locally instead:
  - `python -m build` → sdist + wheel built
  - `twine check dist/*` → PASSED (both artifacts)
  - sdist contents audited — only `src/doberman` + `tests` + LICENSE/README/pyproject; no `graphify-out/`, `.doberman/`, DBs, keys, or plan files
  - clean-venv `pip install` of the wheel → `import doberman` OK, `doberman --help` runs, distribution reports `doberman-core 0.11.0`
  - `ruff check` / `ruff format --check` clean, `lint-imports` → 2 contracts kept

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed
- [x] sdist file list pinned so no local/runtime files can be shipped

## Security checklist
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] No long-lived PyPI API tokens stored (Trusted Publishing / OIDC)
- [x] doberman-core does not import doberman_enterprise

## Follow-up (maintainer actions, see RELEASING.md)
- Register the pending publisher on PyPI (env `pypi`) and TestPyPI (env `testpypi`)
- Create GitHub Environments `pypi` / `testpypi`
- Tag a GitHub Release `v0.11.0` to trigger the first publish
- (Optional, parallel) Pursue the `doberman` name via PEP 541