### PR TITLE
feat(rules,auth): C1 control-plane hardening — interpreter-payload guard + 2FA-rotation proof

### DIFF
--- a/src/doberman/auth/totp.py
+++ b/src/doberman/auth/totp.py
@@ -78,19 +78,40 @@ def is_enrolled() -> bool:
     return _read_secret() is not None
 
 
-def enroll(*, issuer: str = "Doberman", account: str = "local", force: bool = False) -> str:
+def enroll(
+    *,
+    issuer: str = "Doberman",
+    account: str = "local",
+    force: bool = False,
+    current_code: str | None = None,
+) -> str:
     """Generate and store a new TOTP secret; return its provisioning URI.
 
     Refuses to overwrite an existing enrollment unless ``force=True`` (so a
     second ``2fa setup`` cannot silently rotate the secret out from under an
-    authenticator app). The returned URI embeds the secret for QR/manual entry
-    and MUST NOT be logged by the caller.
+    authenticator app). Rotation also requires a valid ``current_code`` proved
+    against the existing secret. The returned URI embeds the secret for
+    QR/manual entry and MUST NOT be logged by the caller.
     """
     path = _secret_path()
-    if path.exists() and not force:
-        raise RuntimeError(
-            "TOTP is already enrolled; pass force=True to deliberately rotate the secret"
-        )
+    if path.exists():
+        if not force:
+            raise RuntimeError(
+                "TOTP is already enrolled; pass force=True to deliberately rotate the secret"
+            )
+        existing_secret = _read_secret()
+        try:
+            verified = (
+                existing_secret is not None
+                and current_code is not None
+                and pyotp.TOTP(existing_secret).verify(
+                    str(current_code), valid_window=_VALID_WINDOW
+                )
+            )
+        except Exception:  # noqa: BLE001 — any proof error refuses rotation
+            verified = False
+        if not verified:
+            raise RuntimeError("a valid current 2FA code is required to rotate TOTP")
 
     secret = pyotp.random_base32()
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -17,6 +17,7 @@ import typer
 
 from doberman import __version__
 from doberman.auth import totp
+from doberman.auth.provider import CliPrompter
 from doberman.config import (
     load_active_role,
     load_enforcement,
@@ -491,8 +492,11 @@ def twofa_setup(
     ),
 ) -> None:
     """Enroll TOTP two-factor and print the provisioning URI for your authenticator."""
+    current_code = None
+    if force and totp.is_enrolled():
+        current_code = CliPrompter().read_code("Current 2FA code")
     try:
-        uri = totp.enroll(force=force)
+        uri = totp.enroll(force=force, current_code=current_code)
     except RuntimeError as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=1) from exc

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -59,9 +59,6 @@ DEFAULT_BULK_THRESHOLD = 25
 #: Branch names whose history is protected — a force-push here is catastrophic.
 DEFAULT_PROTECTED_BRANCHES: tuple[str, ...] = ("main", "master", "release", "develop")
 
-# Shell operators that separate independent commands within one line.
-_SEGMENT_SPLIT = re.compile(r"(?:\|\||&&|\||;|\n)")
-
 # Command-substitution bodies: $(...) and `...`. We recurse into these so a
 # destructive command hidden inside a substitution is still evaluated.
 _SUBSTITUTION = re.compile(r"\$\((?P<paren>[^()]*)\)|`(?P<backtick>[^`]*)`")
@@ -72,6 +69,15 @@ _TRANSPARENT_WRAPPERS = {"sudo", "nice", "ionice", "nohup", "time", "env", "comm
 
 # Shells that take an opaque "-c <payload>" we cannot statically vet.
 _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "fish"}
+
+# Non-shell interpreters whose inline payloads can directly mutate files.
+_INTERPRETERS = {"python", "python3", "py", "node", "nodejs", "deno", "bun", "perl", "ruby"}
+_INLINE_CODE_FLAGS = {"-c", "-e", "--eval", "-p", "--print"}
+_DESTRUCTIVE_INTERPRETER_OP = re.compile(
+    r"\b(?:shutil\.)?rmtree\b|\bos\.(?:remove|unlink)\b|\brmSync\b|"
+    r"\bunlinkSync\b|\bfs\.rm\b|\bRemove-Item\b|\brm\s+-rf\b|\bunlink\b",
+    re.IGNORECASE,
+)
 
 
 def _strip_substitutions(segment: str) -> tuple[str, list[str]]:
@@ -92,7 +98,50 @@ def _strip_substitutions(segment: str) -> tuple[str, list[str]]:
 
 def _split_segments(command: str) -> list[str]:
     """Split a command line into top-level segments on shell operators."""
-    return [seg.strip() for seg in _SEGMENT_SPLIT.split(command) if seg.strip()]
+    segments: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if escaped:
+            current.append(char)
+            escaped = False
+            index += 1
+            continue
+        if char == "\\" and quote != "'":
+            current.append(char)
+            escaped = True
+            index += 1
+            continue
+        if quote is not None:
+            current.append(char)
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            current.append(char)
+            index += 1
+            continue
+
+        operator_width = 2 if command[index : index + 2] in {"&&", "||"} else 0
+        if operator_width or char in {"|", ";", "\n"}:
+            segment = "".join(current).strip()
+            if segment:
+                segments.append(segment)
+            current = []
+            index += operator_width or 1
+            continue
+        current.append(char)
+        index += 1
+
+    segment = "".join(current).strip()
+    if segment:
+        segments.append(segment)
+    return segments
 
 
 def _argv(segment: str) -> list[str] | None:
@@ -222,6 +271,31 @@ def _segment_targets_control_plane(tokens: list[str], root: str) -> bool:
     return False
 
 
+def _interpreter_payload_verdict(tokens: list[str], root: str) -> GuardrailResult | None:
+    """BLOCK obvious control-plane or destructive interpreter one-liners."""
+    if not tokens or tokens[0] not in _INTERPRETERS:
+        return None
+    payloads = [
+        tokens[index + 1]
+        for index in range(1, len(tokens) - 1)
+        if tokens[index] in _INLINE_CODE_FLAGS
+    ]
+    if not payloads:
+        return None
+
+    for payload in payloads:
+        candidates = [
+            candidate for candidate in re.split(r"[\s'\"`(){}\[\],;]+", payload) if candidate
+        ]
+        if _segment_targets_control_plane(candidates, root):
+            return _block_control_plane(
+                "Interpreter inline payload references Doberman's own control plane."
+            )
+    if any(_DESTRUCTIVE_INTERPRETER_OP.search(payload) for payload in payloads):
+        return _block("Interpreter inline payload contains a destructive filesystem operation.")
+    return None
+
+
 def _segment_verdict(
     tokens: list[str], protected_branches: Iterable[str], bulk_threshold: int, root: str
 ) -> GuardrailResult | None:
@@ -247,6 +321,9 @@ def _segment_verdict(
         return _block_control_plane(
             "Package-manager command would uninstall Doberman's guard (control-plane tamper)."
         )
+    interpreter_payload = _interpreter_payload_verdict(tokens, root)
+    if interpreter_payload is not None:
+        return interpreter_payload
 
     # --- Catastrophic → BLOCK ---
     if cmd == "rm" and _rm_is_catastrophic(tokens):

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -73,6 +73,10 @@ _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "fish"}
 # Non-shell interpreters whose inline payloads can directly mutate files.
 _INTERPRETERS = {"python", "python3", "py", "node", "nodejs", "deno", "bun", "perl", "ruby"}
 _INLINE_CODE_FLAGS = {"-c", "-e", "--eval", "-p", "--print"}
