### PR TITLE
feat(policy): record mode-dial changes in the drift ledger via log_change

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ It reports two plugin profiles — `builtins_only` and `with_plugins` (built-ins
 
 ## Tune to your risk tolerance
 
-Set a mode in `.doberman/policies.yaml` or via `doberman policy set-mode <mode>`:
+Set a mode in `.doberman/policies.yaml` or via `doberman policy set-mode <mode>`. Every mode change made this way — the CLI dial or the setup wizard — is recorded in the append-only policy-change ledger (view it with `doberman policy-history`), so a strictness downgrade is always auditable even though it isn't 2FA-gated (F10):
 
 | Mode | Best for | Bulk-delete threshold | Step-up for unknown destinations | Step-up for behavioral anomalies | Lethal-trifecta exfil |
 |---|---|---|---|---|---|

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -27,8 +27,8 @@ from doberman.config import (
 )
 from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, render_risk_map
 from doberman.policy.checklist import recommend_policy
-from doberman.policy.drift import read_policy_changes
-from doberman.policy.modes import SecurityMode
+from doberman.policy.drift import log_change, read_policy_changes
+from doberman.policy.modes import SecurityMode, resolve_mode
 from doberman.policy.preferences import DIMENSIONS, preset_name
 from doberman.storage.db import active_elevations, revoke_elevation
 from doberman.storage.log import memory_summary, read_decisions
@@ -189,6 +189,29 @@ def review(
         typer.echo("\n(read-only; re-run with --yes to save)")
 
 
+def _apply_mode_change(name: str, path: str, reason: str) -> str:
+    """Resolve ``name``, best-effort audit-log the change, then persist it (F10).
+
+    The mode dial is deliberately frictionless, but every user-initiated change
+    still lands in the append-only policy-change ledger via
+    :func:`doberman.policy.drift.log_change` (``method="logged"``). A ledger
+    problem must never block the mode change itself, so logging is attempted
+    *before* saving and any unexpected failure is swallowed with a printed
+    warning; the save always proceeds. A no-op (unchanged mode) skips the
+    ledger call entirely rather than writing a confusing neutral entry.
+    """
+    old = load_mode(path)
+    new = resolve_mode(name).value  # raises ValueError for an unknown mode
+    if old != new:
+        try:
+            asyncio.run(log_change({"mode": old}, {"mode": new}, reason, repo_root=path))
+        except Exception as exc:  # noqa: BLE001 -- ledger issues must never block the mode change
+            typer.echo(
+                f"warning: could not record mode change in the policy ledger: {exc}", err=True
+            )
+    return save_mode(name, path)
+
+
 @app.command()
 def mode(
     name: str = typer.Argument(None, help="Mode to set (light/balanced/strict/paranoid)."),
@@ -199,7 +222,7 @@ def mode(
         typer.echo(load_mode(path))
         return
     try:
-        saved = save_mode(name, path)
+        saved = _apply_mode_change(name, path, "doberman mode CLI")
     except ValueError as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2) from exc
@@ -626,7 +649,7 @@ def setup(
 
     # Save the chosen mode.
     try:
-        save_mode(chosen_mode.value, path)
+        _apply_mode_change(chosen_mode.value, path, "doberman setup wizard")
     except ValueError as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(2) from exc

--- a/tests/unit/test_mode_ledger.py
+++ b/tests/unit/test_mode_ledger.py
@@ -1,0 +1,70 @@
+"""#79 — every user-initiated mode-dial change is recorded in the append-only
+policy-change ledger via `doberman.policy.drift.log_change` (audited-but-not-
+gated, F10). The mode dial stays frictionless: logging never blocks the change,
+and a same-mode no-op never writes a confusing ledger row.
+"""
+
+import asyncio
+
+from typer.testing import CliRunner
+
+from doberman.cli import main as cli_main
+from doberman.cli.main import app
+from doberman.config import load_mode
+from doberman.policy.drift import read_policy_changes
+
+runner = CliRunner()
+
+
+def test_mode_downgrade_from_default_records_a_weaken_row(tmp_path):
+    root = str(tmp_path)
+    # Fresh repo has no saved policy -> default mode is "balanced"; light is a downgrade.
+    result = runner.invoke(app, ["mode", "light", "--path", root])
+    assert result.exit_code == 0, result.output
+
+    rows = asyncio.run(read_policy_changes(root))
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["rule_id"] == "mode"
+    assert row["classification"] == "weaken"
+    assert row["approval_method"] == "logged"
+    assert row["approved"] == 1
+    assert row["from_state"] == "balanced"
+    assert row["to_state"] == "light"
+
+
+def test_mode_upgrade_from_default_records_a_strengthen_row(tmp_path):
+    root = str(tmp_path)
+    result = runner.invoke(app, ["mode", "strict", "--path", root])
+    assert result.exit_code == 0, result.output
+
+    rows = asyncio.run(read_policy_changes(root))
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["classification"] == "strengthen"
+    assert row["approval_method"] == "logged"
+    assert row["from_state"] == "balanced"
+    assert row["to_state"] == "strict"
+
+
+def test_same_mode_invocation_records_nothing(tmp_path):
+    root = str(tmp_path)
+    # Default is already "balanced"; re-asserting it is a no-op.
+    result = runner.invoke(app, ["mode", "balanced", "--path", root])
+    assert result.exit_code == 0, result.output
+    assert asyncio.run(read_policy_changes(root)) == []
+
+
+def test_ledger_failure_never_blocks_the_mode_change(tmp_path, monkeypatch):
+    root = str(tmp_path)
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("ledger db exploded")
+
+    monkeypatch.setattr(cli_main, "log_change", _boom)
+
+    result = runner.invoke(app, ["mode", "light", "--path", root])
+
+    assert result.exit_code == 0, result.output
+    assert "warning" in result.output.lower()
+    assert load_mode(root) == "light"  # the mode change still applied despite the ledger failure


### PR DESCRIPTION
## Slice
- Feature / Slice: F10 follow-up — issue #79 (mode dial → append-only ledger)

Closes #79

## What this PR does
`doberman mode <m>` and the setup wizard called `config.save_mode()` directly — a `paranoid → light` downgrade recorded **nothing**. Both user-initiated call sites now route through a shared `_apply_mode_change` helper that audit-logs via `drift.log_change` (the scope-enforced, audited-but-not-gated path from #72) before saving:
- Downgrades land as `weaken` / `method="logged"` rows in `doberman policy-history`; upgrades as `strengthen`.
- No-op (same mode) skips the ledger call — no confusing neutral rows.
- Best-effort by design: a ledger failure prints a warning and the mode change still applies (the dial stays frictionless; the audit is the addition, not a new gate).
- Unknown-mode error behavior unchanged (`resolve_mode` raises before anything happens).

Test-fixture `save_mode` calls (6 test files) were deliberately left unwired — not user-initiated.

## Tests added (run in CI)
`tests/unit/test_mode_ledger.py` (4): downgrade→weaken row · upgrade→strengthen row · same-mode records nothing · monkeypatched ledger failure → warning + mode still applied.

## Security checklist
- [x] Raise-only: this only ADDS auditing; no gate loosened, no new gate on the dial (per #72's deliberate design)
- [x] No secret logged (mode names only; reason is a fixed constant)
- [x] Fails safe: ledger failure cannot block or corrupt the mode change
- [x] lint-imports green

## Notes
Pre-existing doc bug spotted (out of scope, not fixed here): README references `doberman policy set-mode <mode>`, but the actual command is `doberman mode <name>`.