### PR TITLE
feat(hosthooks): sticky taint ledger + provenance substrate (HK.5.1)

### DIFF
--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -228,6 +228,10 @@ _POST_REASON = (
 )
 _SECRET_REASON_CODES = frozenset({"secret_exfiltration", "sensitive_secret_access"})
 
+#: Tools that pull untrusted external content into the agent's context — the
+#: "untrusted provenance" leg of the multi-step trifecta (HK.5.1 taint ledger).
+_UNTRUSTED_READ_TOOLS: frozenset[str] = frozenset({"WebFetch", "WebSearch"})
+
 
 def _coerce_response_text(tool_response: Any) -> str:
     """Coerce ``tool_response`` (str, dict, list, …) to a single flat string.
@@ -287,6 +291,8 @@ def evaluate_post(payload: dict[str, Any]) -> dict[str, Any] | None:
 
         cwd = payload.get("cwd")
         repo_root = cwd if isinstance(cwd, str) and cwd else "."
+        raw_session = payload.get("session_id")
+        session_id = raw_session if isinstance(raw_session, str) and raw_session else None
 
         # --- Security scan (fail closed on any exception) --------------------
         try:
@@ -313,6 +319,13 @@ def evaluate_post(payload: dict[str, Any]) -> dict[str, Any] | None:
             scan_result = ObjectiveGuardrail().evaluate(action, ctx)
             fired_codes = {rc.value for rc in scan_result.reason_codes}
 
+            # Sticky taint ledger (HK.5.1): record the multi-step-exfil
+            # ingredients (a secret entered context, and/or untrusted data was
+            # read) BEFORE any block return, so a *blocked* secret-output still
+            # taints the session. No verdict authority here — HK.5.2 reads it to
+            # raise risk on a later egress.
+            _record_taint(tool_name, fired_codes, repo_root, session_id)
+
             if fired_codes & _SECRET_REASON_CODES:
                 reason = _POST_REASON.format(
                     reasons=", ".join(sorted(fired_codes & _SECRET_REASON_CODES)),
@@ -325,7 +338,7 @@ def evaluate_post(payload: dict[str, Any]) -> dict[str, Any] | None:
             return _post_block(_POST_FAILSAFE_REASON)
 
         # --- History (best-effort, never raises, never blocks) ---------------
-        _record_post_history(tool_name, tool_input, repo_root)
+        _record_post_history(tool_name, tool_input, repo_root, session_id)
 
         return None  # clean output — abstain
 
@@ -333,7 +346,9 @@ def evaluate_post(payload: dict[str, Any]) -> dict[str, Any] | None:
         return _post_block(_POST_FAILSAFE_REASON)
 
 
-def _record_post_history(tool_name: str, tool_input: dict[str, Any], repo_root: str) -> None:
+def _record_post_history(
+    tool_name: str, tool_input: dict[str, Any], repo_root: str, session_id: str | None
+) -> None:
     """Best-effort: normalize + decide + record_decision for history.
 
     Wrapped in a broad except — must never raise or affect any verdict.
@@ -351,8 +366,55 @@ def _record_post_history(tool_name: str, tool_input: dict[str, Any], repo_root: 
             metadata={"raw_arguments": args, "repo_root": repo_root},
         )
         decision = decide(action, ObjectiveGuardrail(), PASS_STUB, ctx)
-        asyncio.run(record_decision(decision, action, repo_root=repo_root, auth_result="executed"))
+        asyncio.run(
+            record_decision(
+                decision,
+                action,
+                repo_root=repo_root,
+                auth_result="executed",
+                session_id=session_id,
+            )
+        )
     except Exception:  # noqa: BLE001,S110 — history must never break the execution path
