### PR TITLE
fix(rule-lab): guard fpr tolerance and holdout split

### DIFF
--- a/tools/rule_lab/README.md
+++ b/tools/rule_lab/README.md
@@ -33,6 +33,7 @@ builtins_only report ─▶ proposer (proposer.md) ─▶ candidate spec
 | `worker.py` | Thin driver: runs the unmodified benchmark CLI, applies the gate, validates held-out. Never merges. |
 | `proposer.md` | System prompt + JSON spec the proposer agent emits. |
 | `tests/test_scorer.py` | The safety contract for the gate. |
+| `tests/test_worker.py` | Input safeguards for worker CLI and suite splitting. |
 
 ## Run it
 
@@ -44,6 +45,12 @@ pytest tools/rule_lab/tests
 # the candidate is the ONLY installed plugin, so --profile both isolates it)
 python tools/rule_lab/worker.py --tune agentdojo --holdout synthetic
 ```
+
+`--eps-fpr` is deliberately bounded to `0.0 <= eps_fpr <= 0.05`; larger
+tolerance values fail before scoring so the loop cannot silently approve a
+high-friction candidate. Tune and holdout suites must also be disjoint. Reusing
+the same suite on both sides fails fast because it would turn held-out
+validation into train-on-test.
 
 Exit code is `0` only on `ACCEPT -> human review`, so CI / the Slice Loop can
 branch on it.
@@ -61,5 +68,7 @@ branch on it.
   suite (e.g. `synthetic`) via the non-regression predicate. Improvement must
   survive the held-out suite. A candidate tuned and measured on the *same* suite
   is train-on-test — the held-out check, not the tune ΔASR, is the real signal.
+  The worker rejects overlapping tune/holdout lists before spending benchmark
+  budget.
 - **Human in the loop**: the worker stops at `ACCEPT -> human review`. Merging —
   and any 2FA-gated loosening — is never autonomous.

--- a/tools/rule_lab/scorer.py
+++ b/tools/rule_lab/scorer.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+MAX_EPS_FPR = 0.05
+
 
 @dataclass(frozen=True)
 class GateResult:
@@ -37,6 +39,13 @@ def _fatigue(report: dict) -> float:
     return float(report.get("operator", {}).get("asr_under_fatigue", 0.0))
 
 
+def validate_eps_fpr(eps_fpr: float) -> float:
+    """Return a safe FPR tolerance or raise before the gate can be weakened."""
+    if not 0.0 <= eps_fpr <= MAX_EPS_FPR:
+        raise ValueError(f"eps_fpr {eps_fpr!r} outside safe range [0, {MAX_EPS_FPR}]")
+    return eps_fpr
+
+
 def accept(base: dict, cand: dict, eps_fpr: float = 0.0) -> GateResult:
     """Apply the raise-only gate to one suite's baseline vs. candidate report.
 
@@ -52,6 +61,7 @@ def accept(base: dict, cand: dict, eps_fpr: float = 0.0) -> GateResult:
     ``eps_fpr`` is the only tolerance dial. Keep it small; it trades benign
     friction for attack coverage and should be set by a human, not the agent.
     """
+    eps_fpr = validate_eps_fpr(eps_fpr)
     d_asr = round(base["asr"] - cand["asr"], 6)
     d_fpr = round(cand["fpr"] - base["fpr"], 6)
     d_hard = round(cand["hard_fpr"] - base["hard_fpr"], 6)
@@ -95,6 +105,7 @@ def non_regression(base: dict, cand: dict, eps_fpr: float = 0.0) -> GateResult:
     gap) passes. Same rejection conditions as :func:`accept`, minus the
     must-improve clause.
     """
+    eps_fpr = validate_eps_fpr(eps_fpr)
     d_asr = round(base["asr"] - cand["asr"], 6)
     d_fpr = round(cand["fpr"] - base["fpr"], 6)
     d_hard = round(cand["hard_fpr"] - base["hard_fpr"], 6)

--- a/tools/rule_lab/tests/test_scorer.py
+++ b/tools/rule_lab/tests/test_scorer.py
@@ -9,9 +9,18 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scorer import SuiteVerdict, accept, aggregate, non_regression, score_both  # noqa: E402
+from scorer import (  # noqa: E402
+    SuiteVerdict,
+    accept,
+    aggregate,
+    non_regression,
+    score_both,
+    validate_eps_fpr,
+)
 
 
 def _report(asr: float, fpr: float, hard_fpr: float, fatigue: float | None = None) -> dict:
@@ -50,9 +59,17 @@ def test_new_hard_block_on_benign_is_rejected():
 
 def test_extra_friction_beyond_tolerance_is_rejected():
     base = _report(asr=0.40, fpr=0.10, hard_fpr=0.02)
-    cand = _report(asr=0.20, fpr=0.18, hard_fpr=0.02)
-    assert not accept(base, cand, eps_fpr=0.05).accepted
-    assert accept(base, cand, eps_fpr=0.10).accepted  # within a human-set tolerance
+    cand = _report(asr=0.20, fpr=0.14, hard_fpr=0.02)
+    assert not accept(base, cand, eps_fpr=0.03).accepted
+    assert accept(base, cand, eps_fpr=0.05).accepted  # within the bounded tolerance
+
+
+def test_eps_fpr_must_stay_inside_safe_range():
+    assert validate_eps_fpr(0.05) == 0.05
+    with pytest.raises(ValueError, match=r"outside safe range"):
+        validate_eps_fpr(0.050001)
+    with pytest.raises(ValueError, match=r"outside safe range"):
+        accept(_report(0.4, 0.1, 0.02), _report(0.2, 0.1, 0.02), eps_fpr=-0.001)
 
 
 def test_fatigue_breaks_ties_when_asr_unchanged():

--- a/tools/rule_lab/tests/test_worker.py
+++ b/tools/rule_lab/tests/test_worker.py
@@ -1,0 +1,30 @@
+"""Unit tests for rule-lab worker input safeguards."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import worker  # noqa: E402
+
+
+def test_evaluate_rejects_overlapping_tune_and_holdout(monkeypatch: pytest.MonkeyPatch):
+    def fail_if_called(suite: str) -> dict:
+        raise AssertionError(f"unexpected benchmark run for {suite}")
+
+    monkeypatch.setattr(worker, "run_suite_both", fail_if_called)
+
+    with pytest.raises(ValueError, match="must be disjoint"):
+        worker.evaluate(["agentdojo", "synthetic"], ["synthetic"], eps_fpr=0.0)
+
+
+def test_main_rejects_eps_fpr_above_safe_bound(capsys: pytest.CaptureFixture[str]):
+    with pytest.raises(SystemExit) as exc:
+        worker.main(["--tune", "agentdojo", "--holdout", "synthetic", "--eps-fpr", "0.5"])
+
+    assert exc.value.code == 2
+    assert "outside safe range" in capsys.readouterr().err

--- a/tools/rule_lab/worker.py
+++ b/tools/rule_lab/worker.py
@@ -40,7 +40,13 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from scorer import SuiteVerdict, aggregate, non_regression_both, score_both  # noqa: E402
+from scorer import (  # noqa: E402
+    SuiteVerdict,
+    aggregate,
+    non_regression_both,
+    score_both,
+    validate_eps_fpr,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -61,8 +67,29 @@ def run_suite_both(suite: str) -> dict:
     return json.loads(proc.stdout)
 
 
+def _eps_fpr_arg(value: str) -> float:
+    try:
+        eps_fpr = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid eps_fpr {value!r}") from exc
+    try:
+        return validate_eps_fpr(eps_fpr)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def validate_suite_split(tune: list[str], holdout: list[str]) -> None:
+    """Fail fast when held-out validation would reuse a tune suite."""
+    overlap = sorted(set(tune) & set(holdout))
+    if overlap:
+        joined = ", ".join(overlap)
+        raise ValueError(f"tune and holdout suites must be disjoint; overlap: {joined}")
+
+
 def evaluate(tune: list[str], holdout: list[str], eps_fpr: float) -> dict:
     """Run the tune set, apply the gate, then validate on the held-out set."""
+    validate_eps_fpr(eps_fpr)
+    validate_suite_split(tune, holdout)
     verdicts: list[SuiteVerdict] = []
     reports: dict[str, dict] = {}
     for suite in tune:
@@ -128,7 +155,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     p.add_argument(
         "--eps-fpr",
-        type=float,
+        type=_eps_fpr_arg,
         default=0.0,
         help="benign-friction tolerance (human-set; keep small)",
     )


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: #46 — harden the rule-lab acceptance gate
- Plan reference: GitHub issue #46

## What this PR does

Fixes #46.

This tightens the rule-lab worker/gate in two small ways:

- Bounds `--eps-fpr` to `0.0 <= eps_fpr <= 0.05` before scoring, and validates the same bound inside `accept` / `non_regression` so programmatic callers cannot bypass the CLI guard.
- Rejects overlapping `--tune` and `--holdout` suite lists before running benchmarks, so held-out validation cannot accidentally become train-on-test.

Also updates the rule-lab README to document the bounded tolerance and disjoint suite requirement.

AI assistance disclosure: I used Codex to prepare this patch and validation summary; I reviewed the diff and ran the checks below locally.

## Tests added (run in CI)
- `tools/rule_lab/tests/test_scorer.py`: covers the safe `eps_fpr` bound and rejects out-of-range values.
- `tools/rule_lab/tests/test_worker.py`: covers tune/holdout overlap fail-fast and CLI rejection for an unsafe `--eps-fpr`.

Local validation:
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/lint-imports`
- `.venv/bin/pytest --cov=doberman --cov-report=term-missing` (`1070 passed, 2 skipped`, 91% coverage)

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (N/A — rule-lab gate/worker input guards only)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- `eps_fpr` values above `0.05` fail both through the CLI and direct gate calls.
- Negative `eps_fpr` values fail direct gate validation.
- Overlapping tune/holdout lists fail before any benchmark run is attempted.
- The chosen upper bound is intentionally conservative; if maintainers prefer a different cap, it is centralized in `MAX_EPS_FPR`.