### PR TITLE
fix(hosthooks): log post-hook output blocks

### DIFF
--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -537,6 +537,7 @@ def evaluate_post(payload: dict[str, Any]) -> dict[str, Any] | None:
                     action_id=action.id,
                     explanation=(scan_result.explanation or "").strip() or "no further detail",
                 )
+                _record_blocked_post_history(scan_result, action, repo_root, session_id)
                 return _post_block(reason)
 
         except Exception:  # noqa: BLE001 — scan failure → fail closed
@@ -564,10 +565,6 @@ def _record_post_history(
     the strictness mode already resolved by the caller (#51) so the history row uses
     the same safe mode as the live decision, never a re-derived ``load_mode(".")``.
     """
-    import asyncio  # lazy import keeps the module scope light
-
-    from doberman.storage.log import record_decision  # lazy import
-
     try:
         canonical, args = to_normalize_input(tool_name, tool_input)
         action = normalize(canonical, args)
@@ -577,12 +574,63 @@ def _record_post_history(
             metadata={"raw_arguments": args, "repo_root": repo_root},
         )
         decision = decide(action, ObjectiveGuardrail(), PASS_STUB, ctx)
+        _record_post_history_decision(
+            decision, action, repo_root, session_id, auth_result="executed"
+        )
+    except Exception:  # noqa: BLE001,S110 — history must never break the execution path
+        pass
+
+
+def _record_blocked_post_history(
+    scan_result: Any,
+    action: SecurityObject,
+    repo_root: str,
+    session_id: str | None,
+) -> None:
+    """Best-effort: record a PostToolUse output-scan block in ``doberman log``.
+
+    The objective scan may return AUTH for "secret entered context", but the
+    PostToolUse hook's enforcement decision is to block that output from reaching
+    the model. The decision log should therefore show the hook-enforced BLOCK.
+    """
+    try:
+        decision = Decision(
+            action_id=action.id,
+            final_verdict=Verdict.BLOCK,
+            final_risk=max_risk(scan_result.risk, Risk.high),
+            objective=scan_result,
+            subjective=None,
+            reason_codes=list(scan_result.reason_codes),
+            explanation=scan_result.explanation,
+            decided_at=action.ts,
+        )
+        _record_post_history_decision(
+            decision, action, repo_root, session_id, auth_result="blocked"
+        )
+    except Exception:  # noqa: BLE001,S110 — history must never break the block path
+        pass
+
+
+def _record_post_history_decision(
+    decision: Decision,
+    action: SecurityObject,
+    repo_root: str,
+    session_id: str | None,
+    *,
+    auth_result: str,
+) -> None:
+    """Best-effort: persist one PostToolUse decision row."""
+    import asyncio  # lazy import keeps the module scope light
+
+    from doberman.storage.log import record_decision  # lazy import
+
+    try:
         asyncio.run(
             record_decision(
                 decision,
                 action,
                 repo_root=repo_root,
-                auth_result="executed",
+                auth_result=auth_result,
                 session_id=session_id,
             )
         )

--- a/tests/unit/test_hosthook_claude_post.py
+++ b/tests/unit/test_hosthook_claude_post.py
@@ -75,6 +75,23 @@ def test_secret_string_response_is_blocked(cwd):
     assert data["decision"] == "block"
 
 
+def test_secret_string_block_is_recorded_in_decision_log(cwd):
+    secret = _SYNTHETIC_SECRET
+    out = _post(
+        "Bash", {"command": "cat ~/.aws/credentials"}, f"[default]\naws_access_key_id={secret}", cwd
+    )
+    assert out is not None
+
+    rows = asyncio.run(read_decisions(cwd))
+    assert rows
+    latest = rows[0]
+    assert latest["final_verdict"] == "BLOCK"
+    assert latest["auth_result"] == "blocked"
+    reasons = json.loads(latest["reason_codes_json"] or "[]")
+    assert set(reasons) & {"secret_exfiltration", "sensitive_secret_access"}
+    assert secret not in repr(latest)
+
+
 def test_secret_string_not_in_block_reason(cwd):
     secret = _SYNTHETIC_SECRET
     out = _post("Bash", {"command": "cat ~/.aws/credentials"}, f"found key: {secret}", cwd)


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: hosthooks observability — record PostToolUse output blocks in the redacted decision log
- Plan reference: #68

## What this PR does

Refs #68.

This fixes the narrow logging gap where `doberman hook post` blocks a tool result because the output contains credential-like material, but that blocked hook decision never reaches `doberman log`.

Before this change, the PostToolUse flow returned the block response before the best-effort history writer ran. Now, when the output scan fires a secret-related reason code, the hook records a redacted BLOCK row with `auth_result="blocked"` before returning the block response.

The broader `doberman status` request in #68 is intentionally left out so this PR stays small and reviewable.

## Tests added (run in CI)
- `test_secret_string_block_is_recorded_in_decision_log`

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- History writes remain best-effort and cannot weaken or alter the block path.
- The log row records the hook-enforced BLOCK, not the raw scanned output.
- The regression test asserts the synthetic secret does not appear in the recorded row.
- This PR does not implement the separate `doberman status` enhancement from #68.

## Local validation
- `ruff check src/doberman/hosthooks/claude_code.py tests/unit/test_hosthook_claude_post.py`
- `pytest tests/unit/test_hosthook_claude_post.py -v` — 21 passed
- `ruff format --check .`
- `lint-imports` — 2 kept / 0 broken
- `pytest --cov=doberman --cov-report=term-missing` — 1094 passed, 2 skipped, 91% coverage

AI assistance disclosure: this PR was prepared with Codex assistance.