### PR TITLE
feat(cost): CB.1 — CostEvent model + local cost meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Set a mode in `.doberman/policies.yaml` or via `doberman policy set-mode <mode>`
 - ✅ One-command onboarding: `doberman setup` (alertness + guardrails + auto-wires the hooks) · `install-hooks`/`uninstall-hooks`
 - ✅ Host-harness self-protection: an agent cannot disable the hooks by editing `.claude/settings.json` — the hook-install file is a blocked control-plane path (like `.doberman/`)
 - 📋 Host-harness, continued (containment architecture): cross-call multi-step prompt-injection floor over the local history · warm-daemon adaptive layer · honeytoken tripwire + session circuit-breaker
-- 📋 Cost observability (`CostEvent` meter + raise-only loop-anomaly detection)
+- 🛠 Cost observability — **CB.1 landed**: a redaction-safe `CostEvent` + local append-only meter (`doberman.storage.cost`), advisory and strictly off the decision path. Next: `CostObserver` plugin seam (CB.2) and a raise-only loop-anomaly detector (CB.3)
 - 📋 Enterprise platform: centralized control plane, dashboards, org policy, SSO/RBAC
 
 ### Known limitations

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -385,3 +385,39 @@ class Decision(BaseModel):
                 f"risk {self.objective.risk} — risk is never lowered"
             )
         return self
+
+
+class CostKind(StrEnum):
+    """What kind of resource consumption a :class:`CostEvent` meters."""
+
+    tokens_in = "tokens_in"
+    tokens_out = "tokens_out"
+    tool_call = "tool_call"
+    other = "other"
+
+
+class CostEvent(BaseModel):
+    """A redaction-safe record of resource consumption (token burn, tool calls).
+
+    Cost observability is **advisory**, the third boundary's raw material: a
+    ``CostEvent`` never rides the decision path and recording one can never
+    alter a PASS/AUTH/BLOCK verdict. Like every other object here it is
+    redaction-safe by construction — it holds **counts and coarse classes
+    only**, never prompt/response text. ``model`` is a coarse label (e.g.
+    ``"opus"``), and ``entity_id`` is a keyed HMAC fingerprint, never a raw
+    role or path. Immutable (``frozen=True``) so a meter can never adjust a
+    recorded cost downward after the fact.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    action_id: str = Field(min_length=1)
+    ts: AwareDatetime  # forensic timestamp — naive datetimes are rejected
+    kind: CostKind = CostKind.other
+    #: Token count or call count. Non-negative — cost only ever accrues.
+    units: int = Field(default=0, ge=0)
+    #: Coarse model label only (e.g. "opus"); never request/response payload.
+    model: str | None = None
+    #: Keyed HMAC fingerprint of the entity, never a raw role/path string.
+    entity_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -420,4 +420,3 @@ class CostEvent(BaseModel):
     model: str | None = None
     #: Keyed HMAC fingerprint of the entity, never a raw role/path string.
     entity_id: str | None = None
-    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/src/doberman/storage/cost.py
+++ b/src/doberman/storage/cost.py
@@ -1,0 +1,116 @@
+"""Local cost meter (Feature CB.1).
+
+Persists redaction-safe :class:`~doberman.models.CostEvent` rows to the
+append-only ``cost_events`` ledger and reads them back as aggregate totals —
+the raw material for the third boundary (a budget ceiling, platform-side) and
+for the CB.3 loop-anomaly detector.
+
+Two non-negotiables, mirrored from the decision log:
+
+* **Off the decision path.** Cost observability is advisory. Recording a cost
+  event must never alter or block a PASS/AUTH/BLOCK verdict, so every write is
+  inside a failure boundary — ``record_cost_event`` never raises.
+* **Redaction-safe.** A ``CostEvent`` holds counts and coarse classes only; no
+  prompt/response text or raw role/path ever reaches this table.
+
+This module is policy-core storage and must never import ``doberman.proxy``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from doberman.models import CostEvent, CostKind
+from doberman.storage.db import open_db
+
+logger = logging.getLogger("doberman.storage.cost")
+
+_INSERT_COST_EVENT = (
+    "INSERT INTO cost_events (ts, action_id, kind, units, model, entity_id) "
+    "VALUES (?, ?, ?, ?, ?, ?)"
+)
+
+
+async def record_cost_event(event: CostEvent, *, repo_root: str) -> None:
+    """Persist one redacted cost event (best-effort, never raises).
+
+    The build, the open, and the write are all inside the failure boundary: a
+    storage error is logged and swallowed so it can never break the execution
+    path the cost event merely observes.
+    """
+    try:
+        async with open_db(repo_root) as conn:
+            await conn.execute(
+                _INSERT_COST_EVENT,
+                (
+                    event.ts.isoformat(),
+                    event.action_id,
+                    event.kind.value,
+                    int(event.units),
+                    event.model,
+                    event.entity_id,
+                ),
+            )
+            await conn.commit()
+    except Exception:  # noqa: BLE001 — the cost meter must never break execution
+        logger.warning("cost meter write failed for action %s; continuing", event.action_id)
+
+
+async def read_total(
+    repo_root: str,
+    *,
+    entity_id: str | None = None,
+    kind: CostKind | None = None,
+) -> int:
+    """Sum of ``units`` over the ledger (the meter readout).
+
+    Optionally scoped to one ``entity_id`` and/or one ``kind``. Returns 0 on an
+    empty ledger or any read error — a meter read never raises.
+    """
+    clauses: list[str] = []
+    params: list[object] = []
+    if entity_id is not None:
+        clauses.append("entity_id = ?")
+        params.append(entity_id)
+    if kind is not None:
+        clauses.append("kind = ?")
+        params.append(kind.value)
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    try:
+        async with open_db(repo_root) as conn:
+            async with conn.execute(
+                f"SELECT COALESCE(SUM(units), 0) FROM cost_events{where}",  # noqa: S608 — fixed clauses, params bound
+                params,
+            ) as cur:
+                row = await cur.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+    except Exception:  # noqa: BLE001 — a meter read must never break a caller
+        logger.warning("cost meter read failed; reporting 0")
+        return 0
+
+
+async def read_breakdown(repo_root: str, *, entity_id: str | None = None) -> dict[CostKind, int]:
+    """Per-kind ``units`` totals (optionally scoped to one entity).
+
+    Returns an empty mapping on an empty ledger or any read error.
+    """
+    where = " WHERE entity_id = ?" if entity_id is not None else ""
+    params: list[object] = [entity_id] if entity_id is not None else []
+    try:
+        async with open_db(repo_root) as conn:
+            async with conn.execute(
+                f"SELECT kind, COALESCE(SUM(units), 0) FROM cost_events{where} GROUP BY kind",  # noqa: S608 — fixed clause, params bound
+                params,
+            ) as cur:
+                rows = await cur.fetchall()
+        out: dict[CostKind, int] = {}
+        for kind_value, total in rows:
+            try:
+                out[CostKind(kind_value)] = int(total)
+            except ValueError:
+                # Unknown kind from a newer writer — skip rather than crash the read.
+                continue
+        return out
+    except Exception:  # noqa: BLE001 — a meter read must never break a caller
+        logger.warning("cost meter breakdown read failed; reporting empty")
+        return {}