+        pass
+
+
+def _record_taint(
+    tool_name: str, fired_codes: set[str], repo_root: str, session_id: str | None
+) -> None:
+    """Best-effort: record the multi-step-exfil ingredients into the sticky taint
+    ledger (HK.5.1) under the session + entity scope.
+
+    Records ``secret_access`` when a secret reason code fired in the output scan,
+    and ``untrusted_read`` when the tool pulls untrusted external content. No
+    verdict authority — HK.5.2 reads the ledger to raise risk on a later egress.
+    Guards the common (no-taint) path before importing storage so the hook stays
+    light; wrapped so a taint write can never break the execution path.
+    """
+    has_secret = bool(fired_codes & _SECRET_REASON_CODES)
+    has_untrusted = tool_name in _UNTRUSTED_READ_TOOLS
+    if not has_secret and not has_untrusted:
+        return  # nothing to record — avoid the storage import on the common path
+
+    import asyncio  # lazy import keeps the module scope light
+
+    from doberman.storage.taint import (  # lazy import (light: no numpy/scipy/river)
+        TAINT_SECRET_ACCESS,
+        TAINT_UNTRUSTED_READ,
+        entity_scope,
+        record_taints,
+    )
+
+    kinds: list[str] = []
+    if has_secret:
+        kinds.append(TAINT_SECRET_ACCESS)
+    if has_untrusted:
+        kinds.append(TAINT_UNTRUSTED_READ)
+
+    try:
+        scopes = [s for s in (session_id, entity_scope(repo_root)) if s]
+        asyncio.run(record_taints(repo_root, scopes, kinds))
+    except Exception:  # noqa: BLE001,S110 — taint recording must never break execution
         pass
 
 

