### PR TITLE
docs(readme): disclose whole-script homoglyph gap as a known limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ Set a mode in `.doberman/policies.yaml` or via `doberman policy set-mode <mode>`
 - 📋 Cost observability (`CostEvent` meter + raise-only loop-anomaly detection)
 - 📋 Enterprise platform: centralized control plane, dashboards, org policy, SSO/RBAC
 
+### Known limitations
+
+Doberman is **defense-in-depth, not airtight** — no single rule is a guarantee. One concrete, currently-known gap:
+
+- **Whole-script homoglyph confusables.** The deterministic check catches *intra-token* mixed-script confusables (e.g. `раypal`, which mixes Cyrillic and Latin). But a token rendered **entirely in one non-Latin script** that mimics a Latin word (e.g. an all-Cyrillic look-alike of `paypal`) is NFKC-stable and is **not** caught by the core deterministic check today. Closing it is planned via a perplexity/confusable detector. Read the `OOD/homoglyph token signals` item above as defense-in-depth, not a robustness guarantee.
+
 ---
 
 ## License


### PR DESCRIPTION
## What this PR does
Adds a **Known limitations** note to the README's roadmap section, disclosing a real, currently-known gap in the homoglyph/confusable defense.

The roadmap lists `OOD/homoglyph token signals` as shipped (✅). The OOD red-team harness (#21) showed this is only partly true:
- ✅ **Intra-token** mixed-script confusables are caught (e.g. `раypal` — Cyrillic + Latin in one token).
- ❌ **Whole-script** confusables are not — a token rendered entirely in one non-Latin script that mimics a Latin word (e.g. an all-Cyrillic look-alike of `paypal`) is NFKC-stable and escapes the core deterministic check today.

This keeps the public README honest ("don't oversell — it's defense-in-depth", per CLAUDE.md §9) rather than implying airtight homoglyph coverage. Closing the gap itself is left to a future perplexity/confusable detector and is **not** in scope here (a whole-script check in core would risk over-blocking legitimate non-Latin text — a maintainer call).

## Scope
- Docs only. No `src/` change, no behavior change.

## Context
Addresses the **README-caveat open decision (#3)** raised in the QA issue #31. Wording is a starting point — happy to adjust to maintainer preference.