### PR TITLE
feat(hosthooks): protect the host-hook control plane (.claude/) from the agent (HK.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ doberman uninstall-hooks          # remove only Doberman's entries (leaves your 
 
 `install-hooks` is idempotent (safe to re-run), backs up an existing `settings.json` before writing, and never touches your other settings or hooks.
 
+**Doberman protects its own hooks.** Once installed, the agent can't quietly remove them: a write/edit to `.claude/settings.json` (the hook-install file) is **blocked**, and other `.claude/` changes require authentication — so the agent can't disable enforcement by editing the harness config ("firing the cop"). This mirrors how Doberman already hard-blocks its own `.doberman/` control plane.
+
 **Easiest of all — `doberman setup`:** an interactive wizard that picks your alertness mode, tunes your guardrails, and wires the hooks in one step:
 
 ```bash
@@ -324,7 +326,8 @@ Set a mode in `.doberman/policies.yaml` or via `doberman policy set-mode <mode>`
 - ✅ Benchmark harness (suite-agnostic ASR/FPR over labeled actions; `builtins_only` vs `with_plugins`; deterministic synthetic gate; external-suite adapters via `tests/benchmarks/`)
 - ✅ Host-harness integration: Claude Code `PreToolUse` + `PostToolUse` hooks (`doberman hook pre`/`post`) gate every built-in *and* MCP tool call — and scan tool **output** for leaked secrets — with no MCP reconfig; fail-closed, import-light, and recording a local redacted history
 - ✅ One-command onboarding: `doberman setup` (alertness + guardrails + auto-wires the hooks) · `install-hooks`/`uninstall-hooks`
-- 📋 Host-harness, continued: cross-call multi-step prompt-injection floor over the local history · warm-daemon adaptive layer
+- ✅ Host-harness self-protection: an agent cannot disable the hooks by editing `.claude/settings.json` — the hook-install file is a blocked control-plane path (like `.doberman/`)
+- 📋 Host-harness, continued (containment architecture): cross-call multi-step prompt-injection floor over the local history · warm-daemon adaptive layer · honeytoken tripwire + session circuit-breaker
 - 📋 Cost observability (`CostEvent` meter + raise-only loop-anomaly detection)
 - 📋 Enterprise platform: centralized control plane, dashboards, org policy, SSO/RBAC
 

--- a/src/doberman/engine/rules/paths.py
+++ b/src/doberman/engine/rules/paths.py
@@ -60,14 +60,22 @@ DEFAULT_BLOCKED_GLOBS: tuple[str, ...] = (
     ".doberman/**",
     "**/.doberman",
     "**/.doberman/**",
-    # Doberman's host-harness control plane (ADR 0022 / 0024): the Claude Code
-    # hook config that installs Doberman as PreToolUse/PostToolUse hooks. An
-    # agent that edits these files can remove the hooks and disable enforcement
-    # at the harness level ("fire the cop") — the same on-disk bypass `.doberman/`
-    # closes (ADR 0011), extended to the host-hook install target. Block any
-    # agent-proxied write/delete/read of the hook-install settings themselves.
+    # Doberman's host-harness control plane: the Claude Code hook config that
+    # installs Doberman as PreToolUse/PostToolUse hooks (ADR 0022 = host-hook
+    # architecture; ADR 0024 = this block). Editing the settings — or deleting
+    # the whole `.claude/` dir — removes the hooks and disables enforcement at
+    # the harness level ("fire the cop"): the same on-disk bypass `.doberman/`
+    # closes (ADR 0011), extended to the host-hook config. Hard-block the
+    # hook-install settings and the directory itself; the rest of `.claude/`
+    # (project commands/agents) is AUTH (sensitive, below).
+    # NOTE: this matches the path *target* of a file action — a Bash command that
+    # writes the file (e.g. `echo > .claude/settings.json`, `sed -i`) or runs
+    # `doberman uninstall-hooks` is NOT caught here; command-text scanning of the
+    # control plane is tracked as HK.5.0b.
+    ".claude",
     ".claude/settings.json",
     ".claude/settings.local.json",
+    "**/.claude",
     "**/.claude/settings.json",
     "**/.claude/settings.local.json",
 )

--- a/src/doberman/engine/rules/paths.py
+++ b/src/doberman/engine/rules/paths.py
@@ -60,6 +60,16 @@ DEFAULT_BLOCKED_GLOBS: tuple[str, ...] = (
     ".doberman/**",
     "**/.doberman",
     "**/.doberman/**",
+    # Doberman's host-harness control plane (ADR 0022 / 0024): the Claude Code
+    # hook config that installs Doberman as PreToolUse/PostToolUse hooks. An
+    # agent that edits these files can remove the hooks and disable enforcement
+    # at the harness level ("fire the cop") — the same on-disk bypass `.doberman/`
+    # closes (ADR 0011), extended to the host-hook install target. Block any
+    # agent-proxied write/delete/read of the hook-install settings themselves.
+    ".claude/settings.json",
+    ".claude/settings.local.json",
+    "**/.claude/settings.json",
+    "**/.claude/settings.local.json",
 )
 
 #: Paths that are sensitive: allowed, but only after authentication.
@@ -73,6 +83,12 @@ DEFAULT_SENSITIVE_GLOBS: tuple[str, ...] = (
     "migrations/**",
     "**/migrations/**",
     "**/*.tfstate",
+    # The rest of the Claude Code control directory (commands, agents, MCP
+    # config, etc.): not a hook-install file, but still harness configuration —
+    # changing it warrants authentication. The settings.json files above are
+    # hard-blocked (checked first); everything else under .claude/ → AUTH.
+    ".claude/**",
+    "**/.claude/**",
 )
 
 #: Used as the repo root when the context does not supply one. ".": the process

--- a/tests/unit/test_hosthook_control_plane.py
+++ b/tests/unit/test_hosthook_control_plane.py
@@ -1,0 +1,37 @@
+"""HK.5.0: the host-hook PreToolUse path blocks an agent editing its own hooks.
+
+A ``Write``/``Edit`` to ``.claude/settings.json`` is exactly how an agent would
+remove the Doberman hooks and disable enforcement at the harness level ("fire the
+cop"). The control-plane path rule (extended in HK.5.0, ADR 0024) makes that a
+BLOCK, and the hook turns a BLOCK into a Claude Code ``permissionDecision: "deny"``.
+"""
+
+from doberman.hosthooks.claude_code import evaluate_pre
+
+
+def _pre(tool_name, tool_input, cwd):
+    return evaluate_pre({"tool_name": tool_name, "tool_input": tool_input, "cwd": str(cwd)})
+
+
+def test_pre_hook_denies_writing_claude_settings(tmp_path):
+    out = _pre("Write", {"file_path": ".claude/settings.json", "content": "{}"}, tmp_path)
+    assert out is not None
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_pre_hook_denies_editing_claude_settings(tmp_path):
+    out = _pre("Edit", {"file_path": ".claude/settings.json"}, tmp_path)
+    assert out is not None
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_pre_hook_deny_reason_does_not_leak_the_raw_path(tmp_path):
+    out = _pre("Write", {"file_path": ".claude/settings.json", "content": "{}"}, tmp_path)
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert ".claude/settings.json" not in reason
+
+
+def test_pre_hook_allows_an_ordinary_write(tmp_path):
+    # No over-block: an ordinary source write abstains (PASS -> None, raise-only).
+    out = _pre("Write", {"file_path": "src/app/main.py", "content": "print(1)\n"}, tmp_path)
+    assert out is None

--- a/tests/unit/test_rule_paths_control_plane.py
+++ b/tests/unit/test_rule_paths_control_plane.py
@@ -118,6 +118,7 @@ def test_writing_claude_settings_is_blocked(tmp_path):
 def test_writing_claude_local_settings_is_blocked(tmp_path):
     result = RULE.evaluate(_action(".claude/settings.local.json"), _ctx(tmp_path))
     assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
 
 
 def test_deleting_claude_settings_is_blocked(tmp_path):
@@ -125,12 +126,28 @@ def test_deleting_claude_settings_is_blocked(tmp_path):
         _action(".claude/settings.json", action_type=ActionType.file_delete), _ctx(tmp_path)
     )
     assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+def test_deleting_the_whole_claude_dir_is_blocked(tmp_path):
+    # Deleting the entire .claude/ dir removes the hooks just as effectively as
+    # editing settings.json — the bare directory target must block too.
+    result = RULE.evaluate(_action(".claude", action_type=ActionType.file_delete), _ctx(tmp_path))
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
 
 
 def test_nested_claude_settings_is_blocked(tmp_path):
     # A monorepo sub-project's own .claude/settings.json is protected too.
     result = RULE.evaluate(_action("packages/app/.claude/settings.json"), _ctx(tmp_path))
     assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+def test_nested_claude_local_settings_is_blocked(tmp_path):
+    result = RULE.evaluate(_action("packages/app/.claude/settings.local.json"), _ctx(tmp_path))
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
 
 
 def test_traversal_into_claude_settings_is_caught(tmp_path):

--- a/tests/unit/test_rule_paths_control_plane.py
+++ b/tests/unit/test_rule_paths_control_plane.py
@@ -101,3 +101,71 @@ def test_objective_guardrail_blocks_a_control_plane_write(tmp_path):
     result = guardrail.evaluate(_action(".doberman/policies.yaml"), _ctx(tmp_path))
     assert result.verdict is Verdict.BLOCK
     assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+# --- HK.5.0: the host-harness control plane (.claude/) is protected too (ADR 0024) ---
+# Editing .claude/settings.json is how an agent would remove the Doberman hooks
+# and disable enforcement at the harness level ("fire the cop"). Hard-block the
+# hook-install settings; AUTH the rest of .claude/.
+
+
+def test_writing_claude_settings_is_blocked(tmp_path):
+    result = RULE.evaluate(_action(".claude/settings.json"), _ctx(tmp_path))
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+def test_writing_claude_local_settings_is_blocked(tmp_path):
+    result = RULE.evaluate(_action(".claude/settings.local.json"), _ctx(tmp_path))
+    assert result.verdict is Verdict.BLOCK
+
+
+def test_deleting_claude_settings_is_blocked(tmp_path):
+    result = RULE.evaluate(
+        _action(".claude/settings.json", action_type=ActionType.file_delete), _ctx(tmp_path)
+    )
+    assert result.verdict is Verdict.BLOCK
+
+
+def test_nested_claude_settings_is_blocked(tmp_path):
+    # A monorepo sub-project's own .claude/settings.json is protected too.
+    result = RULE.evaluate(_action("packages/app/.claude/settings.json"), _ctx(tmp_path))
+    assert result.verdict is Verdict.BLOCK
+
+
+def test_traversal_into_claude_settings_is_caught(tmp_path):
+    # a/b/../../.claude/settings.json canonicalizes back into .claude → BLOCK.
+    result = RULE.evaluate(_action("a/b/../../.claude/settings.json"), _ctx(tmp_path))
+    assert result.verdict is Verdict.BLOCK
+
+
+def test_other_claude_files_require_auth(tmp_path):
+    # Non-install files under .claude/ (commands, agents, …) are sensitive: AUTH,
+    # not a silent allow — and not a hard block either.
+    result = RULE.evaluate(_action(".claude/commands/build.md"), _ctx(tmp_path))
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.sensitive_path_access in result.reason_codes
+
+
+def test_ordinary_file_still_passes(tmp_path):
+    # No over-blocking: a normal source edit is unaffected by the new globs.
+    result = RULE.evaluate(_action("src/app/main.py"), _ctx(tmp_path))
+    assert result.verdict is Verdict.PASS
+
+
+def test_default_blocked_globs_include_claude_settings():
+    assert any(".claude/settings.json" in glob for glob in DEFAULT_BLOCKED_GLOBS)
+
+
+def test_claude_settings_block_does_not_leak_the_raw_path(tmp_path):
+    # Redaction: the explanation names only the path class, never the raw path.
+    result = RULE.evaluate(_action(".claude/settings.json"), _ctx(tmp_path))
+    assert ".claude/settings.json" not in (result.explanation or "")
+
+
+def test_objective_guardrail_blocks_a_claude_settings_write(tmp_path):
+    # Prove the wired guardrail (not just the rule in isolation) hard-blocks it.
+    guardrail = ObjectiveGuardrail(load_plugins=False)
+    result = guardrail.evaluate(_action(".claude/settings.json"), _ctx(tmp_path))
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: **HK.5.0** — Self-defense: protect Doberman's host-hook control plane (`.claude/`)
- Plan reference: ADR `0024-hk5-containment-architecture` (HK.5 reframed as a layered containment architecture; self-defense ships first). Stacked on #35 (HK.4).

## What this PR does
An agent that can edit `.claude/settings.json` (the Claude Code hook-install file) can remove the Doberman `PreToolUse`/`PostToolUse` hooks and disable enforcement at the harness level — "firing the cop". The protected-path rule covered `.doberman/` (ADR 0011) but **not** `.claude/`, so a `Write`/`Edit` to the hook config PASSed.

- `engine/rules/paths.py`: hard-block the hook-install settings (`.claude/settings.json`, `.claude/settings.local.json`, + nested `**/` variants) via `DEFAULT_BLOCKED_GLOBS`; AUTH the rest of `.claude/**` via `DEFAULT_SENSITIVE_GLOBS`.
- The block flows through the wired `ObjectiveGuardrail` and the `doberman hook pre` path (BLOCK → `permissionDecision: "deny"`); the explanation names only the path **class** (redaction holds).
- `README.md`: "Doberman protects its own hooks" note + roadmap update.

This is the first slice of the HK.5 containment architecture: **self-defense before detection**.

## Tests added (run in CI)
- `tests/unit/test_rule_paths_control_plane.py` — 9 new cases: block `settings.json` / `settings.local.json` / nested / traversal / delete; AUTH other `.claude/**`; no over-block of ordinary files; redaction; wired `ObjectiveGuardrail` block.
- `tests/unit/test_hosthook_control_plane.py` — the `hook pre` path denies a `Write`/`Edit` to `.claude/settings.json`, the deny reason does not leak the raw path, and an ordinary write still abstains.
- Local: ruff ✅ · ruff format ✅ · `lint-imports` ✅ (2 contracts kept) · `pytest --cov=doberman` ✅ **953 passed, 3 skipped, 92% cov**.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (the rule BLOCKs the hook-install file; unknown/escape paths already BLOCK)
- [x] No secret, full file, or unredacted prompt logged or committed (explanation = path class only; asserted in tests)
- [x] Any guardrail/learning change is raise-only (this only *adds* a block/AUTH — never loosens)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (`protected_path_blocked` / `sensitive_path_access`)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Covered: nested monorepo `*/.claude/settings.json`; `..` traversal back into `.claude/`; delete vs write; `.claude/` non-settings files → AUTH (not silent allow, not hard block); ordinary source writes unaffected.
- Deviation: HK.5.0 is scoped to the **control-plane path gating** only. The other Layer-0 items from ADR 0024 (tamper-evident hash-chained log, hook-presence watchdog, degradation-as-alarm) are split into HK.5.0b.
- Risk: `.claude/**` → AUTH may prompt if a user legitimately has the agent edit project commands/agents under `.claude/`; bounded to that dir and intentional (harness config changes warrant auth). Honest limit: hook-level mediation cannot contain a shell — see ADR 0024's OS-level containment note.