### PR TITLE
feat(auth,policy,cli): possession-factor lowering gate — 2FA-or-password (C1 slice 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Prompt injection, tool poisoning, data exfiltration, and runaway agents are the 
 **Two non-negotiable properties:**
 
 - 🔒 **Fail closed** — any error, uncertainty, or unhandled case denies the action. There is no path to a tool around the decision engine.
-- 📈 **Raise-only learning** — guardrails and adaptive learning can auto-*tighten*, never silently loosen. Every weakening requires explicit, 2FA-gated, audited human approval.
+- 📈 **Raise-only learning** — guardrails and adaptive learning can auto-*tighten*, never silently loosen. Every permanent policy weakening requires explicit, possession-factor-gated, audited human approval (TOTP if enrolled, otherwise the local Doberman password).
 
 ---
 
@@ -282,6 +282,14 @@ doberman setup --yes    # accept sensible defaults (balanced mode), non-interact
 
 > The adaptive per-entity layer over the hook path arrives with the warm-daemon slice.
 
+Set the minimum local possession factor before making any later permanent policy lowering;
+TOTP enrollment is optional, but becomes the required (stronger) factor when present:
+
+```bash
+doberman password set   # always-available minimum for mode/prefs lowerings
+doberman 2fa setup      # optional TOTP; required instead of the password once enrolled
+```
+
 ### 4. Check it's healthy — `doberman doctor`
 
 One read-only self-check that answers *"is Doberman actually wired up and healthy?"* — host hooks, config, the decision DB, 2FA, the enforcement dial + strictness mode, and the fingerprint key:
@@ -349,7 +357,7 @@ It reports two plugin profiles — `builtins_only` and `with_plugins` (built-ins
 
 ## Tune to your risk tolerance
 
-Set a mode in `.doberman/policies.yaml` or via `doberman mode <mode>`. Every mode change made this way — the CLI dial or the setup wizard — is recorded in the append-only policy-change ledger (view it with `doberman policy-history`). Lowering strictness (paranoid → strict → balanced → light) is a **weaken** and now requires a **mandatory 2FA code** — an unenrolled user cannot lower it, there is no confirm-only fallback; raising stays frictionless and auto-applies:
+Set a mode in `.doberman/policies.yaml` or via `doberman mode <mode>`. Every mode change made this way — the CLI dial or the setup wizard — is recorded in the append-only policy-change ledger (view it with `doberman policy-history`). Lowering strictness (paranoid → strict → balanced → light) is a **weaken** and requires confirmation plus a possession factor: **TOTP if enrolled, otherwise the local Doberman password**. If neither exists, the lowering fails closed; confirmation alone never suffices. Raising stays frictionless and auto-applies:
 
 | Mode | Best for | Bulk-delete threshold | Step-up for unknown destinations | Step-up for behavioral anomalies | Lethal-trifecta exfil |
 |---|---|---|---|---|---|
@@ -380,7 +388,7 @@ Set it with **`doberman enforcement <enforce|monitor|off>`** (no argument prints
 
 ### Subjective preference weights — `doberman prefs`
 
-The adaptive layer's four SL5 "care" weights (`confidentiality`, `reversibility`, `interruption_tolerance`, `blast_radius`, each in `[0, 1]`) tune how readily *discretionary* behavioral signals step up — the objective hard-block floor never moves. Show the active vector with `doberman prefs`, set one weight with `doberman prefs <dimension> <value>`. Same possession-factor rule as `mode` and `enforcement`: **lowering** a weight is a weaken and is denied without a valid 2FA code (no confirm-only escape hatch); **raising** a weight is a strengthen and always applies immediately. Every attempt, approved or denied, is recorded in the append-only ledger.
+The adaptive layer's four SL5 "care" weights (`confidentiality`, `reversibility`, `interruption_tolerance`, `blast_radius`, each in `[0, 1]`) tune how readily *discretionary* behavioral signals step up — the objective hard-block floor never moves. Show the active vector with `doberman prefs`, set one weight with `doberman prefs <dimension> <value>`. The same permanent-lowering rule as `mode` applies: **lowering** a weight requires TOTP if enrolled, otherwise the local Doberman password; with neither factor it fails closed, and confirmation alone never suffices. **Raising** a weight is a strengthen and always applies immediately. Every attempt, approved or denied, is recorded in the append-only ledger.
 
 ---
 
@@ -394,7 +402,7 @@ The adaptive layer's four SL5 "care" weights (`confidentiality`, `reversibility`
 
 ## Roadmap <a name="roadmap"></a>
 
-- ✅ Tool mediation · decision engine · objective guardrail (paths, commands, destinations, secrets, **smuggled-token channels**) · subjective guardrail (adaptive behavioral baselines, **OOD/homoglyph token signals**) · roles & boundaries · capability discovery · tiered auth (confirm → TOTP → scoped elevation) · audit log · policy-drift & poisoning defense (classify strengthen/weaken, 2FA-gated weakening, append-only ledger, **enforce/monitor/off enforcement dial — now consumed by the decision path (discretionary verdicts soften; the objective floor stays live), gated + ledger-verified tamper clamp**, **strictness `mode` and SL5 `prefs` weights now route through the same mandatory-2FA weaken gate — lowering either is denied without a possession-factor code, raising stays frictionless**) · universal subjective layer (SL1–SL9)
+- ✅ Tool mediation · decision engine · objective guardrail (paths, commands, destinations, secrets, **smuggled-token channels**) · subjective guardrail (adaptive behavioral baselines, **OOD/homoglyph token signals**) · roles & boundaries · capability discovery · tiered auth (confirm → TOTP → scoped elevation) · audit log · policy-drift & poisoning defense (classify strengthen/weaken, possession-factor-gated permanent weakening, append-only ledger, **enforce/monitor/off enforcement dial — now consumed by the decision path (discretionary verdicts soften; the objective floor stays live), gated + ledger-verified tamper clamp**, **strictness `mode` and SL5 `prefs` now use the corrected 2FA-or-password gate: password is the minimum factor, optional TOTP takes precedence when enrolled, neither enrolled fails closed, and raising stays frictionless**) · universal subjective layer (SL1–SL9)
 - ✅ Benchmark harness (suite-agnostic ASR/FPR over labeled actions; `builtins_only` vs `with_plugins`; deterministic synthetic gate; external-suite adapters via `tests/benchmarks/`)
 - ✅ Host-harness integration: Claude Code `PreToolUse` + `PostToolUse` hooks (`doberman hook pre`/`post`) gate every built-in *and* MCP tool call — and scan tool **output** for leaked secrets — with no MCP reconfig; fail-closed, import-light, surfacing an in-session approval dialog (confirm / TOTP 2FA) on a sensitive action, and recording a local redacted history
 - ✅ One-command onboarding: `doberman setup` (alertness + guardrails + auto-wires the hooks) · `install-hooks`/`uninstall-hooks` · `doberman doctor` (read-only health self-check: hooks / config / DB / 2FA / enforcement dial / fingerprint key; non-zero exit on any critical failure)

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ It reports two plugin profiles — `builtins_only` and `with_plugins` (built-ins
 
 ## Tune to your risk tolerance
 
-Set a mode in `.doberman/policies.yaml` or via `doberman policy set-mode <mode>`. Every mode change made this way — the CLI dial or the setup wizard — is recorded in the append-only policy-change ledger (view it with `doberman policy-history`), so a strictness downgrade is always auditable even though it isn't 2FA-gated (F10):
+Set a mode in `.doberman/policies.yaml` or via `doberman mode <mode>`. Every mode change made this way — the CLI dial or the setup wizard — is recorded in the append-only policy-change ledger (view it with `doberman policy-history`). Lowering strictness (paranoid → strict → balanced → light) is a **weaken** and now requires a **mandatory 2FA code** — an unenrolled user cannot lower it, there is no confirm-only fallback; raising stays frictionless and auto-applies:
 
 | Mode | Best for | Bulk-delete threshold | Step-up for unknown destinations | Step-up for behavioral anomalies | Lethal-trifecta exfil |
 |---|---|---|---|---|---|
@@ -378,6 +378,10 @@ Set it with **`doberman enforcement <enforce|monitor|off>`** (no argument prints
 
 **In every state the objective floor stays live.** Secret exfiltration, multi-step/confirmed exfil, destructive commands, protected-path writes, role/policy blocks, and the lethal trifecta always block — `monitor`/`off` can only soften the *discretionary* verdicts, never a catastrophic action. Softening the dial is **2FA-gated** and the on-disk value is **ledger-verified** on every call, so a hand-edited `enforcement: off` in `policies.yaml` with no matching approved change is caught and clamped back to `enforce` (fail-closed).
 
+### Subjective preference weights — `doberman prefs`
+
+The adaptive layer's four SL5 "care" weights (`confidentiality`, `reversibility`, `interruption_tolerance`, `blast_radius`, each in `[0, 1]`) tune how readily *discretionary* behavioral signals step up — the objective hard-block floor never moves. Show the active vector with `doberman prefs`, set one weight with `doberman prefs <dimension> <value>`. Same possession-factor rule as `mode` and `enforcement`: **lowering** a weight is a weaken and is denied without a valid 2FA code (no confirm-only escape hatch); **raising** a weight is a strengthen and always applies immediately. Every attempt, approved or denied, is recorded in the append-only ledger.
+
 ---
 
 ## Who is this for?
@@ -390,7 +394,7 @@ Set it with **`doberman enforcement <enforce|monitor|off>`** (no argument prints
 
 ## Roadmap <a name="roadmap"></a>
 
-- ✅ Tool mediation · decision engine · objective guardrail (paths, commands, destinations, secrets, **smuggled-token channels**) · subjective guardrail (adaptive behavioral baselines, **OOD/homoglyph token signals**) · roles & boundaries · capability discovery · tiered auth (confirm → TOTP → scoped elevation) · audit log · policy-drift & poisoning defense (classify strengthen/weaken, 2FA-gated weakening, append-only ledger, **enforce/monitor/off enforcement dial — now consumed by the decision path (discretionary verdicts soften; the objective floor stays live), gated + ledger-verified tamper clamp**) · universal subjective layer (SL1–SL9)
+- ✅ Tool mediation · decision engine · objective guardrail (paths, commands, destinations, secrets, **smuggled-token channels**) · subjective guardrail (adaptive behavioral baselines, **OOD/homoglyph token signals**) · roles & boundaries · capability discovery · tiered auth (confirm → TOTP → scoped elevation) · audit log · policy-drift & poisoning defense (classify strengthen/weaken, 2FA-gated weakening, append-only ledger, **enforce/monitor/off enforcement dial — now consumed by the decision path (discretionary verdicts soften; the objective floor stays live), gated + ledger-verified tamper clamp**, **strictness `mode` and SL5 `prefs` weights now route through the same mandatory-2FA weaken gate — lowering either is denied without a possession-factor code, raising stays frictionless**) · universal subjective layer (SL1–SL9)
 - ✅ Benchmark harness (suite-agnostic ASR/FPR over labeled actions; `builtins_only` vs `with_plugins`; deterministic synthetic gate; external-suite adapters via `tests/benchmarks/`)
 - ✅ Host-harness integration: Claude Code `PreToolUse` + `PostToolUse` hooks (`doberman hook pre`/`post`) gate every built-in *and* MCP tool call — and scan tool **output** for leaked secrets — with no MCP reconfig; fail-closed, import-light, surfacing an in-session approval dialog (confirm / TOTP 2FA) on a sensitive action, and recording a local redacted history
 - ✅ One-command onboarding: `doberman setup` (alertness + guardrails + auto-wires the hooks) · `install-hooks`/`uninstall-hooks` · `doberman doctor` (read-only health self-check: hooks / config / DB / 2FA / enforcement dial / fingerprint key; non-zero exit on any critical failure)

--- a/src/doberman/auth/password.py
+++ b/src/doberman/auth/password.py
@@ -1,0 +1,176 @@
+"""Local password possession-factor verification (C1, slice 2).
+
+The password tier proves a *human* is present for a permanent policy weakening
+when TOTP is not enrolled. Doberman stores only a salted PBKDF2-SHA256 hash,
+never the password itself, so the out-of-band factor cannot be recovered from
+the enrollment file.
+
+Secret handling (SECURITY):
+
+* Location is ``$DOBERMAN_PASSWORD_FILE`` if set, else a per-user config dir
+  (``%LOCALAPPDATA%`` / ``$XDG_CONFIG_HOME`` / ``~/.config``) — outside any repo.
+* Written ``0600`` in a ``0700`` dir using restrictive permissions from file
+  creation, mirroring :mod:`doberman.auth.totp`.
+* Verification uses a salted 600,000-iteration PBKDF2-SHA256 hash and
+  :func:`hmac.compare_digest` for constant-time comparison.
+* Verification is rate-limited: too many consecutive failures lock further
+  attempts until a reset, blunting online guessing.
+* If a password is **not enrolled**, :func:`verify` returns ``False`` — there
+  is no confirm-only or no-auth fallback. Any malformed state fails closed.
+
+Passwords and stored hashes are never logged or returned.
+"""
+
+import hashlib
+import hmac
+import os
+from pathlib import Path
+
+#: Env var overriding the password-hash file location (tests inject a temp path).
+PASSWORD_FILE_ENV = "DOBERMAN_PASSWORD_FILE"  # noqa: S105 — env-var name, not a secret
+
+_ALGORITHM = "pbkdf2_sha256"
+_PBKDF2_ITERATIONS = 600_000
+_SALT_BYTES = 16
+_HASH_BYTES = 32
+_MIN_PASSWORD_LENGTH = 8
+
+#: Consecutive failed verifications before further attempts are locked out
+#: (until :func:`reset_attempts` or a successful verify).
+_MAX_CONSECUTIVE_FAILURES = 5
+
+#: Per-password-file consecutive-failure counters (isolated by path so
+#: distinct enrollments — and distinct tests — never share rate-limit state).
+_failures: dict[str, int] = {}
+
+
+def _default_secret_path() -> Path:
+    """Per-user password-hash path OUTSIDE any repository (never committed)."""
+    if os.name == "nt":
+        base = os.environ.get("LOCALAPPDATA") or os.path.join(
+            os.path.expanduser("~"), "AppData", "Local"
+        )
+    else:
+        base = os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
+    return Path(base) / "doberman" / "password.hash"
+
+
+def _secret_path() -> Path:
+    override = os.environ.get(PASSWORD_FILE_ENV)
+    return Path(override) if override else _default_secret_path()
+
+
+def _read_record() -> tuple[int, bytes, bytes] | None:
+    """Return ``(iterations, salt, hash)`` or ``None`` if absent/malformed."""
+    path = _secret_path()
+    try:
+        if not path.exists():
+            return None
+        parts = path.read_text(encoding="utf-8").strip().split("$")
+        if len(parts) != 4 or parts[0] != _ALGORITHM:
+            return None
+        iterations = int(parts[1])
+        salt = bytes.fromhex(parts[2])
+        stored_hash = bytes.fromhex(parts[3])
+        if iterations <= 0 or len(salt) != _SALT_BYTES or len(stored_hash) != _HASH_BYTES:
+            return None
+        return iterations, salt, stored_hash
+    except (OSError, UnicodeError, ValueError):
+        return None
+
+
+def is_enrolled() -> bool:
+    """True only when a parseable password-hash record is present."""
+    return _read_record() is not None
+
+
+def enroll(
+    secret: str,
+    *,
+    force: bool = False,
+    current_password: str | None = None,
+) -> None:
+    """Hash and store ``secret``, guarding any rotation with the old password.
+
+    Refuses to overwrite an existing file unless ``force=True`` and
+    ``current_password`` verifies against that existing record. The new password
+    must contain at least eight characters. Neither password nor hash is returned.
+    """
+    if not isinstance(secret, str) or len(secret) < _MIN_PASSWORD_LENGTH:
+        raise ValueError("password must be at least 8 characters")
+
+    path = _secret_path()
+    if path.exists():
+        if not force:
+            raise RuntimeError(
+                "password is already enrolled; pass force=True to deliberately rotate it"
+            )
+        if current_password is None or not verify(current_password):
+            raise RuntimeError("a valid current password is required to rotate the password")
+
+    salt = os.urandom(_SALT_BYTES)
+    derived = hashlib.pbkdf2_hmac(
+        "sha256",
+        secret.encode("utf-8"),
+        salt,
+        _PBKDF2_ITERATIONS,
+    )
+    record = f"{_ALGORITHM}${_PBKDF2_ITERATIONS}${salt.hex()}${derived.hex()}"
+
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(str(path), flags, 0o600)
+    try:
+        os.write(fd, record.encode("ascii"))
+    finally:
+        os.close(fd)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+    _failures.pop(str(path), None)
+
+
+def reset_attempts() -> None:
+    """Clear the consecutive-failure counter for the active password file."""
+    _failures.pop(str(_secret_path()), None)
+
+
+def verify(secret: str) -> bool:
+    """Verify ``secret`` against the stored hash without ever raising.
+
+    Fails closed: not enrolled, malformed input/storage, KDF errors, or a
+    rate-limit lockout all return ``False``. A successful verification resets
+    the counter; each failed comparison or verification error increments it.
+    """
+    try:
+        record = _read_record()
+    except Exception:  # noqa: BLE001 — storage/read errors deny, never escape
+        return False
+    if record is None:
+        return False
+
+    key = str(_secret_path())
+    if _failures.get(key, 0) >= _MAX_CONSECUTIVE_FAILURES:
+        return False
+
+    try:
+        if not isinstance(secret, str):
+            raise TypeError("password must be text")
+        iterations, salt, stored_hash = record
+        candidate_hash = hashlib.pbkdf2_hmac(
+            "sha256",
+            secret.encode("utf-8"),
+            salt,
+            iterations,
+        )
+        ok = hmac.compare_digest(candidate_hash, stored_hash)
+    except Exception:  # noqa: BLE001 — any verify error is failed auth, never a pass
+        ok = False
+
+    if ok:
+        _failures.pop(key, None)
+    else:
+        _failures[key] = _failures.get(key, 0) + 1
+    return ok

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1,9 +1,9 @@
 """The ``doberman`` CLI entry point (Features 5-7).
 
 Exposes ``doberman scan`` (risk map), ``review`` / ``mode`` / ``status``
-(policy), and the Feature 7 auth surface: ``doberman 2fa setup`` (TOTP
-enrollment) and ``doberman revoke`` (revoke a role elevation). ``status`` also
-lists currently-active elevations.
+(policy), and local auth surfaces: ``doberman password set``, ``doberman 2fa
+setup`` (optional TOTP enrollment), and ``doberman revoke`` (revoke a role
+elevation). ``status`` also lists currently-active elevations.
 """
 
 import asyncio
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 import typer
 
 from doberman import __version__
-from doberman.auth import totp
+from doberman.auth import password, totp
 from doberman.auth.provider import CliPrompter
 from doberman.config import (
     load_active_role,
@@ -73,6 +73,12 @@ app = typer.Typer(
 
 twofa_app = typer.Typer(help="Two-factor (TOTP) enrollment.", no_args_is_help=True)
 app.add_typer(twofa_app, name="2fa")
+
+password_app = typer.Typer(
+    help="Local password possession factor (the minimum lowering-gate auth).",
+    no_args_is_help=True,
+)
+app.add_typer(password_app, name="password")
 
 hook_app = typer.Typer(
     help="Host-harness integration hooks (e.g. Claude Code PreToolUse/PostToolUse).",
@@ -201,25 +207,23 @@ def review(
 def _apply_mode_change(
     name: str, path: str, reason: str, *, establish_ok: bool = False
 ) -> str | None:
-    """Resolve ``name``, gate any weakening behind 2FA, then persist it (F10).
+    """Resolve ``name``, gate any weakening behind a possession factor, then persist it.
 
     The mode dial is now gated at parity with the enforcement dial:
     lowering strictness (a downgrade on the paranoid>strict>balanced>light
-    scale) is a ``weaken`` and must clear the **mandatory** 2FA gate
-    (:func:`doberman.policy.drift.apply_change` / ``_run_weaken_gate``)
-    before it is persisted — an unenrolled user cannot lower the mode until
-    they run ``doberman 2fa setup``. Raising stays frictionless: ``apply_change``
-    auto-approves a strengthen with no prompt. A no-op (unchanged mode) skips
-    the gate/ledger entirely. Every attempt (incl. denials) is recorded to the
-    append-only ledger. Returns ``None`` when the gate denies the change —
-    fail closed, nothing persisted.
+    scale) is a ``weaken`` and must clear a possession factor — a 2FA code if
+    enrolled, otherwise the Doberman password set via ``doberman password set`` —
+    before it is persisted. Raising stays frictionless: ``apply_change`` auto-approves
+    a strengthen with no prompt. A no-op (unchanged mode) skips the gate/ledger entirely.
+    Every attempt (incl. denials) is recorded to the append-only ledger. Returns
+    ``None`` when the gate denies the change — fail closed, nothing persisted.
 
     ``establish_ok`` (first-run onboarding via ``doberman setup``) writes the
     INITIAL posture freely when no policy is persisted yet — choosing a starting
     mode is not weakening an existing one, and 2FA is enrolled later in the
     wizard. The change is still recorded to the ledger. Once a policy exists,
     even a setup re-run falls through to the gate, so neither ``setup`` nor
-    ``mode`` can be used to bypass the mandatory 2FA on a lowering.
+    ``mode`` can bypass the possession factor on a lowering.
     """
     old = load_mode(path)
     new = resolve_mode(name).value  # raises ValueError for an unknown mode
@@ -241,8 +245,9 @@ def mode(
 ) -> None:
     """Show or set the security strength mode.
 
-    Lowering strictness requires a 2FA code (mandatory possession factor,
-    parity with `doberman enforcement`); raising is always frictionless.
+    Lowering strictness requires a possession factor — a 2FA code if enrolled,
+    otherwise your Doberman password (set via `doberman password set`). Raising
+    is always frictionless.
     """
     if name is None:
         typer.echo(load_mode(path))
@@ -329,8 +334,8 @@ def prefs(
     With no arguments, prints the active vector and which mode preset it
     matches (if any). Weights tune SUBJECTIVE step-up propensity only - the
     objective hard-block floor is unaffected by every weight. Lowering a
-    weight requires a 2FA code (mandatory possession factor, parity with
-    `doberman enforcement`/`doberman mode`); raising is always frictionless.
+    weight requires a possession factor — a 2FA code if enrolled, otherwise
+    your Doberman password (set via `doberman password set`). Raising is always frictionless.
     """
     if dimension is None:
         vector = load_preferences(path)
@@ -404,8 +409,10 @@ def status(
         enabled = sum(1 for it in doc.items if it.enabled)
         typer.echo(f"Policy: {enabled}/{len(doc.items)} items enabled")
 
-    enrolled = "yes" if totp.is_enrolled() else "no (run `doberman 2fa setup`)"
-    typer.echo(f"2FA:    {enrolled}")
+    twofa_status = "yes" if totp.is_enrolled() else "no"
+    typer.echo(f"2FA:    {twofa_status} (optional; run `doberman 2fa setup`)")
+    password_status = "yes" if password.is_enrolled() else "no (run `doberman password set`)"
+    typer.echo(f"Password: {password_status}")
 
     grants = asyncio.run(active_elevations(path, datetime.now(timezone.utc)))
     if not grants:
@@ -523,6 +530,34 @@ def hook_post() -> None:
     if out is not None:
         sys.stdout.write(out + "\n")
     raise typer.Exit(0)
+
+
+@password_app.command("set")
+def password_set(
+    force: bool = typer.Option(
+        False, "--force", help="Rotate an existing password after proving the current one."
+    ),
+) -> None:
+    """Set or deliberately rotate the local password possession factor."""
+    prompter = CliPrompter()
+    current_password = None
+    if force and password.is_enrolled():
+        current_password = prompter.read_code("Enter your current Doberman password")
+    new_password = prompter.read_code("Enter a new Doberman password")
+    repeated_password = prompter.read_code("Enter the new Doberman password again")
+    if new_password != repeated_password:
+        typer.echo("error: passwords do not match", err=True)
+        raise typer.Exit(code=1)
+    try:
+        password.enroll(
+            new_password,
+            force=force,
+            current_password=current_password,
+        )
+    except (ValueError, RuntimeError) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo("Password set. Stored locally with owner-only permissions; never committed.")
 
 
 @twofa_app.command("setup")
@@ -786,6 +821,8 @@ def setup(
     """Friendly first-run wizard: choose your security posture and wire Claude Code hooks.
 
     Walks through alertness mode, preference tuning, and automatic hook installation.
+    Later lowerings require a possession factor — a 2FA code if enrolled,
+    otherwise your Doberman password (set via ``doberman password set``).
     Pass ``--yes`` for a fully non-interactive run (useful for CI or scripting).
     """
     from doberman.hosthooks.install import (
@@ -836,14 +873,15 @@ def setup(
 
     # Save the chosen mode. First-run onboarding establishes the initial posture
     # freely (establish_ok); a re-run over an existing policy still gates a
-    # lowering behind 2FA, so setup can't be used to bypass the mode gate.
+    # lowering behind a possession factor, so setup can't bypass the mode gate.
     try:
         if (
             _apply_mode_change(chosen_mode.value, path, "doberman setup wizard", establish_ok=True)
             is None
         ):
             typer.echo(
-                "note: mode not lowered (a lowering needs a 2FA code); keeping the current mode",
+                "note: mode not lowered (a lowering needs an enrolled possession factor); "
+                "keeping the current mode",
                 err=True,
             )
     except ValueError as exc:
@@ -944,7 +982,10 @@ def setup(
     typer.echo("")
     typer.echo("Doberman is now active.")
     typer.echo("Restart your Claude Code session to pick up the hooks.")
-    typer.echo("Next steps: `doberman 2fa setup`  |  `doberman status`")
+    typer.echo(
+        "Next steps: `doberman password set`  |  `doberman 2fa setup` (optional)  |  "
+        "`doberman status`"
+    )
 
 
 @app.command()

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -30,7 +30,13 @@ from doberman.config import (
 )
 from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, render_risk_map
 from doberman.policy.checklist import recommend_policy
-from doberman.policy.drift import apply_enforcement_change, log_change, read_policy_changes
+from doberman.policy.drift import (
+    apply_change,
+    apply_enforcement_change,
+    apply_preferences_change,
+    log_change,
+    read_policy_changes,
+)
 from doberman.policy.modes import SecurityMode, resolve_mode
 from doberman.policy.preferences import DIMENSIONS, preset_name
 from doberman.storage.db import active_elevations, revoke_elevation
@@ -192,26 +198,39 @@ def review(
         typer.echo("\n(read-only; re-run with --yes to save)")
 
 
-def _apply_mode_change(name: str, path: str, reason: str) -> str:
-    """Resolve ``name``, best-effort audit-log the change, then persist it (F10).
+def _apply_mode_change(
+    name: str, path: str, reason: str, *, establish_ok: bool = False
+) -> str | None:
+    """Resolve ``name``, gate any weakening behind 2FA, then persist it (F10).
 
-    The mode dial is deliberately frictionless, but every user-initiated change
-    still lands in the append-only policy-change ledger via
-    :func:`doberman.policy.drift.log_change` (``method="logged"``). A ledger
-    problem must never block the mode change itself, so logging is attempted
-    *before* saving and any unexpected failure is swallowed with a printed
-    warning; the save always proceeds. A no-op (unchanged mode) skips the
-    ledger call entirely rather than writing a confusing neutral entry.
+    The mode dial is now gated at parity with the enforcement dial:
+    lowering strictness (a downgrade on the paranoid>strict>balanced>light
+    scale) is a ``weaken`` and must clear the **mandatory** 2FA gate
+    (:func:`doberman.policy.drift.apply_change` / ``_run_weaken_gate``)
+    before it is persisted — an unenrolled user cannot lower the mode until
+    they run ``doberman 2fa setup``. Raising stays frictionless: ``apply_change``
+    auto-approves a strengthen with no prompt. A no-op (unchanged mode) skips
+    the gate/ledger entirely. Every attempt (incl. denials) is recorded to the
+    append-only ledger. Returns ``None`` when the gate denies the change —
+    fail closed, nothing persisted.
+
+    ``establish_ok`` (first-run onboarding via ``doberman setup``) writes the
+    INITIAL posture freely when no policy is persisted yet — choosing a starting
+    mode is not weakening an existing one, and 2FA is enrolled later in the
+    wizard. The change is still recorded to the ledger. Once a policy exists,
+    even a setup re-run falls through to the gate, so neither ``setup`` nor
+    ``mode`` can be used to bypass the mandatory 2FA on a lowering.
     """
     old = load_mode(path)
     new = resolve_mode(name).value  # raises ValueError for an unknown mode
-    if old != new:
-        try:
-            asyncio.run(log_change({"mode": old}, {"mode": new}, reason, repo_root=path))
-        except Exception as exc:  # noqa: BLE001 -- ledger issues must never block the mode change
-            typer.echo(
-                f"warning: could not record mode change in the policy ledger: {exc}", err=True
-            )
+    if old == new:
+        return save_mode(name, path)
+    if establish_ok and load_policy(path) is None:
+        asyncio.run(log_change({"mode": old}, {"mode": new}, reason, repo_root=path))
+        return save_mode(name, path)
+    outcome = asyncio.run(apply_change({"mode": old}, {"mode": new}, reason, repo_root=path))
+    if not outcome.approved:
+        return None
     return save_mode(name, path)
 
 
@@ -220,7 +239,11 @@ def mode(
     name: str = typer.Argument(None, help="Mode to set (light/balanced/strict/paranoid)."),
     path: str = typer.Option(".", "--path", "-p", help="Repository root."),
 ) -> None:
-    """Show or set the security strength mode."""
+    """Show or set the security strength mode.
+
+    Lowering strictness requires a 2FA code (mandatory possession factor,
+    parity with `doberman enforcement`); raising is always frictionless.
+    """
     if name is None:
         typer.echo(load_mode(path))
         return
@@ -229,6 +252,9 @@ def mode(
     except ValueError as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2) from exc
+    if saved is None:
+        typer.echo("mode change denied; unchanged", err=True)
+        raise typer.Exit(code=1)
     typer.echo(f"mode set to {saved}")
 
 
@@ -302,7 +328,9 @@ def prefs(
 
     With no arguments, prints the active vector and which mode preset it
     matches (if any). Weights tune SUBJECTIVE step-up propensity only - the
-    objective hard-block floor is unaffected by every weight.
+    objective hard-block floor is unaffected by every weight. Lowering a
+    weight requires a 2FA code (mandatory possession factor, parity with
+    `doberman enforcement`/`doberman mode`); raising is always frictionless.
     """
     if dimension is None:
         vector = load_preferences(path)
@@ -318,11 +346,23 @@ def prefs(
             "error: provide a value in [0, 1] (e.g. `doberman prefs confidentiality 0.8`)", err=True
         )
         raise typer.Exit(code=2)
+    current = load_preferences(path)
     try:
-        updated = load_preferences(path).with_weight(dimension, value)
+        updated = current.with_weight(dimension, value)
     except (KeyError, ValueError) as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2) from exc
+    outcome = asyncio.run(
+        apply_preferences_change(
+            current.to_mapping(),
+            updated.to_mapping(),
+            "doberman prefs CLI",
+            repo_root=path,
+        )
+    )
+    if not outcome.approved:
+        typer.echo("preference change denied; unchanged", err=True)
+        raise typer.Exit(code=1)
     save_preferences(updated, path)
     typer.echo(f"{dimension} set to {value:.2f}")
 
@@ -794,9 +834,18 @@ def setup(
             typer.echo(f"error: {exc}", err=True)
             raise typer.Exit(2) from exc
 
-    # Save the chosen mode.
+    # Save the chosen mode. First-run onboarding establishes the initial posture
+    # freely (establish_ok); a re-run over an existing policy still gates a
+    # lowering behind 2FA, so setup can't be used to bypass the mode gate.
     try:
-        _apply_mode_change(chosen_mode.value, path, "doberman setup wizard")
+        if (
+            _apply_mode_change(chosen_mode.value, path, "doberman setup wizard", establish_ok=True)
+            is None
+        ):
+            typer.echo(
+                "note: mode not lowered (a lowering needs a 2FA code); keeping the current mode",
+                err=True,
+            )
     except ValueError as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(2) from exc

--- a/src/doberman/policy/drift.py
+++ b/src/doberman/policy/drift.py
@@ -9,8 +9,8 @@ mechanism (a core safety invariant):
 * :func:`classify_change` — labels a proposed change ``strengthen`` /
   ``weaken`` / ``neutral``. **Ambiguous or mixed → weaken** (fail safe).
 * :func:`apply_change` — the **single chokepoint**: a weakening requires a
-  ``two_factor`` confirmation against a rendered Before/After diff and is applied
-  only on approval; strengthening/neutral changes apply (still logged). Every
+  possession factor (TOTP if enrolled, else password) against a rendered
+  Before/After diff and is applied only on approval; strengthening/neutral changes apply. Every
   attempt — including denials (the attack signal) — is written to the ledger and
   fanned out to registered :class:`DriftObserver` s.
 * :func:`apply_enforcement_change` — the same chokepoint for the orthogonal
@@ -19,8 +19,7 @@ mechanism (a core safety invariant):
 * :func:`apply_preferences_change` — the sibling chokepoint for the SL5
   preference vector (numeric weights, so classified directly rather than via
   the token-rank table): lowering any weight is a weaken and requires the
-  same **mandatory** 2FA as a policy-rule weakening; raising applies
-  automatically.
+  same mandatory possession factor as a policy-rule weakening; raising applies automatically.
 * :func:`effective_enforcement` — the **read-side** clamp: turns the on-disk
   enforcement fields into the state to act on, verifying them against the ledger
   so a hand-edit of ``policies.yaml`` (e.g. ``enforcement: off``) that bypassed the
@@ -30,7 +29,7 @@ mechanism (a core safety invariant):
   strictness ``mode`` dial only.
 * :class:`DriftObserver` — the enterprise seam (org-wide drift monitoring /
   compliance). Observers receive **redacted** events and can **never** approve or
-  suppress a weakening — the 2FA gate is core and authoritative. The free-text
+  suppress a weakening — the possession-factor gate is core and authoritative. The free-text
   ``reason`` on every event (and every ledger row) is scrubbed of secret-shaped
   substrings and length-capped by :func:`_redact_reason` before it is ever
   recorded or fanned out — a pasted token in a reason must never reach the
@@ -47,7 +46,7 @@ from datetime import datetime, timezone
 from enum import StrEnum
 from typing import Protocol, runtime_checkable
 
-from doberman.auth import totp
+from doberman.auth import password, totp
 from doberman.auth.challenge import Prompter
 from doberman.models import Decision, ReasonCode, Verdict
 from doberman.storage.db import db_path, open_db
@@ -203,17 +202,29 @@ def _render_diff(before: dict, after: dict, reason: str) -> str:
     return "\n".join(lines)
 
 
+def _verify_possession_factor(prompter: Prompter) -> tuple[bool, str]:
+    """Verify the strongest enrolled factor; never fall back after a failure."""
+    if totp.is_enrolled():
+        code = prompter.read_code("Enter your 2FA code to authorize this policy weakening")
+        return (True, "two_factor") if totp.verify(code) else (False, "denied")
+    if password.is_enrolled():
+        pw = prompter.read_code("Enter your Doberman password to authorize this policy weakening")
+        return (True, "password") if password.verify(pw) else (False, "denied")
+    return False, "no_factor_enrolled"
+
+
 def _run_weaken_gate(
     before: dict, after: dict, reason: str, prompter: Prompter
 ) -> tuple[bool, str]:
-    """Require presence + a valid TOTP code to approve a weakening. Fails closed."""
+    """Require presence + the strongest ENROLLED possession factor.
+
+    TOTP is required if enrolled, otherwise the password is required. Fails
+    closed if neither is enrolled. Never confirm-only.
+    """
     try:
         if not prompter.confirm(_render_diff(before, after, reason)):
             return False, "denied"
-        code = prompter.read_code("Enter your 2FA code to authorize this policy weakening")
-        if totp.verify(code):
-            return True, "two_factor"
-        return False, "denied"
+        return _verify_possession_factor(prompter)
     except Exception:  # noqa: BLE001 — any input/timeout error denies the weakening
         return False, "denied"
 
@@ -272,8 +283,9 @@ async def apply_change(
 ) -> ChangeOutcome:
     """The single chokepoint for a policy change. Returns the outcome.
 
-    A **weaken** is gated behind a 2FA confirmation of a rendered diff and is
-    approved only on success; a **strengthen**/**neutral** applies automatically.
+    A **weaken** is gated behind confirmation of a rendered diff plus a possession
+    factor (TOTP if enrolled, else password), and is approved only on success; a
+    **strengthen**/**neutral** applies automatically.
     Every attempt (incl. denials) is written to the append-only ledger and fanned
     out to registered drift observers. The caller persists the new policy **only
     when** ``outcome.approved`` is True — this function decides, records, and
@@ -321,14 +333,15 @@ async def log_change(
     repo_root: str,
     now: datetime | None = None,
 ) -> ChangeOutcome:
-    """Record a user-initiated, **audited but not 2FA-gated** policy change.
+    """Record an audited, not-possession-factor-gated mode establishment.
 
     For changes the operator has chosen to make frictionless yet auditable — the
     strictness-mode dial (light↔paranoid). The change is classified and written to
     the append-only ledger (``method="logged"``) and applied by the caller; a
     weakening is recorded as such (never hidden) but is not gated. This is a
     separate, explicitly-chosen audit-only path and does NOT relax the general
-    :func:`apply_change` weaken-gate (policy/role weakenings still require 2FA).
+    :func:`apply_change` weaken-gate (policy/role weakenings still require the
+    strongest enrolled possession factor).
     The dramatic enforcement-disable uses :func:`apply_enforcement_change`.
 
     Scope is enforced, not just documented: any changed key other than ``mode``
@@ -506,9 +519,9 @@ async def apply_preferences_change(
     shape), but classification is numeric via :func:`_prefs_classify` instead
     of the token-rank table. Lowering ANY weight is a weaken — it lowers
     subjective step-up propensity, i.e. protection — so it must clear the
-    same **mandatory** 2FA gate as a policy-rule weakening
-    (:func:`_run_weaken_gate`); unlike the enforcement dial there is no
-    confirm-only escape hatch, because prefs are not the safety valve.
+    same mandatory possession-factor gate (TOTP if enrolled, else password) as
+    a policy-rule weakening (:func:`_run_weaken_gate`); unlike the enforcement
+    dial there is no confirm-only escape hatch, because prefs are not the safety valve.
     Raising a weight is a strengthen and applies automatically — raise-only is
     preserved, and the prompter is never invoked on that path. Every attempt
     (incl. denials) is recorded to the append-only ledger and fanned out to
@@ -781,8 +794,8 @@ class DriftObserver(Protocol):
 
     Implementations live in installed packages registered via the
     ``doberman.drift_observers`` entry-point group. ``on_change`` is purely
-    observational: it can never approve, suppress, or alter a weakening (the 2FA
-    gate is core and authoritative) and must not raise into the caller.
+    observational: it can never approve, suppress, or alter a weakening (the
+    possession-factor gate is core and authoritative) and must not raise into the caller.
     """
 
     def on_change(self, event: dict) -> None: ...

--- a/src/doberman/policy/drift.py
+++ b/src/doberman/policy/drift.py
@@ -16,6 +16,11 @@ mechanism (a core safety invariant):
 * :func:`apply_enforcement_change` — the same chokepoint for the orthogonal
   enforcement dial (enforce / monitor / off): softening is gated (confirm +
   TOTP-if-enrolled), re-arming applies automatically.
+* :func:`apply_preferences_change` — the sibling chokepoint for the SL5
+  preference vector (numeric weights, so classified directly rather than via
+  the token-rank table): lowering any weight is a weaken and requires the
+  same **mandatory** 2FA as a policy-rule weakening; raising applies
+  automatically.
 * :func:`effective_enforcement` — the **read-side** clamp: turns the on-disk
   enforcement fields into the state to act on, verifying them against the ledger
   so a hand-edit of ``policies.yaml`` (e.g. ``enforcement: off``) that bypassed the
@@ -429,6 +434,97 @@ async def apply_enforcement_change(
         approved, method = _run_enforcement_gate(before, after, reason, prompter or CliPrompter())
     else:
         approved, method = True, "auto"
+    await _record_change(
+        repo_root,
+        before,
+        after,
+        classification,
+        reason,
+        approved=approved,
+        method=method,
+        now=when,
+    )
+    notify_observers(
+        {
+            "ts": when.isoformat(),
+            "classification": classification.value,
+            "changed_rules": _changed_keys(before, after),
+            "reason": reason,
+            "approved": approved,
+            "method": method,
+        }
+    )
+    return ChangeOutcome(classification=classification, approved=approved, method=method)
+
+
+def _prefs_classify(before: dict, after: dict) -> Classification:
+    """Classify a preference-vector change directly (weights are numeric).
+
+    :func:`classify_change`'s token-rank table cannot distinguish two floats —
+    both land on ``_UNKNOWN_TOKEN_RANK`` and read as neutral — so preference
+    weights need this numeric sibling. **Any** dimension whose weight
+    decreased, or that was present in ``before`` but dropped from ``after``
+    (a removed weight is no protection from that dimension), makes the whole
+    change a ``weaken`` — mixed with a raise elsewhere still weakens (fail
+    safe, matching :func:`classify_change`'s policy). A value that cannot be
+    coerced to ``float`` is treated as a weaken rather than raising (fail
+    safe). Only increases/additions with nothing decreased/removed →
+    ``strengthen``; identical → ``neutral``.
+    """
+    weakened = bool(set(before) - set(after))  # a dropped dimension
+    strengthened = bool(set(after) - set(before))  # an added dimension
+    junk = False
+    for key in set(before) & set(after):
+        try:
+            before_val, after_val = float(before[key]), float(after[key])
+        except (TypeError, ValueError):
+            junk = True
+            continue
+        if after_val < before_val:
+            weakened = True
+        elif after_val > before_val:
+            strengthened = True
+    if weakened or junk:
+        return Classification.weaken
+    if strengthened:
+        return Classification.strengthen
+    return Classification.neutral
+
+
+async def apply_preferences_change(
+    before: dict,
+    after: dict,
+    reason: str,
+    *,
+    repo_root: str,
+    prompter: Prompter | None = None,
+    now: datetime | None = None,
+) -> ChangeOutcome:
+    """Chokepoint for a subjective-preference-vector change (SL5 weights).
+
+    Structural sibling of :func:`apply_change` (same record/notify/return
+    shape), but classification is numeric via :func:`_prefs_classify` instead
+    of the token-rank table. Lowering ANY weight is a weaken — it lowers
+    subjective step-up propensity, i.e. protection — so it must clear the
+    same **mandatory** 2FA gate as a policy-rule weakening
+    (:func:`_run_weaken_gate`); unlike the enforcement dial there is no
+    confirm-only escape hatch, because prefs are not the safety valve.
+    Raising a weight is a strengthen and applies automatically — raise-only is
+    preserved, and the prompter is never invoked on that path. Every attempt
+    (incl. denials) is recorded to the append-only ledger and fanned out to
+    observers; the caller persists only when ``outcome.approved``.
+    """
+    reason = _redact_reason(reason)
+    when = now or datetime.now(timezone.utc)
+    classification = _prefs_classify(before, after)
+
+    if classification is Classification.weaken:
+        from doberman.auth.provider import CliPrompter
+
+        approved, method = _run_weaken_gate(before, after, reason, prompter or CliPrompter())
+    else:
+        approved, method = True, "auto"
+
     await _record_change(
         repo_root,
         before,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ need to exercise key generation/rotation override this with their own
 
 import pytest
 
+from doberman.auth.password import PASSWORD_FILE_ENV
 from doberman.auth.totp import TOTP_FILE_ENV
 from doberman.storage.device_metrics import HOME_ENV
 from doberman.storage.fingerprint import KEY_FILE_ENV
@@ -41,6 +42,18 @@ def isolated_totp_secret(tmp_path, monkeypatch):
     secret_path = tmp_path / "doberman-totp.secret"
     monkeypatch.setenv(TOTP_FILE_ENV, str(secret_path))
     return secret_path
+
+
+@pytest.fixture(autouse=True)
+def isolated_password_hash(tmp_path, monkeypatch):
+    """Point the local password hash at a per-test temp file (C1 slice 2).
+
+    Tests must never touch a real per-user possession factor. The failure
+    counter is keyed by this path, so a fresh path also isolates lockout state.
+    """
+    hash_path = tmp_path / "doberman-password.hash"
+    monkeypatch.setenv(PASSWORD_FILE_ENV, str(hash_path))
+    return hash_path
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_auth_password.py
+++ b/tests/unit/test_auth_password.py
@@ -1,0 +1,117 @@
+"""C1 slice 2 — local password possession-factor enrollment and verification."""
+
+import os
+import stat
+
+import pytest
+
+from doberman.auth import password
+
+_PASSWORD = "correct horse battery staple"  # noqa: S105 — synthetic test credential
+_ROTATED_PASSWORD = "troubador batteries corrected"  # noqa: S105 — synthetic test credential
+
+
+def test_enroll_then_verify_password():
+    password.enroll(_PASSWORD)
+
+    assert password.is_enrolled() is True
+    assert password.verify(_PASSWORD) is True
+
+
+def test_wrong_password_is_rejected():
+    password.enroll(_PASSWORD)
+
+    assert password.verify("this is the wrong password") is False
+
+
+def test_not_enrolled_fails_closed():
+    assert password.is_enrolled() is False
+    assert password.verify(_PASSWORD) is False
+
+
+def test_malformed_hash_is_not_enrolled_and_verify_fails_closed(isolated_password_hash):
+    isolated_password_hash.write_text("not-a-password-hash", encoding="utf-8")
+
+    assert password.is_enrolled() is False
+    assert password.verify(_PASSWORD) is False
+
+
+def test_rate_limited_after_five_consecutive_failures():
+    password.enroll(_PASSWORD)
+    for _ in range(5):
+        assert password.verify("this is the wrong password") is False
+
+    assert password.verify(_PASSWORD) is False
+    password.reset_attempts()
+    assert password.verify(_PASSWORD) is True
+
+
+def test_enroll_refuses_overwrite_without_force(isolated_password_hash):
+    password.enroll(_PASSWORD)
+    original = isolated_password_hash.read_text(encoding="utf-8")
+
+    with pytest.raises(RuntimeError):
+        password.enroll(_ROTATED_PASSWORD)
+
+    assert isolated_password_hash.read_text(encoding="utf-8") == original
+
+
+def test_rotation_refuses_wrong_current_password(isolated_password_hash):
+    password.enroll(_PASSWORD)
+    original = isolated_password_hash.read_text(encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="current password"):
+        password.enroll(
+            _ROTATED_PASSWORD,
+            force=True,
+            current_password="this is the wrong password",  # noqa: S106 — synthetic
+        )
+
+    assert isolated_password_hash.read_text(encoding="utf-8") == original
+
+
+def test_rotation_accepts_correct_current_password():
+    password.enroll(_PASSWORD)
+
+    password.enroll(_ROTATED_PASSWORD, force=True, current_password=_PASSWORD)
+
+    assert password.verify(_ROTATED_PASSWORD) is True
+    assert password.verify(_PASSWORD) is False
+
+
+@pytest.mark.parametrize("secret", ["", "short", "1234567"])
+def test_enroll_rejects_empty_or_too_short_password(secret):
+    with pytest.raises(ValueError, match="at least 8"):
+        password.enroll(secret)
+
+
+def test_stored_file_contains_only_salted_hash(isolated_password_hash):
+    password.enroll(_PASSWORD)
+
+    stored = isolated_password_hash.read_text(encoding="utf-8")
+    assert _PASSWORD not in stored
+    assert stored.startswith("pbkdf2_sha256$600000$")
+    assert len(stored.split("$")) == 4
+
+
+@pytest.mark.parametrize("candidate", [None, object(), b"bytes", ["not", "a", "password"]])
+def test_verify_never_raises_for_non_string_input(candidate):
+    password.enroll(_PASSWORD)
+
+    assert password.verify(candidate) is False
+
+
+def test_verify_fails_closed_when_reading_the_hash_raises(monkeypatch):
+    def _boom():
+        raise RuntimeError("storage failure")
+
+    monkeypatch.setattr(password, "_read_record", _boom)
+
+    assert password.verify(_PASSWORD) is False
+
+
+def test_password_hash_file_is_owner_only(isolated_password_hash):
+    password.enroll(_PASSWORD)
+
+    if os.name != "nt":
+        assert stat.S_IMODE(isolated_password_hash.stat().st_mode) == 0o600

--- a/tests/unit/test_cli_lowering_gate.py
+++ b/tests/unit/test_cli_lowering_gate.py
@@ -1,0 +1,124 @@
+"""C1 slice 2 — CLI-level coverage for the mode/prefs mandatory-2FA lowering
+gate: ``doberman mode`` and ``doberman prefs`` now route through
+:func:`doberman.policy.drift.apply_change` / :func:`apply_preferences_change`
+instead of the old frictionless (mode, ``log_change``) / entirely-ungated
+(prefs) paths. Raising stays frictionless (never prompts); lowering requires a
+possession-factor 2FA code with **no confirm-only escape hatch** — unlike
+``doberman enforcement``'s deliberate safety valve for unenrolled users, mode
+and prefs are not the safety valve, so an unenrolled user cannot lower them.
+"""
+
+import pyotp
+from typer.testing import CliRunner
+
+from doberman.auth import totp
+from doberman.cli.main import app
+from doberman.config import load_mode, load_preferences
+
+runner = CliRunner()
+
+
+class _Decline:
+    def confirm(self, message):
+        return False
+
+    def read_code(self, message):  # pragma: no cover -- never reached after a decline
+        raise AssertionError("read_code must not be reached after a declined confirm")
+
+
+class _Boom:
+    """Any prompt is a failure -- proves a raise is never gated."""
+
+    def confirm(self, message):
+        raise AssertionError("a raise must not prompt")
+
+    def read_code(self, message):
+        raise AssertionError("a raise must not prompt")
+
+
+class _Approve:
+    """Present operator: confirms and supplies a currently-valid 2FA code."""
+
+    def __init__(self, code):
+        self._code = code
+
+    def confirm(self, message):
+        return True
+
+    def read_code(self, message):
+        return self._code
+
+
+def _use_prompter(monkeypatch, prompter_factory):
+    # apply_change / apply_preferences_change lazily do
+    # `from doberman.auth.provider import CliPrompter` only on the weaken path,
+    # so patch the name it constructs there (same pattern as test_cli_enforcement.py).
+    monkeypatch.setattr("doberman.auth.provider.CliPrompter", prompter_factory)
+
+
+def _enrolled_code() -> str:
+    totp.enroll()
+    return pyotp.TOTP(totp._read_secret()).now()
+
+
+# --- mode --------------------------------------------------------------------
+
+
+def test_mode_lowering_with_valid_2fa_is_approved_and_persisted(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    code = _enrolled_code()
+    _use_prompter(monkeypatch, lambda: _Approve(code))
+    # Default is "balanced"; "light" is a downgrade.
+    result = runner.invoke(app, ["mode", "light", "--path", root])
+    assert result.exit_code == 0, result.output
+    assert "mode set to light" in result.output
+    assert load_mode(root) == "light"
+
+
+def test_mode_lowering_not_enrolled_is_denied_and_unchanged(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    _use_prompter(monkeypatch, _Decline)  # not enrolled; a decline still proves fail-closed
+    result = runner.invoke(app, ["mode", "light", "--path", root])
+    assert result.exit_code == 1
+    assert "denied" in result.output.lower()
+    assert load_mode(root) == "balanced"
+
+
+def test_mode_raising_never_prompts_and_applies(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    _use_prompter(monkeypatch, _Boom)
+    result = runner.invoke(app, ["mode", "strict", "--path", root])
+    assert result.exit_code == 0, result.output
+    assert "mode set to strict" in result.output
+    assert load_mode(root) == "strict"
+
+
+# --- prefs ---------------------------------------------------------------------
+
+
+def test_prefs_lowering_without_2fa_is_denied_and_unchanged(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    _use_prompter(monkeypatch, _Decline)
+    result = runner.invoke(app, ["prefs", "confidentiality", "0.1", "--path", root])
+    assert result.exit_code == 1
+    assert "denied" in result.output.lower()
+    assert load_preferences(root).confidentiality == 0.5  # balanced preset default, unchanged
+
+
+def test_prefs_lowering_with_valid_2fa_is_approved_and_persisted(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    code = _enrolled_code()
+    _use_prompter(monkeypatch, lambda: _Approve(code))
+    result = runner.invoke(app, ["prefs", "confidentiality", "0.1", "--path", root])
+    assert result.exit_code == 0, result.output
+    assert "confidentiality set to 0.10" in result.output
+    assert load_preferences(root).confidentiality == 0.1
+
+
+def test_prefs_raising_never_prompts_and_applies(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    _use_prompter(monkeypatch, _Boom)
+    result = runner.invoke(app, ["prefs", "confidentiality", "0.9", "--path", root])
+    assert result.exit_code == 0, result.output
+    assert "confidentiality set to 0.90" in result.output
+    assert load_preferences(root).confidentiality == 0.9

--- a/tests/unit/test_cli_lowering_gate.py
+++ b/tests/unit/test_cli_lowering_gate.py
@@ -1,21 +1,25 @@
-"""C1 slice 2 — CLI-level coverage for the mode/prefs mandatory-2FA lowering
-gate: ``doberman mode`` and ``doberman prefs`` now route through
-:func:`doberman.policy.drift.apply_change` / :func:`apply_preferences_change`
-instead of the old frictionless (mode, ``log_change``) / entirely-ungated
-(prefs) paths. Raising stays frictionless (never prompts); lowering requires a
-possession-factor 2FA code with **no confirm-only escape hatch** — unlike
-``doberman enforcement``'s deliberate safety valve for unenrolled users, mode
-and prefs are not the safety valve, so an unenrolled user cannot lower them.
+"""C1 slice 2 — CLI coverage for permanent mode/preference weakenings.
+
+Lowering requires confirmation plus the strongest enrolled possession factor:
+TOTP when enrolled, otherwise the local password. With neither factor enrolled
+the change fails closed; strengthening and first-run setup remain frictionless.
 """
 
+import asyncio
+
 import pyotp
+import pytest
 from typer.testing import CliRunner
 
-from doberman.auth import totp
+from doberman.auth import password, totp
+from doberman.cli import main as cli_main
 from doberman.cli.main import app
-from doberman.config import load_mode, load_preferences
+from doberman.config import load_mode, load_policy, load_preferences
+from doberman.policy.drift import read_policy_changes
 
 runner = CliRunner()
+
+_PASSWORD = "correct horse battery staple"  # noqa: S105 — synthetic test credential
 
 
 class _Decline:
@@ -27,7 +31,7 @@ class _Decline:
 
 
 class _Boom:
-    """Any prompt is a failure -- proves a raise is never gated."""
+    """Any prompt is a failure — proves a raise is never gated."""
 
     def confirm(self, message):
         raise AssertionError("a raise must not prompt")
@@ -37,7 +41,7 @@ class _Boom:
 
 
 class _Approve:
-    """Present operator: confirms and supplies a currently-valid 2FA code."""
+    """Present operator: confirms and supplies one out-of-band factor."""
 
     def __init__(self, code):
         self._code = code
@@ -49,76 +53,191 @@ class _Approve:
         return self._code
 
 
+class _ConfirmOnly:
+    """No-factor path must return before asking for an unavailable secret."""
+
+    def confirm(self, message):
+        return True
+
+    def read_code(self, message):
+        raise AssertionError("no factor is enrolled, so no secret prompt is valid")
+
+
+class _CodeSequence:
+    def __init__(self, *codes):
+        self._codes = iter(codes)
+
+    def read_code(self, message):
+        return next(self._codes)
+
+
 def _use_prompter(monkeypatch, prompter_factory):
-    # apply_change / apply_preferences_change lazily do
-    # `from doberman.auth.provider import CliPrompter` only on the weaken path,
-    # so patch the name it constructs there (same pattern as test_cli_enforcement.py).
+    # apply_change / apply_preferences_change lazily construct this name only on
+    # the weaken path (same pattern as test_cli_enforcement.py).
     monkeypatch.setattr("doberman.auth.provider.CliPrompter", prompter_factory)
 
 
 def _enrolled_code() -> str:
     totp.enroll()
-    return pyotp.TOTP(totp._read_secret()).now()
+    secret = totp._read_secret()
+    assert secret is not None
+    return pyotp.TOTP(secret).now()
 
 
-# --- mode --------------------------------------------------------------------
+def _invoke_lowering(kind: str, root: str):
+    if kind == "mode":
+        return runner.invoke(app, ["mode", "light", "--path", root])
+    return runner.invoke(app, ["prefs", "confidentiality", "0.1", "--path", root])
 
 
-def test_mode_lowering_with_valid_2fa_is_approved_and_persisted(tmp_path, monkeypatch):
+def _assert_lowering_state(kind: str, root: str, *, applied: bool) -> None:
+    if kind == "mode":
+        assert load_mode(root) == ("light" if applied else "balanced")
+    else:
+        expected = 0.1 if applied else 0.5
+        assert load_preferences(root).confidentiality == expected
+    if not applied:
+        assert load_policy(root) is None
+
+
+def _assert_single_ledger_method(root: str, method: str, *, approved: int) -> None:
+    rows = asyncio.run(read_policy_changes(root))
+    assert len(rows) == 1
+    assert rows[0]["approval_method"] == method
+    assert rows[0]["approved"] == approved
+
+
+@pytest.mark.parametrize("kind", ["mode", "prefs"])
+def test_lowering_with_enrolled_2fa_requires_valid_totp_and_persists(kind, tmp_path, monkeypatch):
     root = str(tmp_path)
+    password.enroll(_PASSWORD)  # TOTP must win when both factors are enrolled.
     code = _enrolled_code()
     _use_prompter(monkeypatch, lambda: _Approve(code))
-    # Default is "balanced"; "light" is a downgrade.
-    result = runner.invoke(app, ["mode", "light", "--path", root])
+
+    result = _invoke_lowering(kind, root)
+
     assert result.exit_code == 0, result.output
-    assert "mode set to light" in result.output
-    assert load_mode(root) == "light"
+    _assert_lowering_state(kind, root, applied=True)
+    _assert_single_ledger_method(root, "two_factor", approved=1)
 
 
-def test_mode_lowering_not_enrolled_is_denied_and_unchanged(tmp_path, monkeypatch):
+@pytest.mark.parametrize("kind", ["mode", "prefs"])
+@pytest.mark.parametrize("prompter", [_Decline(), _Approve(_PASSWORD)])
+def test_lowering_with_enrolled_2fa_decline_or_non_totp_factor_is_denied(
+    kind, prompter, tmp_path, monkeypatch
+):
     root = str(tmp_path)
-    _use_prompter(monkeypatch, _Decline)  # not enrolled; a decline still proves fail-closed
-    result = runner.invoke(app, ["mode", "light", "--path", root])
+    password.enroll(_PASSWORD)
+    _enrolled_code()
+    _use_prompter(monkeypatch, lambda: prompter)
+
+    result = _invoke_lowering(kind, root)
+
     assert result.exit_code == 1
-    assert "denied" in result.output.lower()
-    assert load_mode(root) == "balanced"
+    _assert_lowering_state(kind, root, applied=False)
+    _assert_single_ledger_method(root, "denied", approved=0)
+
+
+@pytest.mark.parametrize("kind", ["mode", "prefs"])
+def test_lowering_with_password_only_accepts_password(kind, tmp_path, monkeypatch):
+    root = str(tmp_path)
+    password.enroll(_PASSWORD)
+    _use_prompter(monkeypatch, lambda: _Approve(_PASSWORD))
+
+    result = _invoke_lowering(kind, root)
+
+    assert result.exit_code == 0, result.output
+    _assert_lowering_state(kind, root, applied=True)
+    _assert_single_ledger_method(root, "password", approved=1)
+
+
+@pytest.mark.parametrize("kind", ["mode", "prefs"])
+def test_lowering_with_password_only_rejects_wrong_password(kind, tmp_path, monkeypatch):
+    root = str(tmp_path)
+    password.enroll(_PASSWORD)
+    _use_prompter(monkeypatch, lambda: _Approve("this is the wrong password"))
+
+    result = _invoke_lowering(kind, root)
+
+    assert result.exit_code == 1
+    _assert_lowering_state(kind, root, applied=False)
+    _assert_single_ledger_method(root, "denied", approved=0)
+
+
+@pytest.mark.parametrize("kind", ["mode", "prefs"])
+def test_lowering_with_no_factor_enrolled_fails_closed(kind, tmp_path, monkeypatch):
+    root = str(tmp_path)
+    _use_prompter(monkeypatch, _ConfirmOnly)
+
+    result = _invoke_lowering(kind, root)
+
+    assert result.exit_code == 1
+    _assert_lowering_state(kind, root, applied=False)
+    _assert_single_ledger_method(root, "no_factor_enrolled", approved=0)
 
 
 def test_mode_raising_never_prompts_and_applies(tmp_path, monkeypatch):
     root = str(tmp_path)
     _use_prompter(monkeypatch, _Boom)
+
     result = runner.invoke(app, ["mode", "strict", "--path", root])
+
     assert result.exit_code == 0, result.output
-    assert "mode set to strict" in result.output
     assert load_mode(root) == "strict"
-
-
-# --- prefs ---------------------------------------------------------------------
-
-
-def test_prefs_lowering_without_2fa_is_denied_and_unchanged(tmp_path, monkeypatch):
-    root = str(tmp_path)
-    _use_prompter(monkeypatch, _Decline)
-    result = runner.invoke(app, ["prefs", "confidentiality", "0.1", "--path", root])
-    assert result.exit_code == 1
-    assert "denied" in result.output.lower()
-    assert load_preferences(root).confidentiality == 0.5  # balanced preset default, unchanged
-
-
-def test_prefs_lowering_with_valid_2fa_is_approved_and_persisted(tmp_path, monkeypatch):
-    root = str(tmp_path)
-    code = _enrolled_code()
-    _use_prompter(monkeypatch, lambda: _Approve(code))
-    result = runner.invoke(app, ["prefs", "confidentiality", "0.1", "--path", root])
-    assert result.exit_code == 0, result.output
-    assert "confidentiality set to 0.10" in result.output
-    assert load_preferences(root).confidentiality == 0.1
+    _assert_single_ledger_method(root, "auto", approved=1)
 
 
 def test_prefs_raising_never_prompts_and_applies(tmp_path, monkeypatch):
     root = str(tmp_path)
     _use_prompter(monkeypatch, _Boom)
+
     result = runner.invoke(app, ["prefs", "confidentiality", "0.9", "--path", root])
+
     assert result.exit_code == 0, result.output
-    assert "confidentiality set to 0.90" in result.output
     assert load_preferences(root).confidentiality == 0.9
+    _assert_single_ledger_method(root, "auto", approved=1)
+
+
+def test_setup_can_establish_initial_mode_without_a_factor(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    _use_prompter(monkeypatch, _Boom)
+
+    result = runner.invoke(app, ["setup", "--yes", "--mode", "light", "--path", root])
+
+    assert result.exit_code == 0, result.output
+    assert load_mode(root) == "light"
+
+
+def test_password_set_command_enrolls_matching_password(tmp_path, monkeypatch):
+    prompter = _CodeSequence(_PASSWORD, _PASSWORD)
+    monkeypatch.setattr(cli_main, "CliPrompter", lambda: prompter)
+
+    result = runner.invoke(app, ["password", "set"])
+
+    assert result.exit_code == 0, result.output
+    assert password.verify(_PASSWORD) is True
+    assert _PASSWORD not in result.output
+
+
+def test_password_set_command_rejects_mismatch(tmp_path, monkeypatch):
+    prompter = _CodeSequence(_PASSWORD, "different password")
+    monkeypatch.setattr(cli_main, "CliPrompter", lambda: prompter)
+
+    result = runner.invoke(app, ["password", "set"])
+
+    assert result.exit_code == 1
+    assert password.is_enrolled() is False
+    assert _PASSWORD not in result.output
+
+
+def test_password_set_force_requires_current_password(tmp_path, monkeypatch):
+    password.enroll(_PASSWORD)
+    rotated = "new correct horse battery staple"
+    prompter = _CodeSequence(_PASSWORD, rotated, rotated)
+    monkeypatch.setattr(cli_main, "CliPrompter", lambda: prompter)
+
+    result = runner.invoke(app, ["password", "set", "--force"])
+
+    assert result.exit_code == 0, result.output
+    assert password.verify(rotated) is True
+    assert _PASSWORD not in result.output

--- a/tests/unit/test_drift_preferences_gate.py
+++ b/tests/unit/test_drift_preferences_gate.py
@@ -1,0 +1,242 @@
+"""C1 slice 2 — subjective preference-vector weakening (SL5 weights) is gated
+behind the same mandatory 2FA chokepoint as a policy-rule weakening
+(:func:`_run_weaken_gate`); raising a weight stays frictionless (raise-only),
+mirroring :func:`doberman.policy.drift.apply_change`.
+"""
+
+from datetime import datetime, timezone
+
+import pyotp
+
+from doberman.auth import totp
+from doberman.policy.drift import Classification, apply_preferences_change, read_policy_changes
+
+_NOW = datetime(2026, 7, 16, tzinfo=timezone.utc)
+
+
+class ScriptedPrompter:
+    def __init__(self, *, confirm=True, code=""):
+        self._confirm, self._code = confirm, code
+        self.confirm_calls = 0
+        self.read_code_calls = 0
+
+    def confirm(self, message):
+        self.confirm_calls += 1
+        return self._confirm
+
+    def read_code(self, message):
+        self.read_code_calls += 1
+        return self._code
+
+
+class _RaisingPrompter:
+    """Confirms, then blows up reading the code (e.g. the operator walked away)."""
+
+    def confirm(self, message):
+        return True
+
+    def read_code(self, message):
+        raise TimeoutError("walked away")
+
+
+def _enrolled_code() -> str:
+    totp.enroll()
+    return pyotp.TOTP(totp._read_secret()).now()
+
+
+# --- A: lowering a weight requires 2FA ---------------------------------------
+
+
+async def test_lowering_a_weight_with_valid_2fa_is_approved(tmp_path):
+    code = _enrolled_code()
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.7},
+        {"confidentiality": 0.3},
+        "lower confidentiality",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=True, code=code),
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.weaken
+    assert outcome.approved is True
+    assert outcome.method == "two_factor"
+
+
+async def test_lowering_a_weight_denied_when_confirmation_declined(tmp_path):
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.7},
+        {"confidentiality": 0.3},
+        "lower confidentiality",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=False),
+        now=_NOW,
+    )
+    assert outcome.approved is False
+    assert outcome.method == "denied"
+
+
+async def test_lowering_a_weight_denied_when_read_code_raises(tmp_path):
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.7},
+        {"confidentiality": 0.3},
+        "lower confidentiality",
+        repo_root=str(tmp_path),
+        prompter=_RaisingPrompter(),
+        now=_NOW,
+    )
+    assert outcome.approved is False
+    assert outcome.method == "denied"
+
+
+async def test_denial_is_still_recorded_in_the_ledger(tmp_path):
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.7},
+        {"confidentiality": 0.3},
+        "lower confidentiality",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=False),
+        now=_NOW,
+    )
+    assert outcome.approved is False
+    rows = await read_policy_changes(str(tmp_path))
+    assert len(rows) == 1
+    assert rows[0]["rule_id"] == "confidentiality"
+    assert rows[0]["approved"] == 0
+    assert rows[0]["classification"] == "weaken"
+    assert rows[0]["approval_method"] == "denied"
+
+
+# --- B: raising a weight is frictionless (raise-only) -------------------------
+
+
+async def test_raising_a_weight_never_prompts(tmp_path):
+    # A wrong code + a would-be-approving confirm proves the prompter is truly
+    # never invoked on a strengthen, not merely that it happens to succeed.
+    prompter = ScriptedPrompter(confirm=True, code="000000")
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.3},
+        {"confidentiality": 0.7},
+        "raise confidentiality",
+        repo_root=str(tmp_path),
+        prompter=prompter,
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.strengthen
+    assert outcome.approved is True
+    assert outcome.method == "auto"
+    assert prompter.confirm_calls == 0
+    assert prompter.read_code_calls == 0
+
+
+async def test_identical_vector_is_neutral_and_never_prompts(tmp_path):
+    prompter = ScriptedPrompter(confirm=True, code="000000")
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.5},
+        {"confidentiality": 0.5},
+        "no-op",
+        repo_root=str(tmp_path),
+        prompter=prompter,
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.neutral
+    assert outcome.approved is True
+    assert prompter.confirm_calls == 0
+
+
+# --- C: mixed change -> weaken (fail safe) -------------------------------------
+
+
+async def test_mixed_change_classifies_as_weaken(tmp_path):
+    code = _enrolled_code()
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.3, "blast_radius": 0.8},
+        {"confidentiality": 0.6, "blast_radius": 0.4},
+        "mixed",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=True, code=code),
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.weaken
+    assert outcome.approved is True
+    assert outcome.method == "two_factor"
+
+
+# --- H: confirm-only can never approve a weaken (possession factor mandatory) -
+
+
+async def test_confirm_true_but_wrong_code_still_denied(tmp_path):
+    totp.enroll()  # enrolled, but the supplied code is wrong
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.7},
+        {"confidentiality": 0.3},
+        "lower confidentiality",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=True, code="000000"),
+        now=_NOW,
+    )
+    assert outcome.approved is False
+    assert outcome.method == "denied"
+
+
+async def test_confirm_only_cannot_approve_when_nothing_is_enrolled(tmp_path):
+    # Not enrolled at all (isolated_totp_secret autouse fixture) -- confirm=True
+    # plus any code must still deny: totp.verify() fails closed with nothing
+    # enrolled, so there is no code path that approves a weaken by confirmation
+    # alone. This is the proof that a plain "yes" can never substitute for the
+    # possession factor.
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.7},
+        {"confidentiality": 0.3},
+        "lower confidentiality",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=True, code="123456"),
+        now=_NOW,
+    )
+    assert outcome.approved is False
+    assert outcome.method == "denied"
+
+
+# --- extra edge cases: removed dimension / non-numeric junk -> weaken ---------
+
+
+async def test_removed_dimension_is_a_weaken(tmp_path):
+    code = _enrolled_code()
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.5, "blast_radius": 0.5},
+        {"confidentiality": 0.5},
+        "drop blast_radius",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=True, code=code),
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.weaken
+
+
+async def test_added_dimension_alone_is_a_strengthen(tmp_path):
+    prompter = ScriptedPrompter(confirm=True, code="000000")
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.5},
+        {"confidentiality": 0.5, "blast_radius": 0.5},
+        "add blast_radius",
+        repo_root=str(tmp_path),
+        prompter=prompter,
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.strengthen
+    assert outcome.approved is True
+    assert prompter.confirm_calls == 0
+
+
+async def test_non_numeric_value_is_treated_as_weaken_not_a_crash(tmp_path):
+    code = _enrolled_code()
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.5},
+        {"confidentiality": "not-a-number"},
+        "junk",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=True, code=code),
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.weaken
+    assert outcome.approved is True
+    assert outcome.method == "two_factor"

--- a/tests/unit/test_drift_preferences_gate.py
+++ b/tests/unit/test_drift_preferences_gate.py
@@ -1,17 +1,18 @@
-"""C1 slice 2 — subjective preference-vector weakening (SL5 weights) is gated
-behind the same mandatory 2FA chokepoint as a policy-rule weakening
-(:func:`_run_weaken_gate`); raising a weight stays frictionless (raise-only),
-mirroring :func:`doberman.policy.drift.apply_change`.
+"""C1 slice 2 — subjective preference-vector permanent-lowering gate.
+
+Lowering an SL5 weight requires confirmation plus the strongest enrolled
+possession factor (TOTP, otherwise password); raising remains frictionless.
 """
 
 from datetime import datetime, timezone
 
 import pyotp
 
-from doberman.auth import totp
+from doberman.auth import password, totp
 from doberman.policy.drift import Classification, apply_preferences_change, read_policy_changes
 
 _NOW = datetime(2026, 7, 16, tzinfo=timezone.utc)
+_PASSWORD = "correct horse battery staple"  # noqa: S105 — synthetic test credential
 
 
 class ScriptedPrompter:
@@ -44,10 +45,11 @@ def _enrolled_code() -> str:
     return pyotp.TOTP(totp._read_secret()).now()
 
 
-# --- A: lowering a weight requires 2FA ---------------------------------------
+# --- A: lowering a weight requires the strongest enrolled factor ------------
 
 
 async def test_lowering_a_weight_with_valid_2fa_is_approved(tmp_path):
+    password.enroll(_PASSWORD)  # TOTP must take precedence when both exist.
     code = _enrolled_code()
     outcome = await apply_preferences_change(
         {"confidentiality": 0.7},
@@ -76,6 +78,7 @@ async def test_lowering_a_weight_denied_when_confirmation_declined(tmp_path):
 
 
 async def test_lowering_a_weight_denied_when_read_code_raises(tmp_path):
+    _enrolled_code()
     outcome = await apply_preferences_change(
         {"confidentiality": 0.7},
         {"confidentiality": 0.3},
@@ -104,6 +107,38 @@ async def test_denial_is_still_recorded_in_the_ledger(tmp_path):
     assert rows[0]["approved"] == 0
     assert rows[0]["classification"] == "weaken"
     assert rows[0]["approval_method"] == "denied"
+
+
+async def test_lowering_with_password_only_is_approved_and_recorded(tmp_path):
+    password.enroll(_PASSWORD)
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.7},
+        {"confidentiality": 0.3},
+        "lower confidentiality",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=True, code=_PASSWORD),
+        now=_NOW,
+    )
+
+    assert outcome.approved is True
+    assert outcome.method == "password"
+    rows = await read_policy_changes(str(tmp_path))
+    assert rows[0]["approval_method"] == "password"
+
+
+async def test_lowering_with_password_only_rejects_wrong_password(tmp_path):
+    password.enroll(_PASSWORD)
+    outcome = await apply_preferences_change(
+        {"confidentiality": 0.7},
+        {"confidentiality": 0.3},
+        "lower confidentiality",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=True, code="this is the wrong password"),
+        now=_NOW,
+    )
+
+    assert outcome.approved is False
+    assert outcome.method == "denied"
 
 
 # --- B: raising a weight is frictionless (raise-only) -------------------------
@@ -165,13 +200,14 @@ async def test_mixed_change_classifies_as_weaken(tmp_path):
 
 
 async def test_confirm_true_but_wrong_code_still_denied(tmp_path):
-    totp.enroll()  # enrolled, but the supplied code is wrong
+    password.enroll(_PASSWORD)
+    totp.enroll()  # enrolled, so even the correct password cannot replace TOTP
     outcome = await apply_preferences_change(
         {"confidentiality": 0.7},
         {"confidentiality": 0.3},
         "lower confidentiality",
         repo_root=str(tmp_path),
-        prompter=ScriptedPrompter(confirm=True, code="000000"),
+        prompter=ScriptedPrompter(confirm=True, code=_PASSWORD),
         now=_NOW,
     )
     assert outcome.approved is False
@@ -179,21 +215,18 @@ async def test_confirm_true_but_wrong_code_still_denied(tmp_path):
 
 
 async def test_confirm_only_cannot_approve_when_nothing_is_enrolled(tmp_path):
-    # Not enrolled at all (isolated_totp_secret autouse fixture) -- confirm=True
-    # plus any code must still deny: totp.verify() fails closed with nothing
-    # enrolled, so there is no code path that approves a weaken by confirmation
-    # alone. This is the proof that a plain "yes" can never substitute for the
-    # possession factor.
+    prompter = ScriptedPrompter(confirm=True, code="123456")
     outcome = await apply_preferences_change(
         {"confidentiality": 0.7},
         {"confidentiality": 0.3},
         "lower confidentiality",
         repo_root=str(tmp_path),
-        prompter=ScriptedPrompter(confirm=True, code="123456"),
+        prompter=prompter,
         now=_NOW,
     )
     assert outcome.approved is False
-    assert outcome.method == "denied"
+    assert outcome.method == "no_factor_enrolled"
+    assert prompter.read_code_calls == 0
 
 
 # --- extra edge cases: removed dimension / non-numeric junk -> weaken ---------

--- a/tests/unit/test_mode_ledger.py
+++ b/tests/unit/test_mode_ledger.py
@@ -1,11 +1,8 @@
-"""#79 / C1 slice 2 — every user-initiated mode-dial change is recorded in the
-append-only policy-change ledger via `doberman.policy.drift.apply_change` (the
-same mandatory-2FA chokepoint as a policy-rule weakening, F10/ADR 0033). A
-downgrade (e.g. balanced -> light) now REQUIRES a 2FA possession factor and is
-denied (fail closed) without one; an upgrade stays frictionless and auto-
-applies. A same-mode no-op never writes a confusing ledger row, and a gate
-failure never applies the change (fail closed, replacing the old fail-open
-`log_change` path).
+"""#79 / C1 slice 2 — mode changes are ledgered through the lowering gate.
+
+A downgrade requires the strongest enrolled possession factor (TOTP, otherwise
+password) and fails closed without one; an upgrade stays frictionless. A no-op
+writes no row, and a gate failure never applies the change.
 """
 
 import asyncio
@@ -13,20 +10,30 @@ import asyncio
 import pyotp
 from typer.testing import CliRunner
 
-from doberman.auth import totp
+from doberman.auth import password, totp
 from doberman.cli import main as cli_main
 from doberman.cli.main import app
 from doberman.config import load_mode
 from doberman.policy.drift import read_policy_changes
 
 runner = CliRunner()
+_PASSWORD = "correct horse battery staple"  # noqa: S105 — synthetic test credential
 
 
-def test_mode_downgrade_without_2fa_is_denied_and_records_a_weaken_row(tmp_path):
+def test_mode_downgrade_without_a_factor_is_denied_and_records_a_weaken_row(tmp_path, monkeypatch):
     root = str(tmp_path)
     # Fresh repo has no saved policy -> default mode is "balanced"; light is a
-    # downgrade. Nothing is enrolled (isolated_totp_secret autouse fixture), so
-    # the mandatory-2FA gate denies it -- fail closed.
+    # downgrade. Nothing is enrolled, so the possession-factor gate denies it.
+
+    class _ConfirmOnly:
+        def confirm(self, message):
+            return True
+
+        def read_code(self, message):
+            raise AssertionError("no factor is enrolled, so no secret prompt is valid")
+
+    monkeypatch.setattr("doberman.auth.provider.CliPrompter", _ConfirmOnly)
+
     result = runner.invoke(app, ["mode", "light", "--path", root])
     assert result.exit_code == 1
     assert "denied" in result.output.lower()
@@ -37,7 +44,7 @@ def test_mode_downgrade_without_2fa_is_denied_and_records_a_weaken_row(tmp_path)
     row = rows[0]
     assert row["rule_id"] == "mode"
     assert row["classification"] == "weaken"
-    assert row["approval_method"] == "denied"
+    assert row["approval_method"] == "no_factor_enrolled"
     assert row["approved"] == 0
     assert row["from_state"] == "balanced"
     assert row["to_state"] == "light"
@@ -45,6 +52,7 @@ def test_mode_downgrade_without_2fa_is_denied_and_records_a_weaken_row(tmp_path)
 
 def test_mode_downgrade_with_valid_2fa_is_approved_and_records_a_weaken_row(tmp_path, monkeypatch):
     root = str(tmp_path)
+    password.enroll(_PASSWORD)  # TOTP is required when both factors exist.
     totp.enroll()
     code = pyotp.TOTP(totp._read_secret()).now()
 
@@ -69,6 +77,29 @@ def test_mode_downgrade_with_valid_2fa_is_approved_and_records_a_weaken_row(tmp_
     assert row["classification"] == "weaken"
     assert row["approval_method"] == "two_factor"
     assert row["approved"] == 1
+
+
+def test_mode_downgrade_with_password_only_records_password_approval(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    password.enroll(_PASSWORD)
+
+    class _Approve:
+        def confirm(self, message):
+            return True
+
+        def read_code(self, message):
+            return _PASSWORD
+
+    monkeypatch.setattr("doberman.auth.provider.CliPrompter", _Approve)
+
+    result = runner.invoke(app, ["mode", "light", "--path", root])
+
+    assert result.exit_code == 0, result.output
+    assert load_mode(root) == "light"
+    rows = asyncio.run(read_policy_changes(root))
+    assert len(rows) == 1
+    assert rows[0]["approval_method"] == "password"
+    assert rows[0]["approved"] == 1
 
 
 def test_mode_upgrade_from_default_records_a_strengthen_row(tmp_path):

--- a/tests/unit/test_mode_ledger.py
+++ b/tests/unit/test_mode_ledger.py
@@ -1,13 +1,19 @@
-"""#79 — every user-initiated mode-dial change is recorded in the append-only
-policy-change ledger via `doberman.policy.drift.log_change` (audited-but-not-
-gated, F10). The mode dial stays frictionless: logging never blocks the change,
-and a same-mode no-op never writes a confusing ledger row.
+"""#79 / C1 slice 2 — every user-initiated mode-dial change is recorded in the
+append-only policy-change ledger via `doberman.policy.drift.apply_change` (the
+same mandatory-2FA chokepoint as a policy-rule weakening, F10/ADR 0033). A
+downgrade (e.g. balanced -> light) now REQUIRES a 2FA possession factor and is
+denied (fail closed) without one; an upgrade stays frictionless and auto-
+applies. A same-mode no-op never writes a confusing ledger row, and a gate
+failure never applies the change (fail closed, replacing the old fail-open
+`log_change` path).
 """
 
 import asyncio
 
+import pyotp
 from typer.testing import CliRunner
 
+from doberman.auth import totp
 from doberman.cli import main as cli_main
 from doberman.cli.main import app
 from doberman.config import load_mode
@@ -16,21 +22,53 @@ from doberman.policy.drift import read_policy_changes
 runner = CliRunner()
 
 
-def test_mode_downgrade_from_default_records_a_weaken_row(tmp_path):
+def test_mode_downgrade_without_2fa_is_denied_and_records_a_weaken_row(tmp_path):
     root = str(tmp_path)
-    # Fresh repo has no saved policy -> default mode is "balanced"; light is a downgrade.
+    # Fresh repo has no saved policy -> default mode is "balanced"; light is a
+    # downgrade. Nothing is enrolled (isolated_totp_secret autouse fixture), so
+    # the mandatory-2FA gate denies it -- fail closed.
     result = runner.invoke(app, ["mode", "light", "--path", root])
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 1
+    assert "denied" in result.output.lower()
+    assert load_mode(root) == "balanced"  # unchanged
 
     rows = asyncio.run(read_policy_changes(root))
     assert len(rows) == 1
     row = rows[0]
     assert row["rule_id"] == "mode"
     assert row["classification"] == "weaken"
-    assert row["approval_method"] == "logged"
-    assert row["approved"] == 1
+    assert row["approval_method"] == "denied"
+    assert row["approved"] == 0
     assert row["from_state"] == "balanced"
     assert row["to_state"] == "light"
+
+
+def test_mode_downgrade_with_valid_2fa_is_approved_and_records_a_weaken_row(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    totp.enroll()
+    code = pyotp.TOTP(totp._read_secret()).now()
+
+    class _Approve:
+        def confirm(self, message):
+            return True
+
+        def read_code(self, message):
+            return code
+
+    # apply_change lazily does `from doberman.auth.provider import CliPrompter`
+    # only on the weaken path, so patch the name it constructs there.
+    monkeypatch.setattr("doberman.auth.provider.CliPrompter", _Approve)
+
+    result = runner.invoke(app, ["mode", "light", "--path", root])
+    assert result.exit_code == 0, result.output
+    assert load_mode(root) == "light"
+
+    rows = asyncio.run(read_policy_changes(root))
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["classification"] == "weaken"
+    assert row["approval_method"] == "two_factor"
+    assert row["approved"] == 1
 
 
 def test_mode_upgrade_from_default_records_a_strengthen_row(tmp_path):
@@ -42,7 +80,8 @@ def test_mode_upgrade_from_default_records_a_strengthen_row(tmp_path):
     assert len(rows) == 1
     row = rows[0]
     assert row["classification"] == "strengthen"
-    assert row["approval_method"] == "logged"
+    assert row["approval_method"] == "auto"
+    assert row["approved"] == 1
     assert row["from_state"] == "balanced"
     assert row["to_state"] == "strict"
 
@@ -55,16 +94,20 @@ def test_same_mode_invocation_records_nothing(tmp_path):
     assert asyncio.run(read_policy_changes(root)) == []
 
 
-def test_ledger_failure_never_blocks_the_mode_change(tmp_path, monkeypatch):
+def test_gate_failure_never_applies_the_mode_change(tmp_path, monkeypatch):
+    """Fail closed: if the gate chokepoint itself blows up, the mode change
+    must NOT apply (this replaces the old fail-OPEN `log_change`-failure test
+    -- the previous behavior silently applied the change despite the failure,
+    which is exactly the bug this slice removes).
+    """
     root = str(tmp_path)
 
     async def _boom(*args, **kwargs):
-        raise RuntimeError("ledger db exploded")
+        raise RuntimeError("gate exploded")
 
-    monkeypatch.setattr(cli_main, "log_change", _boom)
+    monkeypatch.setattr(cli_main, "apply_change", _boom)
 
     result = runner.invoke(app, ["mode", "light", "--path", root])
 
-    assert result.exit_code == 0, result.output
-    assert "warning" in result.output.lower()
-    assert load_mode(root) == "light"  # the mode change still applied despite the ledger failure
+    assert result.exit_code != 0
+    assert load_mode(root) == "balanced"  # unchanged -- the gate failure denied the change


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: C1 slice 2 — possession-factor lowering gate (ADR 0033 sub-project 2)
- Plan reference: ADR 0033 §2 ("a fresh possession factor: a TOTP 2FA code OR a password")

## What this PR does
Gates any **permanent lowering** of security posture — a strictness-**mode** downgrade or an SL5 **preference-weight** downgrade — behind a real out-of-band possession factor, so a poisoned prompt / conversational "yes" can never lower Doberman.

**Factor model (corrected):** a **password is the always-available minimum; 2FA (TOTP) is optional.** For these permanent lowerings the gate requires the *strongest enrolled* factor:
- **TOTP if enrolled** → a valid TOTP code is required; a password does **not** substitute (opting into 2FA adds a real second layer).
- **else password** → a valid local password authorizes the lowering.
- **else fail closed** (`no_factor_enrolled`) — never confirm-only, never auto-pass.

Raising/strengthening stays frictionless (raise-only; the prompter is never invoked). First-run `doberman setup` still establishes the initial posture freely (the `establish_ok` carve-out is unchanged and bypass-safe).

> Corrects this slice's earlier cut, which made **TOTP mandatory with no password path** — contrary to ADR 0033 §2. `password` is now a first-class possession factor.

## Changes
- **`auth/password.py`** (new): local password factor mirroring `auth/totp.py` — PBKDF2-SHA256 (600k iterations, 16-byte salt) hash stored `0600` outside the repo; constant-time `hmac.compare_digest`; rate-limited (5 consecutive failures → lockout); fails closed when not enrolled; min length 8; rotation requires the current password. **Stores/logs only the salted hash, never the password.** stdlib only (no new dependency).
- **`policy/drift.py`**: `_verify_possession_factor` (TOTP → password → `no_factor_enrolled`) drives `_run_weaken_gate`, which gates both `apply_change` (mode) and `apply_preferences_change` (prefs). The enforcement safety-valve gate (`_run_enforcement_gate`) is intentionally **untouched** (see below).
- **`cli/main.py`**: `doberman password set` (+ `--force` rotate, current-password-gated); `status` now shows `Password:` and marks `2FA` optional; `mode`/`prefs`/`setup` help + `setup` next-steps point to `doberman password set`.

## Tests added (run in CI)
- `tests/unit/test_auth_password.py` — enroll/verify roundtrip, wrong password, not-enrolled fail-closed, rate-limit lockout, rotation guards, min-length, **plaintext never in the stored file**, verify never raises.
- `tests/unit/test_cli_lowering_gate.py` (rewritten) — both-enrolled ⇒ TOTP required & **password can't bypass**; password-only ⇒ works / wrong denied; **neither ⇒ fail closed with no secret prompt**; raising never prompts; setup establishes freely; `password set` enrolls / rejects mismatch / rotates and never echoes the password.
- `tests/unit/test_drift_preferences_gate.py`, `tests/unit/test_mode_ledger.py` (updated) — same model at the drift-API level; ledger `approval_method` ∈ {`two_factor`, `password`, `denied`, `no_factor_enrolled`}.
- `tests/conftest.py` — autouse `isolated_password_hash` fixture (per-test temp password file), mirroring the TOTP fixture.

## Security checklist
- [x] Fails closed on error / uncertainty (any exception in the gate → deny; no factor enrolled → deny)
- [x] No secret, full file, or unredacted prompt logged or committed (only a salted PBKDF2 hash is persisted, `0600`, outside the repo)
- [x] Any guardrail/learning change is raise-only (a strengthen auto-applies with no prompt)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (the ledger records every attempt incl. denials)
- [x] doberman-core does not import doberman_enterprise (import-linter: 2 contracts kept, 0 broken)

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list — a local, stdlib password factor + gate wiring; no enterprise/hosted/proprietary code, no secrets, no customer data
- [x] Core still builds/tests/runs with NO enterprise package installed

## Edge cases covered / Deviations from plan / Risks introduced
- **Deliberately out of scope (flagged for a separate decision):** the enforcement kill-switch gate (`_run_enforcement_gate`) still degrades to *confirm-only* when no factor is enrolled. Applying the password floor there is coherent, but disabling enforcement is the safety valve — requiring a factor means a user who never set one can't turn a misbehaving Doberman off (reachability-vs-floor tradeoff). Left untouched here; its own follow-up.
- **Consequence:** with the new gate, a fresh user with **no factor enrolled cannot lower mode/prefs** (fail-closed by design) — hence `doberman password set` + `status`/`setup` surfacing it, so the minimum factor is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
