### PR TITLE
feat(hosthooks): doberman install-hooks / uninstall-hooks (HK.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,18 @@ The proxy above protects the tools you route *through* Doberman. To make Doberma
 
 `doberman hook post` runs *after* a tool executes: it scans the tool's **output** for credential-like material — so a `Read`/`Bash`/MCP call that *returns* a secret is **blocked from reaching the model** (the secret is never echoed) — and records each call in a local, redacted decision history (groundwork for cross-call multi-step-injection defense). Both handlers **fail closed** and are import-light, so they add minimal latency to each call.
 
-> One-command onboarding — `doberman setup`, an interactive wizard that sets your alertness/guardrails and wires these hooks for you — is the next slice; for now, paste the snippet above. The adaptive per-entity layer over the hook path arrives with the warm-daemon slice.
+**Or let Doberman write it for you** — no hand-editing JSON:
+
+```bash
+doberman install-hooks            # writes the snippet above into .claude/settings.json (this project)
+doberman install-hooks --global   # ~/.claude/settings.json (every project)
+doberman install-hooks --dry-run  # show what would change, write nothing
+doberman uninstall-hooks          # remove only Doberman's entries (leaves your other hooks intact)
+```
+
+`install-hooks` is idempotent (safe to re-run), backs up an existing `settings.json` before writing, and never touches your other settings or hooks.
+
+> One-command onboarding — `doberman setup`, an interactive wizard that sets your alertness/guardrails and then runs `install-hooks` for you — is the next slice. The adaptive per-entity layer over the hook path arrives with the warm-daemon slice.
 
 ### 4. Scan (optional)
 

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -425,6 +425,117 @@ def policy_history(
         )
 
 
+@app.command("install-hooks")
+def install_hooks(
+    global_: bool = typer.Option(
+        False, "--global", "-g", help="Install into ~/.claude/settings.json (user-wide)."
+    ),
+    local: bool = typer.Option(
+        False, "--local", help="Install into .claude/settings.local.json (project-local)."
+    ),
+    path: str = typer.Option(".", "--path", "-p", help="Project root (default: current dir)."),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Print what would change; write nothing."
+    ),
+) -> None:
+    """Wire Doberman's PreToolUse and PostToolUse hooks into a Claude Code settings.json.
+
+    Idempotent — safe to run more than once.  Default scope is the project-level
+    ``.claude/settings.json``; use ``--global`` for the user-wide file or
+    ``--local`` for ``.claude/settings.local.json``.
+    """
+    from doberman.hosthooks.install import (
+        load_settings,
+        merge_doberman_hooks,
+        resolve_settings_path,
+        write_settings,
+    )
+
+    scope = "global" if global_ else ("local" if local else "project")
+    settings_path = resolve_settings_path(scope, path)
+
+    try:
+        current = load_settings(settings_path)
+    except ValueError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+    merged = merge_doberman_hooks(current)
+
+    if dry_run:
+        typer.echo(f"[dry-run] target: {settings_path}")
+        typer.echo("[dry-run] would add:")
+        typer.echo("  PreToolUse  → doberman hook pre")
+        typer.echo("  PostToolUse → doberman hook post")
+        return
+
+    write_settings(settings_path, merged)
+    typer.echo(f"wrote {settings_path}")
+    typer.echo("Doberman will now gate every tool call in this project.")
+
+
+@app.command("uninstall-hooks")
+def uninstall_hooks(
+    global_: bool = typer.Option(
+        False, "--global", "-g", help="Remove from ~/.claude/settings.json (user-wide)."
+    ),
+    local: bool = typer.Option(
+        False, "--local", help="Remove from .claude/settings.local.json (project-local)."
+    ),
+    path: str = typer.Option(".", "--path", "-p", help="Project root (default: current dir)."),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Print what would change; write nothing."
+    ),
+) -> None:
+    """Remove Doberman's PreToolUse and PostToolUse hooks from a Claude Code settings.json.
+
+    Idempotent — safe to run even when hooks are not present.  Non-Doberman hooks
+    and every other setting are left untouched.
+    """
+    from doberman.hosthooks.install import (
+        _is_doberman_group,
+        load_settings,
+        remove_doberman_hooks,
+        resolve_settings_path,
+        write_settings,
+    )
+
+    scope = "global" if global_ else ("local" if local else "project")
+    settings_path = resolve_settings_path(scope, path)
+
+    try:
+        current = load_settings(settings_path)
+    except ValueError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+    # Detect whether any Doberman entries exist before removing.
+    hooks_section = current.get("hooks") or {}
+    had_doberman = any(
+        _is_doberman_group(g)
+        for groups in hooks_section.values()
+        if isinstance(groups, list)
+        for g in groups
+    )
+
+    if not had_doberman:
+        typer.echo("No Doberman hooks found — nothing to remove.")
+        return
+
+    cleaned = remove_doberman_hooks(current)
+
+    if dry_run:
+        typer.echo(f"[dry-run] target: {settings_path}")
+        typer.echo("[dry-run] would remove:")
+        typer.echo("  PreToolUse  → doberman hook pre")
+        typer.echo("  PostToolUse → doberman hook post")
+        return
+
+    write_settings(settings_path, cleaned)
+    typer.echo(f"wrote {settings_path}")
+    typer.echo("Doberman hooks removed.")
+
+
 @app.command()
 def version() -> None:
     """Print the installed Doberman version."""

