### PR TITLE
feat(benchmarks): add before_after no-guardrail baseline profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,11 @@ That last assertion is the **chokepoint property** the whole project hangs on.
 A suite-agnostic harness scores Doberman as a **filter over labeled actions** and reports **ASR** (attack bypass rate) and **FPR** (benign over-block / friction). It runs the real decision engine over each labeled tool-call — Doberman is the filter, not the agent — so the gated path is deterministic and offline.
 
 ```bash
-python -m tests.benchmarks.run --suite synthetic --profile both
+python -m tests.benchmarks.run --suite synthetic --profile both          # builtins vs plugins
+python -m tests.benchmarks.run --suite synthetic --profile before_after  # without vs with Doberman
 ```
 
-It reports two profiles — `builtins_only` and `with_plugins` (built-ins plus any installed entry-point plugins) — and their uplift. A deterministic synthetic suite gates in CI; map external task suites (**AgentDojo**, AgentDyn, AgentSentry, …) onto core's types with a small adapter — see [`tests/benchmarks/README.md`](tests/benchmarks/README.md).
+It reports two plugin profiles — `builtins_only` and `with_plugins` (built-ins plus any installed entry-point plugins) — and their uplift. The `before_after` profile adds a **no-guardrail baseline** (the unmediated tool path, where every attack executes) so you can read the engine's effect directly as `{before, after, delta}` — how many otherwise-executing attacks it stops vs. how much benign friction it adds. A deterministic synthetic suite gates in CI; map external task suites (**AgentDojo**, AgentDyn, AgentSentry, …) onto core's types with a small adapter — see [`tests/benchmarks/README.md`](tests/benchmarks/README.md).
 
 > Reports hold counts, verdicts, and reason codes only — never payload text. ASR is reported alongside a stricter `asr_strict` (where only a hard `BLOCK` counts as mitigation): honest measurement, not a single headline number.
 

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -44,9 +44,9 @@ it separately and feed the resulting labeled actions in.
 tests/benchmarks/
 ├── adapter.py     # CandidateAction, BenchmarkCase, SuiteAdapter  (the contract)
 ├── mapping.py     # CandidateAction -> SecurityObject / EvalContext
-├── profiles.py    # build_pipeline(load_plugins=...) -> Pipeline
+├── profiles.py    # build_pipeline(load_plugins=...) -> Pipeline; PassthroughPipeline (no-guardrail baseline)
 ├── metrics.py     # SuiteReport: ASR, asr_strict, FPR, hard_fpr
-├── runner.py      # run_suite(adapter, pipeline), run_profiles(adapter)
+├── runner.py      # run_suite, run_profiles (builtins vs plugins), run_before_after (without vs with Doberman)
 ├── run.py         # CLI: python -m tests.benchmarks.run --suite <name> --profile both
 ├── suites/
 │   ├── synthetic.py   # built-in, deterministic, dependency-free (the CI gate)
@@ -139,6 +139,34 @@ identical and uplift is 0 — install a plugin package and the delta shows what 
 adds. (The harness names no specific plugin package; it just measures whatever is
 installed.)
 
+### `no_guardrail` — the "before Doberman" baseline
+
+`run_before_after()` adds a third arm: a **`PassthroughPipeline`** that allows
+every action without consulting the engine. This models the **unmediated tool
+path** — what happens with no guardrail at all. By construction, on a ground-
+truth attack corpus it bypasses every attack (`asr 1.0`) with zero benign
+friction (`fpr 0.0`), so it is the honest *before* against which a real Doberman
+pipeline is the *after*:
+
+```bash
+python -m tests.benchmarks.run --suite synthetic --profile before_after
+```
+
+The report is `{before (no_guardrail), after (builtins_only), delta}`. The
+`delta` is the headline of what the engine changes:
+
+| field | meaning |
+|---|---|
+| `attacks_stopped` | fraction of otherwise-executing attacks now mitigated (BLOCK **or** AUTH) = `before.asr − after.asr` |
+| `attacks_stopped_strict` | same but BLOCK-only counts (AUTH is *not* counted as stopped) |
+| `fpr_added` | benign friction the engine introduces = `after.fpr − before.fpr` |
+| `hard_fpr_added` | benign hard-blocks the engine introduces = `after.hard_fpr − before.hard_fpr` |
+
+`before` is a *trivial* baseline (1.0 by definition) — it is the denominator
+that makes the *after* legible, not an independent measurement. Report it as
+"with no guardrail every one of these N attacks executes," never as a number the
+harness "discovered."
+
 ---
 
 ## Metrics (read `metrics.py` for the exact math)
