### PR TITLE
feat(branding): mark Doberman's hook prompts with a 🐕 so users can tell it from the host agent

### DIFF
--- a/src/doberman/branding.py
+++ b/src/doberman/branding.py
@@ -1,0 +1,19 @@
+"""Brand marker for Doberman's user-facing messages.
+
+A small dog marker (the 🐕 emoji) prefixes the messages Doberman shows the user,
+so they can tell when it is *Doberman* asking/blocking versus the host agent
+(Claude Code, Cursor, …) whose prompts it interleaves with.
+
+It is used only on the **host-hook decision channel**, which serialises via
+``json.dumps`` (default ``ensure_ascii=True``): the emoji is escaped to a
+``\\uXXXX`` sequence on the wire — ASCII on any stdout, never raising — and the
+harness UI renders it as 🐕.
+
+CLI / terminal output deliberately stays pure ASCII (enforced by
+``tests/unit/test_cli_encode_safe.py``) so it renders cleanly on a legacy cp1252
+Windows console; the emoji is intentionally *not* used there.
+"""
+
+#: The dog marker codepoint (🐕). Safe to embed in any string that is later
+#: JSON-encoded with the default ``ensure_ascii=True`` (the host-hook channel).
+DOG = "\U0001f415"

--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from doberman.branding import DOG
 from doberman.config import load_mode
 from doberman.engine.decision_engine import PASS_STUB, decide, max_risk, max_verdict
 from doberman.engine.objective import ObjectiveGuardrail
@@ -93,8 +94,8 @@ _REQUIRED_FIELD: dict[str, str] = {
 }
 
 _HOOK_EVENT = "PreToolUse"
-_REASON = "Doberman [{verdict}]: {explanation} (reasons: {reasons}; action {action_id})"
-_FAILSAFE_REASON = "Doberman: failing closed — could not evaluate this action safely."
+_REASON = DOG + " Doberman [{verdict}]: {explanation} (reasons: {reasons}; action {action_id})"
+_FAILSAFE_REASON = DOG + " Doberman: failing closed — could not evaluate this action safely."
 
 #: HK.5.2 taint floor: modes where a tainted-session egress is BLOCKed outright
 #: rather than AUTH'd. Mirrors the lethal-trifecta hard block (ADR 0021): raise-only,
@@ -422,9 +423,9 @@ _INTERNAL_TOOLS: frozenset[str] = frozenset(
     {"TodoWrite", "TodoRead", "Task", "ExitPlanMode", "Artifact", "NotebookRead"}
 )
 
-_POST_FAILSAFE_REASON = "Doberman: failing closed — could not vet this tool output."
+_POST_FAILSAFE_REASON = DOG + " Doberman: failing closed — could not vet this tool output."
 _POST_REASON = (
-    "Doberman [post]: output contains credential-like material "
+    DOG + " Doberman [post]: output contains credential-like material "
     "({reasons}; action {action_id}).  Explanation: {explanation}"
 )
 _SECRET_REASON_CODES = frozenset({"secret_exfiltration", "sensitive_secret_access"})

--- a/tests/unit/test_branding.py
+++ b/tests/unit/test_branding.py
@@ -1,0 +1,31 @@
+"""🐕 brand marker on the host-hook decision channel: it must reach the user (so
+they know it's Doberman asking, not the host agent) and stay ASCII-safe on the
+wire (the hook serialises with json.dumps default ensure_ascii=True)."""
+
+import json
+import unicodedata
+
+from doberman.branding import DOG
+from doberman.hosthooks.claude_code import _FAILSAFE_REASON, _REASON
+
+
+def test_dog_is_the_dog_emoji():
+    assert DOG == "\U0001f415"
+    assert "DOG" in unicodedata.name(DOG)
+
+
+def test_hook_decision_messages_carry_the_marker():
+    # The pre/post hook reasons are the surface a user sees when Doberman asks or
+    # blocks mid-session, interleaved with the host agent's own prompts.
+    assert _REASON.startswith(DOG)
+    assert _FAILSAFE_REASON.startswith(DOG)
+
+
+def test_marker_survives_the_hook_json_ascii_roundtrip():
+    # Host-hook output uses json.dumps default (ensure_ascii=True): the emoji is
+    # escaped on the wire (pure ASCII — cannot raise on any stdout) and decodes
+    # back to 🐕 for the harness UI.
+    reason = _REASON.format(verdict="deny", explanation="x", reasons="r", action_id="a")
+    wire = json.dumps({"reason": reason})
+    assert DOG not in wire  # escaped on the wire → ASCII-safe, never crashes a hook
+    assert json.loads(wire)["reason"].startswith(DOG)  # rendered as 🐕 to the user


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: branding — dog marker on Doberman's user-facing decision prompts

## What this PR does
Doberman's `PreToolUse`/`PostToolUse` decision messages interleave with the host agent's own prompts in the Claude Code UI, so a user can't tell *who* is asking. This prefixes those messages with a 🐕 marker (`doberman.branding.DOG`).

**Encoding-safe by design:** the host-hook channel serialises via `json.dumps` with the default `ensure_ascii=True`, so the emoji is escaped to `🐕` on the wire — pure ASCII, can never raise `UnicodeEncodeError` on any stdout — and the harness UI renders it as 🐕. CLI/terminal output is deliberately left **pure ASCII** to honour the existing cp1252-safe onboarding invariant (`tests/unit/test_cli_encode_safe.py`); a pure-ASCII CLI Doberman is a quick follow-up.

Marked surfaces (all in `hosthooks/claude_code.py`): the pre/post decision reason, both fail-safe reasons, and the credential-material post message.

## Tests added (run in CI)
- `tests/unit/test_branding.py`: the marker is the dog codepoint; the hook decision messages carry it; and it survives the hook's `json.dumps` ascii round-trip (escaped on the wire → decodes back to 🐕 for the UI).
- Local: ruff clean; `pytest -k "branding or encode_safe or hosthook or install_hooks"` 128 passed (incl. the cp1252 onboarding invariant).

## Public-release safety (doberman-core only)
- [x] Nothing from the "not allowed" list; pure cosmetic marker; core builds/tests/runs standalone

## Security checklist
- [x] No verdict/decision logic changed — display-only marker on existing reason strings
- [x] Fails closed unchanged; emoji can't crash the hook (ascii-escaped in JSON)
- [x] No secret/unredacted content added to messages
- [x] doberman-core does not import doberman_enterprise