--- a/src/doberman/hosthooks/install.py
+++ b/src/doberman/hosthooks/install.py
@@ -1,0 +1,186 @@
+"""Idempotent install/uninstall of Doberman's Claude Code hooks into a settings.json file.
+
+Pure functions in this module never mutate their inputs (always return new dicts),
+making them straightforward to unit-test without file-system side-effects.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Hook entry constants
+# ---------------------------------------------------------------------------
+
+#: Regex matcher for tools gated by the PreToolUse hook (writes, network, MCP).
+PRE_MATCHER = "Bash|Edit|Write|NotebookEdit|WebFetch|WebSearch|mcp__.*"
+
+#: Command registered as the PreToolUse hook.
+PRE_COMMAND = "doberman hook pre"
+
+#: Regex matcher for tools scanned by the PostToolUse hook (adds reads to the pre set).
+POST_MATCHER = "Bash|Edit|Write|NotebookEdit|WebFetch|WebSearch|Read|Glob|Grep|mcp__.*"
+
+#: Command registered as the PostToolUse hook.
+POST_COMMAND = "doberman hook post"
+
+#: Sentinel substring used to detect Doberman-owned hook entries.
+_DOBERMAN_MARKER = "doberman hook "
+
+_PRE_ENTRY: dict[str, Any] = {
+    "matcher": PRE_MATCHER,
+    "hooks": [{"type": "command", "command": PRE_COMMAND}],
+}
+
+_POST_ENTRY: dict[str, Any] = {
+    "matcher": POST_MATCHER,
+    "hooks": [{"type": "command", "command": POST_COMMAND}],
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_doberman_group(group: dict[str, Any]) -> bool:
+    """Return True if *any* hook command in this matcher group belongs to Doberman."""
+    for h in group.get("hooks", []):
+        cmd = h.get("command", "")
+        if isinstance(cmd, str) and _DOBERMAN_MARKER in cmd:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Pure merge / remove functions
+# ---------------------------------------------------------------------------
+
+
+def merge_doberman_hooks(settings: dict[str, Any]) -> dict[str, Any]:
+    """Return a *new* settings dict with Doberman's PreToolUse and PostToolUse entries added.
+
+    Existing non-Doberman hook entries and every other top-level key are preserved.
+    **Idempotent:** if a Doberman matcher group is already present it is replaced in-place
+    (same position) so that calling this function twice never creates duplicates.
+    """
+    result: dict[str, Any] = copy.deepcopy(settings)
+    hooks: dict[str, Any] = copy.deepcopy(result.get("hooks") or {})
+
+    for event_key, doberman_entry in (
+        ("PreToolUse", _PRE_ENTRY),
+        ("PostToolUse", _POST_ENTRY),
+    ):
+        existing: list[dict[str, Any]] = list(hooks.get(event_key) or [])
+        # Remove any pre-existing Doberman group (idempotency: replace, never duplicate).
+        non_doberman = [g for g in existing if not _is_doberman_group(g)]
+        hooks[event_key] = [*non_doberman, copy.deepcopy(doberman_entry)]
+
+    result["hooks"] = hooks
+    return result
+
+
+def remove_doberman_hooks(settings: dict[str, Any]) -> dict[str, Any]:
+    """Return a *new* settings dict with Doberman's hook entries removed.
+
+    Non-Doberman hook entries and every other top-level key are preserved.
+    Empty lists are dropped; if the ``hooks`` key becomes empty it is removed too.
+    Calling this on a dict that has no Doberman entries is a safe no-op.
+    """
+    result: dict[str, Any] = copy.deepcopy(settings)
+    if "hooks" not in result:
+        return result
+
+    hooks: dict[str, Any] = copy.deepcopy(result["hooks"])
+    cleaned_hooks: dict[str, Any] = {}
+    for event_key, groups in hooks.items():
+        if not isinstance(groups, list):
+            cleaned_hooks[event_key] = groups
+            continue
+        kept = [g for g in groups if not _is_doberman_group(g)]
+        if kept:  # drop empty lists
+            cleaned_hooks[event_key] = kept
+
+    if cleaned_hooks:
+        result["hooks"] = cleaned_hooks
+    else:
+        del result["hooks"]  # drop empty hooks dict
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_settings_path(scope: str, project_root: str) -> Path:
+    """Resolve the target ``settings.json`` path for the given *scope*.
+
+    Args:
+        scope: One of ``"project"`` (default), ``"global"``, or ``"local"``.
+        project_root: Filesystem path to the project root (used for project/local scopes).
+
+    Returns:
+        Resolved :class:`~pathlib.Path` for the settings file.
+
+    Raises:
+        ValueError: If *scope* is not one of the three recognised values.
+    """
+    root = Path(project_root)
+    match scope:
+        case "project":
+            return root / ".claude" / "settings.json"
+        case "global":
+            return Path.home() / ".claude" / "settings.json"
+        case "local":
+            return root / ".claude" / "settings.local.json"
+        case _:
+            raise ValueError(f"Unknown scope {scope!r}; expected 'project', 'global', or 'local'.")
+
+
+# ---------------------------------------------------------------------------
+# File I/O
+# ---------------------------------------------------------------------------
+
+
+def load_settings(path: Path) -> dict[str, Any]:
+    """Load and parse the JSON settings file at *path*.
+
+    Returns an empty dict if the file does not exist.
+
+    Raises:
+        ValueError: If the file exists but cannot be parsed as valid JSON.
+    """
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"Could not parse {path} as JSON: {exc}.  "
+            "Fix or remove the file before running install-hooks."
+        ) from exc
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"{path} is valid JSON but not a settings object (got {type(data).__name__}).  "
+            "Fix or remove the file before running install-hooks."
+        )
+    return data
+
+
+def write_settings(path: Path, settings: dict[str, Any]) -> None:
+    """Write *settings* as pretty JSON to *path*.
+
+    Side-effects (in order):
+    1. Ensures the parent ``.claude/`` directory exists.
+    2. If the file already exists, copies it to ``<path>.bak`` before overwriting.
+    3. Writes the new content with ``indent=2`` and a trailing newline.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        shutil.copy2(path, path.with_suffix(path.suffix + ".bak"))
+    path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")

