### PR TITLE
fix(rules): close destructive command-rule bypasses (force-push refspec, rm //, package self-uninstall)

### DIFF
--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -29,6 +29,7 @@ SECURITY: the explanation names the *category* of danger, never echoes the
 command string or its arguments.
 """
 
+import posixpath
 import re
 import shlex
 from collections.abc import Iterable
@@ -113,7 +114,9 @@ def _argv(segment: str) -> list[str] | None:
 
 def _is_root_or_home_target(arg: str) -> bool:
     """True if an argument denotes ``/``, ``~``, or a whole-tree wildcard."""
-    normalized = arg.strip().strip("'\"")
+    normalized = posixpath.normpath(arg.strip().strip("'\""))
+    if normalized.startswith("//"):
+        normalized = "/" + normalized.lstrip("/")
     return normalized in {"/", "~", "~/", "/*", "/.", "~/*", "*"} or normalized.startswith("/*")
 
 
@@ -147,15 +150,18 @@ def _git_force_push_to_protected(tokens: list[str], protected: Iterable[str]) ->
             return False
         has_force = True
     protected_set = {b.lower() for b in protected}
+    push_args = tokens[tokens.index("push") + 1 :]
+    positional = [t for t in push_args if not t.startswith("-")]
+    explicit_refs = positional[1:]  # the first positional is the remote
     # Any token that names (or pushes to) a protected branch.
-    for token in tokens[2:]:
+    for token in explicit_refs:
         ref = token.lstrip("+").split(":")[-1].lower()
+        ref = re.sub(r"^(?:refs/(?:heads|tags)/|heads/)", "", ref)
         if ref in protected_set:
             return True
     # A bare ``git push --force`` (no explicit ref) defaults to the current
     # branch — unknown here, so treat it as protected (fail safe).
-    explicit_refs = [t for t in tokens[2:] if not t.startswith("-")]
-    return len(explicit_refs) <= 1
+    return not explicit_refs
 
 
 # Catastrophic non-rm commands (whole-disk wipes, fork bombs).
@@ -169,6 +175,31 @@ def _is_doberman_control_cli(tokens: list[str]) -> bool:
         and tokens[0] == "doberman"
         and any(t in _DOBERMAN_CONTROL_SUBCOMMANDS for t in tokens[1:])
     )
+
+
+def _package_manager_removes_doberman(tokens: list[str]) -> bool:
+    """True for package-manager commands that uninstall Doberman itself."""
+    if (
+        len(tokens) >= 3
+        and tokens[0] in {"python", "python3", "py"}
+        and tokens[1] == "-m"
+        and tokens[2] == "pip"
+    ):
+        manager_args = tokens[2:]
+    elif tokens[:2] == ["uv", "pip"]:
+        manager_args = tokens[1:]
+    else:
+        manager_args = tokens
+    if (
+        len(manager_args) < 3
+        or manager_args[0] not in {"pip", "pip3", "pipx", "uv"}
+        or manager_args[1] not in {"uninstall", "remove"}
+    ):
+        return False
+    packages = {
+        token.lower().replace("-", "_") for token in manager_args[2:] if not token.startswith("-")
+    }
+    return bool(packages & {"doberman", "doberman_core", "doberman_enterprise"})
 
 
 def _token_path_candidates(token: str) -> list[str]:
@@ -211,6 +242,10 @@ def _segment_verdict(
     if _is_doberman_control_cli(tokens):
         return _block_control_plane(
             "Shell command would install/remove Doberman's host hooks (control-plane tamper)."
+        )
+    if _package_manager_removes_doberman(tokens):
+        return _block_control_plane(
+            "Package-manager command would uninstall Doberman's guard (control-plane tamper)."
         )
 
     # --- Catastrophic → BLOCK ---

--- a/tests/unit/test_rule_commands.py
+++ b/tests/unit/test_rule_commands.py
@@ -54,6 +54,18 @@ def test_catastrophic_commands_block(command):
     assert ReasonCode.destructive_command in result.reason_codes
 
 
+@pytest.mark.parametrize("command", ["rm -rf //", "rm -rf ///"])
+def test_repeated_slash_root_delete_blocks(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+
+
+@pytest.mark.parametrize("command", ["rm -rf ./build", "rm -rf node_modules"])
+def test_recursive_force_delete_of_non_root_target_is_not_blocked(command):
+    result = _cmd(command)
+    assert result.verdict is not Verdict.BLOCK
+
+
 def test_chained_destructive_segment_blocks():
     # A benign first command followed by a catastrophic one must still BLOCK.
     assert _cmd("echo hi && rm -rf /").verdict is Verdict.BLOCK
@@ -79,8 +91,26 @@ def test_force_push_to_protected_branch_blocks(command):
     assert result.verdict is Verdict.BLOCK
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git push --force origin refs/heads/main",
+        "git push --force origin feature:refs/heads/main",
+        "git push --force origin refs/heads/develop",
+    ],
+)
+def test_force_push_long_refspec_to_protected_branch_blocks(command):
+    result = _cmd(command, action_type=ActionType.git_op)
+    assert result.verdict is Verdict.BLOCK
+
+
 def test_force_push_to_feature_branch_is_not_blocked():
-    result = _cmd("git push --force origin my-feature-branch", action_type=ActionType.git_op)
+    result = _cmd("git push --force origin my-feature", action_type=ActionType.git_op)
+    assert result.verdict is not Verdict.BLOCK
+
+
+def test_non_force_push_to_feature_branch_is_not_blocked():
+    result = _cmd("git push origin my-feature", action_type=ActionType.git_op)
     assert result.verdict is not Verdict.BLOCK
 
 

--- a/tests/unit/test_rule_commands_control_plane.py
+++ b/tests/unit/test_rule_commands_control_plane.py
@@ -9,6 +9,8 @@ hook-install CLI, and BLOCKs them with `protected_path_blocked`.
 
 from datetime import datetime, timezone
 
+import pytest
+
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.engine.rules.commands import DestructiveCommandRule
 from doberman.models import ActionType, EvalContext, ReasonCode, SecurityObject, Verdict
@@ -100,6 +102,32 @@ def test_doberman_install_hooks_is_blocked():
 
 def test_doberman_setup_is_blocked():
     assert _cmd("doberman setup --yes").verdict is Verdict.BLOCK
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pip uninstall doberman -y",
+        "pip3 uninstall doberman",
+        "pipx uninstall doberman",
+        "python -m pip uninstall doberman",
+        "python3 -m pip uninstall doberman",
+        "py -m pip uninstall doberman",
+        "uv pip uninstall doberman",
+        "pip uninstall doberman_enterprise -y",
+        "pip uninstall doberman-core",
+    ],
+)
+def test_package_manager_doberman_uninstall_is_blocked(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+    assert "terminal" in (result.explanation or "").lower()
+
+
+@pytest.mark.parametrize("command", ["pip install requests", "pip uninstall requests"])
+def test_package_manager_commands_for_other_packages_are_not_blocked(command):
+    assert _cmd(command).verdict is not Verdict.BLOCK
 
 
 # --- redaction + no over-block ---


### PR DESCRIPTION
Closes three confirmed command-rule bypasses found in the 2026-07-16 security-pipeline audit, all in engine/rules/commands.py:

- git push --force origin refs/heads/main (and src:refs/heads/main) no longer bypasses the protected-branch force-push block — refspecs are stripped of refs/heads|tags/ before the protected-set check, and the remote name no longer defeats the fail-safe.
- rm -rf // (and ///) is now caught — the root-target operand is normalized before the literal-set check.
- pip/pip3/pipx/uv (uninstall|remove) doberman (incl. python[3]/py -m pip uninstall, and the doberman-core dist name) is now BLOCKed as control-plane tamper.

Fixes 1 and 2 reviewed correct; Fix 3's python3/py-launcher and doberman-core gaps were closed in review. Tests added for every case plus regression guards. Full suite green locally (0 failures), ruff + lint-imports clean.