+# Attached forms (no space before the payload): shlex glues the quoted body to
+# the flag, e.g. `python -c"..."` -> token `-cimport ...` (never equals "-c").
+_SHORT_INLINE_CODE_FLAGS = ("-c", "-e")
+_LONG_INLINE_CODE_FLAG_PREFIXES = ("--eval=", "--print=")
 _DESTRUCTIVE_INTERPRETER_OP = re.compile(
     r"\b(?:shutil\.)?rmtree\b|\bos\.(?:remove|unlink)\b|\brmSync\b|"
     r"\bunlinkSync\b|\bfs\.rm\b|\bRemove-Item\b|\brm\s+-rf\b|\bunlink\b",
@@ -275,11 +279,16 @@ def _interpreter_payload_verdict(tokens: list[str], root: str) -> GuardrailResul
     """BLOCK obvious control-plane or destructive interpreter one-liners."""
     if not tokens or tokens[0] not in _INTERPRETERS:
         return None
-    payloads = [
-        tokens[index + 1]
-        for index in range(1, len(tokens) - 1)
-        if tokens[index] in _INLINE_CODE_FLAGS
-    ]
+    payloads: list[str] = []
+    for index in range(1, len(tokens)):
+        token = tokens[index]
+        if token in _INLINE_CODE_FLAGS:
+            if index + 1 < len(tokens):
+                payloads.append(tokens[index + 1])
+        elif token.startswith(_SHORT_INLINE_CODE_FLAGS) and len(token) > 2:
+            payloads.append(token[2:])
+        elif token.startswith(_LONG_INLINE_CODE_FLAG_PREFIXES):
+            payloads.append(token.split("=", 1)[1])
     if not payloads:
         return None
 

--- a/tests/integration/test_cli_auth.py
+++ b/tests/integration/test_cli_auth.py
@@ -8,6 +8,7 @@ which cannot nest inside a running event loop. Seeding async state uses
 import asyncio
 from datetime import datetime, timezone
 
+import pyotp
 from typer.testing import CliRunner
 
 from doberman.auth import totp
@@ -27,8 +28,24 @@ def test_2fa_setup_enrolls_and_guards_overwrite():
     again = runner.invoke(app, ["2fa", "setup"])
     assert again.exit_code == 1  # refuses to silently overwrite
 
-    forced = runner.invoke(app, ["2fa", "setup", "--force"])
+    first = totp._read_secret()
+    assert first is not None
+    current_code = pyotp.TOTP(first).now()
+    forced = runner.invoke(app, ["2fa", "setup", "--force"], input=f"{current_code}\n")
     assert forced.exit_code == 0
+    assert "Current 2FA code" in forced.stdout
+    assert totp._read_secret() != first
+
+
+def test_2fa_setup_force_rejects_wrong_current_code():
+    totp.enroll()
+    first = totp._read_secret()
+
+    result = runner.invoke(app, ["2fa", "setup", "--force"], input="not-a-code\n")
+
+    assert result.exit_code == 1
+    assert "current 2FA code" in result.stderr
+    assert totp._read_secret() == first
 
 
 def test_status_reports_2fa_and_no_elevations(tmp_path):

--- a/tests/unit/test_rule_commands_control_plane.py
+++ b/tests/unit/test_rule_commands_control_plane.py
@@ -133,6 +133,28 @@ def test_benign_interpreter_command_passes(command):
     assert _cmd(command).verdict is Verdict.PASS
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python -c\"import shutil; shutil.rmtree('.doberman')\"",
+        "node -e\"require('fs').rmSync('.claude',{recursive:true})\"",
+        "python --eval=\"shutil.rmtree('.doberman')\"",
+    ],
+)
+def test_interpreter_attached_inline_payload_targeting_control_plane_is_blocked(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['python -c"print(1)"', 'node -e"console.log(1)"'],
+)
+def test_benign_attached_inline_payload_passes(command):
+    assert _cmd(command).verdict is Verdict.PASS
+
+
 def test_traversal_into_control_plane_is_blocked():
     assert _cmd("rm a/../.doberman/policies.yaml").verdict is Verdict.BLOCK
 

