### PR TITLE
test(engine): add Hypothesis laws for combine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter", "textual"]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter", "textual", "hypothesis"]
 explain = ["anthropic"]
 tui = ["textual"]
 

--- a/tests/unit/test_verdict_ordering.py
+++ b/tests/unit/test_verdict_ordering.py
@@ -3,9 +3,9 @@
 `combine` must NEVER return a verdict or risk lower than either input.
 """
 
-import random
-
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from doberman.engine.decision_engine import combine, max_risk, max_verdict
 from doberman.models import (
@@ -19,6 +19,22 @@ from doberman.models import (
 
 ALL_VERDICTS = list(Verdict)
 ALL_RISKS = list(Risk)
+ALL_REASON_CODES = list(ReasonCode)
+
+
+@st.composite
+def guardrail_results(draw: st.DrawFn) -> GuardrailResult:
+    verdict = draw(st.sampled_from(ALL_VERDICTS))
+    min_reasons = 0 if verdict is Verdict.PASS else 1
+    reasons = draw(
+        st.lists(
+            st.sampled_from(ALL_REASON_CODES),
+            min_size=min_reasons,
+            max_size=len(ALL_REASON_CODES),
+            unique=True,
+        )
+    )
+    return make_result(verdict, draw(st.sampled_from(ALL_RISKS)), reasons)
 
 
 def make_result(
@@ -67,36 +83,42 @@ def test_none_passthrough_returns_equal_but_unaliased_copy():
     assert a.reason_codes == [ReasonCode.unknown_tool]
 
 
-def test_combine_never_lowers_property():
-    """THE invariant: over many random pairs, combine never returns below
-    max(a, b) on either axis, and never drops a reason code."""
-    rng = random.Random(20260607)  # noqa: S311 — seeded PRNG for test determinism only
-    codes = list(ReasonCode)
+@given(guardrail_results(), guardrail_results())
+def test_combine_never_lowers_property(a: GuardrailResult, b: GuardrailResult):
+    """THE invariant: combine never returns below max(a, b) on either axis."""
+    combined = combine(a, b)
+    assert VERDICT_ORDER[combined.verdict] >= VERDICT_ORDER[a.verdict]
+    assert VERDICT_ORDER[combined.verdict] >= VERDICT_ORDER[b.verdict]
+    assert RISK_ORDER[combined.risk] >= RISK_ORDER[a.risk]
+    assert RISK_ORDER[combined.risk] >= RISK_ORDER[b.risk]
+    # No reason is ever lost...
+    assert set(combined.reason_codes) == set(a.reason_codes) | set(b.reason_codes)
+    # ...and the union is order-preserving: a's codes first, then b's new
+    # codes in b's order.
+    expected = list(dict.fromkeys([*a.reason_codes, *b.reason_codes]))
+    assert combined.reason_codes == expected
 
-    def random_result() -> GuardrailResult:
-        verdict = rng.choice(ALL_VERDICTS)
-        # PASS may legally carry ZERO reasons — include that in the distribution.
-        min_reasons = 0 if verdict is Verdict.PASS else 1
-        return make_result(
-            verdict,
-            rng.choice(ALL_RISKS),
-            reasons=rng.sample(codes, rng.randint(min_reasons, len(codes))),
-        )
 
-    for _ in range(1000):
-        a = random_result()
-        b = random_result()
-        combined = combine(a, b)
-        assert VERDICT_ORDER[combined.verdict] >= VERDICT_ORDER[a.verdict]
-        assert VERDICT_ORDER[combined.verdict] >= VERDICT_ORDER[b.verdict]
-        assert RISK_ORDER[combined.risk] >= RISK_ORDER[a.risk]
-        assert RISK_ORDER[combined.risk] >= RISK_ORDER[b.risk]
-        # No reason is ever lost...
-        assert set(combined.reason_codes) == set(a.reason_codes) | set(b.reason_codes)
-        # ...and the union is order-preserving: a's codes (deduped) first,
-        # then b's new codes in b's order.
-        expected = list(dict.fromkeys([*a.reason_codes, *b.reason_codes]))
-        assert combined.reason_codes == expected
+@given(guardrail_results(), guardrail_results())
+def test_combine_is_commutative_up_to_reason_order(a: GuardrailResult, b: GuardrailResult):
+    ab = combine(a, b)
+    ba = combine(b, a)
+    assert ab.verdict == ba.verdict
+    assert ab.risk == ba.risk
+    assert set(ab.reason_codes) == set(ba.reason_codes)
+
+
+@given(guardrail_results(), guardrail_results(), guardrail_results())
+def test_combine_is_associative(a: GuardrailResult, b: GuardrailResult, c: GuardrailResult):
+    assert combine(combine(a, b), c) == combine(a, combine(b, c))
+
+
+@given(guardrail_results())
+def test_combine_is_idempotent_for_decision_strength_and_reasons(a: GuardrailResult):
+    combined = combine(a, a)
+    assert combined.verdict == a.verdict
+    assert combined.risk == a.risk
+    assert combined.reason_codes == a.reason_codes
 
 
 def test_reason_union_is_deduplicated_and_order_preserving():


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: #96 — property-based laws for raise-only `combine()`
- Plan reference: https://github.com/fu351/Doberman-Core/issues/96

## What this PR does
- Replaces the seeded `random.Random` fuzz loop in `tests/unit/test_verdict_ordering.py` with Hypothesis property tests.
- Keeps the existing exhaustive `Verdict x Verdict` and `Risk x Risk` matrices.
- Adds property coverage for raise-only floors, commutativity up to reason-code ordering, associativity, and idempotence of decision strength/reasons.
- Adds `hypothesis` to the `dev` extra.

Fixes #96

## Tests added (run in CI)
- `tests/unit/test_verdict_ordering.py` — Hypothesis strategy builds valid `GuardrailResult` values and exercises the raise-only, commutative, associative, and idempotent laws.

Local validation:
- `.venv/bin/python -m pip install -e ".[dev]"`
- `.venv/bin/python -m pytest tests/unit/test_verdict_ordering.py -v` — 36 passed
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/lint-imports`
- `.venv/bin/python -m pytest --cov=doberman --cov-report=term-missing` — 1370 passed, 2 skipped, 91% coverage

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty — no runtime path changed; this adds tests for the raise-only combine invariant
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — no guardrail/learning behavior changed; tests assert raise-only combine behavior
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — existing model invariant remains unchanged
- [x] doberman-core does not import doberman_enterprise — `lint-imports` kept both contracts

## Edge cases covered / Deviations from plan / Risks introduced
- PASS results may carry zero reason codes; non-PASS generated results always include at least one reason and explanation.
- Commutativity compares reason-code sets because `combine()` intentionally preserves operand order in the merged reason list.
- No README update: this is test coverage plus a dev-only dependency, with no public runtime behavior change.
- Risks introduced: adds Hypothesis to the dev extra only.

AI assistance: Prepared with OpenAI Codex.