### PR TITLE
perf(cli): lazy-import serve entrypoint — CLI cold-start 2.6s → 0.6s

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -13,7 +13,6 @@ import sys
 from datetime import datetime, timezone
 
 import typer
-from mcp import StdioServerParameters
 
 from doberman import __version__
 from doberman.auth import totp
@@ -31,7 +30,6 @@ from doberman.policy.checklist import recommend_policy
 from doberman.policy.drift import read_policy_changes
 from doberman.policy.modes import SecurityMode
 from doberman.policy.preferences import DIMENSIONS, preset_name
-from doberman.proxy.serve import serve_stdio
 from doberman.storage.db import active_elevations, revoke_elevation
 from doberman.storage.log import memory_summary, read_decisions
 
@@ -92,6 +90,14 @@ def serve(
     Point your agent's MCP config at this instead of the real server. AUTH prompts appear on
     your terminal; with no terminal attached (headless) an AUTH action is denied (fail closed).
     """
+    # Imported here, not at module scope, so non-serve CLI commands (`--help`,
+    # `log`, `status`, `scan`, …) don't pay the cost of loading the subjective
+    # layer's heavy numeric stack (river/numpy/scipy) on every invocation. These
+    # imports run synchronously, before asyncio.run, so nothing loads in-loop.
+    from mcp import StdioServerParameters
+
+    from doberman.proxy.serve import serve_stdio
+
     downstream_argv = list(ctx.args)
     if not downstream_argv:
         typer.echo("error: provide the downstream server command after `--`", err=True)

--- a/tests/unit/test_cli_startup.py
+++ b/tests/unit/test_cli_startup.py
@@ -22,7 +22,9 @@ def test_cli_import_does_not_pull_the_heavy_numeric_stack():
         "print(','.join(heavy)); "
         "sys.exit(1 if heavy else 0)"
     )
-    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    result = subprocess.run(  # noqa: S603 — controlled call: our own interpreter + a fixed string
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
     assert result.returncode == 0, (
         f"`import doberman.cli.main` pulled the heavy numeric stack: "
         f"{result.stdout.strip()!r} (stderr: {result.stderr.strip()!r})"

--- a/tests/unit/test_cli_startup.py
+++ b/tests/unit/test_cli_startup.py
@@ -1,0 +1,29 @@
+"""Cold-start guard: the CLI must not pull the heavy numeric stack on import.
+
+`doberman --help` / `log` / `status` / `scan` and the rest of the CLI only need
+Typer + the policy/storage/discovery modules. The subjective layer's numeric
+stack (``river`` → ``numpy`` / ``scipy``) is needed ONLY by ``doberman serve``.
+Importing it on every CLI invocation added ~2.6s of cold-start latency, so the
+serve entrypoint must be imported lazily (inside the ``serve`` command body).
+
+The assertion runs in a CLEAN subprocess: other tests in this process may have
+already imported the heavy modules, so an in-process check would be unreliable.
+"""
+
+import subprocess
+import sys
+
+
+def test_cli_import_does_not_pull_the_heavy_numeric_stack():
+    code = (
+        "import doberman.cli.main, sys; "
+        "heavy = sorted(m for m in sys.modules if m.split('.')[0] in "
+        "('river', 'scipy', 'numpy')); "
+        "print(','.join(heavy)); "
+        "sys.exit(1 if heavy else 0)"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, (
+        f"`import doberman.cli.main` pulled the heavy numeric stack: "
+        f"{result.stdout.strip()!r} (stderr: {result.stderr.strip()!r})"
+    )

--- a/tests/unit/test_serve.py
+++ b/tests/unit/test_serve.py
@@ -51,7 +51,7 @@ def test_missing_downstream_command_exits_2(monkeypatch):
         nonlocal called
         called = True
 
-    monkeypatch.setattr(cli, "serve_stdio", _spy)
+    monkeypatch.setattr(serve_mod, "serve_stdio", _spy)
     result = runner.invoke(cli.app, ["serve"])
     assert result.exit_code == 2
     assert not called
@@ -64,7 +64,7 @@ def test_builds_stdio_params_from_argv(monkeypatch, _no_logging_mutation):
         seen["params"] = params
         seen["repo_root"] = repo_root
 
-    monkeypatch.setattr(cli, "serve_stdio", _spy)
+    monkeypatch.setattr(serve_mod, "serve_stdio", _spy)
     result = runner.invoke(cli.app, ["serve", "--", "mytool", "a", "b"])
     assert result.exit_code == 0
     assert result.output == ""  # nothing on stdout — that is the agent's MCP channel
@@ -79,7 +79,7 @@ def test_path_option_threads_repo_root(monkeypatch, _no_logging_mutation):
     async def _spy(params, *, repo_root):
         seen["repo_root"] = repo_root
 
-    monkeypatch.setattr(cli, "serve_stdio", _spy)
+    monkeypatch.setattr(serve_mod, "serve_stdio", _spy)
     result = runner.invoke(cli.app, ["serve", "-p", "/repo", "--", "mytool"])
     assert result.exit_code == 0
     assert seen["repo_root"] == "/repo"
@@ -91,7 +91,7 @@ def test_serve_reports_downstream_failure_cleanly(monkeypatch, _no_logging_mutat
     async def _boom(*_a, **_k):
         raise RuntimeError("downstream boom")
 
-    monkeypatch.setattr(cli, "serve_stdio", _boom)
+    monkeypatch.setattr(serve_mod, "serve_stdio", _boom)
     result = runner.invoke(cli.app, ["serve", "--", "mytool"])
     assert result.exit_code == 1
     assert "doberman serve failed" in result.output


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Type: performance / UX overhead reduction

## What this PR does
`doberman --help` / `log` / `status` / `scan` (every non-`serve` command) cold-started in **~2.66s** because `cli/main.py` imported `serve_stdio` at module scope, which transitively pulls the subjective layer's heavy numeric stack (`river` → `numpy`/`scipy`). Those are only needed by `doberman serve`.

Moved `serve_stdio` + `StdioServerParameters` into the `serve()` command body. They run **synchronously before `asyncio.run`**, so nothing imports inside the event loop — avoiding the in-loop C-extension import deadlock that a *prior* (reverted) attempt at lazy-importing inside the SL functions hit. **Cold start: ~2.66s → ~0.64s (4×).** Runtime `serve` behavior is unchanged (it loads the full stack when invoked).

## Tests added (run in CI)
- `tests/unit/test_cli_startup.py` — asserts `import doberman.cli.main` loads **no** `river`/`numpy`/`scipy` (subprocess, clean interpreter — RED before the fix, GREEN after).
- `tests/unit/test_serve.py` — 4 `serve_stdio` monkeypatches repointed to the source module (`doberman.proxy.serve`) so the local import in `serve()` resolves the patched function. All serve tests pass.

TDD: RED checkpoint `647ed78`, GREEN checkpoint `6bcdd65`. ruff + format clean, import-linter 2/2 kept.

## Security checklist
- [x] No behavior change to the decision path; `serve` still loads everything at startup
- [x] No secret/file/prompt logged or committed
- [x] doberman-core does not import doberman_enterprise

## Risks
- Minimal: a CLI command that needs `serve_stdio` at module scope would break — grep confirms `serve()` is the only user.