### PR TITLE
test(hosthooks): isolate global setup settings path

### DIFF
--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -180,7 +180,9 @@ def test_interactive_tune_prefs(tmp_path: Path) -> None:
     assert prefs.confidentiality == pytest.approx(0.9)
 
 
-def test_interactive_global_flag_overrides_prompt(tmp_path: Path) -> None:
+def test_interactive_global_flag_overrides_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """With ``--global``, no scope prompt is asked; hooks go to ~/.claude but we
     redirect via monkeypatching ``resolve_settings_path`` to write under tmp_path."""
     from doberman.hosthooks import install as install_mod
@@ -193,15 +195,17 @@ def test_interactive_global_flag_overrides_prompt(tmp_path: Path) -> None:
             return tmp_path / ".claude" / "settings.json"
         return original(scope, project_root)
 
-    # We can't easily patch the inner import, so use --global + --yes together
+    monkeypatch.setattr(install_mod, "resolve_settings_path", _patched_resolve)
+
     result = runner.invoke(
         app,
         ["setup", "--yes", "--global", "--path", str(tmp_path)],
         catch_exceptions=False,
     )
-    # This will write to ~/.claude/settings.json; we just check exit 0 and no crash.
-    # We don't assert on file location here since ~/.claude is real. Just confirm success.
     assert result.exit_code == 0, result.output
+    s = _settings(tmp_path)
+    assert PRE_COMMAND in _doberman_commands(s, "PreToolUse")
+    assert POST_COMMAND in _doberman_commands(s, "PostToolUse")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: #50 — isolate `test_interactive_global_flag_overrides_prompt`
- Plan reference: https://github.com/fu351/Doberman-Core/issues/50

## What this PR does

Fixes #50.

This applies the existing `resolve_settings_path` test double with `monkeypatch` before invoking `doberman setup --yes --global`, then asserts the redirected `tmp_path/.claude/settings.json` contains the installed PreToolUse and PostToolUse Doberman hooks. The test no longer writes to the real `~/.claude/settings.json`.

## Tests added (run in CI)
- `tests/unit/test_setup_wizard.py::test_interactive_global_flag_overrides_prompt` covers the redirected global setup hook-install target.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Covers `--global --yes` setup without touching the real home-directory Claude settings file.
- Test-only change; no production behavior or docs changes.
- AI assistance disclosure: this PR was prepared with Codex assistance.

## Local validation
- `ruff check .`
- `ruff format --check .`
- `lint-imports`
- `pytest --cov=doberman --cov-report=term-missing` — 1056 passed, 2 skipped, 91% coverage
