### PR TITLE
test: skip POSIX-perms doctor tests on Windows (#101)

### DIFF
--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -13,6 +13,7 @@ test ever touches real per-user state.
 """
 
 import asyncio
+import os
 from datetime import datetime, timezone
 
 import pytest
@@ -209,6 +210,9 @@ def test_doctor_reports_2fa_state(tmp_path):
     assert "not enrolled" in twofa.detail
 
 
+@pytest.mark.skipif(
+    os.name == "nt", reason="POSIX file-permission bits are not enforced on Windows (NTFS)"
+)
 def test_doctor_fingerprint_key_loose_perms_warns(tmp_path, isolated_fingerprint_key):
     # The autouse fixture points DOBERMAN_KEY_FILE at this path; create it world-readable.
     isolated_fingerprint_key.write_bytes(b"x" * 32)
@@ -220,6 +224,9 @@ def test_doctor_fingerprint_key_loose_perms_warns(tmp_path, isolated_fingerprint
     assert "group/other-accessible" in key.detail
 
 
+@pytest.mark.skipif(
+    os.name == "nt", reason="POSIX file-permission bits are not enforced on Windows (NTFS)"
+)
 def test_doctor_fingerprint_key_tight_perms_ok(tmp_path, isolated_fingerprint_key):
     isolated_fingerprint_key.write_bytes(b"x" * 32)
     isolated_fingerprint_key.chmod(0o600)


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: #101 — Windows portability of the two doctor fingerprint-key permission tests

## What this PR does
The two `doctor` fingerprint-key permission tests set POSIX modes (`chmod(0o644)` / `chmod(0o600)`) that Windows (NTFS) does not enforce, so they fail on Windows local runs. Adds `@pytest.mark.skipif(os.name == "nt", ...)` to both. They still run on Linux CI (authoritative), so coverage of the permission-warning path is unchanged there.

## Tests added (run in CI)
- test-only change to `test_cli_doctor.py`: 10 passed, 2 skipped on Windows; all run on Linux CI.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] No product-code behavior change (test-only)
- [x] No secret logged or committed

## Edge cases / Deviations / Risks
- None. Linux CI still exercises both tests.