### PR TITLE
feat(engine): shadow-only adjudication seam (Phase 0 of adaptive precision)

### DIFF
--- a/src/doberman/engine/adjudicator.py
+++ b/src/doberman/engine/adjudicator.py
@@ -1,0 +1,149 @@
+"""Shadow-only adjudication seam (Phase 0 of the "adaptive precision" method).
+
+A pluggable **second-opinion** layer that may *observe* a decision and record what
+it WOULD recommend — but **never** changes the live verdict. Phase 0 is
+shadow-only by construction:
+
+* An adjudicator is handed a **redacted feature Mapping** (:func:`redacted_features`),
+  not a :class:`SecurityObject`/:class:`EvalContext`, so it *structurally* cannot see
+  raw arguments, file contents, secrets, or the raw destination — only classes,
+  the algebra, reason-code strings, and fingerprint counts.
+* Its recommendation is attached to :attr:`~doberman.models.Decision.shadow` and is
+  passed to **no** part of the ``final_verdict``/``final_risk`` computation. There is
+  no code path by which an adjudicator can raise (or lower) the live decision.
+* It is **fail-closed**: any error consulting an adjudicator (raise, garbage return)
+  is logged at debug and ignored — the decision proceeds unchanged.
+* It is subordinate to the raise-only floor: the engine only ever consults it in the
+  ambiguous AUTH step-up band; a floor/BLOCK or PASS decision is never shown to it.
+
+A real anomaly-model / cheap-LLM adjudicator (enterprise) plugs in here by
+implementing :class:`Adjudicator` and registering via the ``doberman.adjudicators``
+entry-point group — core never imports it by name.
+"""
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol, runtime_checkable
+
+from doberman.models import GuardrailResult, Risk, SecurityObject, TargetClass, Verdict
+
+logger = logging.getLogger("doberman.engine.adjudicator")
+
+#: The low-sensitivity target classes the built-in reference treats as benign.
+_BENIGN_TARGET_CLASSES = frozenset({TargetClass.public.value, TargetClass.internal.value})
+
+
+@runtime_checkable
+class Adjudicator(Protocol):
+    """The contract a shadow adjudicator implements.
+
+    ``adjudicate`` receives a plain **redacted** feature Mapping (never a
+    ``SecurityObject``/``EvalContext``) plus the current :class:`GuardrailResult`,
+    and returns either a :class:`GuardrailResult` recommendation or ``None`` to
+    abstain. It is SHADOW-ONLY: the engine never uses the return value to build
+    the live verdict.
+
+    CAVEAT: ``isinstance(obj, Adjudicator)`` is structural-only (checks for an
+    ``adjudicate`` attribute, not its signature) — the real gate is that the
+    return value is validated as a ``GuardrailResult``/``None`` and any error is
+    isolated (:func:`run_shadow_adjudication`).
+    """
+
+    def adjudicate(
+        self, features: Mapping[str, Any], current: GuardrailResult
+    ) -> GuardrailResult | None:
+        """Recommend a verdict for a decision, or ``None`` to abstain."""
+        ...
+
+
+def redacted_features(action: SecurityObject, current: GuardrailResult) -> dict[str, Any]:
+    """Build the EXPLICIT allowlist of redacted features shown to an adjudicator.
+
+    Only redaction-safe classes/counts leave here. It MUST NOT include
+    ``raw_args_redacted``, ``ctx.metadata``, the raw ``external_destination``
+    string, ``explanation``, or any raw value — an adjudicator can only ever see
+    the algebra, sensitivity classes, reason-code strings, and fingerprint
+    counts. ``tool_name`` is a low-risk identifier and is kept.
+    """
+    algebra = action.algebra
+    return {
+        "action_type": action.action_type.value,
+        "tool_name": action.tool_name,
+        "target_path_class": action.target_path_class,
+        "risk": action.risk.value,
+        "verdict": current.verdict.value,
+        "reason_codes": [rc.value for rc in current.reason_codes],
+        "algebra": {
+            "capability": algebra.capability.value,
+            "target_class": algebra.target_class.value,
+            "destination_class": algebra.destination_class.value,
+            "blast_radius": algebra.blast_radius.value,
+            "provenance": algebra.provenance.value,
+            "classification_confidence": algebra.classification_confidence,
+        },
+        "has_external_destination": action.external_destination is not None,
+        "fingerprint_count": len(action.payload_fingerprints),
+    }
+
+
+class LocalReferenceAdjudicator:
+    """A minimal, illustrative built-in adjudicator (no network, core-safe).
+
+    This is a REFERENCE demonstrating the seam contract; it is SHADOW-ONLY and
+    never affects the live verdict. On a benign-looking AUTH decision it records
+    a "would-PASS" second opinion; otherwise it abstains. A real anomaly-model /
+    LLM adjudicator plugs in at this same interface.
+    """
+
+    def adjudicate(
+        self, features: Mapping[str, Any], current: GuardrailResult
+    ) -> GuardrailResult | None:
+        algebra = features.get("algebra", {})
+        looks_benign = (
+            current.verdict is Verdict.AUTH
+            and algebra.get("target_class") in _BENIGN_TARGET_CLASSES
+            and not features.get("has_external_destination", True)
+            and algebra.get("classification_confidence", 0.0) >= 0.8
+        )
+        if looks_benign:
+            return GuardrailResult(
+                verdict=Verdict.PASS,
+                risk=Risk.low,
+                explanation="shadow: looks benign for this deployment",
+            )
+        return None
+
+
+def run_shadow_adjudication(
+    adjudicators: Sequence[Adjudicator],
+    action: SecurityObject,
+    current: GuardrailResult,
+) -> GuardrailResult | None:
+    """Consult adjudicators on redacted features; return the first recommendation.
+
+    Fail-closed and NEVER raises: building the features or any adjudicator raising
+    / returning a non-``GuardrailResult`` is logged at debug and skipped. Returns
+    the first non-``None`` :class:`GuardrailResult` recommendation, or ``None``.
+    The return value is a SHADOW annotation only — the caller never uses it to
+    build the live verdict.
+    """
+    if not adjudicators:
+        return None
+    try:
+        features = redacted_features(action, current)
+    except Exception:  # noqa: BLE001 — shadow must never affect the live decision
+        logger.debug("shadow: building redacted features failed; skipping", exc_info=True)
+        return None
+    for adjudicator in adjudicators:
+        try:
+            recommendation = adjudicator.adjudicate(features, current)
+        except Exception:  # noqa: BLE001 — a raising adjudicator is isolated
+            logger.debug("shadow: adjudicator raised; skipping", exc_info=True)
+            continue
+        if recommendation is None:
+            continue
+        if not isinstance(recommendation, GuardrailResult):
+            logger.debug("shadow: adjudicator returned a non-GuardrailResult; skipping")
+            continue
+        return recommendation
+    return None