@@ -168,8 +196,9 @@ serialized report — keep that guarantee for your suite too.
 
 ```bash
 # from the repo root, in the project venv
-python -m tests.benchmarks.run --suite synthetic --profile both     # JSON report
-python -m pytest tests/integration/test_benchmark_synthetic_gate.py  # the gate
+python -m tests.benchmarks.run --suite synthetic --profile both          # builtins vs plugins
+python -m tests.benchmarks.run --suite synthetic --profile before_after  # without vs with Doberman
+python -m pytest tests/integration/test_benchmark_synthetic_gate.py      # the gate
 ```
 
 ---

--- a/tests/benchmarks/profiles.py
+++ b/tests/benchmarks/profiles.py
@@ -20,11 +20,16 @@ from dataclasses import dataclass
 from doberman.engine.decision_engine import Guardrail, decide
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.engine.subjective import SubjectiveGuardrail
-from doberman.models import Decision, EvalContext, SecurityObject
+from doberman.models import Decision, EvalContext, GuardrailResult, Risk, SecurityObject, Verdict
+
+from .mapping import BENCHMARK_TS
 
 #: Profile identifiers used as keys throughout reports.
 BUILTINS_ONLY = "builtins_only"
 WITH_PLUGINS = "with_plugins"
+
+#: The "before Doberman" baseline: no engine on the tool path at all.
+NO_GUARDRAIL = "no_guardrail"
 
 
 @dataclass(frozen=True)
@@ -50,3 +55,33 @@ def build_pipeline(*, load_plugins: bool) -> Pipeline:
         objective=ObjectiveGuardrail(load_plugins=load_plugins),
         subjective=SubjectiveGuardrail(load_plugins=load_plugins),
     )
+
+
+def _allow_decision(action_id: str) -> Decision:
+    """A PASS for any action — models an unmediated tool path (no guardrail)."""
+    return Decision(
+        action_id=action_id,
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=GuardrailResult(verdict=Verdict.PASS, risk=Risk.low),
+        decided_at=BENCHMARK_TS,
+    )
+
+
+@dataclass(frozen=True)
+class PassthroughPipeline:
+    """The "before Doberman" arm: every action is allowed, no engine consulted.
+
+    This is the honest unmediated baseline. With no guardrail on the tool path
+    every candidate action would execute, so every labeled attack bypasses
+    (ASR 1.0) and benign work runs with zero friction (FPR 0.0). The delta of a
+    real Doberman pipeline against this baseline is exactly what the layer adds —
+    attacks stopped vs. benign friction introduced. It conforms to the same
+    ``decide(action, ctx) -> Decision`` shape as :class:`Pipeline` so the runner
+    treats it identically.
+    """
+
+    name: str = NO_GUARDRAIL
+
+    def decide(self, action: SecurityObject, ctx: EvalContext) -> Decision:
+        return _allow_decision(action.id)

--- a/tests/benchmarks/run.py
+++ b/tests/benchmarks/run.py
@@ -16,10 +16,10 @@ import json
 import sys
 
 from .profiles import build_pipeline
-from .runner import run_profiles, run_suite
+from .runner import run_before_after, run_profiles, run_suite
 from .suites import BUILTIN_ADAPTERS
 
-_PROFILES = ("both", "builtins_only", "with_plugins")
+_PROFILES = ("both", "before_after", "builtins_only", "with_plugins")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -41,6 +41,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.profile == "both":
         report: dict = run_profiles(adapter)
