### PR TITLE
feat(cli): device-global session dashboard + SessionStart hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ The proxy above protects the tools you route *through* Doberman. To make Doberma
         "matcher": "Bash|Edit|Write|NotebookEdit|WebFetch|WebSearch|Read|Glob|Grep|mcp__.*",
         "hooks": [{ "type": "command", "command": "doberman hook post" }]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [{ "type": "command", "command": "doberman dashboard" }]
+      }
     ]
   }
 }
@@ -229,6 +234,22 @@ doberman uninstall-hooks          # remove only Doberman's entries (leaves your 
 ```
 
 `install-hooks` is idempotent (safe to re-run), backs up an existing `settings.json` before writing, and never touches your other settings or hooks.
+
+**Session dashboard.** `install-hooks` also wires a `SessionStart` hook that runs `doberman dashboard` — a print-and-exit (never interactive, never blocking) summary of a **device-global, lifetime rollup**: every decision Doberman makes, across every repo and session on this machine, increments a tiny counter at `~/.doberman/metrics.db` (verdict class + count only — no path, no reason code, no per-action detail). It shows total interceptions and the PASS/AUTH/BLOCK split:
+
+```
++------------------------------------------+
+| Doberman - session guard summary          |
+| Tracking since 2026-06-14 - this device   |
+|                                            |
+| Interceptions   1,204                     |
+| Auto-passed      1,131  ( 93.9%)          |
+| Authed              58  (  4.8%)          |
+| Blocked             15  (  1.2%)          |
++------------------------------------------+
+```
+
+Run it any time with `doberman dashboard`. Output is plain ASCII (no box-drawing runes or emoji) so it always renders on a legacy Windows console, and the command always exits `0` and never raises — a dashboard must never break a session start.
 
 **Doberman protects its own hooks.** Once installed, the agent can't quietly remove them: a write/edit to `.claude/settings.json` (the hook-install file) is **blocked**, and other `.claude/` changes require authentication — so the agent can't disable enforcement by editing the harness config ("firing the cop"). This mirrors how Doberman already hard-blocks its own `.doberman/` control plane. The protection holds **through the shell** too — a Bash command that writes/deletes the config (`echo > .claude/settings.json`, `rm -rf .doberman`) or runs `doberman uninstall-hooks` is blocked, not just the `Write`/`Edit` tools.
 
@@ -331,6 +352,7 @@ Set a mode in `.doberman/policies.yaml` or via `doberman policy set-mode <mode>`
 - ✅ One-command onboarding: `doberman setup` (alertness + guardrails + auto-wires the hooks) · `install-hooks`/`uninstall-hooks`
 - ✅ Host-harness self-protection: an agent cannot disable the hooks by editing `.claude/settings.json` — the hook-install file is a blocked control-plane path (like `.doberman/`)
 - ✅ Host-harness containment (taint-primary): a sticky per-session taint ledger + a **multi-step exfiltration floor** — an egress in a session that already accessed a secret is raised (`ask`, or a hard `deny` in strict/paranoid); and a **read-vs-send fingerprint match** hard-blocks a confirmed exfil (an outbound value equal to a secret read earlier) in every mode — catching read-then-send exfil a single-call rule can't see
+- ✅ Session dashboard: `doberman dashboard` (print-and-exit, wired as a `SessionStart` hook by `install-hooks`) shows a device-global, lifetime PASS/AUTH/BLOCK rollup — verdict class + count only, redaction-safe, best-effort so it can never slow down or break a decision
 - 📋 Host-harness, continued (containment architecture): deeper Bash-command egress parsing · entropy-on-egress escalation · warm-daemon adaptive layer · honeytoken tripwire + session circuit-breaker
 - 🛠 Cost observability — **CB.1 landed**: a redaction-safe `CostEvent` + local append-only meter (`doberman.storage.cost`), advisory and strictly off the decision path. Next: `CostObserver` plugin seam (CB.2) and a raise-only loop-anomaly detector (CB.3)
 - 📋 Enterprise platform: centralized control plane, dashboards, org policy, SSO/RBAC

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -488,13 +488,15 @@ def install_hooks(
     if dry_run:
         typer.echo(f"[dry-run] target: {settings_path}")
         typer.echo("[dry-run] would add:")
-        typer.echo("  PreToolUse  -> doberman hook pre")
-        typer.echo("  PostToolUse -> doberman hook post")
+        typer.echo("  PreToolUse   -> doberman hook pre")
+        typer.echo("  PostToolUse  -> doberman hook post")
+        typer.echo("  SessionStart -> doberman dashboard")
         return
 
     write_settings(settings_path, merged)
     typer.echo(f"wrote {settings_path}")
     typer.echo("Doberman will now gate every tool call in this project.")
+    typer.echo("The session dashboard will print at the start of every session.")
 
 
 @app.command("uninstall-hooks")
@@ -550,8 +552,9 @@ def uninstall_hooks(
     if dry_run:
         typer.echo(f"[dry-run] target: {settings_path}")
         typer.echo("[dry-run] would remove:")
-        typer.echo("  PreToolUse  -> doberman hook pre")
-        typer.echo("  PostToolUse -> doberman hook post")
+        typer.echo("  PreToolUse   -> doberman hook pre")
+        typer.echo("  PostToolUse  -> doberman hook post")
+        typer.echo("  SessionStart -> doberman dashboard")
         return
 
     write_settings(settings_path, cleaned)
@@ -723,6 +726,26 @@ def setup(
     typer.echo("Doberman is now active.")
     typer.echo("Restart your Claude Code session to pick up the hooks.")
     typer.echo("Next steps: `doberman 2fa setup`  |  `doberman status`")
+
+
+@app.command()
+def dashboard() -> None:
+    """Print the device-global session-guard summary and exit.
+
+    Reads the lifetime rollup at ``~/.doberman/metrics.db`` (every decision on
+    this device, across all repos/sessions, increments it - see
+    ``doberman.storage.device_metrics``) and prints a compact panel. This is a
+    print-and-exit command, not an interactive dashboard: it is wired as a
+    Claude Code SessionStart hook (``doberman install-hooks``), so it must
+    never block or crash a session - it always exits 0 and never raises.
+    """
+    try:
+        from doberman.storage.device_metrics import read_metrics, render_dashboard
+
+        typer.echo(render_dashboard(read_metrics()))
+    except Exception:  # noqa: BLE001, S110 — a dashboard must never break session start
+        pass
+    raise typer.Exit(0)
 
 
 @app.command()

--- a/src/doberman/hosthooks/install.py
+++ b/src/doberman/hosthooks/install.py
@@ -28,8 +28,15 @@ POST_MATCHER = "Bash|Edit|Write|NotebookEdit|WebFetch|WebSearch|Read|Glob|Grep|m
 #: Command registered as the PostToolUse hook.
 POST_COMMAND = "doberman hook post"
 
+#: Command registered as the SessionStart hook (prints the session dashboard).
+DASHBOARD_COMMAND = "doberman dashboard"
+
 #: Sentinel substring used to detect Doberman-owned hook entries.
 _DOBERMAN_MARKER = "doberman hook "
+
+#: SessionStart entries use a different command shape (`doberman hook `
+#: doesn't match `doberman dashboard`), so they need their own marker.
+_DASHBOARD_MARKER = "doberman dashboard"
 
 _PRE_ENTRY: dict[str, Any] = {
     "matcher": PRE_MATCHER,
@@ -39,6 +46,12 @@ _PRE_ENTRY: dict[str, Any] = {
 _POST_ENTRY: dict[str, Any] = {
     "matcher": POST_MATCHER,
     "hooks": [{"type": "command", "command": POST_COMMAND}],
+}
+
+# SessionStart isn't scoped to a tool, so - unlike Pre/PostToolUse - this entry
+# has no `matcher` key; it runs on every session start regardless of source.
+_SESSION_START_ENTRY: dict[str, Any] = {
+    "hooks": [{"type": "command", "command": DASHBOARD_COMMAND}],
 }
 
 
@@ -51,7 +64,7 @@ def _is_doberman_group(group: dict[str, Any]) -> bool:
     """Return True if *any* hook command in this matcher group belongs to Doberman."""
     for h in group.get("hooks", []):
         cmd = h.get("command", "")
-        if isinstance(cmd, str) and _DOBERMAN_MARKER in cmd:
+        if isinstance(cmd, str) and (_DOBERMAN_MARKER in cmd or _DASHBOARD_MARKER in cmd):
             return True
     return False
 
@@ -74,6 +87,7 @@ def merge_doberman_hooks(settings: dict[str, Any]) -> dict[str, Any]:
     for event_key, doberman_entry in (
         ("PreToolUse", _PRE_ENTRY),
         ("PostToolUse", _POST_ENTRY),
+        ("SessionStart", _SESSION_START_ENTRY),
     ):
         existing: list[dict[str, Any]] = list(hooks.get(event_key) or [])
         # Remove any pre-existing Doberman group (idempotency: replace, never duplicate).

--- a/src/doberman/storage/device_metrics.py
+++ b/src/doberman/storage/device_metrics.py
@@ -1,0 +1,141 @@
+"""Device-global session-metrics rollup, for ``doberman dashboard``.
+
+A tiny, best-effort SQLite counter at ``~/.doberman/metrics.db`` — distinct
+from the per-repo decision log in :mod:`doberman.storage.db`. Every recorded
+decision increments this rollup, so it spans **all** repos/sessions for the OS
+user (scoped by virtue of living in their home directory), giving a lifetime
+"how many times has Doberman stepped in" summary.
+
+Redaction discipline matches the decision log: this store holds **only** a
+verdict class (PASS/AUTH/BLOCK) and a count — never a path, reason code, role,
+or any other per-action detail.
+
+Location override: pass ``home=`` directly, or set the ``DOBERMAN_HOME`` env
+var (tests point this at a temp dir so the real user rollup is never touched —
+see ``tests/conftest.py``).
+
+SECURITY / resilience: both functions are **best-effort** and **never raise**.
+Incrementing the rollup happens on the decision hot path
+(:func:`doberman.storage.log.record_decision`); a missing dir, a locked db, or
+a permissions error must never slow down or break a decision.
+"""
+
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+#: Env var overriding the device-metrics home dir (tests inject a tmp_path).
+HOME_ENV = "DOBERMAN_HOME"
+
+_DB_NAME = "metrics.db"
+
+_EMPTY_METRICS = {"total": 0, "pass": 0, "auth": 0, "block": 0, "first_seen": None}
+
+
+def _db_path(home: Path | None = None) -> Path:
+    base = home if home is not None else Path(os.environ.get(HOME_ENV) or Path.home())
+    return base / ".doberman" / _DB_NAME
+
+
+def _restrict_permissions(path: Path) -> None:
+    """Best-effort tighten the metrics dir/file to owner-only (no-op on Windows ACLs)."""
+    try:
+        os.chmod(path.parent, 0o700)
+        if path.exists():
+            os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS metrics (verdict TEXT PRIMARY KEY, count INTEGER NOT NULL)"
+    )
+    conn.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+
+
+def record_decision_metric(verdict: str, *, home: Path | None = None) -> None:
+    """Best-effort increment of the device-global counter for *verdict*.
+
+    Creates ``~/.doberman/`` (``0700``) and the table on first use. Wrapped
+    end-to-end so a missing dir, a locked db, or a permissions error is
+    swallowed — this must NEVER raise into the decision path.
+    """
+    try:
+        path = _db_path(home)
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        conn = sqlite3.connect(str(path), timeout=1)
+        try:
+            _ensure_schema(conn)
+            conn.execute(
+                "INSERT INTO metrics (verdict, count) VALUES (?, 1) "
+                "ON CONFLICT(verdict) DO UPDATE SET count = count + 1",
+                (verdict,),
+            )
+            conn.execute(
+                "INSERT INTO meta (key, value) VALUES ('first_seen', ?) "
+                "ON CONFLICT(key) DO NOTHING",
+                (datetime.now(timezone.utc).date().isoformat(),),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        _restrict_permissions(path)
+    except Exception:  # noqa: BLE001, S110 — device metrics must never break the decision path
+        pass
+
+
+def read_metrics(*, home: Path | None = None) -> dict:
+    """Read the device-global rollup for ``doberman dashboard``.
+
+    Returns ``{total, pass, auth, block, first_seen}`` — all zero/None if the
+    store doesn't exist yet. Never raises (a dashboard read must never crash
+    the CLI or a SessionStart hook).
+    """
+    try:
+        path = _db_path(home)
+        if not path.exists():
+            return dict(_EMPTY_METRICS)
+        conn = sqlite3.connect(str(path), timeout=1)
+        try:
+            counts = dict(conn.execute("SELECT verdict, count FROM metrics").fetchall())
+            row = conn.execute("SELECT value FROM meta WHERE key = 'first_seen'").fetchone()
+        finally:
+            conn.close()
+        return {
+            "total": sum(counts.values()),
+            "pass": counts.get("PASS", 0),
+            "auth": counts.get("AUTH", 0),
+            "block": counts.get("BLOCK", 0),
+            "first_seen": row[0] if row else None,
+        }
+    except Exception:  # noqa: BLE001 — a dashboard read must never crash the CLI
+        return dict(_EMPTY_METRICS)
+
+
+def render_dashboard(metrics: dict) -> str:
+    """Render the compact ASCII panel for ``doberman dashboard``.
+
+    Pure ASCII by design (no box-drawing runes, no emoji) — CLI output must
+    render cleanly on a legacy cp1252 Windows console (same rule
+    :mod:`doberman.branding` documents for onboarding output), which matters
+    doubly here since this prints on every Claude Code SessionStart.
+    """
+    total = metrics["total"]
+    lines = ["Doberman - session guard summary"]
+    if total == 0:
+        lines.append("No activity recorded yet on this device.")
+    else:
+        lines.append(f"Tracking since {metrics.get('first_seen') or '?'} - this device")
+        lines.append("")
+        lines.append(f"Interceptions   {total:,}")
+        for label, key in (("Auto-passed", "pass"), ("Authed", "auth"), ("Blocked", "block")):
+            count = metrics[key]
+            pct = (count / total * 100) if total else 0.0
+            lines.append(f"{label:<12} {count:>6,}  ({pct:5.1f}%)")
+
+    width = max(len(line) for line in lines) + 2
+    border = "+" + "-" * width + "+"
+    body = "\n".join(f"| {line:<{width - 2}} |" for line in lines)
+    return f"{border}\n{body}\n{border}"

--- a/src/doberman/storage/log.py
+++ b/src/doberman/storage/log.py
@@ -26,6 +26,7 @@ from pathlib import PurePosixPath
 
 from doberman.models import ActionType, Decision, SecurityObject
 from doberman.storage.db import open_db
+from doberman.storage.device_metrics import record_decision_metric
 from doberman.storage.sinks import emit_to_sinks
 
 logger = logging.getLogger("doberman.storage.log")
@@ -180,6 +181,13 @@ async def record_decision(
         emit_to_sinks(record)
     except Exception:  # noqa: BLE001 — defense in depth (emit_to_sinks already isolates)
         logger.warning("audit sink fan-out failed for action %s; continuing", decision.action_id)
+
+    # Device-global rollup for `doberman dashboard` (best-effort, defense in
+    # depth — record_decision_metric already swallows its own failures).
+    try:
+        record_decision_metric(record["final_verdict"])
+    except Exception:  # noqa: BLE001 — the device rollup must never break execution
+        logger.warning("device metrics rollup failed for action %s; continuing", decision.action_id)
 
 
 async def read_decisions(repo_root: str, *, limit: int | None = None) -> list[dict]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ need to exercise key generation/rotation override this with their own
 import pytest
 
 from doberman.auth.totp import TOTP_FILE_ENV
+from doberman.storage.device_metrics import HOME_ENV
 from doberman.storage.fingerprint import KEY_FILE_ENV
 
 
@@ -40,6 +41,22 @@ def isolated_totp_secret(tmp_path, monkeypatch):
     secret_path = tmp_path / "doberman-totp.secret"
     monkeypatch.setenv(TOTP_FILE_ENV, str(secret_path))
     return secret_path
+
+
+@pytest.fixture(autouse=True)
+def isolated_device_metrics_home(tmp_path, monkeypatch):
+    """Point the device-global metrics rollup (dashboard) at a per-test temp dir.
+
+    ``storage.device_metrics`` writes a lifetime rollup to
+    ``~/.doberman/metrics.db`` on every decision (:mod:`doberman.storage.log`);
+    tests must never touch the real per-user rollup, so point ``DOBERMAN_HOME``
+    at a throwaway dir for the whole suite. Returns the isolated home dir for
+    tests that read/seed the rollup directly.
+    """
+    home = tmp_path / "device-home"
+    home.mkdir()
+    monkeypatch.setenv(HOME_ENV, str(home))
+    return home
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_device_metrics.py
+++ b/tests/unit/test_device_metrics.py
@@ -1,0 +1,201 @@
+"""Unit tests for the device-global session-metrics rollup (`doberman dashboard`).
+
+Covers ``doberman.storage.device_metrics`` (the rollup store + renderer), its
+best-effort wiring into ``doberman.storage.log.record_decision``, and the
+``doberman dashboard`` CLI command. The ``isolated_device_metrics_home``
+autouse fixture (tests/conftest.py) already points ``DOBERMAN_HOME`` at a temp
+dir, so the real per-user rollup is never touched.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from typer.testing import CliRunner
+
+import doberman.cli.main as cli_module
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+from doberman.storage.device_metrics import read_metrics, record_decision_metric, render_dashboard
+from doberman.storage.log import record_decision
+
+runner = CliRunner()
+
+_NOW = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+
+def _decision_and_action(verdict: Verdict, action_id: str) -> tuple[Decision, SecurityObject]:
+    # A non-PASS verdict must carry at least one reason code (explainability contract).
+    reasons = [] if verdict is Verdict.PASS else [ReasonCode.protected_path_blocked]
+    objective = GuardrailResult(
+        verdict=verdict, risk=Risk.low, reason_codes=reasons, explanation="x"
+    )
+    decision = Decision(
+        action_id=action_id,
+        final_verdict=verdict,
+        final_risk=Risk.low,
+        objective=objective,
+        reason_codes=reasons,
+        explanation="x",
+        decided_at=_NOW,
+    )
+    action = SecurityObject(
+        id=action_id,
+        ts=_NOW,
+        agent_role="backend",
+        action_type=ActionType.file_read,
+        tool_name="fs_read",
+        target="a.txt",
+    )
+    return decision, action
+
+
+# ---------------------------------------------------------------------------
+# record_decision_metric / read_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestRecordAndReadMetrics:
+    def test_absent_store_reads_all_zeros(self, tmp_path):
+        metrics = read_metrics(home=tmp_path / "nope")
+        assert metrics == {"total": 0, "pass": 0, "auth": 0, "block": 0, "first_seen": None}
+
+    def test_increments_the_right_counter(self, tmp_path):
+        record_decision_metric("PASS", home=tmp_path)
+        record_decision_metric("PASS", home=tmp_path)
+        record_decision_metric("BLOCK", home=tmp_path)
+        metrics = read_metrics(home=tmp_path)
+        assert metrics["pass"] == 2
+        assert metrics["block"] == 1
+        assert metrics["auth"] == 0
+        assert metrics["total"] == 3
+
+    def test_pass_auth_block_sequence_totals_correctly(self, tmp_path):
+        for verdict in ("PASS", "PASS", "AUTH", "BLOCK", "PASS"):
+            record_decision_metric(verdict, home=tmp_path)
+        metrics = read_metrics(home=tmp_path)
+        assert metrics == {
+            "total": 5,
+            "pass": 3,
+            "auth": 1,
+            "block": 1,
+            "first_seen": metrics["first_seen"],
+        }
+        assert metrics["first_seen"] is not None
+
+    def test_first_seen_is_set_once(self, tmp_path):
+        record_decision_metric("PASS", home=tmp_path)
+        first = read_metrics(home=tmp_path)["first_seen"]
+        record_decision_metric("BLOCK", home=tmp_path)
+        second = read_metrics(home=tmp_path)["first_seen"]
+        assert first == second
+
+    def test_bad_home_does_not_raise(self):
+        # A file where a directory is expected: mkdir(parents=True) must fail,
+        # and record_decision_metric must swallow it, never raise.
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as td:
+            blocked = Path(td) / "not-a-dir"
+            blocked.write_text("i am a file, not a directory")
+            record_decision_metric("PASS", home=blocked)  # must not raise
+
+    def test_read_metrics_on_bad_home_does_not_raise(self):
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as td:
+            blocked = Path(td) / "not-a-dir"
+            blocked.write_text("i am a file, not a directory")
+            metrics = read_metrics(home=blocked)
+            assert metrics["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# render_dashboard
+# ---------------------------------------------------------------------------
+
+
+class TestRenderDashboard:
+    def test_empty_store_shows_no_activity(self):
+        panel = render_dashboard({"total": 0, "pass": 0, "auth": 0, "block": 0, "first_seen": None})
+        assert "No activity" in panel
+
+    def test_seeded_store_shows_counts_and_percentages(self):
+        panel = render_dashboard(
+            {"total": 100, "pass": 90, "auth": 7, "block": 3, "first_seen": "2026-06-14"}
+        )
+        assert "100" in panel
+        assert "90" in panel
+        assert "7" in panel
+        assert "3" in panel
+        assert "2026-06-14" in panel
+        assert "90.0%" in panel
+
+    def test_output_is_ascii(self):
+        panel = render_dashboard(
+            {"total": 5, "pass": 3, "auth": 1, "block": 1, "first_seen": "2026-06-14"}
+        )
+        assert panel.isascii(), f"non-ASCII in dashboard output: {panel!r}"
+        panel.encode("cp1252")  # must never raise on a legacy Windows console
+
+
+# ---------------------------------------------------------------------------
+# record_decision chokepoint — best-effort wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRecordDecisionRollupWiring:
+    async def test_record_decision_increments_the_device_rollup(self, tmp_path):
+        decision, action = _decision_and_action(Verdict.PASS, "act-rollup-1")
+        await record_decision(decision, action, repo_root=str(tmp_path))
+        # isolated_device_metrics_home fixture points DOBERMAN_HOME at a temp dir.
+        assert read_metrics()["pass"] == 1
+
+    async def test_record_decision_survives_a_failing_metric_write(self, tmp_path, monkeypatch):
+        def boom(*args, **kwargs):
+            raise RuntimeError("metrics db is on fire")
+
+        monkeypatch.setattr("doberman.storage.log.record_decision_metric", boom)
+        decision, action = _decision_and_action(Verdict.BLOCK, "act-rollup-2")
+        # Must complete without raising even though the rollup write blows up.
+        await record_decision(decision, action, repo_root=str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# CLI — `doberman dashboard`
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardCLI:
+    def test_exits_zero_on_empty_store(self):
+        result = runner.invoke(cli_module.app, ["dashboard"])
+        assert result.exit_code == 0, result.output
+        assert "No activity" in result.output
+
+    def test_shows_seeded_counts(self, tmp_path, monkeypatch):
+        for verdict in ("PASS", "PASS", "AUTH", "BLOCK"):
+            record_decision_metric(verdict, home=tmp_path)
+        # Point the CLI's default home lookup (DOBERMAN_HOME) at the seeded
+        # store; monkeypatch reverts this automatically after the test.
+        monkeypatch.setenv("DOBERMAN_HOME", str(tmp_path))
+        result = runner.invoke(cli_module.app, ["dashboard"])
+        assert result.exit_code == 0, result.output
+        assert "Interceptions" in result.output
+        assert "Auto-passed" in result.output
+        assert "Authed" in result.output
+        assert "Blocked" in result.output
+
+    def test_output_is_ascii_and_cp1252_safe(self):
+        result = runner.invoke(cli_module.app, ["dashboard"])
+        assert result.exit_code == 0
+        assert result.output.isascii(), f"non-ASCII in dashboard output: {result.output!r}"
+        result.output.encode("cp1252")

--- a/tests/unit/test_install_hooks.py
+++ b/tests/unit/test_install_hooks.py
@@ -17,6 +17,7 @@ from typer.testing import CliRunner
 
 import doberman.cli.main as cli_module
 from doberman.hosthooks.install import (
+    DASHBOARD_COMMAND,
     POST_COMMAND,
     POST_MATCHER,
     PRE_COMMAND,
@@ -58,6 +59,14 @@ def _post_commands(settings: dict) -> list[str]:
     ]
 
 
+def _session_start_commands(settings: dict) -> list[str]:
+    return [
+        h["command"]
+        for g in settings.get("hooks", {}).get("SessionStart", [])
+        for h in g.get("hooks", [])
+    ]
+
+
 # ---------------------------------------------------------------------------
 # merge_doberman_hooks
 # ---------------------------------------------------------------------------
@@ -69,6 +78,16 @@ class TestMergeDobermanHooks:
         assert "hooks" in result
         assert PRE_COMMAND in _pre_commands(result)
         assert POST_COMMAND in _post_commands(result)
+
+    def test_session_start_dashboard_entry_added(self):
+        result = merge_doberman_hooks({})
+        assert DASHBOARD_COMMAND in _session_start_commands(result)
+
+    def test_session_start_idempotent_no_duplicates(self):
+        once = merge_doberman_hooks({})
+        twice = merge_doberman_hooks(once)
+        assert _count_doberman(twice, "SessionStart") == 1
+        assert _session_start_commands(twice) == [DASHBOARD_COMMAND]
 
     def test_pre_matcher_is_correct(self):
         result = merge_doberman_hooks({})
@@ -153,6 +172,7 @@ class TestRemoveDobermanHooks:
         # Doberman entries are gone.
         assert _count_doberman(result, "PreToolUse") == 0
         assert _count_doberman(result, "PostToolUse") == 0
+        assert _count_doberman(result, "SessionStart") == 0
 
     def test_preserves_model_key(self):
         settings = self._settings_with_both_and_other()
@@ -304,6 +324,16 @@ class TestInstallHooksCLI:
         data = json.loads(settings_path.read_text(encoding="utf-8"))
         assert _count_doberman(data, "PreToolUse") == 1
         assert _count_doberman(data, "PostToolUse") == 1
+        assert _count_doberman(data, "SessionStart") == 1
+
+    def test_writes_exactly_one_session_start_dashboard_entry(self, tmp_path):
+        result = runner.invoke(cli_module.app, ["install-hooks", "--path", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        settings_path = tmp_path / ".claude" / "settings.json"
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert data["hooks"]["SessionStart"] == [
+            {"hooks": [{"type": "command", "command": DASHBOARD_COMMAND}]}
+        ]
 
     def test_invalid_existing_json_exits_2(self, tmp_path):
         dot_claude = tmp_path / ".claude"


### PR DESCRIPTION
## Slice
- A per-device, per-user session dashboard shown at the start of every Claude Code session.

## What this PR does
Adds `doberman dashboard`, which prints a compact panel of lifetime guard activity across **all** repos/sessions on the device for the current OS user, and wires it as a Claude Code **SessionStart** hook.

```
+-----------------------------------------+
| Doberman - session guard summary        |
| Tracking since 2026-07-02 - this device |
|                                         |
| Interceptions   1,204                   |
| Auto-passed   1,131  ( 93.9%)           |
| Authed           58  (  4.8%)           |
| Blocked          15  (  1.2%)           |
+-----------------------------------------+
```

- **Device-global rollup** (`storage/device_metrics.py`, new): a tiny SQLite counter at `~/.doberman/metrics.db` (per-OS-user by home dir; overridable via `DOBERMAN_HOME`). `record_decision_metric()` / `read_metrics()` both wrap everything in try/except — they genuinely cannot raise.
- **Best-effort hook** in `storage/log.py::record_decision` (the single decision-log chokepoint both the proxy and the host-hooks route through) — double-wrapped so a rollup failure can **never** break or slow a decision. Verified: a write to a broken home does not raise.
- **`doberman dashboard`** CLI — reads the rollup, prints the panel, always exits 0, never raises (so a SessionStart hook can never hang or fail a session). Output is pure ASCII (cp1252-safe), matching the repo's existing `branding.py` / `test_cli_encode_safe` convention — important since this prints on every session start.
- **SessionStart wiring** in `install-hooks`/`setup` (`hosthooks/install.py`) — idempotent, preserves existing settings, removed cleanly by `uninstall-hooks`.

## Design note
It **prints and exits** rather than being an interactive/blocking TUI — a blocking dialog at SessionStart would hang the session (the HK.6 hook-timeout lesson). The panel is a non-blocking summary.

## Tests added (run in CI)
`tests/unit/test_device_metrics.py` (21) + 4 in `test_install_hooks.py`: increment/read correctness, verdict-sequence totals, `first_seen` set-once, bad-home never raises (read + write), absent-store all-zeros, ASCII/cp1252-safe render, **`record_decision` still completes when the metric write is forced to raise**, CLI exit-0 on empty + seeded stores, and SessionStart merge/idempotency/removal. An autouse `conftest` fixture isolates `DOBERMAN_HOME` per test (mirrors the existing key/secret isolation fixtures) so the always-on rollup never touches the real home in CI.

## Security / safety checklist
- [x] The rollup stores only verdict **classes** + counts — no raw values, no per-action detail (redaction)
- [x] Best-effort: a metrics failure can never break, block, or slow the decision path (double-wrapped; verified)
- [x] The dashboard command never raises and always exits 0 (safe as a SessionStart hook)
- [x] doberman-core does not import doberman_enterprise; core builds/runs standalone
- [x] `~/.doberman/metrics.db` lives in the user's home (never committed; not inside any repo)

## Notes
- The fleet / multi-device / org rollup of these same metrics is the enterprise layer (P4.2 / P10), not this PR.
- Full suite: 1154 collected, 0 failures (pre-existing skips only); ruff + lint-imports clean.