--- a/src/doberman/engine/decision_engine.py
+++ b/src/doberman/engine/decision_engine.py
@@ -5,9 +5,12 @@ This module is part of the policy core — it must never import
 ``doberman.proxy`` (enforced by import-linter).
 """
 
+import logging
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Protocol, runtime_checkable
 
+from doberman.engine.adjudicator import Adjudicator, run_shadow_adjudication
 from doberman.models import (
     RISK_ORDER,
     VERDICT_ORDER,
@@ -19,6 +22,8 @@ from doberman.models import (
     SecurityObject,
     Verdict,
 )
+
+logger = logging.getLogger("doberman.engine.decision_engine")
 
 # Reason codes for which a SUBJECTIVE BLOCK is honored as a hard block (rather
 # than clamped to AUTH). The subjective guardrail is otherwise AUTH-only
@@ -141,11 +146,35 @@ def _safe_evaluate(
     return result
 
 
+def _shadow_for(
+    adjudicators: Sequence[Adjudicator] | None,
+    action: SecurityObject,
+    final: GuardrailResult,
+) -> GuardrailResult | None:
+    """The shadow annotation for a FINAL result — shadow-only and fail-closed.
+
+    Consulted ONLY in the ambiguous AUTH step-up band: a floor/BLOCK or a PASS
+    decision is never shown to an adjudicator (floor-untouchable). The return
+    value is attached to ``Decision.shadow`` and is NEVER used to build
+    ``final_verdict``/``final_risk``. Any failure leaves ``shadow=None`` and the
+    decision proceeds unchanged.
+    """
+    if not adjudicators or final.verdict is not Verdict.AUTH:
+        return None
+    try:
+        return run_shadow_adjudication(adjudicators, action, final)
+    except Exception:  # noqa: BLE001 — shadow must never affect the live decision
+        logger.debug("shadow adjudication failed; ignoring", exc_info=True)
+        return None
+
+
 def decide(
     action: SecurityObject,
     objective: Guardrail,
     subjective: Guardrail,
     ctx: EvalContext,
+    *,
+    adjudicators: Sequence[Adjudicator] | None = None,
 ) -> Decision:
     """The execution rule (thesis §4/§8) — objective first, raise-only.
 
