### PR TITLE
fix(rules): drop GCP service-account email from STRONG credential tier

### DIFF
--- a/src/doberman/engine/rules/secrets.py
+++ b/src/doberman/engine/rules/secrets.py
@@ -80,8 +80,6 @@ _CREDENTIAL_PATTERNS: tuple[re.Pattern[str], ...] = (
     # --- GCP ----------------------------------------------------------------
     # GCP service-account key JSON marker (`"type": "service_account"`).
     re.compile(r'"type"\s*:\s*"service_account"'),
-    # GCP service-account client email (`…@….iam.gserviceaccount.com`).
-    re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.iam\.gserviceaccount\.com"),
 )
 
 # ``.env``-style assignment of a secret-looking key to a non-trivial value.

--- a/tests/unit/test_rule_secrets.py
+++ b/tests/unit/test_rule_secrets.py
@@ -165,11 +165,13 @@ def test_benign_lookalikes_do_not_secret_block_on_exfiltration(text):
 
 
 # --- Issue #93: Azure + GCP service-account key shapes ----------------------
+# NOTE: the GCP SA *email* (FAKE_GCP_SA_EMAIL) is intentionally NOT in this
+# BLOCK-on-exfil list — it is an identifier, not credential material; see the
+# dedicated regression tests below.
 AZURE_GCP_CREDENTIALS = [
     FAKE_AZURE_STORAGE_KEY,
     FAKE_AZURE_SB_KEY,
     FAKE_GCP_SA_JSON,
-    FAKE_GCP_SA_EMAIL,
 ]
 # Strings that resemble Azure / GCP material but are NOT secrets — must not block.
 AZURE_GCP_BENIGN = [
@@ -205,6 +207,34 @@ def test_azure_gcp_benign_do_not_block_on_exfiltration(text):
     )
     result = RULE.evaluate(action, _ctx(url="https://example.com/c", body=f"value: {text}"))
     assert ReasonCode.secret_exfiltration not in result.reason_codes
+
+
+def test_gcp_sa_email_alone_external_does_not_block():
+    # Regression: a GCP service-account EMAIL (unlike the SA *key* JSON marker
+    # above) is an identifier that shows up routinely in configs/logs, not
+    # credential material — it must NOT drive a hard BLOCK on exfil.
+    action = _action(
+        ActionType.network_request,
+        target="https://example.com/c",
+        dest="https://example.com/c",
+    )
+    result = RULE.evaluate(
+        action, _ctx(url="https://example.com/c", body=f"data: {FAKE_GCP_SA_EMAIL}")
+    )
+    assert result.verdict is Verdict.PASS
+    assert ReasonCode.secret_exfiltration not in result.reason_codes
+    assert ReasonCode.sensitive_secret_access not in result.reason_codes
+
+
+def test_gcp_sa_email_alone_local_does_not_auth():
+    # Same identifier, staying local — must not step up to AUTH via the
+    # credential path either (it carries no secret material on its own).
+    action = _action(ActionType.file_write, target="scratch.txt")
+    result = RULE.evaluate(
+        action, _ctx(path="scratch.txt", content=f"client_email: {FAKE_GCP_SA_EMAIL}")
+    )
+    assert result.verdict is Verdict.PASS
+    assert ReasonCode.sensitive_secret_access not in result.reason_codes
 
 
 def test_local_secret_file_read_is_auth_not_block():


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: item 2 — SA-email not a credential

## What this PR does
Removes the GCP service-account **email** regex (`…@….iam.gserviceaccount.com`) from `_CREDENTIAL_PATTERNS` in `src/doberman/engine/rules/secrets.py`. An SA email is an *identifier* — it appears routinely in configs, IAM bindings, and logs — not credential material. Keeping it in the STRONG tier drove a false-positive hard `BLOCK (secret_exfiltration)` any time such an email left to an external destination.

**This is a raise-only LOOSENING** (it removes a hard-BLOCK-capable pattern), explicitly human-approved by fu351 (repo owner) ahead of this change. No new abstraction, tier, or reason code was added — pure deletion of the two lines (comment + `re.compile(...)`).

The real GCP credential markers are untouched and still STRONG:
- GCP service-account **key** JSON marker: `"type": "service_account"`
- Azure Storage `AccountKey=...`
- Azure Service Bus/Event Hubs/IoT Hub `SharedAccessKey=...`

## Tests added (run in CI)
`tests/unit/test_rule_secrets.py`:
- Removed `FAKE_GCP_SA_EMAIL` from `AZURE_GCP_CREDENTIALS` (the BLOCK-on-exfil parametrized list), since it must no longer BLOCK.
- Added `test_gcp_sa_email_alone_external_does_not_block` — SA email + external destination → `Verdict.PASS`, with neither `secret_exfiltration` nor `sensitive_secret_access` in reason codes.
- Added `test_gcp_sa_email_alone_local_does_not_auth` — SA email + local file write → `Verdict.PASS` (does not step up to AUTH via the credential path either).
- Confirmed unchanged (still pass, unmodified): `test_azure_gcp_credentials_block_on_exfiltration` (GCP SA key JSON marker + Azure Storage/SB keys still BLOCK on exfil) and `test_known_credential_prefixes_are_detected` (AWS `AKIA…` + others unaffected).

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (unchanged elsewhere in the rule)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] **This IS a raise-only LOOSENING** — flagged prominently: it removes a hard-BLOCK-capable pattern, human-approved by fu351 (owner) as a false-positive fix. The GCP SA *key* is still STRONG-detected (both the JSON marker and, unaffected, the Azure key patterns); every BLOCK/AUTH still carries reason codes; no secret logged.
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged)
- [x] doberman-core does not import doberman_enterprise (N/A — no import changes)

## Edge cases covered / Deviations from plan / Risks introduced
- Edge cases: SA email alone with an external destination (must PASS, not BLOCK); SA email alone staying local (must PASS, not AUTH-via-credential-path); confirmed the SA *key* JSON marker and Azure key patterns are unaffected (still BLOCK on exfil); confirmed an unrelated STRONG pattern (AWS `AKIA…`) is unaffected.
- Deviations: none — pure deletion as scoped.
- Risks: none identified — this only removes a false-positive BLOCK path; no real credential detection capability is lost.

Do NOT merge — peer-review-only per repo policy.