### PR TITLE
feat(hosthooks): block shell commands that tamper with the control plane (HK.5.0b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ doberman uninstall-hooks          # remove only Doberman's entries (leaves your 
 
 `install-hooks` is idempotent (safe to re-run), backs up an existing `settings.json` before writing, and never touches your other settings or hooks.
 
-**Doberman protects its own hooks.** Once installed, the agent can't quietly remove them: a write/edit to `.claude/settings.json` (the hook-install file) is **blocked**, and other `.claude/` changes require authentication — so the agent can't disable enforcement by editing the harness config ("firing the cop"). This mirrors how Doberman already hard-blocks its own `.doberman/` control plane.
+**Doberman protects its own hooks.** Once installed, the agent can't quietly remove them: a write/edit to `.claude/settings.json` (the hook-install file) is **blocked**, and other `.claude/` changes require authentication — so the agent can't disable enforcement by editing the harness config ("firing the cop"). This mirrors how Doberman already hard-blocks its own `.doberman/` control plane. The protection holds **through the shell** too — a Bash command that writes/deletes the config (`echo > .claude/settings.json`, `rm -rf .doberman`) or runs `doberman uninstall-hooks` is blocked, not just the `Write`/`Edit` tools.
 
 **Easiest of all — `doberman setup`:** an interactive wizard that picks your alertness mode, tunes your guardrails, and wires the hooks in one step:
 

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -33,6 +33,7 @@ import re
 import shlex
 from collections.abc import Iterable
 
+from doberman.engine.rules.paths import names_control_plane
 from doberman.models import (
     ActionType,
     EvalContext,
@@ -43,6 +44,12 @@ from doberman.models import (
     Verdict,
 )
 from doberman.policy.modes import thresholds_for
+
+# Doberman's own CLI subcommands that install/remove the host hooks or rewire the
+# control plane: an agent invoking these through a shell is tampering with the
+# cop, not doing project work (HK.5.0b). The human runs these directly (not via a
+# gated tool), so the hook only ever sees the *agent* invoking them.
+_DOBERMAN_CONTROL_SUBCOMMANDS = {"uninstall-hooks", "install-hooks", "setup"}
 
 #: Default bulk-operation threshold: deleting/touching this many paths in one
 #: command steps up to AUTH. Overridable (F6 wires this from policy/mode).
@@ -155,13 +162,56 @@ def _git_force_push_to_protected(tokens: list[str], protected: Iterable[str]) ->
 _DISK_WIPE = re.compile(r"^(?:mkfs(?:\.\w+)?|shred|wipefs)$")
 
 
+def _is_doberman_control_cli(tokens: list[str]) -> bool:
+    """``doberman uninstall-hooks`` / ``install-hooks`` / ``setup`` — control-plane tamper."""
+    return (
+        bool(tokens)
+        and tokens[0] == "doberman"
+        and any(t in _DOBERMAN_CONTROL_SUBCOMMANDS for t in tokens[1:])
+    )
+
+
+def _token_path_candidates(token: str) -> list[str]:
+    """Path-like candidates from one argv token: the token itself and the value
+    after ``=`` (for ``--flag=path`` forms). Redirection targets already arrive as
+    their own tokens (``shlex`` keeps ``>``/``>>`` separate)."""
+    if "=" in token:
+        return [token, token.split("=", 1)[1]]
+    return [token]
+
+
+def _segment_targets_control_plane(tokens: list[str], root: str) -> bool:
+    """True if any argv token (operand or redirect target) names Doberman's
+    control plane. Skips a token's leading ``-`` switch but still checks a
+    ``--flag=path`` value."""
+    for token in tokens:
+        for candidate in _token_path_candidates(token):
+            if candidate and not candidate.startswith("-") and names_control_plane(candidate, root):
+                return True
+    return False
+
+
 def _segment_verdict(
-    tokens: list[str], protected_branches: Iterable[str], bulk_threshold: int
+    tokens: list[str], protected_branches: Iterable[str], bulk_threshold: int, root: str
 ) -> GuardrailResult | None:
     """Classify one parsed segment; ``None`` means this segment is benign."""
     if not tokens:
         return None
     cmd = tokens[0]
+
+    # --- Control-plane tamper → BLOCK (HK.5.0b) ---
+    # A shell command that names .doberman/ or the .claude/ hook config, or runs
+    # the Doberman hook-install CLI, is disabling the cop — block it. (A path-
+    # *target* rule misses a path hidden inside a command string.)
+    if _segment_targets_control_plane(tokens, root):
+        return _block_control_plane(
+            "Shell command targets Doberman's own control plane "
+            "(.doberman/ state or the .claude/ host-hook config)."
+        )
+    if _is_doberman_control_cli(tokens):
+        return _block_control_plane(
+            "Shell command would install/remove Doberman's host hooks (control-plane tamper)."
+        )
 
     # --- Catastrophic → BLOCK ---
     if cmd == "rm" and _rm_is_catastrophic(tokens):
@@ -239,6 +289,17 @@ def _block(explanation: str) -> GuardrailResult:
     )
 
 
+def _block_control_plane(explanation: str) -> GuardrailResult:
+    # Reuse the path rule's reason code — semantically this *is* a protected-path
+    # hit, just surfaced from inside a command string (HK.5.0b).
+    return GuardrailResult(
+        verdict=Verdict.BLOCK,
+        risk=Risk.critical,
+        reason_codes=[ReasonCode.protected_path_blocked],
+        explanation=explanation,
+    )
+
+
 def _auth(reason: ReasonCode, explanation: str) -> GuardrailResult:
     return GuardrailResult(
         verdict=Verdict.AUTH,
@@ -285,12 +346,16 @@ class DestructiveCommandRule:
         if not command or not command.strip():
             return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
 
+        root = "."
+        if isinstance(ctx.metadata, dict):
+            root = str(ctx.metadata.get("repo_root") or ".")
+
         threshold = self._bulk_threshold_override
         if threshold is None:
             threshold = thresholds_for(getattr(ctx, "mode", "balanced")).bulk_delete_threshold
-        return self._classify_line(command, threshold)
+        return self._classify_line(command, threshold, root)
 
-    def _classify_line(self, command: str, bulk_threshold: int) -> GuardrailResult:
+    def _classify_line(self, command: str, bulk_threshold: int, root: str) -> GuardrailResult:
         worst: GuardrailResult = GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
         saw_unparseable = False
 
@@ -327,7 +392,7 @@ class DestructiveCommandRule:
                 pending.extend(_payload_segments(tokens))
                 continue
 
-            verdict = _segment_verdict(tokens, self._protected, bulk_threshold)
+            verdict = _segment_verdict(tokens, self._protected, bulk_threshold, root)
             if verdict is not None:
                 worst = _max_result(worst, verdict)
                 if worst.verdict is Verdict.BLOCK:

--- a/src/doberman/engine/rules/paths.py
+++ b/src/doberman/engine/rules/paths.py
@@ -137,6 +137,14 @@ def names_control_plane(raw_path: str, root: str = _DEFAULT_ROOT) -> bool:
     alone misses a path hidden inside a command string. Checks the raw token
     (catches absolute / ``~`` / Windows-separator paths) and the repo-root
     canonical form (catches ``..`` traversal back into the plane).
+
+    Known limits — static shell analysis cannot resolve runtime semantics, so a
+    control-plane path produced at runtime is NOT caught here (accepted defense-
+    in-depth, tracked for HK.5.6; the OS file owner/mode and the file-target path
+    rule are the backstops): a path built from a variable
+    (``X=.doberman; rm -rf $X``), shell glob / brace expansion (``rm -rf .dober*``),
+    or a scripting-interpreter payload (``python -c "...rmtree('.doberman')..."`` —
+    ``python``/``node``/``perl`` are not shells, so the body is not scanned).
     """
     token = (raw_path or "").strip().strip("\"'").replace("\\", "/").lower()
     if not token:

--- a/src/doberman/engine/rules/paths.py
+++ b/src/doberman/engine/rules/paths.py
@@ -36,9 +36,34 @@ from doberman.models import (
     Verdict,
 )
 
+#: Doberman's own control plane: its state dir (``.doberman/`` — policy doc,
+#: active role, and the DB holding the append-only policy_changes ledger /
+#: decision log / baselines / elevations; ADR 0011) and the Claude Code
+#: host-hook install config (``.claude/settings*.json`` + the ``.claude`` dir
+#: itself; ADR 0022 host-hook architecture / ADR 0024 this block). Editing or
+#: deleting either disables Doberman at the engine or harness level ("fire the
+#: cop") and bypasses the Feature 10 apply_change gate; Doberman writes these via
+#: direct I/O, never through the proxy, so any agent-proxied write/delete/read is
+#: hard-blocked. **Shared with the command rule (HK.5.0b)** via
+#: :func:`names_control_plane`, so a shell command that names one of these
+#: (``echo > .claude/settings.json``, ``rm -rf .doberman``) is caught too — a
+#: path-*target* rule alone misses a path hidden inside a command string.
+CONTROL_PLANE_GLOBS: tuple[str, ...] = (
+    ".doberman",
+    ".doberman/**",
+    "**/.doberman",
+    "**/.doberman/**",
+    ".claude",
+    ".claude/settings.json",
+    ".claude/settings.local.json",
+    "**/.claude",
+    "**/.claude/settings.json",
+    "**/.claude/settings.local.json",
+)
+
 #: Paths that are NEVER allowed without going through the human-approved path.
 #: Overridable (F6 will load these from policy); kept as a module constant so
-#: tests and callers can supply their own.
+#: tests and callers can supply their own. Includes the control plane above.
 DEFAULT_BLOCKED_GLOBS: tuple[str, ...] = (
     ".env",
     ".env.*",
@@ -50,34 +75,7 @@ DEFAULT_BLOCKED_GLOBS: tuple[str, ...] = (
     "**/secrets/**",
     "**/id_rsa*",
     "**/id_ed25519*",
-    # Doberman's own control plane: the policy doc, the active role, and the DB
-    # holding the append-only policy_changes ledger / decision log / baselines /
-    # elevations. A proxied agent has no legitimate path here — Doberman writes
-    # it via direct I/O, never through the proxy — and reaching it would bypass
-    # the Feature 10 apply_change gate (policy rewrite, role expansion, ledger
-    # wipe). Block any agent-proxied read/write/delete of it.
-    ".doberman",
-    ".doberman/**",
-    "**/.doberman",
-    "**/.doberman/**",
-    # Doberman's host-harness control plane: the Claude Code hook config that
-    # installs Doberman as PreToolUse/PostToolUse hooks (ADR 0022 = host-hook
-    # architecture; ADR 0024 = this block). Editing the settings — or deleting
-    # the whole `.claude/` dir — removes the hooks and disables enforcement at
-    # the harness level ("fire the cop"): the same on-disk bypass `.doberman/`
-    # closes (ADR 0011), extended to the host-hook config. Hard-block the
-    # hook-install settings and the directory itself; the rest of `.claude/`
-    # (project commands/agents) is AUTH (sensitive, below).
-    # NOTE: this matches the path *target* of a file action — a Bash command that
-    # writes the file (e.g. `echo > .claude/settings.json`, `sed -i`) or runs
-    # `doberman uninstall-hooks` is NOT caught here; command-text scanning of the
-    # control plane is tracked as HK.5.0b.
-    ".claude",
-    ".claude/settings.json",
-    ".claude/settings.local.json",
-    "**/.claude",
-    "**/.claude/settings.json",
-    "**/.claude/settings.local.json",
+    *CONTROL_PLANE_GLOBS,
 )
 
 #: Paths that are sensitive: allowed, but only after authentication.
@@ -125,6 +123,30 @@ def _matches_any(relposix: str, globs: Sequence[str]) -> bool:
     if not relposix:
         return False
     return any(fnmatch.fnmatch(relposix, pattern) for pattern in globs)
+
+
+_CONTROL_PLANE = _sanitize_globs(CONTROL_PLANE_GLOBS)
+
+
+def names_control_plane(raw_path: str, root: str = _DEFAULT_ROOT) -> bool:
+    """True if a raw path token lands on Doberman's control plane.
+
+    Used by the command rule (HK.5.0b) so a shell command that writes/deletes the
+    control plane (``echo > .claude/settings.json``, ``rm -rf .doberman``,
+    ``sed -i ... .doberman/policies.yaml``) is blocked — a path-*target* rule
+    alone misses a path hidden inside a command string. Checks the raw token
+    (catches absolute / ``~`` / Windows-separator paths) and the repo-root
+    canonical form (catches ``..`` traversal back into the plane).
+    """
+    token = (raw_path or "").strip().strip("\"'").replace("\\", "/").lower()
+    if not token:
+        return False
+    if _matches_any(token, _CONTROL_PLANE):
+        return True
+    canonical = canonicalize(raw_path, root=root)
+    if canonical.escapes_root:
+        return False
+    return _matches_any(canonical.relposix, _CONTROL_PLANE)
 
 
 def _candidate_paths(action: SecurityObject) -> list[str]:

--- a/tests/unit/test_hosthook_control_plane.py
+++ b/tests/unit/test_hosthook_control_plane.py
@@ -35,3 +35,30 @@ def test_pre_hook_allows_an_ordinary_write(tmp_path):
     # No over-block: an ordinary source write abstains (PASS -> None, raise-only).
     out = _pre("Write", {"file_path": "src/app/main.py", "content": "print(1)\n"}, tmp_path)
     assert out is None
+
+
+# --- HK.5.0b: Bash commands that tamper with the control plane are denied too ---
+
+
+def test_pre_hook_denies_bash_rm_of_doberman(tmp_path):
+    out = _pre("Bash", {"command": "rm -rf .doberman"}, tmp_path)
+    assert out is not None
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_pre_hook_denies_bash_write_to_claude_settings(tmp_path):
+    out = _pre("Bash", {"command": "echo '{}' > .claude/settings.json"}, tmp_path)
+    assert out is not None
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_pre_hook_denies_doberman_uninstall_hooks(tmp_path):
+    out = _pre("Bash", {"command": "doberman uninstall-hooks"}, tmp_path)
+    assert out is not None
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_pre_hook_allows_an_ordinary_bash_command(tmp_path):
+    # No over-block: a benign shell command abstains (PASS -> None).
+    out = _pre("Bash", {"command": "echo hello && ls src"}, tmp_path)
+    assert out is None

--- a/tests/unit/test_rule_commands_control_plane.py
+++ b/tests/unit/test_rule_commands_control_plane.py
@@ -1,0 +1,142 @@
+"""HK.5.0b: shell commands that target Doberman's control plane are blocked.
+
+A path-*target* rule misses a control-plane path hidden inside a Bash command
+string (`echo > .claude/settings.json`, `rm -rf .doberman`,
+`doberman uninstall-hooks`). The command rule scans each segment's argv tokens
+(operands + redirect targets) via `names_control_plane`, and the Doberman
+hook-install CLI, and BLOCKs them with `protected_path_blocked`.
+"""
+
+from datetime import datetime, timezone
+
+from doberman.engine.objective import ObjectiveGuardrail
+from doberman.engine.rules.commands import DestructiveCommandRule
+from doberman.models import ActionType, EvalContext, ReasonCode, SecurityObject, Verdict
+
+RULE = DestructiveCommandRule()
+
+
+def _cmd(command, *, root="."):
+    action = SecurityObject(
+        id="cp-cmd-1",
+        ts=datetime(2026, 6, 26, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.shell_exec,
+        tool_name="Bash",
+        target=command,
+        metadata={},
+    )
+    ctx = EvalContext(metadata={"raw_arguments": {"command": command}, "repo_root": root})
+    return RULE.evaluate(action, ctx)
+
+
+# --- writes/deletes of the control plane via shell → BLOCK ---
+
+
+def test_redirect_into_claude_settings_is_blocked():
+    result = _cmd("echo '{}' > .claude/settings.json")
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+def test_append_into_claude_settings_is_blocked():
+    assert _cmd("echo x >> .claude/settings.json").verdict is Verdict.BLOCK
+
+
+def test_sed_in_place_on_claude_settings_is_blocked():
+    assert _cmd("sed -i s/a/b/ .claude/settings.json").verdict is Verdict.BLOCK
+
+
+def test_rm_rf_doberman_is_blocked():
+    result = _cmd("rm -rf .doberman")
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+def test_cat_doberman_policy_is_blocked():
+    # Reading the control plane via shell is blocked too — mirrors the path rule,
+    # which blocks .doberman reads (planning evasion off the policy/baseline).
+    assert _cmd("cat .doberman/policies.yaml").verdict is Verdict.BLOCK
+
+
+def test_mv_over_claude_settings_is_blocked():
+    assert _cmd("mv evil.json .claude/settings.json").verdict is Verdict.BLOCK
+
+
+def test_flag_attached_control_plane_path_is_blocked():
+    # --flag=path form: the path is the value after '='.
+    result = _cmd("git config --file=.claude/settings.json user.name x")
+    assert result.verdict is Verdict.BLOCK
+
+
+def test_chained_command_is_blocked():
+    assert _cmd("cd src && echo x > .claude/settings.json").verdict is Verdict.BLOCK
+
+
+def test_substitution_body_is_scanned():
+    assert _cmd("echo $(rm -rf .doberman)").verdict is Verdict.BLOCK
+
+
+def test_nested_bash_c_payload_is_blocked():
+    assert _cmd('bash -c "rm -rf .doberman"').verdict is Verdict.BLOCK
+
+
+def test_traversal_into_control_plane_is_blocked():
+    assert _cmd("rm a/../.doberman/policies.yaml").verdict is Verdict.BLOCK
+
+
+# --- the Doberman hook-install CLI invoked via shell → BLOCK ---
+
+
+def test_doberman_uninstall_hooks_is_blocked():
+    result = _cmd("doberman uninstall-hooks")
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+def test_doberman_install_hooks_is_blocked():
+    assert _cmd("doberman install-hooks --global").verdict is Verdict.BLOCK
+
+
+def test_doberman_setup_is_blocked():
+    assert _cmd("doberman setup --yes").verdict is Verdict.BLOCK
+
+
+# --- redaction + no over-block ---
+
+
+def test_explanation_does_not_echo_the_command_or_path():
+    result = _cmd("echo supersecret > .claude/settings.json")
+    explanation = result.explanation or ""
+    assert ".claude/settings.json" not in explanation
+    assert "supersecret" not in explanation
+
+
+def test_benign_command_passes():
+    assert _cmd("echo hello world").verdict is Verdict.PASS
+
+
+def test_similar_but_different_paths_pass():
+    # `mydoberman` / `claude.md` must not trip the `.doberman` / `.claude` globs.
+    assert _cmd("cat src/mydoberman_notes.md").verdict is Verdict.PASS
+    assert _cmd("cat docs/claude.md").verdict is Verdict.PASS
+
+
+def test_ordinary_git_commit_passes():
+    assert _cmd('git commit -m "update project config"').verdict is Verdict.PASS
+
+
+def test_objective_guardrail_blocks_a_control_plane_command():
+    action = SecurityObject(
+        id="cp-cmd-2",
+        ts=datetime(2026, 6, 26, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.shell_exec,
+        tool_name="Bash",
+        target="rm -rf .doberman",
+        metadata={},
+    )
+    ctx = EvalContext(metadata={"raw_arguments": {"command": "rm -rf .doberman"}, "repo_root": "."})
+    result = ObjectiveGuardrail(load_plugins=False).evaluate(action, ctx)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: **HK.5.0b** — Command-text control-plane protection (closes the HK.5.0-review HIGH)
- Plan reference: ADR `0024-hk5-containment-architecture`. Stacked on #41 (HK.5.0).

## What this PR does
HK.5.0 hard-blocks `Write`/`Edit` to the control plane, but a path-*target* rule misses a control-plane path **hidden inside a Bash command string**: `echo > .claude/settings.json`, `rm -rf .doberman`, `sed -i … .doberman/policies.yaml`, or `doberman uninstall-hooks` all PASSed (the action target is the command string, not a path). Two independent reviews flagged this as the top gap in the self-defense layer.

Give the command rule eyes into path tokens:
- `engine/rules/paths.py`: extract **`CONTROL_PLANE_GLOBS`** (one source of truth, spliced into `DEFAULT_BLOCKED_GLOBS`) + a public **`names_control_plane()`** that matches the raw token (absolute / `~` / Windows paths) and the repo-root-canonical form (`..` traversal); fails closed (`canonicalize` never raises).
- `engine/rules/commands.py`: import it; thread `repo_root`; **BLOCK** (`protected_path_blocked`) any segment whose argv token — operand, redirect target, or `--flag=path` value — names the control plane, and `doberman uninstall-hooks`/`install-hooks`/`setup`. Runs inside the existing segment / `$()` / `bash -c` recursion, so nested payloads are caught.

## Tests added (run in CI)
- `tests/unit/test_rule_commands_control_plane.py` — redirect/append/`sed -i`/`rm -rf`/`cat`/`mv`/`--flag=path`/chained/`$()`-substitution/`bash -c`/`..`-traversal; the `doberman` hook CLI; redaction (no command/path echo); no-over-block (`echo hello && ls src`, `git commit -m …`, `mydoberman_notes.md`); wired `ObjectiveGuardrail`.
- `tests/unit/test_hosthook_control_plane.py` — +4 Bash cases through `doberman hook pre` (`rm -rf .doberman` → deny, `echo > .claude/settings.json` → deny, `doberman uninstall-hooks` → deny, ordinary command → abstain).
- Local: ruff ✅ · ruff format ✅ · `lint-imports` ✅ (2 kept) · `pytest --cov=doberman` ✅ **978 passed, 3 skipped, 92% cov**.

## Public-release safety (doberman-core only)
- [x] Nothing from the "not allowed" list; core builds/tests/runs with no enterprise installed.

## Security checklist
- [x] Fails closed (`canonicalize` → `escapes_root`; rule errors isolated to AUTH by the guardrail)
- [x] Redaction: explanation names the class only — never the command string or path (asserted)
- [x] Raise-only: only adds BLOCKs; loosens nothing
- [x] BLOCK carries reason code (`protected_path_blocked`) + human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations / Risks
- Covered: redirect targets, `--flag=path`, `$()` + `bash -c` payload recursion, `..` traversal, absolute/`~` paths (raw-token match), the hook-install CLI; benign look-alikes (`mydoberman`, `claude.md`) pass.
- Deviation: scoped to the **control-plane** globs (`.doberman/`, `.claude/` hook config), not all blocked globs — broader "secret path inside a shell command" (`cat .env | curl`) is HK.5.6 egress hardening.
- Residual (honest): static command analysis can't catch a path the model fully obfuscates/reconstructs at runtime (e.g. `python -c` building the path from pieces) — the "hook-level mediation can't contain a shell" ceiling from ADR 0024; OS-level egress/FS containment is the platform answer.