### PR TITLE
fix(secrets): exclude hash-shaped hex from the weak-entropy heuristic (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Set a mode in `.doberman/policies.yaml` or via `doberman policy set-mode <mode>`
 Doberman is **defense-in-depth, not airtight** — no single rule is a guarantee. One concrete, currently-known gap:
 
 - **Whole-script homoglyph confusables.** The deterministic check catches *intra-token* mixed-script confusables (e.g. `раypal`, which mixes Cyrillic and Latin). But a token rendered **entirely in one non-Latin script** that mimics a Latin word (e.g. an all-Cyrillic look-alike of `paypal`) is NFKC-stable and is **not** caught by the core deterministic check today. Closing it is planned via a perplexity/confusable detector. Read the `OOD/homoglyph token signals` item above as defense-in-depth, not a robustness guarantee.
+- **Bare high-entropy hex.** To avoid flagging git SHAs, content/AST digests, and lockfile hashes as secrets — a noisy false positive that also poisoned the multi-step taint ledger — the generic high-entropy heuristic ignores tokens that are *entirely* hash-shaped hex (≥ 40 chars). A real secret that is bare hex with **no** surrounding credential name is therefore not stepped up by this heuristic alone; it is still caught when it carries a credential key-name (e.g. `API_KEY=…`), matches a known credential shape, or is later matched by the read-vs-send fingerprint. Defense-in-depth, not a guarantee.
 
 ---
 

--- a/src/doberman/engine/rules/secrets.py
+++ b/src/doberman/engine/rules/secrets.py
@@ -97,12 +97,24 @@ _SECRET_PATH = re.compile(
     """
 )
 
-# Entropy thresholds for the generic high-entropy heuristic. Lockfile hashes
-# and asset digests are long but we require BOTH length and high Shannon
-# entropy AND a charset that looks like a token to reduce false positives.
+# Entropy thresholds for the generic high-entropy heuristic. We require BOTH
+# length and high Shannon entropy AND a charset that looks like a token to
+# reduce false positives.
 _ENTROPY_MIN_LEN = 24
 _ENTROPY_BITS_PER_CHAR = 3.6  # ~ base64 randomness; below this is likely text
 _ENTROPY_TOKEN = re.compile(r"^[A-Za-z0-9+/=_\-]+$")
+
+# A git SHA-1 (40 hex) / SHA-256 (64 hex), content digest, or AST hash is long,
+# pure hex, and high-entropy — but it is NOT a credential. These are a common
+# false positive in tool output (manifests, lockfiles, git output), and a
+# spurious ``sensitive_secret_access`` here also poisons the host-hook taint
+# ledger. A token that is *entirely* hex of hash length (>= 40) is excluded from
+# the WEAK-entropy verdict path. Scope is deliberately narrow: a real base64
+# secret is virtually never all-hex; a hex value carrying a credential KEY name
+# is still caught by the strong env-assignment path; and the read-vs-send
+# fingerprint path (``_candidate_secret_tokens``) is unchanged, so a hex secret
+# that does fire is still fingerprinted.
+_HASH_LIKE_HEX = re.compile(r"[0-9a-fA-F]{40,}")
 
 # Bounds for the encoded-exfil decoder: avoid decode bombs / runaway recursion.
 # One decode layer only (no recursive base64 peeling), bounded token count/size.
@@ -161,7 +173,12 @@ def _token_looks_like_weak_secret(token: str) -> bool:
     judged whole, so splitting can never fragment a secret below the length
     floor and silently drop it. This keeps the rule raise-only: it removes a
     false positive without ever weakening detection.
+
+    A token that is entirely hash-shaped hex (a git SHA / content digest) is not
+    a credential and is excluded up front (#56) — see ``_HASH_LIKE_HEX``.
     """
+    if _HASH_LIKE_HEX.fullmatch(token):
+        return False
     if token.startswith("/"):
         return any(_looks_high_entropy_secret(segment) for segment in token.split("/"))
     return _looks_high_entropy_secret(token)

--- a/src/doberman/engine/rules/secrets.py
+++ b/src/doberman/engine/rules/secrets.py
@@ -394,6 +394,12 @@ def _candidate_secret_tokens(strings: Iterable[str]) -> list[str]:
     (HK.5.2b): every STRONG credential match plus any high-entropy token — the same
     token shapes the rule treats as secret-bearing. Bounded by ``_MAX_FINGERPRINTS``
     so a giant payload cannot produce unbounded work.
+
+    Pure hash-shaped hex (git SHA / content digest, ``_HASH_LIKE_HEX``) is excluded
+    here too (#56), consistently with the detection path: a hash is not a secret, so
+    fingerprinting one as a candidate would let a benign hash later trip a false
+    ``confirmed_exfil`` match. No recall cost — a bare hash never reaches this path
+    alone (fingerprinting only runs once a real secret reason code has fired).
     """
     string_list = list(strings)
     tokens: list[str] = list(_detected_secret_tokens(string_list))
@@ -402,6 +408,8 @@ def _candidate_secret_tokens(strings: Iterable[str]) -> list[str]:
             break
         sample = text[:_SCAN_MAX_CHARS]
         for token in re.findall(r"[A-Za-z0-9+/=_\-]{%d,}" % _ENTROPY_MIN_LEN, sample):
+            if _HASH_LIKE_HEX.fullmatch(token):
+                continue
             if _looks_high_entropy_secret(token):
                 tokens.append(token)
                 if len(tokens) >= _MAX_FINGERPRINTS:

--- a/tests/unit/test_hosthook_taint.py
+++ b/tests/unit/test_hosthook_taint.py
@@ -69,6 +69,23 @@ def test_benign_tool_records_no_taint(tmp_path):
     assert _taint(tmp_path, "s4") == {}
 
 
+def test_hash_in_output_does_not_taint_or_block(tmp_path):
+    # #56 (end-to-end): a tool output containing a git-SHA / content-hash hex is
+    # benign. It must NOT block AND must NOT write a false ``secret_access`` taint —
+    # a false taint is sticky, entity-scoped, and cross-session, so it would later
+    # spuriously AUTH/BLOCK a legitimate egress (the taint-ledger poisoning).
+    manifest = (
+        '{"commit": "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678", '
+        '"node": "316d28fa2542938cc69aeef1188fa340fd69b94080dc7745d06dcd1dd1932738"}'
+    )
+    out = _post(
+        "Read", manifest, tmp_path, tool_input={"file_path": "manifest.json"}, session_id="s56"
+    )
+    assert out is None  # benign hashes → abstain
+    assert _taint(tmp_path, "s56") == {}
+    assert _taint(tmp_path, entity_scope(str(tmp_path))) == {}
+
+
 def test_post_history_persists_the_session_id(tmp_path):
     _post("Write", "wrote ok", tmp_path, tool_input={"file_path": "a.py"}, session_id="s5")
 

--- a/tests/unit/test_rule_secrets.py
+++ b/tests/unit/test_rule_secrets.py
@@ -266,3 +266,68 @@ def test_secret_in_git_push_destination_blocks():
     result = RULE.evaluate(action, _ctx(command=f"git push https://x.test?t={FAKE_AWS}"))
     # git_op counts as external; strong secret present → BLOCK.
     assert result.verdict is Verdict.BLOCK
+
+
+# --- #56: hash-shaped hex (git SHA / content digest) is not a secret ----------
+
+GIT_SHA1 = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"  # 40 hex — a git commit SHA
+SHA256_HEX = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"  # 64 hex
+AST_HASH = "316d28fa2542938cc69aeef1188fa340fd69b94080dc7745d06dcd1dd1932738"  # 64 hex
+
+
+@pytest.mark.parametrize("digest", [GIT_SHA1, SHA256_HEX, AST_HASH])
+def test_hash_shaped_hex_is_not_flagged_as_secret(digest):
+    # #56: a bare git SHA / content / AST hash is long, high-entropy hex but NOT
+    # a credential. The weak-entropy path must not step it up to AUTH
+    # (sensitive_secret_access) — that over-block was the alert-fatigue source and
+    # (on the host-hook path) poisoned the multi-step-exfil taint ledger.
+    action = _action(ActionType.file_read, target="manifest.json")
+    result = RULE.evaluate(action, _ctx(path="manifest.json", content=f"node hash: {digest}"))
+    assert result.verdict is Verdict.PASS
+    assert ReasonCode.sensitive_secret_access not in result.reason_codes
+
+
+def test_manifest_of_hashes_sent_external_is_not_flagged():
+    # The concrete #56 case: a manifest JSON full of git-SHA + AST hashes, sent to
+    # an external destination, must read as neither exfil nor sensitive access.
+    manifest = f'{{"commit": "{GIT_SHA1}", "tree": "{SHA256_HEX}", "node": "{AST_HASH}"}}'
+    action = _action(
+        ActionType.network_request,
+        target="https://api.internal/sync",
+        dest="https://api.internal/sync",
+    )
+    result = RULE.evaluate(action, _ctx(url="https://api.internal/sync", body=manifest))
+    assert ReasonCode.secret_exfiltration not in result.reason_codes
+    assert ReasonCode.sensitive_secret_access not in result.reason_codes
+
+
+def test_hash_exclusion_is_scoped_to_pure_hex_only():
+    # Recall guard: the exclusion only fires on *entirely* hex tokens. A 40-char
+    # high-entropy token with a single non-hex char is still judged by entropy and
+    # steps up — the carve-out must not become a blanket high-entropy bypass.
+    not_pure_hex = "g1b2c3d4e5f60718293a4b5c6d7e8f9012345678"  # noqa: S105 — leading 'g' (not hex)
+    action = _action(ActionType.file_write, target="dump.bin")
+    result = RULE.evaluate(action, _ctx(path="dump.bin", content=not_pure_hex))
+    assert result.verdict is Verdict.AUTH
+
+
+def test_hex_value_with_credential_key_name_still_detected():
+    # Recall guard: the hash-hex exclusion is scoped to the WEAK path only, so a
+    # hex value carrying a credential KEY name is still a secret via the strong
+    # env-assignment path (AUTH locally).
+    action = _action(ActionType.file_write, target="cfg.env")
+    result = RULE.evaluate(action, _ctx(path="cfg.env", content=f"API_KEY={SHA256_HEX}"))
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.sensitive_secret_access in result.reason_codes
+
+
+def test_hex_value_with_credential_key_name_to_external_still_blocks():
+    # Recall guard: a real hex secret named as a credential, sent external → BLOCK.
+    action = _action(
+        ActionType.network_request, target="https://evil.example/c", dest="https://evil.example/c"
+    )
+    result = RULE.evaluate(
+        action, _ctx(url="https://evil.example/c", body=f"SECRET_KEY={SHA256_HEX}")
+    )
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.secret_exfiltration in result.reason_codes

--- a/tests/unit/test_rule_secrets.py
+++ b/tests/unit/test_rule_secrets.py
@@ -331,3 +331,33 @@ def test_hex_value_with_credential_key_name_to_external_still_blocks():
     )
     assert result.verdict is Verdict.BLOCK
     assert ReasonCode.secret_exfiltration in result.reason_codes
+
+
+def test_hash_is_not_a_fingerprint_candidate():
+    # #56 (review finding #1): a pure hash must not be fingerprinted as a read-vs-send
+    # candidate — consistently with the detection path. Otherwise a benign git SHA
+    # co-located with a real secret would be stored and later trip a false
+    # confirmed_exfil BLOCK when that same SHA is sent.
+    from doberman.engine.rules.secrets import candidate_secret_fingerprints
+
+    assert candidate_secret_fingerprints(f"commit {GIT_SHA1} tree {SHA256_HEX}") == set()
+
+
+def test_real_secret_is_still_a_fingerprint_candidate():
+    # Control for the above: a genuine credential is still fingerprinted (recall
+    # of the read-vs-send exfil store is preserved).
+    from doberman.engine.rules.secrets import candidate_secret_fingerprints
+
+    assert candidate_secret_fingerprints(f"AWS={FAKE_AWS}") != set()
+
+
+def test_bare_bearer_hex_token_is_an_accepted_gap_pass():
+    # Documented #56 tradeoff (README "Known limitations"): a bare hash-shaped hex
+    # token with NO credential key-name is not stepped up by the entropy heuristic
+    # alone. Pinned so the gap is an intentional, reviewed decision — not a silent
+    # regression. Name the token (API_KEY=) or use a known shape to catch it.
+    action = _action(ActionType.network_request, target="https://api.x/y", dest="https://api.x/y")
+    result = RULE.evaluate(
+        action, _ctx(url="https://api.x/y", body=f"Authorization: Bearer {SHA256_HEX}")
+    )
+    assert result.verdict is Verdict.PASS


### PR DESCRIPTION
## Slice
- Feature / Slice: #56 — PostToolUse output-scan over-blocks benign output as credential-like (HK.2 precision)
- Plan reference: ADR 0025 (doberman-memory) — PR1 of the #56 fix

Closes #56.

## What this PR does
The output scanner flagged benign tool output containing **git SHAs / content / AST hashes** as `sensitive_secret_access` (alert fatigue per #29/#31). On the host-hook path this also wrote a **false `secret_access` taint** — which is sticky, entity-scoped (keyed-HMAC) and **cross-session**, so it could later spuriously `ask`/`deny` a legitimate egress via the live multi-step-exfil floor (`_apply_taint_floor`).

Fix: tokens that are **entirely** hash-shaped hex (`[0-9a-fA-F]{40,}`, `re.fullmatch`) are excluded from the **weak-entropy verdict path only** (`_token_looks_like_weak_secret`).
- The **strong** env-assignment / credential-pattern path is untouched → a hex value carrying a credential key-name (`API_KEY=<hex>`) is still caught.
- The **read-vs-send fingerprint** path (`_candidate_secret_tokens`) is untouched → real hex secrets that fire are still fingerprinted.
- `_record_taint` and `_record_secret_fingerprints` are gated on the secret reason code firing, so fixing the verdict **transitively** stops the taint-ledger poisoning — no `claude_code.py` change needed.

Deferred to a follow-up: `_ENV_ASSIGNMENT` precision (drop `(?i)`, reject path/URL/placeholder values) — it entangles with the weak-entropy heuristic and carries its own recall tradeoff.

## Tests added (run in CI)
- `tests/unit/test_rule_secrets.py`: hash-shaped hex (40/64-hex) not flagged; pure-hex-only scoping guard; recall guards (key-named hex still AUTH/BLOCK local + external).
- `tests/unit/test_hosthook_taint.py`: end-to-end — a git-SHA/hash output abstains **and writes no `secret_access` taint** (the poisoning regression).
- RED proven by stashing the fix (5 failures, incl. the exact #56 block); GREEN with it. Full suite green, 92% cov; ruff + `lint-imports` clean.

## Public-release safety (doberman-core)
- [x] Contains nothing from the "not allowed" list (no enterprise/hosted code, proprietary detection, customer data, secrets, commercial-license code)
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (unchanged)
- [x] No secret, full file, or unredacted prompt logged or committed (synthetic values only)
- [x] Raise-only: this removes a false positive on a non-secret hash; the strong path, fingerprint path, and taint-on-real-secret are preserved (recall guards prove it)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations / Risks
- Scoped to *entirely*-hex tokens (a single non-hex char → still entropy-judged); covered by a test.
- Accepted defense-in-depth tradeoff (documented in README "Known limitations"): a **bare** hex secret with no credential key-name is not stepped up by the entropy heuristic alone — still caught with a key-name, a known shape, or the read-vs-send fingerprint.