### PR TITLE
fix(hosthooks): floor strictness mode to safe default on missing cwd (#51)

### DIFF
--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -44,6 +44,7 @@ from doberman.config import load_mode
 from doberman.engine.decision_engine import PASS_STUB, decide, max_risk, max_verdict
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.models import Decision, EvalContext, ReasonCode, Risk, SecurityObject, Verdict
+from doberman.policy.modes import DEFAULT_MODE
 from doberman.proxy.normalize import normalize
 
 #: Claude Code built-in tools whose *action* we gate before execution. Pure reads
@@ -154,6 +155,22 @@ def _deny(reason: str = _FAILSAFE_REASON) -> dict[str, Any]:
     return _hook_output("deny", reason)
 
 
+def _resolve_root_and_mode(cwd: object) -> tuple[str, str]:
+    """Resolve ``(repo_root, strictness_mode)`` from a hook payload's ``cwd``.
+
+    #51: with a valid ``cwd`` we read the project's saved mode. With a
+    missing/empty/invalid ``cwd`` we must NOT fall back to ``load_mode(".")`` —
+    that reads whatever ``.doberman/policies.yaml`` happens to sit in the hook
+    process's working directory (a *different* project's policy, or none), which
+    can silently apply a **weaker** mode than the real project's (e.g. Light when
+    the project is Strict). Fail safe: use the recommended default mode instead.
+    ``repo_root`` keeps the ``"."`` fallback for storage scoping (unchanged).
+    """
+    if isinstance(cwd, str) and cwd:
+        return cwd, load_mode(cwd)
+    return ".", DEFAULT_MODE.value
+
+
 def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
     """Decide one ``PreToolUse`` call.
 
@@ -180,7 +197,7 @@ def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
                 return _deny()
 
         cwd = payload.get("cwd")
-        repo_root = cwd if isinstance(cwd, str) and cwd else "."
+        repo_root, mode = _resolve_root_and_mode(cwd)
         raw_session = payload.get("session_id")
         session_id = raw_session if isinstance(raw_session, str) and raw_session else None
 
@@ -192,7 +209,7 @@ def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
         # token channels) is what fires here.
         ctx = EvalContext(
             role=None,
-            mode=load_mode(repo_root),
+            mode=mode,
             metadata={"raw_arguments": args, "repo_root": repo_root},
         )
         decision = decide(action, ObjectiveGuardrail(), PASS_STUB, ctx)
@@ -474,7 +491,7 @@ def evaluate_post(payload: dict[str, Any]) -> dict[str, Any] | None:
             return None
 
         cwd = payload.get("cwd")
-        repo_root = cwd if isinstance(cwd, str) and cwd else "."
+        repo_root, mode = _resolve_root_and_mode(cwd)
         raw_session = payload.get("session_id")
         session_id = raw_session if isinstance(raw_session, str) and raw_session else None
 
@@ -496,7 +513,7 @@ def evaluate_post(payload: dict[str, Any]) -> dict[str, Any] | None:
             action = normalize(canonical, scan_args)
             ctx = EvalContext(
                 role=None,
-                mode=load_mode(repo_root),
+                mode=mode,
                 metadata={"raw_arguments": scan_args, "repo_root": repo_root},
             )
 
@@ -525,7 +542,7 @@ def evaluate_post(payload: dict[str, Any]) -> dict[str, Any] | None:
             return _post_block(_POST_FAILSAFE_REASON)
 
         # --- History (best-effort, never raises, never blocks) ---------------
-        _record_post_history(tool_name, tool_input, repo_root, session_id)
+        _record_post_history(tool_name, tool_input, repo_root, mode, session_id)
 
         return None  # clean output — abstain
 
@@ -534,11 +551,17 @@ def evaluate_post(payload: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def _record_post_history(
-    tool_name: str, tool_input: dict[str, Any], repo_root: str, session_id: str | None
+    tool_name: str,
+    tool_input: dict[str, Any],
+    repo_root: str,
+    mode: str,
+    session_id: str | None,
 ) -> None:
     """Best-effort: normalize + decide + record_decision for history.
 
-    Wrapped in a broad except — must never raise or affect any verdict.
+    Wrapped in a broad except — must never raise or affect any verdict. ``mode`` is
+    the strictness mode already resolved by the caller (#51) so the history row uses
+    the same safe mode as the live decision, never a re-derived ``load_mode(".")``.
     """
     import asyncio  # lazy import keeps the module scope light
 
@@ -549,7 +572,7 @@ def _record_post_history(
         action = normalize(canonical, args)
         ctx = EvalContext(
             role=None,
-            mode=load_mode(repo_root),
+            mode=mode,
             metadata={"raw_arguments": args, "repo_root": repo_root},
         )
         decision = decide(action, ObjectiveGuardrail(), PASS_STUB, ctx)

--- a/tests/unit/test_hosthook_cwd_mode.py
+++ b/tests/unit/test_hosthook_cwd_mode.py
@@ -1,0 +1,38 @@
+"""#51: the host-hook strictness mode must not silently fall back to a *weaker*
+mode read from the hook process's working directory when a payload omits ``cwd``.
+
+The bug: ``repo_root = cwd or "."`` then ``load_mode(repo_root)`` meant a missing
+``cwd`` read whatever ``.doberman/policies.yaml`` sat in the process CWD — a
+different project's policy (possibly Light) or none — instead of the real
+project's mode. The fix floors to the recommended default on a missing/invalid
+``cwd``. These tests pin that: they FAIL on the old behavior (which returns the
+process-dir's "light") and pass on the fix.
+"""
+
+import pytest
+
+from doberman.config import save_mode
+from doberman.hosthooks.claude_code import _resolve_root_and_mode
+from doberman.policy.modes import DEFAULT_MODE
+
+
+def test_valid_cwd_reads_that_projects_saved_mode(tmp_path):
+    # With a real cwd, the project's own saved mode is honored (unchanged behavior).
+    save_mode("strict", str(tmp_path))
+    repo_root, mode = _resolve_root_and_mode(str(tmp_path))
+    assert repo_root == str(tmp_path)
+    assert mode == "strict"
+
+
+@pytest.mark.parametrize("bad_cwd", [None, "", 123, {}])
+def test_missing_or_invalid_cwd_uses_safe_default_not_process_dir_policy(
+    bad_cwd, tmp_path, monkeypatch
+):
+    # A *different* project's weaker (Light) policy sits in the process CWD…
+    save_mode("light", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    # …but with no usable cwd in the payload we must NOT pick it up. Fail safe to
+    # the recommended default, never the weaker Light mode (the #51 defect).
+    _, mode = _resolve_root_and_mode(bad_cwd)
+    assert mode == DEFAULT_MODE.value
+    assert mode != "light"


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: #51 — PreToolUse `cwd="."` fallback may load the wrong strictness mode (HK.1)

Closes #51.

## What this PR does
The `PreToolUse`/`PostToolUse` hooks did `repo_root = cwd if isinstance(cwd, str) and cwd else "."` then `load_mode(repo_root)`. When a payload **omits `cwd`**, `load_mode(".")` reads whatever `.doberman/policies.yaml` sits in the **hook process's** working directory — a *different* project's policy (possibly the weaker **Light** mode), or none — silently applying a mode weaker than the real project's. That's a fail-**open** gap on an anomalous payload (against the fail-closed prime directive).

Fix: new `_resolve_root_and_mode(cwd)` —
- **valid cwd** → `(cwd, load_mode(cwd))` (unchanged behavior);
- **missing / empty / non-str cwd** → `(".", DEFAULT_MODE.value)` — never trust the process dir; floor to the recommended default.

Wired through `evaluate_pre`, `evaluate_post`, and `_record_post_history` so the live decision **and** the recorded history row use the same safe mode. `repo_root` keeps its `"."` fallback for storage scoping (taint/fingerprint) — unchanged, out of scope.

### Design note
On a missing `cwd` we genuinely can't locate the project, so we floor to **Balanced** (`DEFAULT_MODE`) — never weaker than the recommended default, and non-disruptive if a harness occasionally omits `cwd`. A stricter floor (Strict) is a one-line change if the team prefers harder fail-closed here; flagged for reviewer judgment.

## Tests added (run in CI)
- `tests/unit/test_hosthook_cwd_mode.py`: a valid cwd reads that project's saved mode; a missing/invalid cwd (`None`, `""`, non-str) floors to `DEFAULT_MODE` and **not** the Light policy planted in the process CWD (the #51 defect).

## Public-release safety (doberman-core only)
- [x] Nothing from the "not allowed" list; core builds/tests/runs with no enterprise installed
## Security checklist
- [x] **Fails closed**: this *closes* a fail-open gap (missing cwd no longer loads a weaker mode)
- [x] No secret/full-file/unredacted prompt logged or committed
- [x] Raise-only: a missing-cwd payload can now only get a *stronger-or-equal* mode than before, never weaker
- [x] Every BLOCK/AUTH keeps reason codes + explanation (unchanged)
- [x] doberman-core does not import doberman_enterprise (lint-imports: 2 contracts kept)