### PR TITLE
feat(hosthooks): Claude Code PostToolUse output-scan + local history (HK.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,12 +204,20 @@ The proxy above protects the tools you route *through* Doberman. To make Doberma
         "matcher": "Bash|Edit|Write|NotebookEdit|WebFetch|WebSearch|mcp__.*",
         "hooks": [{ "type": "command", "command": "doberman hook pre" }]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|NotebookEdit|WebFetch|WebSearch|Read|Glob|Grep|mcp__.*",
+        "hooks": [{ "type": "command", "command": "doberman hook post" }]
+      }
     ]
   }
 }
 ```
 
-`doberman hook pre` reads the tool call on stdin, runs Doberman's deterministic **objective floor** (path confinement, destructive commands, external-destination & secret-exfil, smuggled-token channels), and returns a decision: a routine action passes silently (Doberman is raise-only — it never strips the harness's own prompts), a sensitive one prompts you (`ask`), and a dangerous one is blocked (`deny`) with a redaction-safe reason. It **fails closed** and is import-light, so it adds minimal latency to each call. Pure reads aren't gated here — their *output* is scanned by a post-tool hook (on the roadmap).
+`doberman hook pre` reads the tool call on stdin, runs Doberman's deterministic **objective floor** (path confinement, destructive commands, external-destination & secret-exfil, smuggled-token channels), and returns a decision: a routine action passes silently (Doberman is raise-only — it never strips the harness's own prompts), a sensitive one prompts you (`ask`), and a dangerous one is blocked (`deny`) with a redaction-safe reason.
+
+`doberman hook post` runs *after* a tool executes: it scans the tool's **output** for credential-like material — so a `Read`/`Bash`/MCP call that *returns* a secret is **blocked from reaching the model** (the secret is never echoed) — and records each call in a local, redacted decision history (groundwork for cross-call multi-step-injection defense). Both handlers **fail closed** and are import-light, so they add minimal latency to each call.
 
 > One-command onboarding — `doberman setup`, an interactive wizard that sets your alertness/guardrails and wires these hooks for you — is the next slice; for now, paste the snippet above. The adaptive per-entity layer over the hook path arrives with the warm-daemon slice.
 
@@ -296,8 +304,8 @@ Set a mode in `.doberman/policies.yaml` or via `doberman policy set-mode <mode>`
 
 - ✅ Tool mediation · decision engine · objective guardrail (paths, commands, destinations, secrets, **smuggled-token channels**) · subjective guardrail (adaptive behavioral baselines, **OOD/homoglyph token signals**) · roles & boundaries · capability discovery · tiered auth (confirm → TOTP → scoped elevation) · audit log · policy-drift & poisoning defense · universal subjective layer (SL1–SL9) · turn gate (pre-inference prompt-injection screening)
 - ✅ Benchmark harness (suite-agnostic ASR/FPR over labeled actions; `builtins_only` vs `with_plugins`; deterministic synthetic gate; external-suite adapters via `tests/benchmarks/`)
-- ✅ Host-harness integration: Claude Code `PreToolUse` hook (`doberman hook pre`) gates every built-in *and* MCP tool call with no MCP reconfig — fail-closed, import-light
-- 📋 Host-harness, continued: `PostToolUse` output scan/redaction · one-command `doberman setup` onboarding · cross-call multi-step prompt-injection floor over a local history
+- ✅ Host-harness integration: Claude Code `PreToolUse` + `PostToolUse` hooks (`doberman hook pre`/`post`) gate every built-in *and* MCP tool call — and scan tool **output** for leaked secrets — with no MCP reconfig; fail-closed, import-light, and recording a local redacted history
+- 📋 Host-harness, continued: one-command `doberman setup` onboarding · `install-hooks` · cross-call multi-step prompt-injection floor over the local history
 - 📋 Cost observability (`CostEvent` meter + raise-only loop-anomaly detection)
 - 📋 Enterprise platform: centralized control plane, dashboards, org policy, SSO/RBAC
 

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -289,6 +289,34 @@ def hook_pre() -> None:
     raise typer.Exit(0)
 
 
+@hook_app.command("post")
+def hook_post() -> None:
+    """Claude Code PostToolUse hook — scan tool output for secrets; record history.
+
+    Reads the harness hook payload as JSON on stdin.  If the tool output
+    contains credential-like material, writes ``{"decision":"block","reason":"…"}``
+    to stdout (exit 0) so Claude never uses the tainted result.  On a clean
+    output (or a non-gated / internal tool) nothing is written to stdout.
+
+    History is best-effort: the call is always recorded in the local decision
+    log when the tool is a gated built-in or an MCP tool, but a history write
+    failure never blocks or raises.
+
+    Runs only the fast deterministic objective floor (no numpy/scipy/river),
+    fails closed on any malformed input or engine error.
+
+    Wire it into Claude Code's settings (a later slice adds `doberman
+    install-hooks` to do this for you).
+    """
+    _configure_stderr_logging()
+    from doberman.hosthooks.claude_code import run_post_hook
+
+    out = run_post_hook(sys.stdin.read())
+    if out is not None:
+        sys.stdout.write(out + "\n")
+    raise typer.Exit(0)
+
+
 @twofa_app.command("setup")
 def twofa_setup(
     force: bool = typer.Option(

--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -17,13 +17,22 @@ denies the call — if we cannot identify an action, we refuse it. The reason te
 is built only from ``Decision.explanation`` + ``reason_codes`` (already
 redaction-safe); no raw argument value is ever echoed back to the agent.
 
-**Speed.** A ``PreToolUse`` hook runs before *every* tool call, so this module
-imports only the light decision path (``normalize`` + the objective guardrail +
-``decide``). It must NEVER import :mod:`doberman.proxy.executor` or the subjective
-baseline — those pull ``numpy``/``scipy``/``river`` at module scope (~2s), which
-would be paid on every single tool call. The fast, deterministic floor here is
-the "objective floor"; the adaptive per-entity layer is a separate, warm-process
-slice.
+**PostToolUse hook (HK.2).** After a tool completes, Claude Code delivers the
+tool response on stdin. ``doberman hook post`` scans the output for secret
+material and records the decision in the local decision history.  If the output
+contains credential-like content it returns ``{"decision":"block","reason":"…"}``
+(exit 0) so Claude never uses that tainted result.  Non-security-relevant tools
+(internal tools such as TodoWrite) return no output (abstain).  The history write
+is best-effort and is wrapped in a broad except so it can **never** block or
+raise.
+
+**Speed.** A ``PreToolUse``/``PostToolUse`` hook runs before or after *every*
+tool call, so this module imports only the light decision path (``normalize`` +
+the objective guardrail + ``decide``). It must NEVER import
+:mod:`doberman.proxy.executor` or the subjective baseline — those pull
+``numpy``/``scipy``/``river`` at module scope (~2s), which would be paid on every
+single tool call. The fast, deterministic floor here is the "objective floor"; the
+adaptive per-entity layer is a separate, warm-process slice.
 """
 
 from __future__ import annotations
@@ -193,4 +202,171 @@ def run_pre_hook(stdin_text: str) -> str | None:
     if not isinstance(payload, dict):
         return json.dumps(_deny())
     out = evaluate_pre(payload)
+    return json.dumps(out) if out is not None else None
+
+
+# ---------------------------------------------------------------------------
+# PostToolUse hook (HK.2)
+# ---------------------------------------------------------------------------
+
+#: Tools whose *output* we scan after execution.  Pure-read built-ins (Read,
+#: Glob, Grep) are included here — their output may contain secrets even though
+#: their *invocation* is safe.  The set is GATED_BUILTINS ∪ {Read, Glob, Grep};
+#: all ``mcp__*`` tools are also gated (matched dynamically in evaluate_post).
+_POST_GATED_BUILTINS: frozenset[str] = GATED_BUILTINS | frozenset({"Read", "Glob", "Grep"})
+
+#: Internal / meta tools whose output we never scan.  Their responses are
+#: harness-internal state (todo lists, task results) — not real-resource output.
+_INTERNAL_TOOLS: frozenset[str] = frozenset(
+    {"TodoWrite", "TodoRead", "Task", "ExitPlanMode", "Artifact", "NotebookRead"}
+)
+
+_POST_FAILSAFE_REASON = "Doberman: failing closed — could not vet this tool output."
+_POST_REASON = (
+    "Doberman [post]: output contains credential-like material "
+    "({reasons}; action {action_id}).  Explanation: {explanation}"
+)
+_SECRET_REASON_CODES = frozenset({"secret_exfiltration", "sensitive_secret_access"})
+
+
+def _coerce_response_text(tool_response: Any) -> str:
+    """Coerce ``tool_response`` (str, dict, list, …) to a single flat string.
+
+    Never raises.  JSON-dumps non-string values so the secret scanner can look
+    inside nested structures without recursive logic of its own.
+    """
+    if isinstance(tool_response, str):
+        return tool_response
+    try:
+        return json.dumps(tool_response, ensure_ascii=False)
+    except Exception:  # noqa: BLE001 — best-effort coercion
+        try:
+            return str(tool_response)
+        except Exception:  # noqa: BLE001
+            return ""
+
+
+def _post_block(reason: str) -> dict[str, Any]:
+    """PostToolUse block response: ``{"decision":"block","reason":"…"}``."""
+    return {"decision": "block", "reason": reason}
+
+
+def evaluate_post(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Decide one ``PostToolUse`` call.
+
+    Returns a block dict if the tool output contains secret material, or
+    ``None`` to abstain (non-gated tool or clean output).  NEVER raises —
+    any unhandled failure in the *security check* path returns a fail-closed
+    block; failures in the *history* path are swallowed silently.
+
+    Security check (fail-closed):
+        Build a synthetic ``SecurityObject`` whose ``metadata["raw_arguments"]``
+        contains the coerced tool output, run ``ObjectiveGuardrail``.  If a
+        secret reason code fires, return a block whose reason is built only from
+        the guardrail explanation + reason-code names (never the output text).
+
+    History (best-effort, swallowed):
+        Normalize the call, run ``decide``, and ``await record_decision``.
+        Wrapped in a broad except so it can never affect the return value.
+    """
+    try:
+        tool_name = payload.get("tool_name")
+        if not isinstance(tool_name, str) or not tool_name:
+            # No identifiable tool — fail closed.
+            return _post_block(_POST_FAILSAFE_REASON)
+
+        # Internal / meta tools produce harness-internal state, not resource
+        # output — abstain entirely (no scan, no history).
+        if tool_name in _INTERNAL_TOOLS:
+            return None
+
+        # Gate: only scan output for gated built-ins and mcp__ tools.
+        is_mcp = tool_name.startswith("mcp__")
+        if not is_mcp and tool_name not in _POST_GATED_BUILTINS:
+            return None
+
+        cwd = payload.get("cwd")
+        repo_root = cwd if isinstance(cwd, str) and cwd else "."
+
+        # --- Security scan (fail closed on any exception) --------------------
+        try:
+            tool_response = payload.get("tool_response", "")
+            output_text = _coerce_response_text(tool_response)
+
+            raw_input = payload.get("tool_input")
+            tool_input = raw_input if isinstance(raw_input, dict) else {}
+            canonical, args = to_normalize_input(tool_name, tool_input)
+            # Build a synthetic action whose raw_arguments expose the tool
+            # output so the secret rule can scan it. The output text is
+            # under "tool_output" — never under a key that normalize would
+            # publish as the action target.
+            scan_args = dict(args)
+            scan_args["tool_output"] = output_text
+
+            action = normalize(canonical, scan_args)
+            ctx = EvalContext(
+                role=None,
+                mode=load_mode(repo_root),
+                metadata={"raw_arguments": scan_args, "repo_root": repo_root},
+            )
+
+            scan_result = ObjectiveGuardrail().evaluate(action, ctx)
+            fired_codes = {rc.value for rc in scan_result.reason_codes}
+
+            if fired_codes & _SECRET_REASON_CODES:
+                reason = _POST_REASON.format(
+                    reasons=", ".join(sorted(fired_codes & _SECRET_REASON_CODES)),
+                    action_id=action.id,
+                    explanation=(scan_result.explanation or "").strip() or "no further detail",
+                )
+                return _post_block(reason)
+
+        except Exception:  # noqa: BLE001 — scan failure → fail closed
+            return _post_block(_POST_FAILSAFE_REASON)
+
+        # --- History (best-effort, never raises, never blocks) ---------------
+        _record_post_history(tool_name, tool_input, repo_root)
+
+        return None  # clean output — abstain
+
+    except Exception:  # noqa: BLE001 — outer guard: fail closed
+        return _post_block(_POST_FAILSAFE_REASON)
+
+
+def _record_post_history(tool_name: str, tool_input: dict[str, Any], repo_root: str) -> None:
+    """Best-effort: normalize + decide + record_decision for history.
+
+    Wrapped in a broad except — must never raise or affect any verdict.
+    """
+    import asyncio  # lazy import keeps the module scope light
+
+    from doberman.storage.log import record_decision  # lazy import
+
+    try:
+        canonical, args = to_normalize_input(tool_name, tool_input)
+        action = normalize(canonical, args)
+        ctx = EvalContext(
+            role=None,
+            mode=load_mode(repo_root),
+            metadata={"raw_arguments": args, "repo_root": repo_root},
+        )
+        decision = decide(action, ObjectiveGuardrail(), PASS_STUB, ctx)
+        asyncio.run(record_decision(decision, action, repo_root=repo_root, auth_result="executed"))
+    except Exception:  # noqa: BLE001,S110 — history must never break the execution path
+        pass
+
+
+def run_post_hook(stdin_text: str) -> str | None:
+    """Parse the PostToolUse stdin, evaluate the tool output, and return the
+    JSON decision string — or ``None`` to abstain (print nothing).
+
+    An unparseable payload or a non-object payload fails closed (block).
+    """
+    try:
+        payload = json.loads(stdin_text)
+    except Exception:  # noqa: BLE001 — unparseable input fails closed
+        return json.dumps(_post_block(_POST_FAILSAFE_REASON))
+    if not isinstance(payload, dict):
+        return json.dumps(_post_block(_POST_FAILSAFE_REASON))
+    out = evaluate_post(payload)
     return json.dumps(out) if out is not None else None

--- a/tests/unit/test_hosthook_claude_post.py
+++ b/tests/unit/test_hosthook_claude_post.py
@@ -1,0 +1,268 @@
+"""Unit tests for the Claude Code PostToolUse host-hook adapter (Feature HK.2).
+
+Covers output-scanning for secret material (string and dict responses), the
+fail-closed behaviour on bad input, the internal-tool abstain rule, the
+history-recording guarantee, redaction safety (secret never in block reason),
+and the hot-path weight guarantee (river/numpy/scipy must not load).
+"""
+
+import asyncio
+import json
+import subprocess
+import sys
+
+import pytest
+
+from doberman.hosthooks.claude_code import evaluate_post, run_post_hook
+from doberman.storage.log import read_decisions
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_SYNTHETIC_SECRET = "AKIAIOSFODNN7EXAMPLE"  # noqa: S105 — synthetic test value
+
+
+@pytest.fixture
+def cwd(tmp_path):
+    """An isolated repo root so the test never inherits a real ``.doberman`` policy."""
+    return str(tmp_path)
+
+
+def _post(tool, tool_input, tool_response, cwd_path):
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": tool,
+        "tool_input": tool_input,
+        "tool_response": tool_response,
+        "cwd": cwd_path,
+    }
+    return run_post_hook(json.dumps(payload))
+
+
+# ---------------------------------------------------------------------------
+# Benign output — abstain (return None)
+# ---------------------------------------------------------------------------
+
+
+def test_benign_bash_output_abstains(cwd):
+    out = _post("Bash", {"command": "echo hi"}, "build succeeded", cwd)
+    assert out is None
+
+
+def test_benign_read_output_abstains(cwd):
+    out = _post("Read", {"file_path": "README.md"}, "# Project\nsome docs", cwd)
+    assert out is None
+
+
+def test_benign_grep_output_abstains(cwd):
+    out = _post("Grep", {"pattern": "def main"}, "src/main.py:1:def main():", cwd)
+    assert out is None
+
+
+# ---------------------------------------------------------------------------
+# Secret in tool_response (string) → block; secret never in reason
+# ---------------------------------------------------------------------------
+
+
+def test_secret_string_response_is_blocked(cwd):
+    secret = _SYNTHETIC_SECRET
+    out = _post(
+        "Bash", {"command": "cat ~/.aws/credentials"}, f"[default]\naws_access_key_id={secret}", cwd
+    )
+    assert out is not None
+    data = json.loads(out)
+    assert data["decision"] == "block"
+
+
+def test_secret_string_not_in_block_reason(cwd):
+    secret = _SYNTHETIC_SECRET
+    out = _post("Bash", {"command": "cat ~/.aws/credentials"}, f"found key: {secret}", cwd)
+    assert out is not None
+    # The raw secret must never appear in the agent-visible block reason
+    assert secret not in out
+
+
+# ---------------------------------------------------------------------------
+# Secret in tool_response (dict) → block
+# ---------------------------------------------------------------------------
+
+
+def test_secret_dict_response_is_blocked(cwd):
+    secret = _SYNTHETIC_SECRET
+    response_dict = {"content": f"found: {secret}"}
+    out = _post("Read", {"file_path": ".env"}, response_dict, cwd)
+    assert out is not None
+    data = json.loads(out)
+    assert data["decision"] == "block"
+
+
+def test_secret_dict_response_secret_not_in_reason(cwd):
+    secret = _SYNTHETIC_SECRET
+    response_dict = {"result": secret}
+    out = _post("Read", {"file_path": "secrets.txt"}, response_dict, cwd)
+    assert out is not None
+    assert secret not in out
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_unparseable_stdin_fails_closed():
+    out = run_post_hook("not json at all")
+    assert out is not None
+    data = json.loads(out)
+    assert data["decision"] == "block"
+
+
+def test_non_object_payload_fails_closed():
+    out = run_post_hook(json.dumps([1, 2, 3]))
+    assert out is not None
+    data = json.loads(out)
+    assert data["decision"] == "block"
+
+
+def test_empty_tool_name_fails_closed(cwd):
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "",
+        "tool_input": {},
+        "tool_response": "ok",
+        "cwd": cwd,
+    }
+    out = run_post_hook(json.dumps(payload))
+    assert out is not None
+    data = json.loads(out)
+    assert data["decision"] == "block"
+
+
+# ---------------------------------------------------------------------------
+# Internal tools → abstain (no scan, no history)
+# ---------------------------------------------------------------------------
+
+
+def test_internal_tool_todowrite_abstains(cwd):
+    out = _post("TodoWrite", {"todos": []}, "ok", cwd)
+    assert out is None
+
+
+def test_internal_tool_task_abstains(cwd):
+    out = _post("Task", {"prompt": "do x"}, "done", cwd)
+    assert out is None
+
+
+# ---------------------------------------------------------------------------
+# History: after a post-hook call for a Bash, a decision row is recorded
+# ---------------------------------------------------------------------------
+
+
+def test_history_is_recorded_after_benign_bash(cwd):
+    # A benign Bash call should still record a history row.
+    out = _post("Bash", {"command": "ls -la"}, "total 0", cwd)
+    assert out is None  # benign → no block
+    rows = asyncio.run(read_decisions(cwd))
+    assert len(rows) >= 1
+
+
+def test_history_is_recorded_after_benign_read(cwd):
+    out = _post("Read", {"file_path": "app.py"}, "import sys", cwd)
+    assert out is None
+    rows = asyncio.run(read_decisions(cwd))
+    assert len(rows) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Redaction: secret never appears in the block reason (comprehensive)
+# ---------------------------------------------------------------------------
+
+
+def test_redaction_comprehensive(cwd):
+    """All possible output paths must not echo the secret back to the agent."""
+    secret = _SYNTHETIC_SECRET
+    for tool, tool_input, tool_response in [
+        ("Bash", {"command": "cat file"}, f"key={secret}"),
+        ("Read", {"file_path": ".env"}, {"key": secret}),
+        ("Grep", {"pattern": "secret"}, f"line 1: AWS_KEY={secret}"),
+    ]:
+        out = _post(tool, tool_input, tool_response, cwd)
+        if out is not None:
+            assert secret not in out, f"secret leaked in output for {tool}: {out!r}"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_post API contract
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_post_returns_dict_or_none_for_clean(cwd):
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo hi"},
+        "tool_response": "hi",
+        "cwd": cwd,
+    }
+    result = evaluate_post(payload)
+    assert result is None
+
+
+def test_evaluate_post_returns_dict_for_secret(cwd):
+    secret = _SYNTHETIC_SECRET
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "cat secrets"},
+        "tool_response": f"aws_key={secret}",
+        "cwd": cwd,
+    }
+    result = evaluate_post(payload)
+    assert isinstance(result, dict)
+    assert result.get("decision") == "block"
+
+
+# ---------------------------------------------------------------------------
+# MCP tools are gated (output scanned)
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_tool_with_secret_output_is_blocked(cwd):
+    secret = _SYNTHETIC_SECRET
+    out = _post("mcp__fs__read_file", {"path": "/home/.aws/credentials"}, f"KEY={secret}", cwd)
+    assert out is not None
+    data = json.loads(out)
+    assert data["decision"] == "block"
+
+
+def test_mcp_tool_clean_output_abstains(cwd):
+    out = _post("mcp__fs__list_dir", {"path": "/home"}, ["a", "b", "c"], cwd)
+    assert out is None
+
+
+# ---------------------------------------------------------------------------
+# Hot-path weight (UX guarantee): heavy numeric stack must not load
+# ---------------------------------------------------------------------------
+
+
+def test_post_hook_does_not_load_the_numeric_stack():
+    """A PostToolUse hook runs after EVERY tool call — it must stay light.
+
+    Asserts (in a clean subprocess) that running the post-hook does NOT import
+    river/numpy/scipy (the subjective baseline stack), mirroring the guard in
+    test_hosthook_claude_pre.
+    """
+    code = (
+        "import sys, json;"
+        "from doberman.hosthooks.claude_code import run_post_hook;"
+        "run_post_hook(json.dumps({"
+        "'tool_name':'Bash',"
+        "'tool_input':{'command':'ls'},"
+        "'tool_response':'total 0',"
+        "'cwd':'.',"
+        "}));"
+        "print(','.join(m for m in ('river','numpy','scipy') if m in sys.modules))"
+    )
+    result = subprocess.run(  # noqa: S603 — controlled call: our own interpreter + a fixed string
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "", f"hot path pulled heavy modules: {result.stdout!r}"


### PR DESCRIPTION
## Slice
- Feature / Slice: **HK.2** — Claude Code `PostToolUse` output-scan + local decision history. **Stacked on HK.1 (#32)** — base is the HK.1 branch; review/merge #32 first.

## What this PR does
Adds `doberman hook post`, the PostToolUse half of the host-harness adapter:
- **Output scan (the post-read gate you asked for):** scans a tool's *output* (`tool_response`) for credential-like material via the objective secret detection. If a secret fires → `{"decision":"block","reason":…}` so Claude never ingests the tainted result. The reason carries only reason-code names + the guardrail explanation — **the secret/output is never echoed**.
- **Coverage:** mutating+egress (the pre set) **and** reads (`Read`/`Glob`/`Grep`) **and** `mcp__*` — so outbound/external actions are gated **both** pre and post, and reads get a post output-scan. Internal tools aren't scanned.
- **Local history:** every gated call is recorded (best-effort, fully swallowed) to the redacted decisions log — the substrate for the future cross-call multi-step-injection floor (HK.5).
- **Fail closed:** malformed payload / missing tool name / any scan error → block. History failures never affect the verdict.
- Import-light; mirrors `hook pre` (stderr-logging guard, lazy import, trailing newline).

## Tests added (run in CI)
`tests/unit/test_hosthook_claude_post.py` (20): secret-in-output (string + dict) → block without leaking; benign → abstain; malformed → fail-closed block; internal tools abstain; history recorded; redaction; hot-path no-numeric-stack guard.

## Public-release safety (doberman-core only)
- [x] Nothing from the not-allowed list; core-only public adapter
- [x] Standalone (no enterprise) — guard test green

## Security checklist
- [x] Fails closed on error/uncertainty (verified empirically + by reading every path)
- [x] No secret/output echoed in the block reason or any log (redaction tests cover string + dict outputs)
- [x] Raise-only (block is the safe direction; observability never breaks the path)
- [x] doberman-core does not import doberman_enterprise

## Edge cases / Deviations / Risks
- Uses `decision:block` (the certain PostToolUse primitive) rather than `updatedToolOutput` redaction, which the docs don't reliably confirm — fail-closed by design.
- Known limitation (HK.5 follow-up): a secret-blocked output is not itself written to history (the block is the protection; history is for correlation). Output-scan false positives are a tuning surface, not a correctness bug.
- Reviewed by security-reviewer; verified independently before opening.

Do not merge without peer review.