--- a/tests/unit/test_rule_commands_control_plane.py
+++ b/tests/unit/test_rule_commands_control_plane.py
@@ -83,6 +83,56 @@ def test_nested_bash_c_payload_is_blocked():
     assert _cmd('bash -c "rm -rf .doberman"').verdict is Verdict.BLOCK
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python -c \"import shutil; shutil.rmtree('.doberman')\"",
+        "python3 -c \"shutil.rmtree('.doberman')\"",
+        "py -c \"print('.doberman')\"",
+        "node -e \"require('fs').rmSync('.claude',{recursive:true})\"",
+        "nodejs --eval \"console.log('.doberman')\"",
+        "node -p \"'.claude'\"",
+        "node --print \"'.doberman'\"",
+        "deno -e \"console.log('.doberman')\"",
+        "bun -e \"console.log('.claude')\"",
+        "perl -e \"unlink '.doberman/policies.yaml'\"",
+        "ruby -e \"puts '.claude'\"",
+    ],
+)
+def test_interpreter_payload_targeting_control_plane_is_blocked(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python -c \"import shutil; shutil.rmtree('build')\"",
+        "python -c \"import os; os.remove('scratch.txt')\"",
+        "python -c \"import os; os.unlink('scratch.txt')\"",
+        "node -e \"require('fs').rmSync('build',{recursive:true})\"",
+        "node -e \"require('fs').unlinkSync('scratch.txt')\"",
+        "node -e \"fs.rm('build',()=>{})\"",
+        "perl -e \"unlink '.scratch'\"",
+        "ruby -e \"system('Remove-Item scratch.txt')\"",
+        "ruby -e \"system('rm -rf build')\"",
+    ],
+)
+def test_interpreter_payload_with_destructive_filesystem_op_is_blocked(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.destructive_command in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['python -c "print(1)"', 'node -e "console.log(1)"', "python script.py"],
+)
+def test_benign_interpreter_command_passes(command):
+    assert _cmd(command).verdict is Verdict.PASS
+
+
 def test_traversal_into_control_plane_is_blocked():
     assert _cmd("rm a/../.doberman/policies.yaml").verdict is Verdict.BLOCK
 

--- a/tests/unit/test_totp.py
+++ b/tests/unit/test_totp.py
@@ -57,8 +57,39 @@ def test_enroll_refuses_silent_overwrite():
     with pytest.raises(RuntimeError):
         totp.enroll()
     assert totp._read_secret() == first  # unchanged
-    totp.enroll(force=True)
-    assert totp._read_secret() != first  # rotated only with force
+
+
+def test_enroll_rotation_requires_current_code():
+    totp.enroll()
+    first = totp._read_secret()
+    with pytest.raises(RuntimeError, match="current 2FA code"):
+        totp.enroll(force=True)
+    assert totp._read_secret() == first
+
+
+def test_enroll_rotation_rejects_wrong_current_code():
+    totp.enroll()
+    first = totp._read_secret()
+    with pytest.raises(RuntimeError, match="current 2FA code"):
+        totp.enroll(force=True, current_code="not-a-code")
+    assert totp._read_secret() == first
+
+
+def test_enroll_rotation_accepts_current_code_without_logging_credentials(caplog):
+    caplog.set_level("DEBUG")
+    first_uri = totp.enroll()
+    first = totp._read_secret()
+    assert first is not None
+    current_code = pyotp.TOTP(first).now()
+
+    rotated_uri = totp.enroll(force=True, current_code=current_code)
+    rotated = totp._read_secret()
+
+    assert rotated_uri.startswith("otpauth://")
+    assert rotated_uri != first_uri
+    assert rotated is not None and rotated != first
+    for sensitive_value in (first, rotated, current_code, first_uri, rotated_uri):
+        assert sensitive_value not in caplog.text
 
 
 def test_secret_file_is_owner_only(isolated_totp_secret):


### PR DESCRIPTION
C1 control-plane hardening from the 2026-07-16 security audit (findings C1 + H5). Two changes:

1. Interpreter-payload guard (engine/rules/commands.py): python -c / node -e / perl -e / etc. one-liners whose inline payload references the control plane (.doberman/.claude) or performs a destructive filesystem op are now BLOCKed — previously only real shells (bash -c) were scanned, so an interpreter payload could wipe .doberman unblocked. Handles both space-separated (-c "code") and attached (-c"code") forms; benign one-liners still pass (no AUTH-fatigue). Also makes _split_segments quote/escape-aware so payloads containing ; inside quotes parse correctly.

2. 2FA-rotation proof (auth/totp.py + cli/main.py): enroll(force=True) now requires a valid current 2FA code verified against the existing secret before rotating — closes the agent-driven 2FA-takeover path. Fail-closed. The CLI 2fa setup --force prompts for the current code.

Tests cover every case. Follow-ups (noted, not in this PR): route the rotation-proof through the rate-limited verify() path (depends on H5 persistent lockout); C1 slice 2 = the mode/prefs/enforcement possession-factor lowering gate (ADR 0033).