### PR TITLE
fix(drift): redact free-text reason before ledger writes and observer fan-out

### DIFF
--- a/src/doberman/policy/drift.py
+++ b/src/doberman/policy/drift.py
@@ -20,13 +20,18 @@ mechanism (a core safety invariant):
   strictness ``mode`` dial only.
 * :class:`DriftObserver` — the enterprise seam (org-wide drift monitoring /
   compliance). Observers receive **redacted** events and can **never** approve or
-  suppress a weakening — the 2FA gate is core and authoritative.
+  suppress a weakening — the 2FA gate is core and authoritative. The free-text
+  ``reason`` on every event (and every ledger row) is scrubbed of secret-shaped
+  substrings and length-capped by :func:`_redact_reason` before it is ever
+  recorded or fanned out — a pasted token in a reason must never reach the
+  ledger or an observer.
 
 This module is policy core: it may import ``doberman.auth`` / ``doberman.storage``
-but never ``doberman.proxy``.
+/ ``doberman.engine`` (secret-detection reuse only) but never ``doberman.proxy``.
 """
 
 import logging
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import StrEnum
@@ -98,6 +103,46 @@ def _rank(value: object) -> int:
     if isinstance(value, bool):
         return 2 if value else 0
     return _RANK.get(str(value).strip().lower(), _UNKNOWN_TOKEN_RANK)
+
+
+#: A `reason` is free text supplied by whatever triggered the policy change — it
+#: is never trusted and must never carry a secret into the ledger. Cap length so
+#: the ledger (a decision record, not a payload store) can't be used to smuggle a
+#: huge blob either.
+_REASON_MAX_CHARS = 300
+_HIGH_ENTROPY_CANDIDATE = re.compile(r"[A-Za-z0-9+/=_\-]{24,}")
+
+
+def _redact_reason(reason: str) -> str:
+    """Scrub a free-text ``reason`` before it reaches the ledger or an observer.
+
+    Reuses the credential-pattern and high-entropy-token detectors from
+    :mod:`doberman.engine.rules.secrets` (imported lazily to avoid a module-load
+    cycle, matching the pattern already used by :func:`notify_observers`):
+    every known credential shape is replaced outright, and every long
+    high-entropy token is replaced if it looks secret-shaped. The result is then
+    capped at ``_REASON_MAX_CHARS``. Fails safe: any internal error returns a
+    fixed placeholder — never the raw ``reason`` — and never raises.
+    """
+    if not reason:
+        return reason
+    try:
+        from doberman.engine.rules.secrets import _CREDENTIAL_PATTERNS, _looks_high_entropy_secret
+
+        scrubbed = reason
+        for pattern in _CREDENTIAL_PATTERNS:
+            scrubbed = pattern.sub("[redacted]", scrubbed)
+
+        def _scrub_candidate(match: re.Match[str]) -> str:
+            token = match.group(0)
+            return "[redacted]" if _looks_high_entropy_secret(token) else token
+
+        scrubbed = _HIGH_ENTROPY_CANDIDATE.sub(_scrub_candidate, scrubbed)
+        if len(scrubbed) > _REASON_MAX_CHARS:
+            scrubbed = scrubbed[:_REASON_MAX_CHARS] + "…"
+        return scrubbed
+    except Exception:  # noqa: BLE001 — never leak the raw reason on any failure
+        return "[reason redaction failed]"
 
 
 def classify_change(before: dict, after: dict) -> Classification:
@@ -223,6 +268,7 @@ async def apply_change(
     when** ``outcome.approved`` is True — this function decides, records, and
     notifies; it never weakens silently.
     """
+    reason = _redact_reason(reason)
     when = now or datetime.now(timezone.utc)
     classification = classify_change(before, after)
 