--- a/src/doberman/storage/db.py
+++ b/src/doberman/storage/db.py
@@ -42,9 +42,10 @@ DB_FILE = "doberman.db"
 
 #: Current schema version. Bumped to 2 in Feature 8 (decision log + stores), to 3
 #: for the universal subjective layer (SL4/SL6/SL8: baselines re-keyed by entity,
-#: transitions, score history, preference feedback), and to 4 for the host-hook
-#: sticky taint ledger (HK.5.1: decisions.session_id + the session_taint table).
-SCHEMA_VERSION = 4
+#: transitions, score history, preference feedback), to 4 for the host-hook sticky
+#: taint ledger (HK.5.1: decisions.session_id + the session_taint table), and to 5
+#: for Feature CB (CB.1: the append-only ``cost_events`` meter ledger).
+SCHEMA_VERSION = 5
 
 # Every table uses CREATE TABLE IF NOT EXISTS so opening an older DB transparently
 # adds the new tables (a forward-only, additive migration; the one re-shape —
@@ -163,6 +164,17 @@ CREATE TABLE IF NOT EXISTS policy_changes (
     approved        INTEGER,
     approved_by     TEXT
 );
+
+CREATE TABLE IF NOT EXISTS cost_events (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts        TEXT NOT NULL,
+    action_id TEXT NOT NULL,
+    kind      TEXT NOT NULL,
+    units     INTEGER NOT NULL DEFAULT 0,
+    model     TEXT,
+    entity_id TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_cost_events ON cost_events (entity_id, kind, id);
 """
 
 

--- a/tests/unit/test_cost_meter.py
+++ b/tests/unit/test_cost_meter.py
@@ -48,6 +48,19 @@ def test_model_has_no_payload_bearing_field():
     assert set(CostEvent.model_fields) & forbidden == set()
 
 
+def test_model_fields_are_an_exact_scalar_allowlist():
+    """Ratchet: CostEvent may carry ONLY these scalar fields.
+
+    A free-form mapping (e.g. ``metadata: dict[str, Any]``) passes the
+    forbidden-name check above yet can hold arbitrary payload in memory and
+    would leak if ever logged/serialized — exactly the redaction-safe-by-
+    construction hole flagged in review. Pinning the exact field set means any
+    new field — especially a payload-capable one — fails CI until it is added
+    here deliberately (with justification), never slips in silently.
+    """
+    assert set(CostEvent.model_fields) == {"action_id", "ts", "kind", "units", "model", "entity_id"}
+
+
 # ---- ledger writes + aggregate reads ---------------------------------------
 
 

--- a/tests/unit/test_cost_meter.py
+++ b/tests/unit/test_cost_meter.py
@@ -1,0 +1,116 @@
+"""Feature CB.1 — CostEvent model + local cost meter.
+
+Covers the model's redaction-safe / non-negative / frozen guarantees, the
+append-only ledger writes and aggregate reads, and the two safety invariants:
+the meter is off the decision path (recording never touches ``decisions`` and
+never raises) and a meter read never raises.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from doberman.models import CostEvent, CostKind
+from doberman.storage.cost import read_breakdown, read_total, record_cost_event
+
+_NOW = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def _event(
+    units: int, *, kind: CostKind = CostKind.tokens_in, entity_id: str | None = "e1"
+) -> CostEvent:
+    return CostEvent(action_id="a1", ts=_NOW, kind=kind, units=units, entity_id=entity_id)
+
+
+# ---- model guarantees -------------------------------------------------------
+
+
+def test_units_cannot_be_negative():
+    with pytest.raises(ValidationError):
+        CostEvent(action_id="a1", ts=_NOW, units=-1)
+
+
+def test_naive_timestamp_is_rejected():
+    with pytest.raises(ValidationError):
+        CostEvent(action_id="a1", ts=datetime(2026, 1, 1, 12, 0))  # no tzinfo
+
+
+def test_event_is_frozen():
+    ev = _event(10)
+    with pytest.raises(ValidationError):
+        ev.units = 99  # type: ignore[misc]
+
+
+def test_model_has_no_payload_bearing_field():
+    # Redaction by construction: the schema exposes counts + coarse classes only.
+    forbidden = {"content", "prompt", "response", "payload", "text", "target", "raw_args"}
+    assert set(CostEvent.model_fields) & forbidden == set()
+
+
+# ---- ledger writes + aggregate reads ---------------------------------------
+
+
+async def test_record_then_total(tmp_path):
+    root = str(tmp_path)
+    await record_cost_event(_event(100), repo_root=root)
+    await record_cost_event(_event(50, kind=CostKind.tokens_out), repo_root=root)
+    assert await read_total(root) == 150
+
+
+async def test_total_scopes_by_entity_and_kind(tmp_path):
+    root = str(tmp_path)
+    await record_cost_event(_event(100, entity_id="e1"), repo_root=root)
+    await record_cost_event(_event(40, entity_id="e2"), repo_root=root)
+    await record_cost_event(_event(7, kind=CostKind.tool_call, entity_id="e1"), repo_root=root)
+    assert await read_total(root, entity_id="e1") == 107
+    assert await read_total(root, kind=CostKind.tokens_in) == 140
+    assert await read_total(root, entity_id="e1", kind=CostKind.tool_call) == 7
+
+
+async def test_breakdown_groups_by_kind(tmp_path):
+    root = str(tmp_path)
+    await record_cost_event(_event(100, kind=CostKind.tokens_in), repo_root=root)
+    await record_cost_event(_event(30, kind=CostKind.tokens_out), repo_root=root)
+    await record_cost_event(_event(2, kind=CostKind.tool_call), repo_root=root)
+    assert await read_breakdown(root) == {
+        CostKind.tokens_in: 100,
+        CostKind.tokens_out: 30,
+        CostKind.tool_call: 2,
+    }
+
+
+async def test_total_on_empty_ledger_is_zero(tmp_path):
+    assert await read_total(str(tmp_path)) == 0
+
+
+# ---- safety invariants ------------------------------------------------------
+
+
+async def test_recording_cost_does_not_touch_decisions_table(tmp_path):
+    from doberman.storage.db import open_db
+
+    root = str(tmp_path)
+    await record_cost_event(_event(100), repo_root=root)
+    async with open_db(root) as conn:
+        async with conn.execute("SELECT COUNT(*) FROM decisions") as cur:
+            decisions = (await cur.fetchone())[0]
+        async with conn.execute("SELECT COUNT(*) FROM cost_events") as cur:
+            costs = (await cur.fetchone())[0]
+    assert decisions == 0  # cost observability never writes a verdict
+    assert costs == 1
+
+
+async def test_record_never_raises_on_unwritable_root(tmp_path):
+    # A regular file where the repo root should be makes open_db's mkdir fail;
+    # the meter must swallow it (off the decision path → never break execution).
+    bad = tmp_path / "not_a_dir"
+    bad.write_text("x")
+    await record_cost_event(_event(100), repo_root=str(bad))  # must not raise
+
+
+async def test_read_never_raises_on_unwritable_root(tmp_path):
+    bad = tmp_path / "not_a_dir"
+    bad.write_text("x")
+    assert await read_total(str(bad)) == 0
+    assert await read_breakdown(str(bad)) == {}

--- a/tests/unit/test_db_schema.py
+++ b/tests/unit/test_db_schema.py
@@ -13,6 +13,7 @@ _EXPECTED_TABLES = {
     "secret_fingerprints",
     "baseline_counts",
     "policy_changes",
+    "cost_events",
 }
 
 #: Column names that would (or could) hold raw secret material. The decisions
@@ -58,6 +59,13 @@ async def test_decisions_table_has_no_secret_bearing_columns(tmp_path):
         cols = set(await _columns(conn, "decisions"))
     assert cols & _FORBIDDEN_COLUMNS == set()
     assert "target_path_class" in cols  # the redacted class IS present
+
+
+async def test_cost_events_table_has_no_secret_bearing_columns(tmp_path):
+    async with open_db(str(tmp_path)) as conn:
+        cols = set(await _columns(conn, "cost_events"))
+    assert cols & _FORBIDDEN_COLUMNS == set()
+    assert {"kind", "units", "entity_id"} <= cols  # counts + coarse class + keyed id only
 
 
 async def test_schema_creation_is_idempotent(tmp_path):


### PR DESCRIPTION
## Slice
- Feature / Slice: **CB.1** — CostEvent + local meter (first slice of Feature CB, Cost Observability)

## What this PR does
Adds the raw material for Doberman's third boundary (a budget ceiling, platform-side) and the future CB.3 loop-anomaly detector:
- **`CostEvent`** (`models.py`) — redaction-safe, frozen: counts + coarse classes only (`kind`, non-negative `units`, coarse `model` label, keyed `entity_id`). Never holds prompt/response text.
- **`cost_events`** append-only ledger (`storage/db.py`, schema **v4**, additive `CREATE TABLE IF NOT EXISTS` — an older DB gains it transparently).
- **Local meter** (`storage/cost.py`): `record_cost_event` (never raises), `read_total`, `read_breakdown`.

Cost observability is **advisory and strictly off the decision path** — recording a cost event never touches the `decisions` table and never alters a PASS/AUTH/BLOCK verdict. No `CostObserver` plugin seam yet (that is CB.2).

## Tests added (run in CI)
- `tests/unit/test_cost_meter.py` — model guarantees (non-negative / frozen / tz-aware / no payload-bearing field); ledger record + aggregate (total, scoped by entity/kind, breakdown); safety invariants (recording never writes `decisions`; record & read never raise on an unwritable root).
- `tests/unit/test_db_schema.py` — `cost_events` in expected tables + no secret-bearing columns.
- `tests/unit/test_entity_baseline.py` — schema-version assertions pinned to `SCHEMA_VERSION` (was hardcoded `3`).

## Security checklist
- [x] Fails closed / fail-safe — meter is off the decision path; record & read swallow errors, never break execution
- [x] No secret, full file, or unredacted prompt logged or committed — CostEvent holds counts + coarse classes only
- [x] Raise-only — `units` is non-negative; CostEvent is frozen; no verdict path touched
- [x] N/A verdicts — cost events carry no verdict (advisory only)

## Edge cases covered / Risks
- Empty ledger → total 0, breakdown {}. Unwritable root → swallowed. Unknown `kind` from a newer writer → skipped on read, not crashed. Schema bump is additive (no data migration).