--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -411,8 +411,16 @@ def _record_taint(
     if has_untrusted:
         kinds.append(TAINT_UNTRUSTED_READ)
 
+    # Build the scopes defensively: a failure computing the entity scope (e.g. the
+    # HMAC key dir is unwritable on first use) must not drop the session-scoped
+    # taint too — record under whatever scopes we can resolve.
+    scopes: list[str] = [session_id] if session_id else []
     try:
-        scopes = [s for s in (session_id, entity_scope(repo_root)) if s]
+        scopes.append(entity_scope(repo_root))
+    except Exception:  # noqa: BLE001,S110 — keep the session scope even if the entity scope fails
+        pass
+
+    try:
         asyncio.run(record_taints(repo_root, scopes, kinds))
     except Exception:  # noqa: BLE001,S110 — taint recording must never break execution
         pass

--- a/src/doberman/storage/db.py
+++ b/src/doberman/storage/db.py
@@ -40,10 +40,11 @@ from doberman.auth.elevation import DEFAULT_TTL_SECONDS, ElevationGrant
 CONFIG_DIR = ".doberman"
 DB_FILE = "doberman.db"
 
-#: Current schema version. Bumped to 2 in Feature 8 (decision log + stores) and
-#: to 3 for the universal subjective layer (SL4/SL6/SL8: baselines re-keyed by
-#: entity, transitions, score history, preference feedback).
-SCHEMA_VERSION = 3
+#: Current schema version. Bumped to 2 in Feature 8 (decision log + stores), to 3
+#: for the universal subjective layer (SL4/SL6/SL8: baselines re-keyed by entity,
+#: transitions, score history, preference feedback), and to 4 for the host-hook
+#: sticky taint ledger (HK.5.1: decisions.session_id + the session_taint table).
+SCHEMA_VERSION = 4
 
 # Every table uses CREATE TABLE IF NOT EXISTS so opening an older DB transparently
 # adds the new tables (a forward-only, additive migration; the one re-shape —
@@ -79,7 +80,8 @@ CREATE TABLE IF NOT EXISTS decisions (
     auth_required     INTEGER NOT NULL DEFAULT 0,
     auth_result       TEXT,
     elevation_id      TEXT,
-    entity_id         TEXT
+    entity_id         TEXT,
+    session_id        TEXT
 );
 
 CREATE TABLE IF NOT EXISTS secret_fingerprints (
@@ -88,6 +90,20 @@ CREATE TABLE IF NOT EXISTS secret_fingerprints (
     first_seen        TEXT,
     last_seen         TEXT,
     source_path_class TEXT
+);
+
+-- Sticky, monotonic taint ledger (HK.5.1): the *ingredients* of a multi-step
+-- exfiltration (a secret was accessed, untrusted data was read) accumulated per
+-- session or per entity scope. `scope` is an opaque harness session id or a
+-- keyed-HMAC entity fingerprint; `kind` is a fixed constant; `count` only ever
+-- rises. No raw secret/path/prompt is stored. HK.5.2 consumes it to raise risk.
+CREATE TABLE IF NOT EXISTS session_taint (
+    scope      TEXT NOT NULL,
+    kind       TEXT NOT NULL,
+    first_seen TEXT,
+    last_seen  TEXT,
+    count      INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (scope, kind)
 );
 
 CREATE TABLE IF NOT EXISTS baseline_counts (
@@ -186,6 +202,12 @@ async def _migrate_legacy(conn: aiosqlite.Connection) -> None:
     decision_cols = await _table_columns(conn, "decisions")
     if decision_cols and "entity_id" not in decision_cols:
         await conn.execute("ALTER TABLE decisions ADD COLUMN entity_id TEXT")
+    # v3 → v4: decisions gain ``session_id`` (HK.5.1) so the host-hook taint
+    # ledger can correlate calls within one agent session. Additive ALTER on an
+    # existing table; fresh DBs get it from _SCHEMA above. session_taint itself is
+    # created additively by executescript (CREATE TABLE IF NOT EXISTS).
+    if decision_cols and "session_id" not in decision_cols:
+        await conn.execute("ALTER TABLE decisions ADD COLUMN session_id TEXT")
 
 
 async def _ensure_schema(conn: aiosqlite.Connection) -> None:

--- a/src/doberman/storage/log.py
+++ b/src/doberman/storage/log.py
@@ -36,8 +36,8 @@ _INSERT_DECISION = (
     "INSERT INTO decisions "
     "(ts, action_id, agent_role, action_type, target_path_class, risk, source_context, "
     "final_verdict, decided_layer, reason_codes_json, auth_required, auth_result, elevation_id, "
-    "entity_id) "
-    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    "entity_id, session_id) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 )
 
 _UPSERT_FINGERPRINT = (
@@ -84,12 +84,15 @@ def build_record(
     elevation_id: str | None,
     now: datetime,
     entity_id: str | None = None,
+    session_id: str | None = None,
 ) -> dict:
     """Build the single redacted record persisted and handed to every sink.
 
     ``entity_id`` is a keyed HMAC fingerprint of role+workspace (SL4) — itself
     redaction-safe — that powers the per-entity step-up budget and
-    revealed-preference learning.
+    revealed-preference learning. ``session_id`` is the host harness's opaque
+    session identifier (HK.5.1) — a UUID, not a secret — used to correlate the
+    calls of one agent session for the multi-step taint floor.
     """
     return {
         "ts": now.isoformat(),
@@ -106,6 +109,7 @@ def build_record(
         "auth_result": auth_result,
         "elevation_id": elevation_id,
         "entity_id": entity_id,
+        "session_id": session_id,
     }
 
 
@@ -118,6 +122,7 @@ async def record_decision(
     elevation_id: str | None = None,
     now: datetime | None = None,
     entity_id: str | None = None,
+    session_id: str | None = None,
 ) -> None:
     """Persist one redacted decision row and fan it out to sinks (best-effort).
 
@@ -133,6 +138,7 @@ async def record_decision(
             elevation_id=elevation_id,
             now=now or datetime.now(timezone.utc),
             entity_id=entity_id,
+            session_id=session_id,
         )
     except Exception:  # noqa: BLE001 — the decision log must never break execution
         logger.warning("decision log: could not build record for action %s", decision.action_id)
@@ -157,6 +163,7 @@ async def record_decision(
                     record["auth_result"],
                     record["elevation_id"],
                     record["entity_id"],
+                    record["session_id"],
                 ),
             )
             for fp in action.payload_fingerprints:

--- a/src/doberman/storage/taint.py
+++ b/src/doberman/storage/taint.py
@@ -1,0 +1,108 @@
+"""Sticky per-session / per-entity taint ledger (HK.5.1).
+
+Records the *ingredients* of a multi-step exfiltration — that a secret was
+accessed, and/or untrusted data was read — under a session scope (the harness
+session id) and an entity scope (a keyed-HMAC of the repo root), so a later
+egress decision can ask "has this scope already accumulated the trifecta?"
+(HK.5.2 consumes this; HK.5.1 only records — it has **no verdict authority**).
+
+Design:
+
+* **Sticky / monotonic (raise-only):** a ``(scope, kind)`` counter only ever
+  rises; nothing here clears a flag. A secret read at the start of a session
+  taints it for the rest of that session — a bounded time/count window is a
+  bypass an attacker just waits out (ADR 0024, structural truth #3).
+* **Redaction-safe:** a ``scope`` is an opaque harness session id (a UUID) or a
+  keyed-HMAC entity fingerprint; a ``kind`` is one of the fixed constants below.
+  No raw secret, path, or prompt is ever stored.
+* **Best-effort:** writes never raise into the execution path; reads fail closed
+  to an empty result (a corrupt/locked DB can never *clear* taint).
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from doberman.storage.db import db_path, open_db
+from doberman.storage.fingerprint import fingerprint
+
+#: A secret / sensitive credential entered the agent's context (read into a tool
+#: output, or accessed locally) — the "sensitive data" leg of the trifecta.
+TAINT_SECRET_ACCESS = "secret_access"  # noqa: S105 — a taint-kind label, not a credential
+#: Untrusted external data entered the agent's context (a web fetch / search) —
+#: the "untrusted provenance" leg of the trifecta.
+TAINT_UNTRUSTED_READ = "untrusted_read"
+
+_UPSERT_TAINT = (
+    "INSERT INTO session_taint (scope, kind, first_seen, last_seen, count) "
+    "VALUES (?, ?, ?, ?, 1) "
+    "ON CONFLICT(scope, kind) DO UPDATE SET last_seen = excluded.last_seen, count = count + 1"
+)
+
+_SELECT_TAINT = "SELECT kind, count FROM session_taint WHERE scope = ?"
+
+
+def entity_scope(repo_root: str) -> str:
+    """A stable, redaction-safe per-repo scope: ``"repo:" + HMAC(resolved root)``.
+
+    A coarse backstop to the harness session id so taint survives a session
+    rotation (read a secret in session A, exfiltrate in session B — same repo).
+    Uses the same keyed-HMAC helper as every other fingerprint, so the raw path
+    never appears.
+    """
+    try:
+        resolved = str(Path(repo_root).resolve())
+    except Exception:  # noqa: BLE001 — an odd root must not break taint recording
+        resolved = repo_root or "."
+    return "repo:" + fingerprint(resolved)
+
+
+async def record_taints(
+    repo_root: str,
+    scopes: list[str],
+    kinds: list[str],
+    *,
+    now: datetime | None = None,
+) -> None:
+    """Bump the ``(scope, kind)`` counter for every scope × kind (best-effort).
+
+    Empty/falsy scopes and kinds are dropped. Never raises — a taint-write
+    failure must never affect a verdict (the action has already been decided).
+    """
+    scopes = [s for s in scopes if s]
+    kinds = [k for k in kinds if k]
+    if not scopes or not kinds:
+        return
+    ts = (now or datetime.now(timezone.utc)).isoformat()
+    try:
+        async with open_db(repo_root) as conn:
+            for scope in scopes:
+                for kind in kinds:
+                    await conn.execute(_UPSERT_TAINT, (scope, kind, ts, ts))
+            await conn.commit()
+    except Exception:  # noqa: BLE001 — taint recording must never break execution
+        return
+
+
+async def record_taint(
+    repo_root: str, scope: str, kind: str, *, now: datetime | None = None
+) -> None:
+    """Convenience single-``(scope, kind)`` wrapper over :func:`record_taints`."""
+    await record_taints(repo_root, [scope], [kind], now=now)
+
+
+async def read_taint(repo_root: str, scope: str) -> dict[str, int]:
+    """Return ``{kind: count}`` accumulated under ``scope``. Fails closed to ``{}``.
+
+    A missing DB, a locked DB, or any read error yields ``{}`` — taint can never
+    be *cleared* by a storage problem, only fail to be *seen* (which leaves the
+    per-call objective floor as the protection, never silently lowering it).
+    """
+    if not scope or not db_path(repo_root).exists():
+        return {}
+    try:
+        async with open_db(repo_root) as conn:
+            async with conn.execute(_SELECT_TAINT, (scope,)) as cur:
+                rows = await cur.fetchall()
+    except Exception:  # noqa: BLE001 — a read failure must never crash a decision
+        return {}
+    return {row[0]: int(row[1]) for row in rows}

--- a/tests/unit/test_entity_baseline.py
+++ b/tests/unit/test_entity_baseline.py
@@ -184,7 +184,7 @@ async def test_schema_change_resets_only_that_tools_contribution(tmp_path):
 # --- migration ----------------------------------------------------------------
 
 
-async def test_v2_database_migrates_to_v3(tmp_path):
+async def test_v2_database_migrates_to_current(tmp_path):
     root = str(tmp_path)
     path = db_path(root)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -228,20 +228,26 @@ async def test_v2_database_migrates_to_v3(tmp_path):
 
     assert "entity_id" in count_cols  # re-keyed
     assert remaining == 0  # old global rows dropped (raise-safe: relearning is colder)
-    assert "entity_id" in decision_cols  # additive column
+    assert "entity_id" in decision_cols  # additive column (v2→v3)
+    assert "session_id" in decision_cols  # additive column (v3→v4, HK.5.1)
     assert decisions == [("a1",)]  # existing decision rows preserved
-    assert version == SCHEMA_VERSION == 3
+    assert version == SCHEMA_VERSION
 
 
-async def test_fresh_database_starts_at_v3(tmp_path):
+async def test_fresh_database_starts_at_current_version(tmp_path):
     root = str(tmp_path)
     async with open_db(root) as conn:
         async with conn.execute("SELECT version FROM schema_version") as cur:
             version = (await cur.fetchone())[0]
-        for table in ("baseline_transitions", "score_history", "preference_feedback"):
+        for table in (
+            "baseline_transitions",
+            "score_history",
+            "preference_feedback",
+            "session_taint",
+        ):
             async with conn.execute(f"SELECT COUNT(*) FROM {table}") as cur:  # noqa: S608
                 assert (await cur.fetchone())[0] == 0
-    assert version == 3
+    assert version == SCHEMA_VERSION
 
 
 async def test_observe_never_raises_on_broken_db(tmp_path, monkeypatch):

--- a/tests/unit/test_hosthook_taint.py
+++ b/tests/unit/test_hosthook_taint.py
@@ -1,0 +1,89 @@
+"""HK.5.1: the PostToolUse hook records multi-step-exfil taint into the ledger.
+
+These mirror the real ``doberman hook post`` process: ``evaluate_post`` is sync
+and runs its taint/history writes via ``asyncio.run`` internally, so the tests
+are sync too and read the ledger back with ``asyncio.run``.
+"""
+
+import asyncio
+
+from doberman.hosthooks.claude_code import evaluate_post
+from doberman.storage.db import open_db
+from doberman.storage.taint import (
+    TAINT_SECRET_ACCESS,
+    TAINT_UNTRUSTED_READ,
+    entity_scope,
+    read_taint,
+)
+
+# Canonical AWS example access key — a well-known synthetic, never a real secret.
+_SYNTHETIC_AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _post(tool_name, tool_response, cwd, *, tool_input=None, session_id="sess-1"):
+    return evaluate_post(
+        {
+            "tool_name": tool_name,
+            "tool_input": tool_input or {},
+            "tool_response": tool_response,
+            "cwd": str(cwd),
+            "session_id": session_id,
+        }
+    )
+
+
+def _taint(cwd, scope):
+    return asyncio.run(read_taint(str(cwd), scope))
+
+
+def test_webfetch_records_untrusted_read_under_session_and_entity(tmp_path):
+    out = _post(
+        "WebFetch", "ordinary page text", tmp_path, tool_input={"url": "https://example.com"}
+    )
+    assert out is None  # clean content → abstain
+    assert _taint(tmp_path, "sess-1").get(TAINT_UNTRUSTED_READ) == 1
+    assert _taint(tmp_path, entity_scope(str(tmp_path))).get(TAINT_UNTRUSTED_READ) == 1
+
+
+def test_secret_in_output_taints_session_even_when_blocked(tmp_path):
+    # A secret in a Read's output → the post-hook BLOCKs, but the session must
+    # still be tainted (the secret entered context) — recorded before the block.
+    out = _post(
+        "Read", _SYNTHETIC_AWS_KEY, tmp_path, tool_input={"file_path": "cfg.txt"}, session_id="s2"
+    )
+    assert out is not None and out.get("decision") == "block"
+    assert _taint(tmp_path, "s2").get(TAINT_SECRET_ACCESS) == 1
+    assert _taint(tmp_path, entity_scope(str(tmp_path))).get(TAINT_SECRET_ACCESS) == 1
+
+
+def test_block_reason_never_echoes_the_secret(tmp_path):
+    out = _post(
+        "Read", _SYNTHETIC_AWS_KEY, tmp_path, tool_input={"file_path": "cfg.txt"}, session_id="s3"
+    )
+    assert _SYNTHETIC_AWS_KEY not in out["reason"]
+
+
+def test_benign_tool_records_no_taint(tmp_path):
+    out = _post("Write", "wrote ok", tmp_path, tool_input={"file_path": "a.py"}, session_id="s4")
+    assert out is None
+    assert _taint(tmp_path, "s4") == {}
+
+
+def test_post_history_persists_the_session_id(tmp_path):
+    _post("Write", "wrote ok", tmp_path, tool_input={"file_path": "a.py"}, session_id="s5")
+
+    async def _session_ids():
+        async with open_db(str(tmp_path)) as conn:
+            async with conn.execute("SELECT session_id FROM decisions") as cur:
+                return [row[0] for row in await cur.fetchall()]
+
+    assert "s5" in asyncio.run(_session_ids())
+
+
+def test_missing_session_id_still_taints_entity_scope(tmp_path):
+    # Older harness with no session_id: the entity scope is the backstop.
+    out = _post(
+        "WebFetch", "page", tmp_path, tool_input={"url": "https://example.com"}, session_id=None
+    )
+    assert out is None
+    assert _taint(tmp_path, entity_scope(str(tmp_path))).get(TAINT_UNTRUSTED_READ) == 1

--- a/tests/unit/test_taint_ledger.py
+++ b/tests/unit/test_taint_ledger.py
@@ -116,3 +116,14 @@ async def test_fresh_db_has_session_id_and_taint_table(tmp_path):
     async with open_db(str(tmp_path)) as conn:
         assert "session_id" in await _columns(conn, "decisions")
         assert "scope" in await _columns(conn, "session_taint")
+
+
+async def test_reopening_a_migrated_db_is_idempotent(tmp_path):
+    # Re-running _ensure_schema / _migrate_legacy on an already-v4 DB must not
+    # error, double-add session_id, or lose data.
+    root = str(tmp_path)
+    await record_taint(root, "sess-1", TAINT_SECRET_ACCESS)  # first open → v4
+    async with open_db(root) as conn:  # second open re-runs the migration guards
+        cols = await _columns(conn, "decisions")
+    assert cols.count("session_id") == 1  # not double-added
+    assert await read_taint(root, "sess-1") == {TAINT_SECRET_ACCESS: 1}  # data intact

--- a/tests/unit/test_taint_ledger.py
+++ b/tests/unit/test_taint_ledger.py
@@ -1,0 +1,118 @@
+"""HK.5.1: the sticky per-session/entity taint ledger + the v3→v4 migration.
+
+The ledger records the *ingredients* of a multi-step exfiltration (secret-access,
+untrusted-read) per scope, monotonically. It has no verdict authority here —
+HK.5.2 consumes it. These tests cover the storage API, the additive schema
+migration, and redaction (a scope never carries a raw path).
+"""
+
+import aiosqlite
+
+from doberman.storage.db import db_path, open_db
+from doberman.storage.taint import (
+    TAINT_SECRET_ACCESS,
+    TAINT_UNTRUSTED_READ,
+    entity_scope,
+    read_taint,
+    record_taint,
+    record_taints,
+)
+
+
+async def _columns(conn, table):
+    async with conn.execute(f"PRAGMA table_info({table})") as cur:  # noqa: S608 — fixed name
+        return [row[1] for row in await cur.fetchall()]
+
+
+# --- storage API ---
+
+
+async def test_record_and_read_taint(tmp_path):
+    root = str(tmp_path)
+    await record_taint(root, "sess-1", TAINT_SECRET_ACCESS)
+    assert await read_taint(root, "sess-1") == {TAINT_SECRET_ACCESS: 1}
+
+
+async def test_taint_is_monotonic(tmp_path):
+    root = str(tmp_path)
+    await record_taint(root, "sess-1", TAINT_SECRET_ACCESS)
+    await record_taint(root, "sess-1", TAINT_SECRET_ACCESS)
+    await record_taint(root, "sess-1", TAINT_UNTRUSTED_READ)
+    assert await read_taint(root, "sess-1") == {TAINT_SECRET_ACCESS: 2, TAINT_UNTRUSTED_READ: 1}
+
+
+async def test_record_taints_batch_writes_every_scope_and_kind(tmp_path):
+    root = str(tmp_path)
+    await record_taints(root, ["sess-1", "repo:x"], [TAINT_SECRET_ACCESS, TAINT_UNTRUSTED_READ])
+    both = {TAINT_SECRET_ACCESS: 1, TAINT_UNTRUSTED_READ: 1}
+    assert await read_taint(root, "sess-1") == both
+    assert await read_taint(root, "repo:x") == both
+
+
+async def test_record_taints_drops_empty_scopes_and_kinds(tmp_path):
+    root = str(tmp_path)
+    await record_taints(root, ["", None, "sess-1"], ["", TAINT_SECRET_ACCESS])
+    assert await read_taint(root, "sess-1") == {TAINT_SECRET_ACCESS: 1}
+
+
+async def test_read_taint_fails_closed_when_no_db(tmp_path):
+    # No DB created yet → empty, never raises (a storage problem can't clear taint).
+    assert await read_taint(str(tmp_path), "sess-1") == {}
+
+
+async def test_read_taint_unknown_scope_is_empty(tmp_path):
+    root = str(tmp_path)
+    await record_taint(root, "sess-1", TAINT_SECRET_ACCESS)
+    assert await read_taint(root, "nope") == {}
+
+
+# --- entity scope (redaction) ---
+
+
+def test_entity_scope_is_deterministic_and_prefixed():
+    a = entity_scope(".")
+    assert a == entity_scope(".")
+    assert a.startswith("repo:")
+
+
+def test_entity_scope_redacts_the_raw_path(tmp_path):
+    scope = entity_scope(str(tmp_path))
+    # It's "repo:" + a keyed HMAC — the raw path must not appear.
+    assert str(tmp_path) not in scope
+    assert tmp_path.name not in scope
+
+
+# --- v3 → v4 additive migration ---
+
+
+async def test_migration_adds_session_id_and_taint_table(tmp_path):
+    # Simulate a pre-HK.5.1 DB: a decisions table without session_id, no
+    # session_taint, with one existing row.
+    path = db_path(str(tmp_path))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = await aiosqlite.connect(str(path))
+    await conn.execute(
+        "CREATE TABLE decisions (id INTEGER PRIMARY KEY AUTOINCREMENT, ts TEXT NOT NULL, "
+        "action_id TEXT NOT NULL, final_verdict TEXT NOT NULL, entity_id TEXT)"
+    )
+    await conn.execute(
+        "INSERT INTO decisions (ts, action_id, final_verdict) VALUES ('t','a','PASS')"
+    )
+    await conn.commit()
+    await conn.close()
+
+    # Opening through Doberman triggers the additive migration.
+    async with open_db(str(tmp_path)) as conn:
+        decision_cols = await _columns(conn, "decisions")
+        assert "session_id" in decision_cols  # added by the ALTER
+        assert await _columns(conn, "session_taint")  # table created by executescript
+        async with conn.execute("SELECT action_id FROM decisions") as cur:
+            rows = await cur.fetchall()
+        assert [r[0] for r in rows] == ["a"]  # existing data preserved
+
+
+async def test_fresh_db_has_session_id_and_taint_table(tmp_path):
+    # A brand-new DB gets session_id from _SCHEMA (not the ALTER) and the table.
+    async with open_db(str(tmp_path)) as conn:
+        assert "session_id" in await _columns(conn, "decisions")
+        assert "scope" in await _columns(conn, "session_taint")


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: **HK.5.1** — Sticky taint ledger + provenance-aware history substrate
- Plan reference: ADR `0024-hk5-containment-architecture` (Layer 1). Stacked on #42 (HK.5.0b). **Substrate only — no verdict change** (HK.5.2 consumes it).

## What this PR does
The foundation for the cross-call multi-step prompt-injection floor: record the *ingredients* of a multi-step exfiltration — a secret entered context, and untrusted data was read — per agent session, so a later egress decision (HK.5.2) can ask "has this session already accumulated the trifecta?".

- **Schema v3→v4** (additive — mirrors the `entity_id` precedent exactly): `decisions.session_id` (ALTER in `_migrate_legacy` for old DBs + in `_SCHEMA` for fresh DBs) and a new **monotonic** `session_taint(scope, kind, first_seen, last_seen, count)` table.
- **`storage/taint.py`** (new): `record_taint(s)` / `read_taint` (best-effort write, **fail-closed read** — a storage problem can never *clear* taint) + `entity_scope()`, a keyed-HMAC per-repo backstop so taint survives a **session rotation** (read in session A, exfil in session B). **Sticky/monotonic**, not a bounded window an attacker waits out (ADR 0024, truth #3).
- **`storage/log.py`**: `record_decision`/`build_record` accept + persist `session_id`.
- **`hosthooks`**: `evaluate_post` captures `session_id` and records taint under the session + entity scope **before any block return** — so a *blocked* secret-output still taints the session (closes the HK.2 "blocked secret not recorded" gap). Secret reason codes → `secret_access`; `WebFetch`/`WebSearch` → `untrusted_read`.

## Deferral (honest)
The fingerprint-level **exact-match** session-secret store (the HIGH/BLOCK tier) is deferred to HK.5.2: `payload_fingerprints` is not populated anywhere in `src/` today, and the taint ledger is the *primary* mechanism regardless (ADR 0024, truth #2 — taint-primary, fingerprint confirmatory).

## Tests added (run in CI)
- `tests/unit/test_taint_ledger.py` — storage API, monotonic counters, fail-closed read (missing/unknown scope), the v3→v4 additive migration (old data preserved), and redaction (scope never carries a raw path).
- `tests/unit/test_hosthook_taint.py` — `WebFetch` → `untrusted_read`; a secret in output → `secret_access` **even when the output is BLOCKed**; `session_id` persisted to `decisions`; benign tool → no taint; missing `session_id` still taints the entity scope.
- `tests/unit/test_entity_baseline.py` — schema-version asserts made version-agnostic (v2→current, fresh→current) + strengthened to assert the new `session_id` column.
- Local: ruff ✅ · ruff format ✅ · `lint-imports` ✅ (2 kept) · `pytest --cov=doberman` ✅ **994 passed, 3 skipped, 92% cov**.

## Security checklist
- [x] Fails closed: `read_taint` → `{}` on any error (taint can only fail to be *seen*, never be cleared); writes are best-effort and never raise into the execution path.
- [x] No verdict authority here — the ledger cannot allow/deny anything yet; the per-call objective floor is unchanged.
- [x] Redaction: a `scope` is an opaque harness session UUID or a keyed HMAC; a `kind` is a fixed constant — no raw secret/path/prompt stored (asserted).
- [x] Migration is additive and idempotent (CREATE IF NOT EXISTS + guarded ALTER); existing rows preserved (asserted).
- [x] doberman-core does not import doberman_enterprise.

## Edge cases / Risks
- Old DB without `session_id`/`session_taint` migrates in place; fresh DB gets both; existing data preserved.
- Missing `session_id` (older harness) → entity scope is the backstop.
- Risk/residual: `untrusted_read` is currently derived from `WebFetch`/`WebSearch` only (mcp fetch tools + Bash-fetch deferred to HK.5.2/5.6); the exact-match tier is deferred (see above).