### PR TITLE
feat(cli): add `doberman enforcement <enforce|monitor|off>` command (UX-A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,8 @@ Orthogonal to the strictness *mode* is an **enforcement dial** (`enforce` *(defa
 - **`monitor`** — a deliberate **observe mode**. The *discretionary* layer (behavioral anomalies, soft step-ups) is evaluated and **recorded** — `doberman log` / `doberman tui` show what *would* have happened — but it never blocks or prompts. Use it to try Doberman on a repo without friction, or to tune before turning it on.
 - **`off`** — the discretionary layer is not evaluated.
 
+Set it with **`doberman enforcement <enforce|monitor|off>`** (no argument prints the current state). Turning the dial *down* is confirmed — plus a 2FA code when one is enrolled, and confirm-only otherwise so the safety valve is never out of reach — and recorded in the ledger (view it with `doberman policy-history`); turning it back *up* re-arms automatically.
+
 **In every state the objective floor stays live.** Secret exfiltration, multi-step/confirmed exfil, destructive commands, protected-path writes, role/policy blocks, and the lethal trifecta always block — `monitor`/`off` can only soften the *discretionary* verdicts, never a catastrophic action. Softening the dial is **2FA-gated** and the on-disk value is **ledger-verified** on every call, so a hand-edited `enforcement: off` in `policies.yaml` with no matching approved change is caught and clamped back to `enforce` (fail-closed).
 
 ---

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -19,6 +19,7 @@ from doberman import __version__
 from doberman.auth import totp
 from doberman.config import (
     load_active_role,
+    load_enforcement,
     load_mode,
     load_policy,
     load_preferences,
@@ -28,7 +29,7 @@ from doberman.config import (
 )
 from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, render_risk_map
 from doberman.policy.checklist import recommend_policy
-from doberman.policy.drift import log_change, read_policy_changes
+from doberman.policy.drift import apply_enforcement_change, log_change, read_policy_changes
 from doberman.policy.modes import SecurityMode, resolve_mode
 from doberman.policy.preferences import DIMENSIONS, preset_name
 from doberman.storage.db import active_elevations, revoke_elevation
@@ -228,6 +229,64 @@ def mode(
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2) from exc
     typer.echo(f"mode set to {saved}")
+
+
+_ENFORCEMENT_STATES = ("enforce", "monitor", "off")
+
+
+@app.command()
+def enforcement(
+    state: str = typer.Argument(None, help="Enforcement state to set (enforce/monitor/off)."),
+    path: str = typer.Option(".", "--path", "-p", help="Repository root."),
+) -> None:
+    """Show or set the enforcement dial (enforce / monitor / off).
+
+    Orthogonal to the strictness ``mode``: this decides whether Doberman *acts*
+    on a discretionary verdict (``enforce``, the default) or only observes
+    (``monitor`` records what would have happened; ``off`` skips the discretionary
+    layer). The objective floor (secret exfil, destructive commands, ...) stays
+    live in every state.
+
+    Turning the dial DOWN is a weaken: it is confirmed -- plus a 2FA code when one
+    is enrolled, and confirm-only otherwise so the safety valve is never out of
+    reach -- and recorded in the append-only policy-change ledger. Re-arming
+    (``-> enforce``) is a strengthen and applies automatically. A softened state is
+    honored only while the ledger confirms it; hand-editing ``policies.yaml`` is
+    clamped back to ``enforce`` (fail closed). With no argument, prints the current
+    on-disk state.
+    """
+    current, _expires, _revert = load_enforcement(path)
+    if state is None:
+        typer.echo(current)
+        return
+    new = state.strip().lower()
+    if new not in _ENFORCEMENT_STATES:
+        typer.echo(
+            f"error: unknown enforcement state {state!r}; "
+            f"choose one of {', '.join(_ENFORCEMENT_STATES)}",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    if new == current:
+        typer.echo(f"enforcement already {current}")
+        return
+    # Route through the gated chokepoint: it confirms a soften (2FA-if-enrolled),
+    # auto-approves a re-arm, and records every attempt to the ledger. Persist the
+    # new state ONLY when it approved, and persist the exact fields the ledger just
+    # recorded so the read-side effective_enforcement clamp confirms the soften.
+    outcome = asyncio.run(
+        apply_enforcement_change(
+            {"enforcement": current},
+            {"enforcement": new},
+            "doberman enforcement CLI",
+            repo_root=path,
+        )
+    )
+    if not outcome.approved:
+        typer.echo("enforcement change denied; unchanged", err=True)
+        raise typer.Exit(code=1)
+    save_policy((load_policy(path) or recommend_policy()).with_enforcement(new), path)
+    typer.echo(f"enforcement set to {new}")
 
 
 @app.command()

--- a/tests/unit/test_cli_enforcement.py
+++ b/tests/unit/test_cli_enforcement.py
@@ -1,0 +1,126 @@
+"""CLI: ``doberman enforcement <enforce|monitor|off>`` (UX-A).
+
+Wires the gated setter :func:`doberman.policy.drift.apply_enforcement_change` to a
+command so a user finally has an in-product way to turn Doberman's enforcement
+down. The security-critical property is the round trip: a soften set through this
+command persists the exact fields the ledger recorded, so the read-side
+:func:`effective_enforcement` clamp *confirms* it -- while a soften hand-edited
+straight into the yaml (no approved ledger row) is still clamped back to
+``enforce``.
+
+Covers: show, the confirm-gated soften round trip, denial leaves state unchanged
+(fail closed), unknown state rejected, re-arm is never gated, and the hand-edit
+tamper contrast. 2FA is unenrolled here (the ``isolated_totp_secret`` conftest
+fixture points the secret at an empty temp path), so the gate takes the
+confirm-only safety-valve path.
+"""
+
+import yaml
+from typer.testing import CliRunner
+
+from doberman import config
+from doberman.cli.main import app
+
+runner = CliRunner()
+
+
+class _Approve:
+    """Present operator who confirms (and would supply a code if asked)."""
+
+    def confirm(self, message):
+        return True
+
+    def read_code(self, message):  # pragma: no cover -- unenrolled path never asks
+        return "999999"
+
+
+class _Decline:
+    def confirm(self, message):
+        return False
+
+    def read_code(self, message):  # pragma: no cover -- never reached after a decline
+        raise AssertionError("read_code must not be reached after a declined confirm")
+
+
+class _Boom:
+    """Any prompt is a failure -- proves a re-arm (strengthen) is never gated."""
+
+    def confirm(self, message):
+        raise AssertionError("a re-arm must not prompt")
+
+    def read_code(self, message):
+        raise AssertionError("a re-arm must not prompt")
+
+
+def _use_prompter(monkeypatch, prompter_cls):
+    # apply_enforcement_change lazily does `from doberman.auth.provider import CliPrompter`
+    # only on the weaken path, so patch the class it constructs there.
+    monkeypatch.setattr("doberman.auth.provider.CliPrompter", prompter_cls)
+
+
+def test_show_defaults_to_enforce(tmp_path):
+    result = runner.invoke(app, ["enforcement", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "enforce"
+
+
+def test_set_off_is_confirm_gated_persisted_and_effective(tmp_path, monkeypatch):
+    _use_prompter(monkeypatch, _Approve)
+    result = runner.invoke(app, ["enforcement", "off", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "enforcement set to off" in result.stdout
+    # Persisted on disk AND the ledger confirms it -> the effective state is really off.
+    assert config.load_enforcement(str(tmp_path))[0] == "off"
+    assert config.resolve_enforcement_sync(str(tmp_path)) == "off"
+
+
+def test_set_monitor_round_trips(tmp_path, monkeypatch):
+    _use_prompter(monkeypatch, _Approve)
+    result = runner.invoke(app, ["enforcement", "monitor", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert config.resolve_enforcement_sync(str(tmp_path)) == "monitor"
+
+
+def test_denied_soften_leaves_state_unchanged(tmp_path, monkeypatch):
+    _use_prompter(monkeypatch, _Decline)
+    result = runner.invoke(app, ["enforcement", "off", "--path", str(tmp_path)])
+    assert result.exit_code == 1
+    # Nothing persisted; effective stays enforce (fail closed).
+    assert config.load_enforcement(str(tmp_path))[0] == "enforce"
+    assert config.resolve_enforcement_sync(str(tmp_path)) == "enforce"
+
+
+def test_unknown_state_is_rejected(tmp_path):
+    result = runner.invoke(app, ["enforcement", "banana", "--path", str(tmp_path)])
+    assert result.exit_code == 2
+    # A typo never reaches the gate or the policy file.
+    assert config.load_enforcement(str(tmp_path))[0] == "enforce"
+
+
+def test_no_op_is_a_friendly_noop(tmp_path):
+    result = runner.invoke(app, ["enforcement", "enforce", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "already enforce" in result.stdout
+
+
+def test_re_arm_is_never_gated(tmp_path, monkeypatch):
+    _use_prompter(monkeypatch, _Approve)
+    assert runner.invoke(app, ["enforcement", "off", "--path", str(tmp_path)]).exit_code == 0
+    # Re-arming is a strengthen: it must apply with no prompt at all.
+    _use_prompter(monkeypatch, _Boom)
+    result = runner.invoke(app, ["enforcement", "enforce", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "enforcement set to enforce" in result.stdout
+    assert config.resolve_enforcement_sync(str(tmp_path)) == "enforce"
+
+
+def test_hand_edited_off_without_ledger_is_clamped(tmp_path):
+    # Why the command exists: writing `enforcement: off` straight into the yaml with
+    # no approved ledger row is tamper -> the read-side clamp forces enforce.
+    ddir = tmp_path / ".doberman"
+    ddir.mkdir()
+    (ddir / "policies.yaml").write_text(
+        yaml.safe_dump({"items": [], "enforcement": "off"}), encoding="utf-8"
+    )
+    assert config.load_enforcement(str(tmp_path))[0] == "off"  # raw on-disk claim
+    assert config.resolve_enforcement_sync(str(tmp_path)) == "enforce"  # clamped


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: **UX-A** — `doberman enforcement <enforce|monitor|off>` CLI command
- Plan reference: F10 enforcement dial (`doberman_core_plan.md`); vault TODO #2 (2026-07-09 softlock audit, gap A)

## What this PR does
Adds the **setter** for the enforcement dial that #88 wired the *consumption* of. Before this there was no in-product way to turn Doberman's enforcement down — the single "turn it down" knob a frustrated user reaches for simply didn't exist as a command.

It routes through the existing gated chokepoint `apply_enforcement_change()` (`policy/drift.py`) — semantics unchanged:
- **Soften** (`enforce` → `monitor`/`off`) is confirmed — plus a TOTP code when 2FA is enrolled, and **confirm-only otherwise** so the safety valve is never out of reach — and recorded in the append-only policy-change ledger.
- **Re-arm** (`→ enforce`) is a strengthen and applies automatically, ungated.
- Persists exactly the fields the ledger recorded, so the read-side `effective_enforcement` clamp **confirms** a soften; a hand-edited `enforcement: off` with no approved ledger row is still **clamped back to `enforce`** (fail closed).
- No argument → prints the current on-disk state. Mirrors the existing `mode` / `prefs` command shape.

Also fixes two import bugs in the pre-existing in-progress work: `load_enforcement` was used but not imported (would `NameError` at runtime); `resolve_enforcement_sync` was imported into `main.py` but unused (ruff `F401`).

## Tests added (run in CI)
- `tests/unit/test_cli_enforcement.py` (8 tests): show defaults to `enforce`; confirm-gated soften round-trips and becomes **effective** (`resolve_enforcement_sync`); `monitor` round-trips; a **denied** soften leaves state unchanged (fail closed); an **unknown** state is rejected before it reaches the gate or the policy file; no-op is a friendly no-op; **re-arm is never gated** (a prompter that raises on any prompt proves it); and a **hand-edited `off` with no ledger row is clamped back to `enforce`** (the tamper contrast that is the whole reason the command exists). Unenrolled 2FA exercises the confirm-only safety-valve path.

Local: `ruff check` ✓, `ruff format --check` ✓, `lint-imports` ✓ (2/2 contracts kept), the 8 enforcement tests ✓ (full suite running for coverage).

## Security checklist
- [x] Fails closed on error / uncertainty — a denied/failed gate leaves `enforce`; an unknown argument exits `2` before the gate.
- [x] No secret, full file, or unredacted prompt logged or committed.
- [x] Any guardrail/learning change is **raise-only** — soften is human-gated + ledgered; re-arm auto-applies; a hand-edited soften is clamped back up.
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — N/A (this is a CLI setter, not a decision-path rule); the gate it calls is unchanged.
- [x] doberman-core does not import doberman_enterprise.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list.
- [x] Core still builds/tests/runs with NO enterprise package installed.

## Edge cases covered / Deviations from plan / Risks introduced
- Edge cases: unenrolled-2FA confirm-only path; no-op set; unknown state; hand-edit tamper clamp; explicit denial.
- Deviations: none — implements TODO #2 against the existing gated setter without changing its semantics.
- Risks: none new — the gate/ledger/clamp mechanics are unchanged (merged in #86/#88); this only adds the missing CLI verb in front of them.
