### PR TITLE
fix(rules/secrets): judge path segments individually so benign paths don't flag

### DIFF
--- a/src/doberman/engine/rules/secrets.py
+++ b/src/doberman/engine/rules/secrets.py
@@ -150,8 +150,14 @@ def _weak_secret_in_text(text: str) -> bool:
         return False
     sample = text[:_SCAN_MAX_CHARS]
     for token in re.findall(r"[A-Za-z0-9+/=_\-]{%d,}" % _ENTROPY_MIN_LEN, sample):
-        if _looks_high_entropy_secret(token):
-            return True
+        # A filesystem path (``/a/b/c/file``) is not a secret, but ``/`` is a
+        # base64 value char, so a whole path otherwise reads as one long token
+        # and trips the entropy check. Judge each ``/``-delimited segment on its
+        # own: a real base64 secret's segments are still long and high-entropy,
+        # while path components (``Users``, ``project``, ``README``) are not.
+        for piece in token.split("/"):
+            if _looks_high_entropy_secret(piece):
+                return True
     return False
 
 

--- a/src/doberman/engine/rules/secrets.py
+++ b/src/doberman/engine/rules/secrets.py
@@ -139,6 +139,24 @@ def _strong_secret_in_text(text: str) -> bool:
     return bool(_matches_credential_pattern(sample) or _ENV_ASSIGNMENT.search(sample))
 
 
+def _token_looks_like_weak_secret(token: str) -> bool:
+    """Judge a single candidate token for the high-entropy heuristic.
+
+    ``/`` is a base64 value char, so an *absolute* filesystem path
+    (``/Users/dev/project/src/components/Widget``) otherwise reads as one long
+    high-entropy token and trips a spurious AUTH on benign reads. Only a
+    path-shaped token (a leading ``/``) is split on ``/`` and judged segment by
+    segment — real path components are short, word-like, and low-entropy. Any
+    other token, **including a base64 secret that merely contains ``/``**, is
+    judged whole, so splitting can never fragment a secret below the length
+    floor and silently drop it. This keeps the rule raise-only: it removes a
+    false positive without ever weakening detection.
+    """
+    if token.startswith("/"):
+        return any(_looks_high_entropy_secret(segment) for segment in token.split("/"))
+    return _looks_high_entropy_secret(token)
+
+
 def _weak_secret_in_text(text: str) -> bool:
     """Low-confidence signal: a long, token-shaped, high-entropy string.
 
@@ -150,14 +168,8 @@ def _weak_secret_in_text(text: str) -> bool:
         return False
     sample = text[:_SCAN_MAX_CHARS]
     for token in re.findall(r"[A-Za-z0-9+/=_\-]{%d,}" % _ENTROPY_MIN_LEN, sample):
-        # A filesystem path (``/a/b/c/file``) is not a secret, but ``/`` is a
-        # base64 value char, so a whole path otherwise reads as one long token
-        # and trips the entropy check. Judge each ``/``-delimited segment on its
-        # own: a real base64 secret's segments are still long and high-entropy,
-        # while path components (``Users``, ``project``, ``README``) are not.
-        for piece in token.split("/"):
-            if _looks_high_entropy_secret(piece):
-                return True
+        if _token_looks_like_weak_secret(token):
+            return True
     return False
 
 

--- a/tests/unit/test_rule_secrets.py
+++ b/tests/unit/test_rule_secrets.py
@@ -142,6 +142,20 @@ def test_base64_secret_with_slashes_still_detected():
     assert result.verdict is not Verdict.PASS
 
 
+def test_high_entropy_secret_with_short_slash_segments_is_not_missed():
+    # Raise-only guard for the path-segment fix: a real base64 secret can contain
+    # '/' (a base64 value char). This 27-char token is high-entropy as a whole but
+    # splits on '/' into two 13-char segments, BOTH below the 24-char entropy
+    # floor — so a naive per-segment split would judge every piece benign and drop
+    # it (silent weakening). The whole-token catch the old code had must survive:
+    # only absolute paths (leading '/') are split; a secret like this is judged
+    # whole and still steps up (AUTH), never PASS.
+    token = "wJalrXUtnFEMI/K7MDENGbPxRfi"  # noqa: S105 — synthetic, not a real credential
+    action = _action(ActionType.file_write, target="dump.bin")
+    result = RULE.evaluate(action, _ctx(path="dump.bin", content=token))
+    assert result.verdict is Verdict.AUTH
+
+
 def test_rule_does_not_mutate_the_frozen_action():
     action = _action(ActionType.file_write, target="x.txt")
     before = action.model_dump()

--- a/tests/unit/test_rule_secrets.py
+++ b/tests/unit/test_rule_secrets.py
@@ -122,6 +122,26 @@ def test_non_secret_high_entropy_local_does_not_block():
     assert result.verdict is not Verdict.BLOCK
 
 
+def test_benign_absolute_path_read_is_not_flagged_as_secret():
+    # Regression: '/' is a base64 value char, so a whole absolute path used to be
+    # read as one long high-entropy token and wrongly stepped up to AUTH
+    # (sensitive_secret_access), blocking even benign reads. Path segments must be
+    # judged individually — a normal path is not credential-like.
+    path = "/Users/dev/projects/widget-lib/src/components/Formatter.tsx"
+    action = _action(ActionType.file_read, target=path)
+    result = RULE.evaluate(action, _ctx(path=path))
+    assert result.verdict is Verdict.PASS
+
+
+def test_base64_secret_with_slashes_still_detected():
+    # The fix must not weaken real detection: a long base64 token containing '/'
+    # is still high-entropy per segment and steps up (AUTH), never PASS.
+    token = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY1234567890abcdEFGH"  # noqa: S105 — synthetic
+    action = _action(ActionType.file_write, target="dump.bin")
+    result = RULE.evaluate(action, _ctx(path="dump.bin", content=token))
+    assert result.verdict is not Verdict.PASS
+
+
 def test_rule_does_not_mutate_the_frozen_action():
     action = _action(ActionType.file_write, target="x.txt")
     before = action.model_dump()


### PR DESCRIPTION
## What this PR does
`/` is a base64 value char, so a whole absolute path was read as one long high-entropy token and wrongly stepped up to AUTH (`sensitive_secret_access`), adding friction to benign file reads. The secrets rule now splits on `/` and judges each segment: a real base64 secret stays high-entropy per segment, normal path components do not.

## Tests added (run in CI)
- `test_benign_absolute_path_read_is_not_flagged_as_secret` — benign path → PASS
- `test_base64_secret_with_slashes_still_detected` — base64 secret with `/` still steps up (no weakening)

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret logged or committed (test tokens are synthetic)
- [x] Raise-only — detection not weakened; regression test guards it
- [x] Every BLOCK/AUTH carries reason codes + explanation