### PR TITLE
fix(auth): escape glob metacharacters in elevation scope (H3)

### DIFF
--- a/src/doberman/auth/elevation.py
+++ b/src/doberman/auth/elevation.py
@@ -23,6 +23,7 @@ a forward), never softened here.
 from dataclasses import dataclass
 from datetime import datetime
 from fnmatch import fnmatch
+from glob import escape as glob_escape
 
 from doberman.canonical import canonicalize
 
@@ -81,13 +82,19 @@ def scope_for_target(target: str | None, *, root: str = ".") -> str | None:
     the grant covers *that one file* and nothing else. Returns ``None`` for a
     non-path target, a path that escapes the repo root, or a whole-tree result —
     none of which may ever be elevated (fail toward refusing the grant).
+
+    SECURITY (H3): ``covers`` matches the stored scope as an ``fnmatch`` glob
+    pattern, so any ``*``/``?``/``[``/``]`` in the target's canonical path must
+    be escaped before it becomes the scope — otherwise a target like
+    ``secret*`` would grant a wildcard instead of the one literal path
+    requested (scope widening).
     """
     if not target:
         return None
     canonical = canonicalize(target, root=root)
     if canonical.escapes_root or canonical.relposix in _WHOLE_TREE:
         return None
-    return canonical.relposix
+    return glob_escape(canonical.relposix)
 
 
 def find_cover(

--- a/tests/unit/test_elevation.py
+++ b/tests/unit/test_elevation.py
@@ -64,6 +64,38 @@ def test_covers_matches_exact_path_only_and_never_whole_tree():
     assert _grant("**").covers("anything") is False  # whole-tree never covers
 
 
+# H3 — elevation scope must not glob-widen -------------------------------
+
+
+def test_scope_for_target_escapes_glob_metacharacters():
+    # A target containing fnmatch metacharacters must come back with those
+    # characters escaped, so the stored scope matches only the literal path.
+    assert scope_for_target("secret*", root=".") == "secret[*]"
+    assert scope_for_target("report[1].txt", root=".") == "report[[]1].txt"
+
+
+def test_elevation_scoped_to_star_target_does_not_cover_other_paths():
+    scope = scope_for_target("secret*", root=".")
+    g = _grant(scope)
+    assert g.covers("secret*") is True  # the literal target still covers itself
+    assert g.covers("secretsauce.txt") is False  # '*' must not act as a wildcard
+    assert g.covers("secret") is False
+
+
+def test_elevation_scoped_to_bracket_target_does_not_cover_other_paths():
+    scope = scope_for_target("report[1].txt", root=".")
+    g = _grant(scope)
+    assert g.covers("report[1].txt") is True  # the literal target still covers itself
+    assert g.covers("report1.txt") is False  # '[1]' must not act as a character class
+
+
+def test_elevation_literal_target_still_covers_itself_and_nothing_else():
+    scope = scope_for_target("backend/api.ts", root=".")
+    g = _grant(scope)
+    assert g.covers("backend/api.ts") is True
+    assert g.covers("backend/other.ts") is False
+
+
 def test_find_cover_canonicalizes_target():
     grants = (_grant("backend/api.ts"),)
     assert find_cover("backend/api.ts", grants, root=".") is not None


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: H3 (2026-07-16 audit) — elevation scope must not glob-widen

## What this PR does
`scope_for_target` returned the canonical target path verbatim, and `ElevationGrant.covers` matches it with `fnmatch`, so a target containing glob metacharacters (`secret*`, `report[1].txt`) acted as a wildcard / character-class and **over-covered other concrete paths** — a temporary elevation would relax more than the single path requested (scope widening = a silent loosening). Fix: escape metacharacters via `glob.escape` in `scope_for_target` (the single choke point where a grant's scope is built), so the scope matches only the intended literal path. `covers` / `find_cover` / the whole-tree refusal are untouched.

## Tests added (run in CI)
- `test_elevation.py`: `secret*` scope covers itself but not `secretsauce.txt`; `report[1].txt` scope covers itself but not `report1.txt`; escaping output asserted; literal-target regression.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed (non-path / escapes-root / whole-tree still return None = no grant)
- [x] No secret logged or committed
- [x] Raise-only (narrows elevation scope matching; never widens; hard block never relaxed)
- [x] doberman-core does not import doberman_enterprise

## Edge cases / Deviations / Risks
- A file literally named `report[1].txt` now gets a correctly-scoped (escaped) grant covering exactly itself — the intended behavior. Normal paths (no metacharacters) are unchanged by `glob.escape`.