### PR TITLE
fix(hosthooks): point control-plane blocks at the out-of-band recovery path

### DIFF
--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -289,6 +289,17 @@ def _block(explanation: str) -> GuardrailResult:
     )
 
 
+# Surfaced on every control-plane block so a legitimate user isn't dead-ended:
+# the agent is intentionally blocked from touching its own guard (anti-tamper),
+# so the recovery path is out-of-band — a regular terminal where the hooks don't
+# intercept. No user path is echoed here, so redaction holds.
+_CONTROL_PLANE_RECOVERY_HINT = (
+    " To change Doberman's own hooks/config, do it in a regular terminal outside the"
+    " agent session (e.g. `doberman uninstall-hooks`) — the agent is intentionally"
+    " blocked from tampering with its own guard."
+)
+
+
 def _block_control_plane(explanation: str) -> GuardrailResult:
     # Reuse the path rule's reason code — semantically this *is* a protected-path
     # hit, just surfaced from inside a command string (HK.5.0b).
@@ -296,7 +307,7 @@ def _block_control_plane(explanation: str) -> GuardrailResult:
         verdict=Verdict.BLOCK,
         risk=Risk.critical,
         reason_codes=[ReasonCode.protected_path_blocked],
-        explanation=explanation,
+        explanation=explanation + _CONTROL_PLANE_RECOVERY_HINT,
     )
 
 

--- a/tests/unit/test_rule_commands_control_plane.py
+++ b/tests/unit/test_rule_commands_control_plane.py
@@ -112,6 +112,22 @@ def test_explanation_does_not_echo_the_command_or_path():
     assert "supersecret" not in explanation
 
 
+def test_control_plane_block_explains_the_recovery_path():
+    # A legitimate user who wants to change/uninstall the hooks needs to know the
+    # recovery path is out-of-band (a plain terminal) — the agent itself is blocked
+    # from doing it (anti-tamper). The block message must point there so the user
+    # isn't dead-ended.
+    explanation = (_cmd("doberman uninstall-hooks").explanation or "").lower()
+    assert "uninstall-hooks" in explanation
+    assert "terminal" in explanation
+
+
+def test_recovery_hint_does_not_echo_a_user_control_plane_path():
+    # The appended hint must not leak the user's targeted path (redaction holds).
+    explanation = _cmd("echo x > .claude/settings.json").explanation or ""
+    assert ".claude/settings.json" not in explanation
+
+
 def test_benign_command_passes():
     assert _cmd("echo hello world").verdict is Verdict.PASS
 


### PR DESCRIPTION
## What
Control-plane self-defense (HK.5.0b) correctly hard-blocks the agent from tampering with its own guard config (anti-tamper, by design). But the block gave a legitimate user **no recovery path** — they're dead-ended mid-session with no hint how to proceed. This appends a recovery hint to every control-plane block: make the change out-of-band in a regular terminal (e.g. `doberman uninstall-hooks`), where the hooks don't intercept.

## Why
Found while **dogfooding** the host hooks. Hitting a bare control-plane BLOCK with no next step is a real adoption snag. UX-only — the security behavior is unchanged (still fail-closed, still blocks the agent).

## How
- New `_CONTROL_PLANE_RECOVERY_HINT`, appended in `_block_control_plane` (DRY — both control-plane messages get it).
- No user path is echoed in the hint, so redaction holds.

## Tests
- `test_control_plane_block_explains_the_recovery_path` — block explanation names the recovery path (RED before, GREEN after).
- `test_recovery_hint_does_not_echo_a_user_control_plane_path` — hint doesn't leak the targeted path.
- Full control-plane + path suites green; ruff/format clean; lint-imports 2/2.

Self-defense / raise-only / fail-closed all preserved. Separate from the over-block FPR work (#56 / PR #57). Peer review + merge (no-self-merge).