+    elif args.profile == "before_after":
+        report = run_before_after(adapter)
     else:
         load_plugins = args.profile == "with_plugins"
         report = run_suite(adapter, build_pipeline(load_plugins=load_plugins)).to_dict()

--- a/tests/benchmarks/runner.py
+++ b/tests/benchmarks/runner.py
@@ -21,7 +21,7 @@ from doberman.models import Decision, EvalContext, SecurityObject
 from .adapter import BenchmarkCase, CandidateAction, SuiteAdapter
 from .mapping import to_eval_context, to_security_object
 from .metrics import ActionOutcome, Bucket, SuiteReport, build_report
-from .profiles import build_pipeline
+from .profiles import PassthroughPipeline, build_pipeline
 
 logger = logging.getLogger("doberman.benchmarks.runner")
 
@@ -115,5 +115,32 @@ def run_profiles(adapter: SuiteAdapter) -> dict:
         "uplift": {
             "delta_asr": round(builtins.asr - with_plugins.asr, 6),
             "delta_fpr": round(with_plugins.fpr - builtins.fpr, 6),
+        },
+    }
+
+
+def run_before_after(adapter: SuiteAdapter, *, load_plugins: bool = False) -> dict:
+    """Run the no-guardrail baseline (**before**) and a real Doberman pipeline
+    (**after**), reporting each plus what the engine changed.
+
+    ``before`` is the unmediated tool path — every action allowed, so on a
+    ground-truth attack corpus ASR is 1.0 and benign FPR is 0.0 by construction.
+    ``after`` is Doberman (built-ins; plus entry-point plugins when
+    ``load_plugins`` is set). The ``delta`` is the headline: ``attacks_stopped``
+    is the fraction of otherwise-executing attacks the engine now mitigates
+    (BLOCK or AUTH), ``attacks_stopped_strict`` counts BLOCK only, and the two
+    ``*_added`` fields are the benign friction the engine introduces.
+    """
+    before = run_suite(adapter, PassthroughPipeline())
+    after = run_suite(adapter, build_pipeline(load_plugins=load_plugins))
+    return {
+        "suite": adapter.suite_name,
+        "before": before.to_dict(),
+        "after": after.to_dict(),
+        "delta": {
+            "attacks_stopped": round(before.asr - after.asr, 6),
+            "attacks_stopped_strict": round(before.asr_strict - after.asr_strict, 6),
+            "fpr_added": round(after.fpr - before.fpr, 6),
+            "hard_fpr_added": round(after.hard_fpr - before.hard_fpr, 6),
         },
     }

--- a/tests/integration/test_benchmark_synthetic_gate.py
+++ b/tests/integration/test_benchmark_synthetic_gate.py
@@ -17,13 +17,18 @@ import json
 
 import pytest
 
-from tests.benchmarks.runner import run_profiles
+from tests.benchmarks.runner import run_before_after, run_profiles
 from tests.benchmarks.suites.synthetic import PAYLOAD_MARKER, SyntheticAdapter
 
 
 @pytest.fixture(scope="module")
 def report() -> dict:
     return run_profiles(SyntheticAdapter())
+
+
+@pytest.fixture(scope="module")
+def before_after() -> dict:
+    return run_before_after(SyntheticAdapter())
 
 
 def test_report_structure(report):
@@ -66,3 +71,41 @@ def test_no_plugins_means_zero_uplift(report):
     # On a standalone core install nothing registers, so the two profiles match.
     assert report["uplift"] == {"delta_asr": 0.0, "delta_fpr": 0.0}
     assert report["builtins_only"] == {**report["with_plugins"], "profile": "builtins_only"}