@@ -278,6 +324,7 @@ async def log_change(
     raises ``ValueError`` (fail closed — nothing recorded, nothing approved), so
     this path can never be miswired into rubber-stamping a rule/role weakening.
     """
+    reason = _redact_reason(reason)
     extra = set(_changed_keys(before, after)) - {"mode"}
     if extra:
         raise ValueError(
@@ -358,6 +405,7 @@ async def apply_enforcement_change(
     append-only ledger and fanned out to observers; the caller persists only when
     ``approved`` is True.
     """
+    reason = _redact_reason(reason)
     when = now or datetime.now(timezone.utc)
     classification = classify_change(before, after)
     # Extending a softened state's auto-revert deadline keeps protection down for

--- a/tests/unit/test_drift_reason_redaction.py
+++ b/tests/unit/test_drift_reason_redaction.py
@@ -1,0 +1,165 @@
+"""Issue #80 — the free-text ``reason`` on a policy-drift change must never carry a
+secret into the append-only ledger or out to a registered :class:`DriftObserver`.
+
+Covers ``_redact_reason`` directly (pass-through, truncation, fail-safe fallback) and
+end-to-end through all three chokepoints (``apply_change``, ``apply_enforcement_change``,
+``log_change``): a synthetic AWS-style key and a high-entropy token embedded in a
+reason must never appear in a ledger row or an observer event.
+"""
+
+from datetime import datetime, timezone
+
+from doberman.policy.drift import (
+    _redact_reason,
+    apply_change,
+    apply_enforcement_change,
+    log_change,
+    read_policy_changes,
+)
+
+_NOW = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+# AWS docs' own canonical example access-key shape: AKIA + 16 chars — matches the
+# STRONG credential pattern regardless of the "EXAMPLE" fixture marker (that marker
+# only ever suppresses the WEAK entropy path, never a strong credential match).
+_FAKE_AWS_KEY = "AKIAIOSFODNN7EXAMPLE"  # noqa: S105
+# 32 distinct characters -> ~5 bits/char Shannon entropy, comfortably above the
+# high-entropy-secret threshold (3.6 bits/char) used by the weak-path heuristic.
+_FAKE_HIGH_ENTROPY_TOKEN = "Zk9mQ2vL7bN4wJ8pR1sT6yC3dF0gH5xU"  # noqa: S105 — synthetic, not a real credential
+
+
+class RecordingObserver:
+    def __init__(self):
+        self.events: list[dict] = []
+
+    def on_change(self, event):
+        self.events.append(event)
+
+
+class _Decline:
+    """Refuses every confirmation (used to exercise the softened/denied path)."""
+
+    def confirm(self, message):
+        return False
+
+    def read_code(self, message):  # pragma: no cover — never reached after a decline
+        raise AssertionError("read_code must not be reached after a declined confirm")
+
+
+def _install_observer(monkeypatch) -> RecordingObserver:
+    obs = RecordingObserver()
+    monkeypatch.setattr("doberman.engine.registry.discover_drift_observers", lambda: [obs])
+    return obs
+
+
+# --- _redact_reason unit behavior -------------------------------------------
+
+
+def test_redact_reason_scrubs_credential_and_high_entropy_matches():
+    reason = f"rotating creds: {_FAKE_AWS_KEY} / {_FAKE_HIGH_ENTROPY_TOKEN}"
+    scrubbed = _redact_reason(reason)
+    assert _FAKE_AWS_KEY not in scrubbed
+    assert _FAKE_HIGH_ENTROPY_TOKEN not in scrubbed
+    assert "[redacted]" in scrubbed
+
+
+def test_redact_reason_passes_through_normal_text_unchanged():
+    reason = "tightening the block rule for CI"
+    assert _redact_reason(reason) == reason
+
+
+def test_redact_reason_truncates_over_cap():
+    long_reason = "a" * 400
+    scrubbed = _redact_reason(long_reason)
+    assert scrubbed == "a" * 300 + "…"
+
+
+def test_redact_reason_empty_string_passes_through():
+    assert _redact_reason("") == ""
+
+
+def test_redact_reason_failure_falls_back_to_placeholder(monkeypatch):
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("doberman.engine.rules.secrets._looks_high_entropy_secret", _boom)
+    # Needs a >=24-char entropy-charset run to reach the patched function at all.
+    reason = "leak attempt: " + "x" * 30
+    assert _redact_reason(reason) == "[reason redaction failed]"
+
+
+# --- end-to-end: ledger + observer never see the raw secret -----------------
+
+
+async def test_apply_change_redacts_reason_for_ledger_and_observers(tmp_path, monkeypatch):
+    obs = _install_observer(monkeypatch)
+    reason = f"tightening after incident, leaked key was {_FAKE_AWS_KEY}"
+
+    outcome = await apply_change(
+        {"r": "auth"}, {"r": "block"}, reason, repo_root=str(tmp_path), now=_NOW
+    )
+    assert outcome.approved is True  # strengthen: auto-approved, no prompter needed
+
+    rows = await read_policy_changes(str(tmp_path))
+    assert rows and _FAKE_AWS_KEY not in str(rows)
+    assert "[redacted]" in rows[0]["reason"]
+
+    assert obs.events and _FAKE_AWS_KEY not in str(obs.events)
+    assert "[redacted]" in obs.events[0]["reason"]
+
+
+async def test_apply_enforcement_change_redacts_reason_for_ledger_and_observers(
+    tmp_path, monkeypatch
+):
+    obs = _install_observer(monkeypatch)
+    reason = f"softening enforcement, token={_FAKE_HIGH_ENTROPY_TOKEN}"
+
+    outcome = await apply_enforcement_change(
+        {"enforcement": "enforce"},
+        {"enforcement": "monitor"},
+        reason,
+        repo_root=str(tmp_path),
+        prompter=_Decline(),
+        now=_NOW,
+    )
+    assert outcome.approved is False  # denial is still recorded — the attack signal
+
+    rows = await read_policy_changes(str(tmp_path))
+    assert rows and _FAKE_HIGH_ENTROPY_TOKEN not in str(rows)
+    assert "[redacted]" in rows[0]["reason"]
+
+    assert obs.events and _FAKE_HIGH_ENTROPY_TOKEN not in str(obs.events)
+    assert "[redacted]" in obs.events[0]["reason"]
+
+
+async def test_log_change_redacts_reason_for_ledger_and_observers(tmp_path, monkeypatch):
+    obs = _install_observer(monkeypatch)
+    reason = f"relaxing for exploration, backup key {_FAKE_AWS_KEY}"
+
+    outcome = await log_change(
+        {"mode": "strict"}, {"mode": "light"}, reason, repo_root=str(tmp_path), now=_NOW
+    )
+    assert outcome.method == "logged"
+
+    rows = await read_policy_changes(str(tmp_path))
+    assert rows and _FAKE_AWS_KEY not in str(rows)
+    assert "[redacted]" in rows[0]["reason"]
+
+    assert obs.events and _FAKE_AWS_KEY not in str(obs.events)
+    assert "[redacted]" in obs.events[0]["reason"]
+
+
+async def test_apply_change_reason_redaction_failure_stores_placeholder(tmp_path, monkeypatch):
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("doberman.engine.rules.secrets._looks_high_entropy_secret", _boom)
+    reason = "leak attempt: " + "x" * 30
+
+    outcome = await apply_change(
+        {"r": "auth"}, {"r": "block"}, reason, repo_root=str(tmp_path), now=_NOW
+    )
+    assert outcome.approved is True  # redaction failure must not block the change
+
+    rows = await read_policy_changes(str(tmp_path))
+    assert rows[0]["reason"] == "[reason redaction failed]"


### PR DESCRIPTION
## Slice
- Feature / Slice: F10 hardening — issue #80 (found during the PR #72 security review)

Closes #80

## What this PR does
The `reason` parameter of `apply_change` / `apply_enforcement_change` / `log_change` was written **verbatim** to the policy-change ledger and fanned out unredacted to `DriftObserver` plugins — contradicting the module's own "observers receive redacted events" promise. A pasted token in a reason would have been persisted and shipped to any enterprise sink.

Adds `_redact_reason`, applied once at the entry of each chokepoint so the scrubbed value flows everywhere (ledger, observers, rendered confirm diff):
- Reuses the existing detectors from `doberman.engine.rules.secrets` (credential-shape patterns + high-entropy heuristic) — no new detection logic; lazy import, policy→engine is within the import contract (lint-imports green).
- Redacts **before** truncating (a secret straddling the cap is still fully scanned), then caps at 300 chars.
- Fails safe: any internal error stores the fixed placeholder `[reason redaction failed]` — never the raw string, never raises.

## Tests added (run in CI)
`tests/unit/test_drift_reason_redaction.py` (9): synthetic AWS key + high-entropy token never appear in ledger rows or observer events across all three paths; pass-through for normal reasons; truncation; empty string; monkeypatched redaction failure → placeholder stored, call still completes.

## Security checklist
- [x] Fails closed on error (placeholder, never raw)
- [x] No secret logged or persisted (that's the point; tested end-to-end)
- [x] Raise-only untouched (redaction never alters classification/gating)
- [x] lint-imports 2/2 contracts kept