@@ -159,6 +188,12 @@ def decide(
        on ``SUBJECTIVE_HARD_BLOCK_ALLOWLIST``; otherwise it is clamped to
        ``AUTH`` (the original subjective result is preserved on the
        Decision for audit).
+
+    ``adjudicators`` (default ``None`` → zero behavior change) enables the
+    shadow-only seam: when the FINAL verdict is ``AUTH``, a second-opinion
+    recommendation is computed on REDACTED features and attached to
+    ``Decision.shadow`` for observation. It never touches ``final_verdict``/
+    ``final_risk`` and is never consulted for a floor/BLOCK or PASS decision.
     """
     objective_result = _safe_evaluate(
         objective,
@@ -181,6 +216,8 @@ def decide(
             reason_codes=list(objective_result.reason_codes),
             explanation=objective_result.explanation,
             decided_at=datetime.now(timezone.utc),
+            # Shadow-only annotation; never part of final_verdict/final_risk above.
+            shadow=_shadow_for(adjudicators, action, objective_result),
         )
 
     # Step 4: objective PASS → consult the subjective guardrail.
@@ -218,4 +255,6 @@ def decide(
         reason_codes=list(combined.reason_codes),
         explanation=combined.explanation,
         decided_at=datetime.now(timezone.utc),
+        # Shadow-only annotation; never part of final_verdict/final_risk above.
+        shadow=_shadow_for(adjudicators, action, combined),
     )

--- a/src/doberman/engine/registry.py
+++ b/src/doberman/engine/registry.py
@@ -48,6 +48,10 @@ DRIFT_OBSERVER_GROUP = "doberman.drift_observers"
 #: Distinct from ``doberman.detectors``: adapters REFINE the action algebra
 #: (clamped raise-only) and never score or verdict anything.
 ALGEBRA_ADAPTER_GROUP = "doberman.algebra_adapters"
+#: Shadow adjudicators (adaptive-precision Phase 0) register here; resolved by
+#: the decision engine. Shadow-only: they observe a decision on REDACTED features
+#: and can never change the live verdict.
+ADJUDICATOR_GROUP = "doberman.adjudicators"
 
 
 def _iter_entry_points(group: str) -> Iterator[EntryPoint]:
@@ -281,6 +285,42 @@ def discover_algebra_adapters() -> list[object]:
             continue
         adapters.append(candidate)
     return adapters
+
+
+def discover_adjudicators() -> list[object]:
+    """Discover registered shadow adjudicators (group ``doberman.adjudicators``).
+
+    Loaded defensively like every other seam: an import/constructor failure, or
+    an object that is not adjudicator-shaped (no ``adjudicate`` attribute), is
+    logged and skipped. Returns ``[]`` when nothing is installed — the engine
+    then simply records no shadow annotation. Core never imports an adjudicator
+    by name, and the seam is shadow-only: a discovered adjudicator can never
+    change the live verdict (:mod:`doberman.engine.adjudicator`).
+    """
+    # Local import mirrors the other seams and keeps discovery self-contained.
+    from doberman.engine.adjudicator import Adjudicator
+
+    adjudicators: list[object] = []
+    seen: set[str] = set()
+    for entry_point in _iter_entry_points(ADJUDICATOR_GROUP):
+        key = f"{ADJUDICATOR_GROUP}:{getattr(entry_point, 'name', id(entry_point))}"
+        if key in seen:
+            continue
+        seen.add(key)
+        candidate = _load_and_construct(entry_point)
+        if candidate is None:
+            continue
+        # Structural check only (runtime_checkable verifies the ``adjudicate``
+        # attribute, not its signature) — the real gate is that the engine
+        # validates every return value and isolates exceptions.
+        if not isinstance(candidate, Adjudicator):
+            logger.warning(
+                "skipping adjudicator %r: does not implement the Adjudicator protocol",
+                getattr(entry_point, "name", "?"),
+            )
+            continue
+        adjudicators.append(candidate)
+    return adjudicators
 
 
 def discover_drift_observers() -> list[object]:

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -352,6 +352,12 @@ class Decision(BaseModel):
     It MAY be weaker than ``subjective.verdict`` — the execution rule clamps
     a non-allowlisted subjective BLOCK to AUTH by design.
 
+    ``shadow`` is a NON-AUTHORITATIVE, shadow-only annotation (Phase 0 of the
+    adaptive-precision seam): what a second-opinion adjudicator WOULD have
+    recommended. It is deliberately tied to nothing — no validator relates it
+    to ``final_verdict``/``final_risk`` — so it is structurally incapable of
+    changing the live decision. It exists only for observation/audit.
+
     ``action_id`` must equal the ``SecurityObject.id`` of the action being
     decided (chain of custody for audit).
     """
@@ -366,6 +372,8 @@ class Decision(BaseModel):
     reason_codes: list[ReasonCode] = Field(default_factory=list)
     explanation: str = ""
     decided_at: AwareDatetime
+    #: Shadow-only second opinion; never affects final_verdict/final_risk.
+    shadow: GuardrailResult | None = None
 
     @model_validator(mode="after")
     def _non_pass_must_be_explained(self) -> "Decision":

--- a/src/doberman/storage/db.py
+++ b/src/doberman/storage/db.py
@@ -44,9 +44,11 @@ DB_FILE = "doberman.db"
 #: for the universal subjective layer (SL4/SL6/SL8: baselines re-keyed by entity,
 #: transitions, score history, preference feedback), to 4 for the host-hook sticky
 #: taint ledger (HK.5.1: decisions.session_id + the session_taint table), to 5 for
-#: Feature CB (CB.1: the append-only ``cost_events`` meter ledger), and to 6 for the
-#: read-vs-send exfil store (HK.5.2b: session_secret_fingerprints).
-SCHEMA_VERSION = 6
+#: Feature CB (CB.1: the append-only ``cost_events`` meter ledger), to 6 for the
+#: read-vs-send exfil store (HK.5.2b: session_secret_fingerprints), and to 7 for the
+#: shadow-only adjudication ledger (adaptive-precision Phase 0: shadow_adjudications;
+#: additive CREATE TABLE — no legacy migration needed).
+SCHEMA_VERSION = 7
 
 # Every table uses CREATE TABLE IF NOT EXISTS so opening an older DB transparently
 # adds the new tables (a forward-only, additive migration; the one re-shape —
@@ -188,6 +190,22 @@ CREATE TABLE IF NOT EXISTS cost_events (
     entity_id TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_cost_events ON cost_events (entity_id, kind, id);
+
+-- Shadow-only adjudication ledger (adaptive-precision Phase 0): what a
+-- second-opinion adjudicator WOULD have recommended for an AUTH decision. It is
+-- observability, never the decision path — a row here can never alter a verdict.
+-- Redaction-safe by construction: verdict/reason-code CLASSES only, plus the
+-- action id, the live verdict, and a keyed-HMAC entity_id. No raw secret/path/
+-- prompt is ever stored.
+CREATE TABLE IF NOT EXISTS shadow_adjudications (
+    id                  INTEGER PRIMARY KEY,
+    ts                  TEXT,
+    action_id           TEXT,
+    live_verdict        TEXT,
+    shadow_verdict      TEXT,
+    shadow_reason_codes TEXT,
+    entity_id           TEXT
+);
 """
 
 

--- a/src/doberman/storage/log.py
+++ b/src/doberman/storage/log.py
@@ -40,6 +40,12 @@ _INSERT_DECISION = (
     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 )
 
+_INSERT_SHADOW = (
+    "INSERT INTO shadow_adjudications "
+    "(ts, action_id, live_verdict, shadow_verdict, shadow_reason_codes, entity_id) "
+    "VALUES (?, ?, ?, ?, ?, ?)"
+)
+
 _UPSERT_FINGERPRINT = (
     "INSERT INTO secret_fingerprints (fingerprint, label, first_seen, last_seen, source_path_class) "
     "VALUES (?, ?, ?, ?, ?) "
@@ -180,6 +186,46 @@ async def record_decision(
         emit_to_sinks(record)
     except Exception:  # noqa: BLE001 — defense in depth (emit_to_sinks already isolates)
         logger.warning("audit sink fan-out failed for action %s; continuing", decision.action_id)
+
+
+async def record_shadow(
+    decision: Decision,
+    action: SecurityObject,
+    *,
+    repo_root: str,
+    entity_id: str | None = None,
+) -> None:
+    """Persist one redacted shadow-adjudication row (best-effort, shadow-only).
+
+    Writes a row ONLY when ``decision.shadow`` is set. Stores the live verdict and
+    the shadow verdict/reason-code **classes** — never a raw value — so this
+    ledger is redaction-safe by construction. Like :func:`record_decision` it is
+    outside the decision path: any failure is logged and swallowed, so it can
+    never raise into execution or alter a verdict (the decision is already made).
+
+    Not yet wired into the executor persist path — this slice provides + unit-tests
+    the writer; wiring is a follow-up.
+    """
+    if decision.shadow is None:
+        return
+    try:
+        shadow = decision.shadow
+        ts = datetime.now(timezone.utc).isoformat()
+        async with open_db(repo_root) as conn:
+            await conn.execute(
+                _INSERT_SHADOW,
+                (
+                    ts,
+                    decision.action_id,
+                    decision.final_verdict.value,
+                    shadow.verdict.value,
+                    json.dumps([rc.value for rc in shadow.reason_codes]),
+                    entity_id,
+                ),
+            )
+            await conn.commit()
+    except Exception:  # noqa: BLE001 — the shadow log must never break execution
+        logger.warning("shadow log write failed for action %s; continuing", decision.action_id)
 
 
 async def read_decisions(repo_root: str, *, limit: int | None = None) -> list[dict]:

--- a/tests/unit/test_adjudicator_seam.py
+++ b/tests/unit/test_adjudicator_seam.py
@@ -1,0 +1,425 @@
+"""Adaptive-precision Phase 0 — the SHADOW-ONLY adjudication seam.
+
+Every test here defends one security guarantee: an adjudicator may *observe* a
+decision (on redacted features only) and record what it WOULD recommend, but it
+can NEVER change ``final_verdict``/``final_risk``. The seam is fail-closed
+(errors ignored), floor-untouchable (never consulted for a non-AUTH decision),
+and redaction-safe (no raw secret/path/destination reaches the adjudicator).
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from doberman.engine import registry
+from doberman.engine.adjudicator import (
+    Adjudicator,
+    LocalReferenceAdjudicator,
+    redacted_features,
+    run_shadow_adjudication,
+)
+from doberman.engine.decision_engine import decide
+from doberman.models import (
+    ActionType,
+    Algebra,
+    Decision,
+    EvalContext,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    TargetClass,
+    Verdict,
+)
+from doberman.storage.db import open_db
+from doberman.storage.log import record_shadow
+
+CTX = EvalContext()
+SECRET = "AKIA" + "IOSFODNN7EXAMPLE"  # synthetic AWS-shaped key, never a real one
+RAW_PATH = "/home/user/project/.env.production"
+
+# --- guardrail stubs --------------------------------------------------------
+
+
+class Static:
+    """A guardrail returning a fixed result (or raising, for the error paths)."""
+
+    def __init__(self, outcome: GuardrailResult | Exception) -> None:
+        self.outcome = outcome
+
+    def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return self.outcome
+
+
+def _r(verdict: Verdict, risk: Risk = Risk.medium) -> GuardrailResult:
+    if verdict is Verdict.PASS:
+        return GuardrailResult(verdict=verdict, risk=risk)
+    return GuardrailResult(
+        verdict=verdict,
+        risk=risk,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation=f"{verdict}.",
+    )
+
+
+PASS_OBJ = Static(_r(Verdict.PASS))
+AUTH_SUBJ = Static(_r(Verdict.AUTH))  # objective PASS + this → combined AUTH
+
+
+def make_action(**over) -> SecurityObject:
+    base = dict(
+        id="adj-1",
+        ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.file_write,
+        tool_name="fs_write",
+        target="backend/auth/session.ts",
+        target_path_class="backend/auth/*.ts",
+    )
+    base.update(over)
+    return SecurityObject(**base)
+
+
+# --- adjudicator stubs ------------------------------------------------------
+
+
+class AlwaysPass:
+    def adjudicate(self, features, current):
+        return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low, explanation="shadow benign")
+
+
+class AlwaysBlock:
+    def adjudicate(self, features, current):
+        return GuardrailResult(
+            verdict=Verdict.BLOCK,
+            risk=Risk.critical,
+            reason_codes=[ReasonCode.unusual_for_deployment],
+            explanation="shadow: anomalous",
+        )
+
+
+class Raising:
+    def adjudicate(self, features, current):
+        raise RuntimeError("adjudicator exploded")
+
+
+class Garbage:
+    def adjudicate(self, features, current):
+        return "not-a-guardrail-result"
+
+
+class Spy:
+    def __init__(self) -> None:
+        self.seen = None
+
+    def adjudicate(self, features, current):
+        self.seen = features
+        return None
+
+
+# --- 1. backward-compat -----------------------------------------------------
+
+
+def test_backward_compat_no_adjudicators_arg_unchanged():
+    # AUTH-producing decision, called the classic 4-arg way: shadow must be None
+    # and the verdict identical to today.
+    decision = decide(make_action(), PASS_OBJ, AUTH_SUBJ, CTX)
+    assert decision.final_verdict is Verdict.AUTH
+    assert decision.shadow is None
+    # A PASS decision likewise carries no shadow.
+    pass_decision = decide(make_action(), PASS_OBJ, Static(_r(Verdict.PASS)), CTX)
+    assert pass_decision.final_verdict is Verdict.PASS
+    assert pass_decision.shadow is None
+
+
+# --- 2. shadow-only (the core guarantee) ------------------------------------
+
+
+def test_shadow_pass_recommendation_never_moves_live_auth_verdict():
+    decision = decide(make_action(), PASS_OBJ, AUTH_SUBJ, CTX, adjudicators=[AlwaysPass()])
+    # Live verdict did NOT move — still AUTH.
+    assert decision.final_verdict is Verdict.AUTH
+    assert decision.final_risk is Risk.medium
+    # The shadow annotation records what the adjudicator WOULD do.
+    assert decision.shadow is not None
+    assert decision.shadow.verdict is Verdict.PASS
+
+
+# --- 3. fail-closed ---------------------------------------------------------
+
+
+def test_raising_adjudicator_is_isolated_and_leaves_shadow_none():
+    decision = decide(make_action(), PASS_OBJ, AUTH_SUBJ, CTX, adjudicators=[Raising()])
+    assert decision.final_verdict is Verdict.AUTH  # unchanged
+    assert decision.shadow is None  # error → ignored
+
+
+def test_garbage_adjudicator_return_is_skipped():
+    decision = decide(make_action(), PASS_OBJ, AUTH_SUBJ, CTX, adjudicators=[Garbage()])
+    assert decision.final_verdict is Verdict.AUTH
+    assert decision.shadow is None
+
+
+# --- 4. floor-untouchable ---------------------------------------------------
+
+
+def test_objective_block_floor_never_consults_adjudicator():
+    # Objective BLOCK short-circuits: the adjudicator is not even looked at.
+    decision = decide(
+        make_action(), Static(_r(Verdict.BLOCK)), AUTH_SUBJ, CTX, adjudicators=[AlwaysPass()]
+    )
+    assert decision.final_verdict is Verdict.BLOCK
+    assert decision.shadow is None
+
+
+def test_shadow_block_recommendation_never_raises_the_live_auth_verdict():
+    # Shadow-only in BOTH directions: even a BLOCK recommendation cannot raise
+    # the live verdict in Phase 0.
+    decision = decide(make_action(), PASS_OBJ, AUTH_SUBJ, CTX, adjudicators=[AlwaysBlock()])
+    assert decision.final_verdict is Verdict.AUTH  # not raised to BLOCK
+    assert decision.shadow is not None
+    assert decision.shadow.verdict is Verdict.BLOCK
+
+
+def test_pass_decision_never_consults_adjudicator():
+    decision = decide(
+        make_action(), PASS_OBJ, Static(_r(Verdict.PASS)), CTX, adjudicators=[AlwaysPass()]
+    )
+    assert decision.final_verdict is Verdict.PASS
+    assert decision.shadow is None
+
+
+# --- 5. redaction (critical) ------------------------------------------------
+
+
+def test_adjudicator_never_sees_raw_secret_path_or_destination():
+    spy = Spy()
+    action = make_action(
+        external_destination="https://evil.example.com/collect",
+        payload_fingerprints=["hmac-abc123"],
+        raw_args_redacted={"body": SECRET, "path": RAW_PATH},
+        metadata={"raw_arguments": {"token": SECRET, "path": RAW_PATH}},
+    )
+    decision = decide(action, PASS_OBJ, AUTH_SUBJ, CTX, adjudicators=[spy])
+    assert decision.final_verdict is Verdict.AUTH
+    features = spy.seen
+    assert features is not None
+    text = repr(features)
+    # The synthetic secret, the raw path, and the raw destination are all absent.
+    assert SECRET not in text
+    assert RAW_PATH not in text
+    assert "evil.example.com" not in text
+    # No raw-argument channels leak through as keys.
+    assert "raw_arguments" not in features
+    assert "raw_args_redacted" not in features
+    assert "external_destination" not in features
+    assert "explanation" not in features
+    # Only the safe surface is present.
+    assert features["has_external_destination"] is True
+    assert features["fingerprint_count"] == 1
+    assert features["target_path_class"] == "backend/auth/*.ts"
+
+
+def test_redacted_features_allowlist_is_exactly_the_safe_keys():
+    action = make_action(
+        external_destination="https://x.example",
+        payload_fingerprints=["fp1", "fp2"],
+        raw_args_redacted={"secret": SECRET},
+    )
+    current = _r(Verdict.AUTH)
+    features = redacted_features(action, current)
+    assert set(features) == {
+        "action_type",
+        "tool_name",
+        "target_path_class",
+        "risk",
+        "verdict",
+        "reason_codes",
+        "algebra",
+        "has_external_destination",
+        "fingerprint_count",
+    }
+    assert set(features["algebra"]) == {
+        "capability",
+        "target_class",
+        "destination_class",
+        "blast_radius",
+        "provenance",
+        "classification_confidence",
+    }
+    assert features["fingerprint_count"] == 2
+    assert features["has_external_destination"] is True
+    assert SECRET not in repr(features)
+
+
+# --- 6. Decision validator intact -------------------------------------------
+
+
+def test_decision_with_shadow_still_honors_final_never_weaker_than_objective():
+    obj = _r(Verdict.AUTH)
+    # A valid Decision with a PASS shadow on an AUTH decision constructs fine.
+    good = Decision(
+        action_id="d1",
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.medium,
+        objective=obj,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation="auth.",
+        decided_at=datetime.now(timezone.utc),
+        shadow=GuardrailResult(verdict=Verdict.PASS, risk=Risk.low),
+    )
+    assert good.shadow is not None and good.shadow.verdict is Verdict.PASS
+    # Shadow does NOT disable the raise-only invariant: a final weaker than the
+    # objective still fails, even with a shadow attached.
+    with pytest.raises(ValueError, match="weaker than the objective"):
+        Decision(
+            action_id="d2",
+            final_verdict=Verdict.PASS,
+            final_risk=Risk.low,
+            objective=GuardrailResult(
+                verdict=Verdict.BLOCK,
+                risk=Risk.high,
+                reason_codes=[ReasonCode.protected_path_blocked],
+                explanation="blocked.",
+            ),
+            decided_at=datetime.now(timezone.utc),
+            shadow=GuardrailResult(verdict=Verdict.PASS, risk=Risk.low),
+        )
+
+
+# --- 7. registry ------------------------------------------------------------
+
+
+def test_discover_adjudicators_empty_with_nothing_installed():
+    assert registry.discover_adjudicators() == []
+
+
+def test_discover_adjudicators_finds_shaped_and_skips_others(monkeypatch):
+    class _FakeEP:
+        def __init__(self, name, loader):
+            self.name = name
+            self._loader = loader
+
+        def load(self):
+            return self._loader()
+
+    class _FakeEPs:
+        def __init__(self, eps):
+            self._eps = eps
+
+        def select(self, *, group):
+            return list(self._eps) if group == registry.ADJUDICATOR_GROUP else []
+
+    instance = LocalReferenceAdjudicator()
+    table = _FakeEPs([_FakeEP("good", lambda: instance), _FakeEP("bad", lambda: 42)])
+    monkeypatch.setattr(registry, "entry_points", lambda: table)
+    found = registry.discover_adjudicators()
+    assert found == [instance]  # adjudicator-shaped kept; the int skipped
+
+
+# --- LocalReferenceAdjudicator (the built-in reference) ---------------------
+
+
+def test_local_reference_recommends_pass_only_on_benign_auth():
+    ref = LocalReferenceAdjudicator()
+    benign = redacted_features(
+        make_action(
+            algebra=Algebra(target_class=TargetClass.public, classification_confidence=0.9)
+        ),
+        _r(Verdict.AUTH),
+    )
+    assert ref.adjudicate(benign, _r(Verdict.AUTH)).verdict is Verdict.PASS
+    # Abstains when it has an external destination, low confidence, or sensitive class.
+    external = redacted_features(
+        make_action(
+            algebra=Algebra(target_class=TargetClass.public, classification_confidence=0.9),
+            external_destination="https://x.example",
+        ),
+        _r(Verdict.AUTH),
+    )
+    assert ref.adjudicate(external, _r(Verdict.AUTH)) is None
+    low_conf = redacted_features(
+        make_action(
+            algebra=Algebra(target_class=TargetClass.public, classification_confidence=0.5)
+        ),
+        _r(Verdict.AUTH),
+    )
+    assert ref.adjudicate(low_conf, _r(Verdict.AUTH)) is None
+
+
+def test_run_shadow_adjudication_never_raises_and_returns_first():
+    action = make_action()
+    # Empty → None; raising first, then a real recommendation → returns the real one.
+    assert run_shadow_adjudication([], action, _r(Verdict.AUTH)) is None
+    rec = run_shadow_adjudication([Raising(), AlwaysPass()], action, _r(Verdict.AUTH))
+    assert rec is not None and rec.verdict is Verdict.PASS
+
+
+def test_stub_adjudicators_satisfy_the_protocol():
+    assert isinstance(AlwaysPass(), Adjudicator)
+    assert isinstance(LocalReferenceAdjudicator(), Adjudicator)
+    assert not isinstance(object(), Adjudicator)
+
+
+# --- 8. record_shadow (best-effort writer) ----------------------------------
+
+
+def _shadow_decision() -> Decision:
+    return Decision(
+        action_id="adj-shadow-1",
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.medium,
+        objective=_r(Verdict.AUTH),
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation="auth.",
+        decided_at=datetime.now(timezone.utc),
+        shadow=GuardrailResult(
+            verdict=Verdict.BLOCK,
+            risk=Risk.critical,
+            reason_codes=[ReasonCode.unusual_for_deployment],
+            explanation="shadow: anomalous",
+        ),
+    )
+
+
+async def test_record_shadow_writes_a_row_when_shadow_present(tmp_path):
+    decision = _shadow_decision()
+    await record_shadow(decision, make_action(), repo_root=str(tmp_path), entity_id="ent-hmac")
+    async with open_db(str(tmp_path)) as conn:
+        async with conn.execute(
+            "SELECT action_id, live_verdict, shadow_verdict, shadow_reason_codes, entity_id "
+            "FROM shadow_adjudications"
+        ) as cur:
+            rows = await cur.fetchall()
+    assert len(rows) == 1
+    action_id, live_v, shadow_v, codes, entity = rows[0]
+    assert action_id == "adj-shadow-1"
+    assert live_v == "AUTH"
+    assert shadow_v == "BLOCK"
+    assert codes == '["unusual_for_deployment"]'
+    assert entity == "ent-hmac"
+
+
+async def test_record_shadow_writes_nothing_when_shadow_absent(tmp_path):
+    decision = Decision(
+        action_id="no-shadow",
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=_r(Verdict.PASS, Risk.low),
+        decided_at=datetime.now(timezone.utc),
+    )
+    await record_shadow(decision, make_action(), repo_root=str(tmp_path))
+    async with open_db(str(tmp_path)) as conn:
+        async with conn.execute("SELECT COUNT(*) FROM shadow_adjudications") as cur:
+            count = (await cur.fetchone())[0]
+    assert count == 0
+
+
+async def test_record_shadow_is_best_effort_on_bad_repo_root(tmp_path):
+    # repo_root points at a FILE, so opening the DB under it fails — record_shadow
+    # must swallow the error and never raise into the (already-made) decision.
+    bad = tmp_path / "not_a_dir"
+    bad.write_text("x")
+    await record_shadow(_shadow_decision(), make_action(), repo_root=str(bad))  # must not raise


### PR DESCRIPTION
## Slice
- Phase 0 of the adaptive-precision method (vault ADR 0028). The safe substrate that a future anomaly model / cheap-LLM adjudicator and the human-anchored suppression learning plug into.

## What this PR does
Adds a pluggable **shadow-only** adjudication seam to the decision path. An adjudicator may *observe* a decision and record what it WOULD recommend — but it is **structurally incapable of changing the live verdict**. This is how you introduce a model/LLM into a security boundary safely: shadow first, measure, then graduate (never flip it on blind).

- `engine/adjudicator.py` (new): `Adjudicator` protocol whose input is a **redacted feature Mapping** (never a `SecurityObject`/`EvalContext`), a strict `redacted_features()` allowlist (algebra classes, reason-code strings, risk, `has_external_destination` bool, fingerprint **count** — no raw args/content/destination), a no-network `LocalReferenceAdjudicator`, and a fail-closed `run_shadow_adjudication()` (never raises).
- `decide()`: new keyword-only `adjudicators=None` (default → **zero behavior change**). A shadow recommendation is computed **only when the final verdict is AUTH** and attached to a new additive `Decision.shadow` field — never to `final_verdict`/`final_risk`.
- `registry.py`: `doberman.adjudicators` entry-point group + `discover_adjudicators()` (mirrors the detector seam).
- Storage: additive `shadow_adjudications` sibling table (SCHEMA 6→7, `CREATE TABLE IF NOT EXISTS`, no ALTER on `decisions`) + a best-effort `record_shadow()` (never raises).

## The security invariants (all tested + independently verified)
- **Shadow-only:** an adversarial adjudicator returning PASS on everything **cannot move the verdict** — verified live against a secret-exfil BLOCK (stays BLOCK). `Decision.shadow` feeds no verdict computation and is tied to no validator.
- **Floor-untouchable:** the adjudicator is consulted **only** on an AUTH decision; a floor/BLOCK or a PASS decision is never shown to it (`shadow` stays None).
- **Fail-closed:** any adjudicator raising / returning garbage is isolated and ignored; the decision proceeds unchanged.
- **Redaction:** verified that a synthetic secret, the raw host, and the raw path are all **absent** from the features an adjudicator receives — only classes/algebra/reason-codes/fingerprint-count.
- `Decision._final_never_weaker_than_objective` still enforced.

## Tests added (run in CI)
`tests/unit/test_adjudicator_seam.py` — 18 cases covering all 8 invariants (backward-compat, shadow-only both directions, fail-closed on raise + garbage, floor-untouchable, redaction + allowlist, validator intact, registry discovery, best-effort `record_shadow`).

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret / full file / unredacted prompt logged (adjudicator sees redacted classes only; shadow log stores verdict/reason-code classes only)
- [x] Raise-only — shadow can never lower (or raise) the live verdict in Phase 0; subordinate to the objective floor
- [x] doberman-core does not import doberman_enterprise (core defines the interface; a model/LLM plug-in registers via entry points)

## Public-release safety (doberman-core only)
- [x] Nothing from the "not allowed" list — the core ships the seam + a no-network local reference; a network-calling LLM adjudicator is a separate registered plug-in, not in core
- [x] Core still builds/tests/runs with NO enterprise / no adjudicator installed (`adjudicators` defaults to None)

## Notes
- Phase 0 = shadow-only (records, never enforces). Later phases (per ADR 0028): eval harness → wire the subjective layer to the host-hook path → the Haiku adjudicator plug-in (run in shadow → measured → graduate the raise side) → the F10-gated, Martingale-guarded suppression lever.
- Full suite: 1155 collected, 0 failures, 3 skipped, 92% coverage; ruff + lint-imports clean.