--- a/tests/unit/test_install_hooks.py
+++ b/tests/unit/test_install_hooks.py
@@ -1,0 +1,397 @@
+"""Unit tests for Feature HK.3 — doberman install-hooks / uninstall-hooks.
+
+Covers:
+- Pure functions in ``doberman.hosthooks.install`` (merge, remove, resolve, load, write).
+- CLI commands ``install-hooks`` and ``uninstall-hooks`` via Typer's CliRunner.
+
+All tests use ``tmp_path``; no real ``~/.claude`` directory is ever touched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import doberman.cli.main as cli_module
+from doberman.hosthooks.install import (
+    POST_COMMAND,
+    POST_MATCHER,
+    PRE_COMMAND,
+    PRE_MATCHER,
+    _is_doberman_group,
+    load_settings,
+    merge_doberman_hooks,
+    remove_doberman_hooks,
+    resolve_settings_path,
+    write_settings,
+)
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_doberman(settings: dict, event_key: str) -> int:
+    """Count Doberman-owned groups in a hook event list."""
+    return sum(1 for g in settings.get("hooks", {}).get(event_key, []) if _is_doberman_group(g))
+
+
+def _pre_commands(settings: dict) -> list[str]:
+    return [
+        h["command"]
+        for g in settings.get("hooks", {}).get("PreToolUse", [])
+        for h in g.get("hooks", [])
+    ]
+
+
+def _post_commands(settings: dict) -> list[str]:
+    return [
+        h["command"]
+        for g in settings.get("hooks", {}).get("PostToolUse", [])
+        for h in g.get("hooks", [])
+    ]
+
+
+# ---------------------------------------------------------------------------
+# merge_doberman_hooks
+# ---------------------------------------------------------------------------
+
+
+class TestMergeDobermanHooks:
+    def test_empty_settings_produces_both_hook_events(self):
+        result = merge_doberman_hooks({})
+        assert "hooks" in result
+        assert PRE_COMMAND in _pre_commands(result)
+        assert POST_COMMAND in _post_commands(result)
+
+    def test_pre_matcher_is_correct(self):
+        result = merge_doberman_hooks({})
+        pre_groups = result["hooks"]["PreToolUse"]
+        doberman_groups = [g for g in pre_groups if _is_doberman_group(g)]
+        assert len(doberman_groups) == 1
+        assert doberman_groups[0]["matcher"] == PRE_MATCHER
+
+    def test_post_matcher_is_correct(self):
+        result = merge_doberman_hooks({})
+        post_groups = result["hooks"]["PostToolUse"]
+        doberman_groups = [g for g in post_groups if _is_doberman_group(g)]
+        assert len(doberman_groups) == 1
+        assert doberman_groups[0]["matcher"] == POST_MATCHER
+
+    def test_preserves_existing_unrelated_key_and_hook(self):
+        existing = {
+            "model": "x",
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher": "Foo", "hooks": [{"type": "command", "command": "other"}]}
+                ]
+            },
+        }
+        result = merge_doberman_hooks(existing)
+        # Top-level key survives.
+        assert result["model"] == "x"
+        # Existing non-Doberman PreToolUse entry survives.
+        pre = result["hooks"]["PreToolUse"]
+        non_dob = [g for g in pre if not _is_doberman_group(g)]
+        assert len(non_dob) == 1
+        assert non_dob[0]["matcher"] == "Foo"
+        assert non_dob[0]["hooks"][0]["command"] == "other"
+        # Doberman entry was added.
+        assert PRE_COMMAND in _pre_commands(result)
+
+    def test_idempotent_no_duplicates(self):
+        once = merge_doberman_hooks({})
+        twice = merge_doberman_hooks(once)
+        # Exactly one Doberman group per event after two merges.
+        assert _count_doberman(twice, "PreToolUse") == 1
+        assert _count_doberman(twice, "PostToolUse") == 1
+
+    def test_does_not_mutate_input(self):
+        original: dict = {}
+        merge_doberman_hooks(original)
+        assert original == {}
+
+    def test_does_not_mutate_nested_input(self):
+        existing = {"hooks": {"PreToolUse": [{"matcher": "Foo", "hooks": []}]}}
+        import copy
+
+        snapshot = copy.deepcopy(existing)
+        merge_doberman_hooks(existing)
+        assert existing == snapshot
+
+
+# ---------------------------------------------------------------------------
+# remove_doberman_hooks
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveDobermanHooks:
+    def _settings_with_both_and_other(self) -> dict:
+        return merge_doberman_hooks(
+            {
+                "model": "x",
+                "hooks": {
+                    "PreToolUse": [
+                        {"matcher": "Foo", "hooks": [{"type": "command", "command": "other"}]}
+                    ]
+                },
+            }
+        )
+
+    def test_removes_only_doberman_entries(self):
+        settings = self._settings_with_both_and_other()
+        result = remove_doberman_hooks(settings)
+        # Non-Doberman PreToolUse "other" survives.
+        pre = result.get("hooks", {}).get("PreToolUse", [])
+        assert any(g.get("matcher") == "Foo" for g in pre)
+        # Doberman entries are gone.
+        assert _count_doberman(result, "PreToolUse") == 0
+        assert _count_doberman(result, "PostToolUse") == 0
+
+    def test_preserves_model_key(self):
+        settings = self._settings_with_both_and_other()
+        result = remove_doberman_hooks(settings)
+        assert result["model"] == "x"
+
+    def test_no_op_when_no_doberman_entries(self):
+        settings = {"model": "y", "hooks": {"PreToolUse": []}}
+        result = remove_doberman_hooks(settings)
+        assert result["model"] == "y"
+
+    def test_drops_empty_hook_event_list(self):
+        settings = merge_doberman_hooks({})
+        result = remove_doberman_hooks(settings)
+        # Both PreToolUse and PostToolUse were only Doberman entries → entire hooks key removed.
+        assert "hooks" not in result
+
+    def test_drops_empty_hooks_dict(self):
+        settings = merge_doberman_hooks({})
+        result = remove_doberman_hooks(settings)
+        assert "hooks" not in result
+
+    def test_does_not_mutate_input(self):
+        settings = merge_doberman_hooks({})
+        import copy
+
+        snapshot = copy.deepcopy(settings)
+        remove_doberman_hooks(settings)
+        assert settings == snapshot
+
+    def test_no_op_on_empty_dict(self):
+        result = remove_doberman_hooks({})
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# resolve_settings_path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSettingsPath:
+    def test_project_scope(self, tmp_path):
+        p = resolve_settings_path("project", str(tmp_path))
+        assert p == tmp_path / ".claude" / "settings.json"
+
+    def test_local_scope(self, tmp_path):
+        p = resolve_settings_path("local", str(tmp_path))
+        assert p == tmp_path / ".claude" / "settings.local.json"
+
+    def test_global_scope_is_home(self, tmp_path):
+        p = resolve_settings_path("global", str(tmp_path))
+        assert p == Path.home() / ".claude" / "settings.json"
+
+    def test_unknown_scope_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="Unknown scope"):
+            resolve_settings_path("invalid", str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# load_settings / write_settings
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSettings:
+    def test_missing_file_returns_empty_dict(self, tmp_path):
+        p = tmp_path / "nonexistent.json"
+        assert load_settings(p) == {}
+
+    def test_valid_json_file_is_parsed(self, tmp_path):
+        p = tmp_path / "settings.json"
+        p.write_text('{"model": "z"}', encoding="utf-8")
+        assert load_settings(p) == {"model": "z"}
+
+    def test_invalid_json_raises_value_error(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("{not: valid json}", encoding="utf-8")
+        with pytest.raises(ValueError, match="Could not parse"):
+            load_settings(p)
+
+
+class TestWriteSettings:
+    def test_creates_dot_claude_directory(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        write_settings(p, {"k": "v"})
+        assert p.exists()
+
+    def test_round_trips_json(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        data = {"hooks": {"PreToolUse": [{"matcher": "X", "hooks": []}]}}
+        write_settings(p, data)
+        assert json.loads(p.read_text(encoding="utf-8")) == data
+
+    def test_trailing_newline(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        write_settings(p, {})
+        assert p.read_text(encoding="utf-8").endswith("\n")
+
+    def test_creates_bak_when_overwriting(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('{"old": true}', encoding="utf-8")
+        write_settings(p, {"new": True})
+        bak = p.with_suffix(".json.bak")
+        assert bak.exists()
+        assert json.loads(bak.read_text(encoding="utf-8")) == {"old": True}
+
+    def test_no_bak_for_new_file(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        write_settings(p, {"x": 1})
+        bak = p.with_suffix(".json.bak")
+        assert not bak.exists()
+
+
+# ---------------------------------------------------------------------------
+# CLI — install-hooks
+# ---------------------------------------------------------------------------
+
+
+class TestInstallHooksCLI:
+    def test_writes_settings_json_with_both_hooks(self, tmp_path):
+        result = runner.invoke(cli_module.app, ["install-hooks", "--path", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        settings_path = tmp_path / ".claude" / "settings.json"
+        assert settings_path.exists()
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert PRE_COMMAND in _pre_commands(data)
+        assert POST_COMMAND in _post_commands(data)
+
+    def test_dry_run_writes_nothing(self, tmp_path):
+        result = runner.invoke(
+            cli_module.app, ["install-hooks", "--path", str(tmp_path), "--dry-run"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "[dry-run]" in result.output
+        settings_path = tmp_path / ".claude" / "settings.json"
+        assert not settings_path.exists()
+
+    def test_dry_run_output_mentions_hooks(self, tmp_path):
+        result = runner.invoke(
+            cli_module.app, ["install-hooks", "--path", str(tmp_path), "--dry-run"]
+        )
+        assert "doberman hook pre" in result.output
+        assert "doberman hook post" in result.output
+
+    def test_install_is_idempotent(self, tmp_path):
+        runner.invoke(cli_module.app, ["install-hooks", "--path", str(tmp_path)])
+        runner.invoke(cli_module.app, ["install-hooks", "--path", str(tmp_path)])
+        settings_path = tmp_path / ".claude" / "settings.json"
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert _count_doberman(data, "PreToolUse") == 1
+        assert _count_doberman(data, "PostToolUse") == 1
+
+    def test_invalid_existing_json_exits_2(self, tmp_path):
+        dot_claude = tmp_path / ".claude"
+        dot_claude.mkdir(parents=True)
+        (dot_claude / "settings.json").write_text("{bad json}", encoding="utf-8")
+        result = runner.invoke(cli_module.app, ["install-hooks", "--path", str(tmp_path)])
+        assert result.exit_code == 2
+
+    def test_output_confirms_written_path(self, tmp_path):
+        result = runner.invoke(cli_module.app, ["install-hooks", "--path", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "settings.json" in result.output
+
+    def test_confirmation_message(self, tmp_path):
+        result = runner.invoke(cli_module.app, ["install-hooks", "--path", str(tmp_path)])
+        assert "Doberman will now gate" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI — uninstall-hooks
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallHooksCLI:
+    def _install(self, tmp_path: Path) -> None:
+        runner.invoke(cli_module.app, ["install-hooks", "--path", str(tmp_path)])
+
+    def test_removes_doberman_hooks(self, tmp_path):
+        self._install(tmp_path)
+        result = runner.invoke(cli_module.app, ["uninstall-hooks", "--path", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        settings_path = tmp_path / ".claude" / "settings.json"
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert _count_doberman(data, "PreToolUse") == 0
+        assert _count_doberman(data, "PostToolUse") == 0
+
+    def test_uninstall_preserves_other_hooks(self, tmp_path):
+        # Manually write a settings file that has both Doberman and a foreign hook.
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True)
+        initial: dict = {
+            "model": "x",
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher": "Foo", "hooks": [{"type": "command", "command": "other"}]}
+                ]
+            },
+        }
+        merged = merge_doberman_hooks(initial)
+        settings_path.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
+
+        result = runner.invoke(cli_module.app, ["uninstall-hooks", "--path", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert data["model"] == "x"
+        pre = data.get("hooks", {}).get("PreToolUse", [])
+        assert any(g.get("matcher") == "Foo" for g in pre)
+        assert _count_doberman(data, "PreToolUse") == 0
+
+    def test_no_doberman_hooks_reports_not_found(self, tmp_path):
+        result = runner.invoke(cli_module.app, ["uninstall-hooks", "--path", str(tmp_path)])
+        assert result.exit_code == 0
+        assert (
+            "nothing to remove" in result.output.lower() or "no doberman" in result.output.lower()
+        )
+
+    def test_dry_run_writes_nothing(self, tmp_path):
+        self._install(tmp_path)
+        settings_path = tmp_path / ".claude" / "settings.json"
+        content_before = settings_path.read_text(encoding="utf-8")
+        result = runner.invoke(
+            cli_module.app, ["uninstall-hooks", "--path", str(tmp_path), "--dry-run"]
+        )
+        assert result.exit_code == 0
+        assert "[dry-run]" in result.output
+        assert settings_path.read_text(encoding="utf-8") == content_before
+
+    def test_creates_bak_on_uninstall(self, tmp_path):
+        self._install(tmp_path)
+        settings_path = tmp_path / ".claude" / "settings.json"
+        runner.invoke(cli_module.app, ["uninstall-hooks", "--path", str(tmp_path)])
+        bak = settings_path.with_suffix(".json.bak")
+        assert bak.exists()
+
+    def test_invalid_existing_json_exits_2(self, tmp_path):
+        dot_claude = tmp_path / ".claude"
+        dot_claude.mkdir(parents=True)
+        (dot_claude / "settings.json").write_text("{bad json}", encoding="utf-8")
+        result = runner.invoke(cli_module.app, ["uninstall-hooks", "--path", str(tmp_path)])
+        assert result.exit_code == 2


### PR DESCRIPTION
## Slice
- Feature / Slice: **HK.3** — `doberman install-hooks` / `uninstall-hooks`. **Stacked on HK.2 (#33)** → HK.1 (#32). Review/merge in order.

## What this PR does
One command to wire Doberman's Claude Code hooks into a `settings.json` — no hand-editing JSON.
- New `hosthooks/install.py`: pure, **immutable** functions (deepcopy; never mutate input — the repo values immutability). `merge_doberman_hooks` is **idempotent** (strips any existing Doberman group, re-adds; preserves every other key + non-Doberman hook). `remove_doberman_hooks` removes only Doberman entries and drops empties. `load_settings` returns `{}` for a missing file but **raises on invalid or non-object JSON** (never silently clobbers). `write_settings` backs up to `.bak` before overwriting.
- CLI: `install-hooks` / `uninstall-hooks` with `--global` / `--local` / `--path` / `--dry-run`. PreToolUse gates mutating+egress+mcp; PostToolUse adds reads. Invalid existing JSON → clean error, exit 2.
- README now shows `doberman install-hooks` instead of a manual paste.

## Tests added (run in CI)
`tests/unit/test_install_hooks.py` (39): merge on empty/with-existing, idempotency, no-mutation, remove-only-Doberman, path resolution, load/write round-trip + backup, non-object-JSON rejected, and CLI-level install/uninstall/dry-run via Typer's CliRunner.

## Security checklist
- [x] Never clobbers an unparseable/non-object settings.json (raises a clean error)
- [x] Backs up before overwriting; preserves all non-Doberman settings + hooks
- [x] Idempotent; immutable pure functions
- [x] doberman-core does not import doberman_enterprise

## Notes
- `uninstall-hooks` imports a module-private `_is_doberman_group` for the pre-check (repo pattern of exposing helpers for tests).
- Reviewed independently (read-through + hardened `load_settings` to reject non-object JSON).

Do not merge without peer review.