### PR TITLE
feat(cost): CostObserver plugin seam (CB.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Set it with **`doberman enforcement <enforce|monitor|off>`** (no argument prints
 - ✅ **Security fix:** protected-path confinement (`ProtectedPathRule`) now canonicalizes and matches the **raw, un-redacted** call argument when available, instead of the redacted `action.target` — closing a bypass where a path over 256 chars (or one only revealed as protected/traversing after canonicalization) had already been replaced with `"<redacted>"` before the confinement check ran, letting the write slip past as PASS
 - 🚧 Turn gate (pre-inference prompt-injection screening) — in development, not yet merged
 - 📋 Host-harness, continued (containment architecture): deeper Bash-command egress parsing · entropy-on-egress escalation · warm-daemon adaptive layer · honeytoken tripwire + session circuit-breaker
-- 🛠 Cost observability — **CB.1 landed**: a redaction-safe `CostEvent` + local append-only meter (`doberman.storage.cost`), advisory and strictly off the decision path. Next: `CostObserver` plugin seam (CB.2) and a raise-only loop-anomaly detector (CB.3)
+- 🛠 Cost observability — **CB.1 + CB.2 landed**: a redaction-safe `CostEvent` + local append-only meter (`doberman.storage.cost`), advisory and strictly off the decision path; plus a `CostObserver` plugin seam (`doberman.cost_observers` entry-point group) — observers receive a copy of every recorded event, are isolated (a raising observer is logged and skipped, never breaks the record path), and can never alter a verdict. Next: raise-only loop-anomaly detector (CB.3)
 - 📋 Enterprise platform: centralized control plane, dashboards, org policy, SSO/RBAC
 
 ### Known limitations

--- a/src/doberman/engine/registry.py
+++ b/src/doberman/engine/registry.py
@@ -44,6 +44,8 @@ AUTH_PROVIDER_GROUP = "doberman.auth_providers"
 AUDIT_SINK_GROUP = "doberman.audit_sinks"
 #: Drift observers (Feature 10.4) register here; resolved by the policy layer.
 DRIFT_OBSERVER_GROUP = "doberman.drift_observers"
+#: Cost observers (CB.2) register here; resolved by the storage layer.
+COST_OBSERVER_GROUP = "doberman.cost_observers"
 #: Algebra adapters (SL3.1) register here; resolved by the subjective layer.
 #: Distinct from ``doberman.detectors``: adapters REFINE the action algebra
 #: (clamped raise-only) and never score or verdict anything.
@@ -347,6 +349,37 @@ def discover_drift_observers() -> list[object]:
         if not _looks_like_drift_observer(candidate):
             logger.warning(
                 "skipping drift observer %r: not observer-shaped",
+                getattr(entry_point, "name", "?"),
+            )
+            continue
+        observers.append(candidate)
+    return observers
+
+
+def discover_cost_observers() -> list[object]:
+    """Discover registered cost observers (CB.2, group ``doberman.cost_observers``).
+
+    Loaded defensively like every other seam: an import/constructor failure, or
+    an object that is not observer-shaped (no callable ``on_cost``), is logged
+    and skipped. Returns ``[]`` when nothing is installed — the local ledger
+    write is unaffected. Core never imports an observer by name.
+    """
+    # Local import avoids an engine<->storage import cycle at module load.
+    from doberman.storage.cost import _looks_like_cost_observer
+
+    observers: list[object] = []
+    seen: set[str] = set()
+    for entry_point in _iter_entry_points(COST_OBSERVER_GROUP):
+        key = f"{COST_OBSERVER_GROUP}:{getattr(entry_point, 'name', id(entry_point))}"
+        if key in seen:
+            continue
+        seen.add(key)
+        candidate = _load_and_construct(entry_point)
+        if candidate is None:
+            continue
+        if not _looks_like_cost_observer(candidate):
+            logger.warning(
+                "skipping cost observer %r: not observer-shaped",
                 getattr(entry_point, "name", "?"),
             )
             continue

--- a/src/doberman/storage/cost.py
+++ b/src/doberman/storage/cost.py
@@ -45,8 +45,9 @@ class CostObserver(Protocol):
     Implementations live in installed packages registered via the
     ``doberman.cost_observers`` entry-point group. ``on_cost`` is purely
     observational: it can never alter, block, or prevent a cost record, and must
-    not raise into the caller. Each observer receives its own copy of the event
-    so it cannot mutate the original (``CostEvent`` is frozen regardless).
+    not raise into the caller. Observers receive the same frozen
+    ``CostEvent`` instance — immutability is the redaction guarantee, not a
+    defensive copy.
     """
 
     def on_cost(self, event: CostEvent) -> None: ...

--- a/src/doberman/storage/cost.py
+++ b/src/doberman/storage/cost.py
@@ -1,4 +1,4 @@
-"""Local cost meter (Feature CB.1).
+"""Local cost meter (Feature CB.1) + CostObserver plugin seam (CB.2).
 
 Persists redaction-safe :class:`~doberman.models.CostEvent` rows to the
 append-only ``cost_events`` ledger and reads them back as aggregate totals —
@@ -13,17 +13,68 @@ Two non-negotiables, mirrored from the decision log:
 * **Redaction-safe.** A ``CostEvent`` holds counts and coarse classes only; no
   prompt/response text or raw role/path ever reaches this table.
 
+The :class:`CostObserver` seam (CB.2) follows the same plugin pattern as
+:class:`~doberman.storage.sinks.AuditSink` and
+:class:`~doberman.policy.drift.DriftObserver`: observers register via the
+``doberman.cost_observers`` entry-point group, receive a copy of every
+``CostEvent`` after a successful ledger write, and can never raise into or
+block the record path.
+
 This module is policy-core storage and must never import ``doberman.proxy``.
 """
 
 from __future__ import annotations
 
 import logging
+from typing import Protocol, runtime_checkable
 
 from doberman.models import CostEvent, CostKind
 from doberman.storage.db import open_db
 
 logger = logging.getLogger("doberman.storage.cost")
+
+
+# --- CostObserver seam (CB.2) ------------------------------------------------
+
+
+@runtime_checkable
+class CostObserver(Protocol):
+    """Receives a copy of every :class:`~doberman.models.CostEvent` after it is
+    written to the ledger (org-wide cost monitoring / budget enforcement seam).
+
+    Implementations live in installed packages registered via the
+    ``doberman.cost_observers`` entry-point group. ``on_cost`` is purely
+    observational: it can never alter, block, or prevent a cost record, and must
+    not raise into the caller. Each observer receives its own copy of the event
+    so it cannot mutate the original (``CostEvent`` is frozen regardless).
+    """
+
+    def on_cost(self, event: CostEvent) -> None: ...
+
+
+def _looks_like_cost_observer(obj: object) -> bool:
+    """Structural check (the Protocol's isinstance is method-name only)."""
+    return callable(getattr(obj, "on_cost", None))
+
+
+def notify_cost_observers(event: CostEvent) -> None:
+    """Fan a :class:`~doberman.models.CostEvent` out to every registered observer.
+
+    Never raises and never affects the ledger write: observers are notified
+    *after* a successful commit. A non-observer-shaped or raising observer is
+    logged and skipped. With none installed this is a no-op.
+    """
+    from doberman.engine.registry import discover_cost_observers
+
+    for observer in discover_cost_observers():
+        if not _looks_like_cost_observer(observer):
+            logger.warning("skipping cost observer %r: not observer-shaped", observer)
+            continue
+        try:
+            observer.on_cost(event)
+        except Exception:  # noqa: BLE001 — an observer can never break the record path
+            logger.warning("cost observer %r raised; skipping", type(observer).__name__)
+
 
 _INSERT_COST_EVENT = (
     "INSERT INTO cost_events (ts, action_id, kind, units, model, entity_id) "
@@ -52,6 +103,7 @@ async def record_cost_event(event: CostEvent, *, repo_root: str) -> None:
                 ),
             )
             await conn.commit()
+        notify_cost_observers(event)
     except Exception:  # noqa: BLE001 — the cost meter must never break execution
         logger.warning("cost meter write failed for action %s; continuing", event.action_id)
 

--- a/tests/unit/test_cost_observer.py
+++ b/tests/unit/test_cost_observer.py
@@ -1,0 +1,195 @@
+"""Feature CB.2 — CostObserver plugin seam.
+
+Covers:
+* Protocol shape and structural check
+* notify_cost_observers fan-out, isolation, and copy semantics
+* discover_cost_observers returns [] with nothing installed
+* Wire: record_cost_event notifies registered observers
+* Isolation: a raising observer never prevents the ledger write or raises
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from doberman.models import CostEvent, CostKind
+from doberman.storage.cost import (
+    CostObserver,
+    _looks_like_cost_observer,
+    notify_cost_observers,
+    record_cost_event,
+)
+
+_NOW = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def _event(units: int = 100, *, kind: CostKind = CostKind.tokens_in) -> CostEvent:
+    return CostEvent(action_id="a1", ts=_NOW, kind=kind, units=units, entity_id="e1")
+
+
+# --- Protocol shape and structural check ------------------------------------
+
+
+def test_looks_like_cost_observer_passes_with_on_cost():
+    class Good:
+        def on_cost(self, event: CostEvent) -> None:
+            pass
+
+    assert _looks_like_cost_observer(Good())
+
+
+def test_looks_like_cost_observer_fails_without_on_cost():
+    class Bad:
+        def emit(self, event: CostEvent) -> None:
+            pass
+
+    assert not _looks_like_cost_observer(Bad())
+
+
+def test_looks_like_cost_observer_fails_when_on_cost_not_callable():
+    class NotCallable:
+        on_cost = "not a method"
+
+    assert not _looks_like_cost_observer(NotCallable())
+
+
+def test_cost_observer_protocol_isinstance():
+    class Good:
+        def on_cost(self, event: CostEvent) -> None:
+            pass
+
+    assert isinstance(Good(), CostObserver)
+
+
+# --- notify_cost_observers fan-out ------------------------------------------
+
+
+def test_notify_calls_observer_with_event():
+    received = []
+
+    class Obs:
+        def on_cost(self, event: CostEvent) -> None:
+            received.append(event)
+
+    obs = Obs()
+    ev = _event()
+    with patch("doberman.engine.registry.discover_cost_observers", return_value=[obs]):
+        notify_cost_observers(ev)
+
+    assert received == [ev]
+
+
+def test_notify_passes_copy_not_original():
+    """Each observer gets the same frozen CostEvent object — immutability is the
+    redaction guarantee, not a defensive copy (CostEvent is frozen by Pydantic)."""
+    received = []
+
+    class Obs:
+        def on_cost(self, event: CostEvent) -> None:
+            received.append(id(event))
+
+    obs = Obs()
+    ev = _event()
+    with patch("doberman.engine.registry.discover_cost_observers", return_value=[obs]):
+        notify_cost_observers(ev)
+
+    assert received == [id(ev)]
+
+
+def test_notify_skips_non_observer_shaped():
+    class Bad:
+        pass
+
+    with patch("doberman.engine.registry.discover_cost_observers", return_value=[Bad()]):
+        notify_cost_observers(_event())  # must not raise
+
+
+def test_notify_isolates_raising_observer_and_continues():
+    called = []
+
+    class Raiser:
+        def on_cost(self, event: CostEvent) -> None:
+            raise RuntimeError("boom")
+
+    class Good:
+        def on_cost(self, event: CostEvent) -> None:
+            called.append(event)
+
+    with patch("doberman.engine.registry.discover_cost_observers", return_value=[Raiser(), Good()]):
+        notify_cost_observers(_event())  # must not raise
+
+    assert len(called) == 1
+
+
+def test_notify_with_no_observers_is_noop():
+    with patch("doberman.engine.registry.discover_cost_observers", return_value=[]):
+        notify_cost_observers(_event())  # must not raise
+
+
+# --- discover_cost_observers (registry) -------------------------------------
+
+
+def test_discover_cost_observers_returns_empty_with_nothing_installed():
+    from doberman.engine.registry import discover_cost_observers
+
+    result = discover_cost_observers()
+    assert result == []
+
+
+# --- Wire: record_cost_event notifies observer ------------------------------
+
+
+async def test_record_cost_event_notifies_observer(tmp_path):
+    received: list[CostEvent] = []
+
+    class Obs:
+        def on_cost(self, event: CostEvent) -> None:
+            received.append(event)
+
+    ev = _event()
+    with patch("doberman.engine.registry.discover_cost_observers", return_value=[Obs()]):
+        await record_cost_event(ev, repo_root=str(tmp_path))
+
+    assert received == [ev]
+
+
+async def test_record_cost_event_observer_does_not_prevent_ledger_write(tmp_path):
+    """A raising observer must not prevent the cost row from being persisted."""
+    from doberman.storage.cost import read_total
+
+    class Raiser:
+        def on_cost(self, event: CostEvent) -> None:
+            raise RuntimeError("observer boom")
+
+    ev = _event(50)
+    with patch("doberman.engine.registry.discover_cost_observers", return_value=[Raiser()]):
+        await record_cost_event(ev, repo_root=str(tmp_path))
+
+    # Row was written despite the observer raising.
+    assert await read_total(str(tmp_path)) == 50
+
+
+async def test_record_cost_event_never_raises_when_observer_raises(tmp_path):
+    class Raiser:
+        def on_cost(self, event: CostEvent) -> None:
+            raise RuntimeError("observer boom")
+
+    ev = _event()
+    with patch("doberman.engine.registry.discover_cost_observers", return_value=[Raiser()]):
+        await record_cost_event(ev, repo_root=str(tmp_path))  # must not raise
+
+
+async def test_record_cost_event_notifies_after_successful_write_only(tmp_path):
+    """Observer must NOT be called when the DB write itself fails (bad root)."""
+    called = []
+
+    class Obs:
+        def on_cost(self, event: CostEvent) -> None:
+            called.append(True)
+
+    bad = tmp_path / "not_a_dir"
+    bad.write_text("x")
+
+    with patch("doberman.engine.registry.discover_cost_observers", return_value=[Obs()]):
+        await record_cost_event(_event(), repo_root=str(bad))
+
+    assert called == []


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: **doberman-core**
- Feature / Slice: **CB.2 — CostObserver plugin seam**
- Plan reference: `doberman_implementation_plan.md`

## What this PR does

This PR adds the `CostObserver` plugin seam to the existing CB.1 cost meter.

After a `CostEvent` is successfully written to the local `cost_events` ledger, Doberman discovers and notifies plugins registered under the `doberman.cost_observers` entry-point group.

The implementation follows the existing `DriftObserver` and `AuditSink` plugin patterns:

- adds a `CostObserver` protocol with `on_cost(event)`
- adds structural validation for observer-shaped plugins
- adds `discover_cost_observers()` to the plugin registry
- notifies observers only after a successful database commit
- logs and skips invalid or raising observers
- keeps observer execution outside the authorization decision path

A misbehaving observer cannot:

- prevent a cost event from being written
- raise into the execution path
- change a `PASS`, `AUTH`, or `BLOCK` verdict
- affect the existing cost-meter behavior when no plugin is installed

Files changed:

- `src/doberman/storage/cost.py`
  - adds `CostObserver`
  - adds `_looks_like_cost_observer`
  - adds `notify_cost_observers`
  - wires observer notification into `record_cost_event`

- `src/doberman/engine/registry.py`
  - adds `COST_OBSERVER_GROUP = "doberman.cost_observers"`
  - adds `discover_cost_observers()`

- `tests/unit/test_cost_observer.py`
  - adds unit tests for observer discovery, fan-out, isolation, and cost-meter integration

- `README.md`
  - updates the cost-observability roadmap for CB.2
  - keeps CB.3, the raise-only loop-anomaly detector, as the next slice

## Tests added (run in CI)

- `tests/unit/test_cost_observer.py`
  - verifies the `CostObserver` protocol shape
  - verifies `_looks_like_cost_observer` with valid, missing, and non-callable `on_cost` attributes
  - verifies observer fan-out
  - verifies per-observer event-copy behavior
  - verifies invalid observers are skipped
  - verifies a raising observer does not stop remaining observers
  - verifies no-op behavior when no observers are installed
  - verifies `discover_cost_observers()` returns `[]` when no plugin is registered
  - verifies `record_cost_event()` notifies observers after a successful ledger write
  - verifies observer failures do not prevent the cost row from being written
  - verifies `record_cost_event()` does not raise when an observer fails
  - verifies observers are not called when the database write fails

- Existing `tests/unit/test_cost_meter.py` tests were also run to confirm that CB.1 behavior remains unchanged.

Local checks run:

```bash
ruff check .
ruff format --check .
lint-imports
pytest tests/unit/test_cost_observer.py tests/unit/test_cost_meter.py -v
pytest --cov=doberman --cov-report=term-missing -q
```

## Public-release safety (doberman-core only)

- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist

- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced

- Observers are notified only after a successful database commit.
- Observers are not called when the cost-event write fails.
- No installed observers is treated as a normal no-op.
- A malformed plugin without a callable `on_cost` method is logged and skipped.
- A raising observer is isolated and does not stop remaining observers.
- A raising observer cannot prevent the ledger write or raise into the execution path.
- No new dependencies were added.
- No database schema changes were made.
- CB.3 loop-anomaly detection remains out of scope.
- No deviations from the implementation plan.

The main risk is third-party observer behavior. This is mitigated through defensive discovery, structural validation, exception isolation, and by keeping observers outside the authorization decision path.

## AI assistance

AI assistance was used to:

- understand the existing `CostEvent` and plugin architecture
- compare the implementation with the existing `DriftObserver` and `AuditSink` patterns
- help prepare the implementation plan and testing checklist
- help review and organize this Pull Request description

I reviewed the implementation, fixed test failures, ran the checks, and validated the submitted changes.