### PR TITLE
docs: add CONTRIBUTORS.md recognizing project contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,34 @@
+# Contributors
+
+Doberman is open source under the [Apache-2.0 license](./LICENSE). It is built in
+the open, and it is better for every person who has contributed code, review,
+testing, or ideas. Thank you. 🐕
+
+## Maintainer
+
+- **Alan Fu** — [@fu351](https://github.com/fu351)
+
+## Contributors
+
+In alphabetical order by handle (ordering is not a ranking):
+
+- [@Bestpart-Irene](https://github.com/Bestpart-Irene)
+- **Lee Sang Hoon** — [@leemeo3](https://github.com/leemeo3)
+- [@Tian-Tan](https://github.com/Tian-Tan)
+
+The living list of everyone who has landed a commit is always on the
+[GitHub contributors graph](https://github.com/fu351/Doberman-Core/graphs/contributors).
+
+## How to join the list
+
+Open a pull request — a bug fix, a test, a doc improvement, or a new guardrail
+rule all count. Please:
+
+- Keep one slice per PR, with tests (CI must be green).
+- Note any AI-assistance you used in the PR description (we value the
+  transparency — see [PR #58](https://github.com/fu351/Doberman-Core/pull/58) for
+  an example).
+- Preserve Doberman's two non-negotiable properties: **fail closed** and
+  **raise-only** (guardrails may auto-tighten, never silently loosen).
+
+New contributors are genuinely welcome — your name belongs here.


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Docs: add a standard open-source `CONTRIBUTORS.md`

## What this PR does
Adds `CONTRIBUTORS.md` recognizing everyone who has contributed to Doberman — the maintainer plus all contributors from the GitHub contributor graph (@Bestpart-Irene, @Tian-Tan, and first-time contributor **@leemeo3 / Lee Sang Hoon**, who fixed #50 in #58). Links to the live contributor graph and documents how to join (one slice per PR, tests green, AI-assistance disclosure, fail-closed / raise-only preserved).

Docs-only; no code, no behavior change.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list (no enterprise/hosted code, proprietary detection, customer data, secrets, commercial-license code)
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (N/A — docs only)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] No guardrail/learning change
- [x] doberman-core does not import doberman_enterprise

## Notes
- Names/handles taken from the real GitHub contributor graph, not invented.