### PR TITLE
fix(rules/secrets): detect modern provider key shapes (Anthropic/OpenAI-proj/GitLab/Stripe-test)

### DIFF
--- a/src/doberman/engine/rules/secrets.py
+++ b/src/doberman/engine/rules/secrets.py
@@ -52,14 +52,19 @@ logger = logging.getLogger("doberman.engine.rules.secrets")
 _CREDENTIAL_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"AKIA[0-9A-Z]{16}"),  # AWS access key id
     re.compile(r"ASIA[0-9A-Z]{16}"),  # AWS temporary access key id
-    re.compile(r"sk-[A-Za-z0-9]{20,}"),  # OpenAI-style secret key
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),  # OpenAI-style secret key (classic sk-…)
+    re.compile(r"sk-proj-[A-Za-z0-9_-]{20,}"),  # OpenAI project/scoped key (hyphenated)
+    re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"),  # Anthropic API key (sk-ant-api03-…)
     re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"),  # GitHub classic/app tokens
     re.compile(r"github_pat_[A-Za-z0-9_]{22,}"),  # GitHub fine-grained PAT
+    re.compile(r"glpat-[A-Za-z0-9_-]{20,}"),  # GitLab personal access token
     re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),  # Slack tokens
     # Slack incoming-webhook URL (carries send capability)
     re.compile(r"https://hooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]{16,}"),
     re.compile(r"AIza[0-9A-Za-z_\-]{20,}"),  # Google API key
-    re.compile(r"(?:sk|rk)_live_[A-Za-z0-9]{20,}"),  # Stripe live secret/restricted key
+    re.compile(
+        r"(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{20,}"
+    ),  # Stripe live/test secret/restricted key
     re.compile(r"SG\.[A-Za-z0-9_\-]{16,}\.[A-Za-z0-9_\-]{16,}"),  # SendGrid API key
     re.compile(r"npm_[A-Za-z0-9]{36}"),  # npm access token
     # JWT: two base64url JSON segments (header/payload start with eyJ) + signature

--- a/tests/unit/test_rule_secrets.py
+++ b/tests/unit/test_rule_secrets.py
@@ -42,6 +42,13 @@ FAKE_SLACK_HOOK = (  # noqa: S105
 FAKE_SENDGRID = "SG" + ".EXAMPLEabcdef0123456789" + ".EXAMPLE_ABCDEFGHIJ0123456789klmnop"  # noqa: S105
 FAKE_NPM = "npm" + "_" + "EXAMPLE" + "0123456789abcdefABCDEF0123456"  # noqa: S105
 FAKE_DB_URI = "postgres://" + "dbuser:" + "EXAMPLEpass123" + "@db.internal:5432/app"  # noqa: S105
+# Modern provider key shapes the original _CREDENTIAL_PATTERNS missed (so they only
+# got AUTH-via-entropy, not BLOCK, on exfil). Built via `+` so push-protection/gitleaks
+# does not flag the literals; the runtime value still matches the rule's regex.
+FAKE_ANTHROPIC = "sk-ant-" + "api03-" + "EXAMPLE0123456789abcdefABCDEF0123456789"  # noqa: S105
+FAKE_OPENAI_PROJ = "sk-proj-" + "EXAMPLE0123456789abcdefABCDEF0123456789"  # noqa: S105
+FAKE_GITLAB = "glpat-" + "EXAMPLE0123456789abcdefABCDE"  # noqa: S105
+FAKE_STRIPE_TEST = "sk" + "_test_" + "EXAMPLE0123456789abcdef99"  # noqa: S105
 
 NEW_CREDENTIALS = [
     FAKE_JWT,
@@ -51,6 +58,10 @@ NEW_CREDENTIALS = [
     FAKE_SENDGRID,
     FAKE_NPM,
     FAKE_DB_URI,
+    FAKE_ANTHROPIC,
+    FAKE_OPENAI_PROJ,
+    FAKE_GITLAB,
+    FAKE_STRIPE_TEST,
 ]
 # Strings that RESEMBLE but are NOT strong credentials — must never strong-block.
 BENIGN_LOOKALIKES = [


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: detection-recall hardening — credential patterns (from the FP/FN audit)

## What this PR does
`_CREDENTIAL_PATTERNS` predated several now-common credential shapes, so they only reached **AUTH** (via the generic entropy heuristic) instead of a hard **BLOCK** on exfil. A bare key in a network body — without a credential-keyword variable name — was the realistic attacker path, and AUTH can be satisfied/retried while BLOCK cannot.

Added four patterns (all **raise-only** — they add detection, never weaken it):
- `sk-ant-[A-Za-z0-9_-]{20,}` — **Anthropic** `sk-ant-api03-…` (the existing `sk-[A-Za-z0-9]{20,}` can't match across the hyphen after `ant`)
- `sk-proj-[A-Za-z0-9_-]{20,}` — **OpenAI** project/scoped keys (same hyphen problem)
- `glpat-[A-Za-z0-9_-]{20,}` — **GitLab** personal access token (no pattern existed)
- widened Stripe to `(?:sk|rk)_(?:live|test)_…` — **Stripe test** keys were uncovered

Ironically the pre-fix gap meant Doberman did not hard-block exfil of **Anthropic's own** key shape.

## Tests added (run in CI)
- `tests/unit/test_rule_secrets.py`: four synthetic keys join `NEW_CREDENTIALS`, exercised by the existing `exfil → BLOCK (secret_exfiltration)` parametrized test. Synthetic keys are built via string concatenation so the **gitleaks** CI scanner does not flag the literals. Classic `sk-…` and benign-text regressions preserved.
- Local gate green: `ruff check` ✓, `ruff format --check` ✓, `lint-imports` (2 kept/0 broken) ✓, `pytest tests/unit/test_rule_secrets.py` 55/55 ✓.

## Public-release safety (doberman-core only)
- [x] Nothing from the "not allowed" list; core builds/tests/runs with no enterprise installed

## Security checklist
- [x] **Raise-only**: only adds detection; existing patterns, PEM, decode-chain untouched — a BLOCK can never become weaker
- [x] No secret/full-file/unredacted prompt logged or committed (synthetic keys via concatenation)
- [x] Every BLOCK/AUTH keeps reason codes + explanation (unchanged)
- [x] doberman-core does not import doberman_enterprise (lint-imports kept)

## Notes
- No README change: secret-exfil detection is described generically (no enumerated pattern list); this broadens an already-documented capability without changing the public surface or adding a limitation.
- Part of a broader FP/FN audit; remaining findings (command-bypass, token-channel decode, path globs) tracked separately.