+
+
+# --- before/after: the no-guardrail baseline vs. the real engine ------------
+def test_before_after_brackets_the_engine_effect(before_after):
+    before, after, delta = (
+        before_after["before"],
+        before_after["after"],
+        before_after["delta"],
+    )
+    assert before["profile"] == "no_guardrail"
+    assert after["profile"] == "builtins_only"
+    # Before: the unmediated path — every synthetic attack would execute, and
+    # benign work runs with zero friction (true by construction of passthrough).
+    assert before["asr"] == 1.0
+    assert before["fpr"] == 0.0
+    assert before["hard_fpr"] == 0.0
+    # After: the real engine mitigates every synthetic attack (none bypasses).
+    assert after["asr"] == 0.0
+    # Delta: Doberman stops 100% of the otherwise-executing attacks and, on this
+    # trusted-host benign set, adds no friction.
+    assert delta["attacks_stopped"] == 1.0
+    assert delta["fpr_added"] == 0.0
+    assert delta["hard_fpr_added"] == 0.0
+    # The strict delta is rule-dependent (AUTH counts as not-stopped); assert the
+    # identity against the sub-reports rather than a brittle absolute number.
+    assert delta["attacks_stopped_strict"] == round(before["asr_strict"] - after["asr_strict"], 6)
+    assert 0.0 <= delta["attacks_stopped_strict"] <= 1.0
+
+
+def test_before_after_is_deterministic():
+    assert run_before_after(SyntheticAdapter()) == run_before_after(SyntheticAdapter())
+
+
+def test_before_after_never_leaks_payload(before_after):
+    serialized = json.dumps(before_after)
+    assert PAYLOAD_MARKER not in serialized
+    assert "attacker-domain" not in serialized
+    assert "stolen-data" not in serialized

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -17,7 +17,13 @@ from doberman.models import (
 from tests.benchmarks.adapter import BenchmarkCase, CandidateAction
 from tests.benchmarks.mapping import BENCHMARK_TS
 from tests.benchmarks.metrics import ActionOutcome, build_report
-from tests.benchmarks.profiles import BUILTINS_ONLY, WITH_PLUGINS, build_pipeline
+from tests.benchmarks.profiles import (
+    BUILTINS_ONLY,
+    NO_GUARDRAIL,
+    WITH_PLUGINS,
+    PassthroughPipeline,
+    build_pipeline,
+)
 from tests.benchmarks.runner import run_suite
 
 
@@ -151,3 +157,21 @@ def test_with_plugins_profile_picks_up_a_registered_rule(monkeypatch):
     # The fake rule escalates otherwise-benign trusted traffic only in with_plugins.
     assert builtins.fpr == 0.0
     assert with_plugins.fpr > builtins.fpr
+
+
+# --- before/after baseline arm ----------------------------------------------
+def test_passthrough_pipeline_is_the_unmediated_baseline():
+    from tests.benchmarks.suites.synthetic import SyntheticAdapter
+
+    report = run_suite(SyntheticAdapter(), PassthroughPipeline())
+    assert report.profile == NO_GUARDRAIL
+    # The passthrough never consults the engine: every action is allowed,
+    # independent of which rules would otherwise fire. So on a ground-truth
+    # attack corpus every attack bypasses and benign work has zero friction.
+    assert report.asr == 1.0
+    assert report.asr_strict == 1.0
+    assert report.fpr == 0.0
+    assert report.hard_fpr == 0.0
+    assert report.verdict_histogram == {"PASS": report.n_attack + report.n_benign}
+    # A PASS carries no reason codes, so the baseline report attributes nothing.
+    assert report.reason_codes == {}


### PR DESCRIPTION
## What this PR does
Adds a `PassthroughPipeline` (no engine on the tool path) and `run_before_after()` exposed as the `before_after` CLI profile. It reports `{before, after, delta}`: against an unmediated tool path (every action executes), how many otherwise-executing attacks the engine stops vs. how much benign friction it adds. Builds on the merged suite-adapter harness (PR #22).

## Tests added (run in CI)
- before_after harness unit coverage + synthetic gate assertions
- Verified locally: synthetic → before ASR 1.0, after ASR 0.0, attacks_stopped 1.0, fpr_added 0.0

## Security checklist
- [x] Reports hold counts/verdicts/reason codes only — never payload text
- [x] No change to the decision engine or its invariants (harness only)