### PR TITLE
refactor(engine): extract cross-call taint floor to engine/taint_floor.py

### DIFF
--- a/src/doberman/engine/taint_floor.py
+++ b/src/doberman/engine/taint_floor.py
@@ -1,0 +1,192 @@
+"""HK.5.2 / 5.2b — the cross-call, taint-primary multi-step exfiltration floor.
+
+Extracted (H2a, behavior-preserving) from the Claude Code host-hook adapter so
+both host-hook adapters and the pure-MCP proxy can share it (the proxy wiring
+itself is H2b — not this slice). See :func:`apply_taint_floor` for the
+mechanism.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from doberman.engine.decision_engine import max_risk, max_verdict
+from doberman.models import Decision, ReasonCode, Risk, SecurityObject, Verdict
+
+#: HK.5.2 taint floor: modes where a tainted-session egress is BLOCKed outright
+#: rather than AUTH'd. Mirrors the lethal-trifecta hard block (ADR 0021): raise-only,
+#: strictest modes only — light/balanced keep the human in the loop.
+_STRICT_MODES: frozenset[str] = frozenset({"strict", "paranoid"})
+_FLOOR_EXPLANATION = (
+    "A secret entered this session's context earlier; this egress is a potential "
+    "multi-step exfiltration."
+)
+_CONFIRMED_EXFIL_EXPLANATION = (
+    "An outbound value matches a secret that entered this session's context earlier "
+    "— a confirmed read-then-send exfiltration."
+)
+
+
+def apply_taint_floor(
+    action: SecurityObject,
+    decision: Decision,
+    mode: str,
+    repo_root: str,
+    session_id: str | None,
+    args: dict[str, Any],
+) -> Decision:
+    """HK.5.2 / 5.2b — the taint-primary multi-step exfiltration floor (raise-only).
+
+    The objective floor judges each call in isolation, so a cross-call exfil —
+    read a secret in call N (HK.5.1 records ``secret_access`` taint), then send it
+    in call M whose own payload looks clean — slips through. When THIS action is an
+    egress and the session already holds ``secret_access`` taint, raise the verdict:
+    ``AUTH`` in light/balanced (human-in-the-loop) or ``BLOCK`` in strict/paranoid,
+    mirroring the single-call lethal-trifecta floor (ADR 0021/0024). **Raise-only** —
+    it never lowers a verdict or risk. Best-effort and light: one SQLite taint read,
+    only on the egress path, and any failure leaves the objective decision untouched.
+
+    Scope note: the egress signal is ``action.external_destination`` (what
+    ``normalize`` recognises — WebFetch, network requests, domain/MCP egress tools).
+    Deep Bash-command egress parsing is HK.5.6; entropy-on-egress and the read-vs-send
+    fingerprint match (→ confirmatory BLOCK) are HK.5.2b.
+    """
+    if action.external_destination is None:
+        return decision  # not an egress — nothing can leave through this action
+    if decision.final_verdict is Verdict.BLOCK:
+        return decision  # already maximally raised; skip the reads
+
+    # HK.5.2b — confirmatory read-vs-send match: an outbound token whose keyed-HMAC
+    # fingerprint was recorded when a secret entered this session is the SAME secret
+    # leaving. A CONFIRMED exfil → hard BLOCK in EVERY mode (highest confidence; not
+    # mode-gated like the taint floor below).
+    if _outbound_matches_recorded_secret(args, action.external_destination, repo_root, session_id):
+        reasons = list(dict.fromkeys([*decision.reason_codes, ReasonCode.confirmed_exfil]))
+        explanation = " ".join(
+            part for part in (decision.explanation.strip(), _CONFIRMED_EXFIL_EXPLANATION) if part
+        )
+        return decision.model_copy(
+            update={
+                "final_verdict": Verdict.BLOCK,
+                "final_risk": Risk.critical,
+                "reason_codes": reasons,
+                "explanation": explanation,
+            }
+        )
+
+    if not _session_holds_secret(repo_root, session_id):
+        return decision
+
+    floor_verdict = Verdict.BLOCK if mode in _STRICT_MODES else Verdict.AUTH
+    floor_risk = Risk.critical if floor_verdict is Verdict.BLOCK else Risk.high
+    reasons = list(dict.fromkeys([*decision.reason_codes, ReasonCode.multi_step_exfil]))
+    explanation = " ".join(
+        part for part in (decision.explanation.strip(), _FLOOR_EXPLANATION) if part
+    )
+    return decision.model_copy(
+        update={
+            "final_verdict": max_verdict(decision.final_verdict, floor_verdict),
+            "final_risk": max_risk(decision.final_risk, floor_risk),
+            "reason_codes": reasons,
+            "explanation": explanation,
+        }
+    )
+
+
+def _session_holds_secret(repo_root: str, session_id: str | None) -> bool:
+    """True iff this session has accumulated ``secret_access`` taint (a secret
+    entered its context) under the session or entity scope.
+
+    A light SQLite read on the egress path only. On any error it returns ``False`` —
+    it never *fabricates* taint (which would AUTH/BLOCK every egress). A degraded
+    taint store is the alarm-not-downgrade concern of HK.5.0c, not a place to
+    silently escalate here.
+    """
+    import asyncio  # lazy: keep this module's import light
+
+    from doberman.storage.taint import (  # lazy: light (no numpy/scipy/river)
+        TAINT_SECRET_ACCESS,
+        entity_scope,
+        read_taint,
+    )
+
+    scopes: list[str] = [session_id] if session_id else []
+    try:
+        scopes.append(entity_scope(repo_root))
+    except Exception:  # noqa: BLE001,S110 — keep the session scope even if entity scope fails
+        pass
+    if not scopes:
+        return False
+
+    async def _any_secret() -> bool:
+        for scope in scopes:
+            counts = await read_taint(repo_root, scope)
+            if counts.get(TAINT_SECRET_ACCESS, 0) > 0:
+                return True
+        return False
+
+    try:
+        return asyncio.run(_any_secret())
+    except Exception:  # noqa: BLE001 — a failed taint read never fabricates a verdict
+        return False
+
+
+def _outbound_secret_fingerprints(args: dict[str, Any], dest: str | None) -> set[str]:
+    """Keyed-HMAC fingerprints of secret-candidate tokens anywhere in the outbound
+    payload (the call's arguments + its external destination). Light + best-effort;
+    the plaintext is never stored or logged."""
+    from doberman.engine.rules.secrets import candidate_secret_fingerprints
+
+    fps: set[str] = set()
+
+    def _walk(value: Any) -> None:
+        if isinstance(value, str):
+            fps.update(candidate_secret_fingerprints(value))
+        elif isinstance(value, dict):
+            for item in value.values():
+                _walk(item)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                _walk(item)
+
+    _walk(args)
+    if dest:
+        fps.update(candidate_secret_fingerprints(dest))
+    return fps
+
+
+def _outbound_matches_recorded_secret(
+    args: dict[str, Any], dest: str | None, repo_root: str, session_id: str | None
+) -> bool:
+    """True iff an outbound token matches a secret fingerprint recorded earlier in
+    this session/entity scope (a confirmed read-then-send). One light SQLite read on
+    the egress path only — and only when something secret-shaped is actually going
+    out. Fails closed to False (never fabricates a match)."""
+    fps = _outbound_secret_fingerprints(args, dest)
+    if not fps:
+        return False  # nothing secret-shaped outbound — skip the DB read
+
+    import asyncio
+
+    from doberman.storage.taint import entity_scope, match_secret_fingerprint
+
+    scopes: list[str] = [session_id] if session_id else []
+    try:
+        scopes.append(entity_scope(repo_root))
+    except Exception:  # noqa: BLE001,S110 — keep the session scope even if entity scope fails
+        pass
+    if not scopes:
+        return False
+
+    fp_list = list(fps)
+
+    async def _any_match() -> bool:
+        for scope in scopes:
+            if await match_secret_fingerprint(repo_root, scope, fp_list):
+                return True
+        return False
+
+    try:
+        return asyncio.run(_any_match())
+    except Exception:  # noqa: BLE001 — a failed match read never fabricates a verdict
+        return False

--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -44,8 +44,9 @@ from typing import TYPE_CHECKING, Any
 
 from doberman.branding import DOG
 from doberman.config import load_mode, resolve_enforcement_sync
-from doberman.engine.decision_engine import PASS_STUB, decide, max_risk, max_verdict
+from doberman.engine.decision_engine import PASS_STUB, decide, max_risk
 from doberman.engine.objective import ObjectiveGuardrail
+from doberman.engine.taint_floor import apply_taint_floor
 from doberman.models import Decision, EvalContext, ReasonCode, Risk, SecurityObject, Verdict
 from doberman.policy.drift import acted_verdict
 from doberman.policy.modes import DEFAULT_MODE
@@ -131,19 +132,6 @@ _BLOCK_NEXT_STEP_BY_REASON: dict[str, str] = {
 #: ``proxy.executor.AUTH_PROMPTER``). Never the MCP elicitation channel — a host hook
 #: has no agent session to elicit over.
 AUTH_PROMPTER: Prompter | None = None
-
-#: HK.5.2 taint floor: modes where a tainted-session egress is BLOCKed outright
-#: rather than AUTH'd. Mirrors the lethal-trifecta hard block (ADR 0021): raise-only,
-#: strictest modes only — light/balanced keep the human in the loop.
-_STRICT_MODES: frozenset[str] = frozenset({"strict", "paranoid"})
-_FLOOR_EXPLANATION = (
-    "A secret entered this session's context earlier; this egress is a potential "
-    "multi-step exfiltration."
-)
-_CONFIRMED_EXFIL_EXPLANATION = (
-    "An outbound value matches a secret that entered this session's context earlier "
-    "— a confirmed read-then-send exfiltration."
-)
 
 
 def to_normalize_input(
@@ -357,7 +345,7 @@ def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
         # HK.5.2 / 5.2b: taint-primary multi-step floor — raise an egress the
         # per-call floor judged clean when the session already accessed a secret,
         # and hard-BLOCK when an outbound value is a CONFIRMED read secret.
-        decision = _apply_taint_floor(action, decision, ctx.mode, repo_root, session_id, args)
+        decision = apply_taint_floor(action, decision, ctx.mode, repo_root, session_id, args)
         # F10: honor the enforcement dial (Option A). monitor/off soften a
         # DISCRETIONARY AUTH/BLOCK to observe-only; the objective floor
         # (secrets / exfil / taint / destructive / role / policy / trifecta) stays
@@ -432,171 +420,6 @@ def _record_pre_history(
         )
     except Exception:  # noqa: BLE001,S110 — history must never alter the hook's return value
         pass
-
-
-def _apply_taint_floor(
-    action: SecurityObject,
-    decision: Decision,
-    mode: str,
-    repo_root: str,
-    session_id: str | None,
-    args: dict[str, Any],
-) -> Decision:
-    """HK.5.2 / 5.2b — the taint-primary multi-step exfiltration floor (raise-only).
-
-    The objective floor judges each call in isolation, so a cross-call exfil —
-    read a secret in call N (HK.5.1 records ``secret_access`` taint), then send it
-    in call M whose own payload looks clean — slips through. When THIS action is an
-    egress and the session already holds ``secret_access`` taint, raise the verdict:
-    ``AUTH`` in light/balanced (human-in-the-loop) or ``BLOCK`` in strict/paranoid,
-    mirroring the single-call lethal-trifecta floor (ADR 0021/0024). **Raise-only** —
-    it never lowers a verdict or risk. Best-effort and light: one SQLite taint read,
-    only on the egress path, and any failure leaves the objective decision untouched.
-
-    Scope note: the egress signal is ``action.external_destination`` (what
-    ``normalize`` recognises — WebFetch, network requests, domain/MCP egress tools).
-    Deep Bash-command egress parsing is HK.5.6; entropy-on-egress and the read-vs-send
-    fingerprint match (→ confirmatory BLOCK) are HK.5.2b.
-    """
-    if action.external_destination is None:
-        return decision  # not an egress — nothing can leave through this action
-    if decision.final_verdict is Verdict.BLOCK:
-        return decision  # already maximally raised; skip the reads
-
-    # HK.5.2b — confirmatory read-vs-send match: an outbound token whose keyed-HMAC
-    # fingerprint was recorded when a secret entered this session is the SAME secret
-    # leaving. A CONFIRMED exfil → hard BLOCK in EVERY mode (highest confidence; not
-    # mode-gated like the taint floor below).
-    if _outbound_matches_recorded_secret(args, action.external_destination, repo_root, session_id):
-        reasons = list(dict.fromkeys([*decision.reason_codes, ReasonCode.confirmed_exfil]))
-        explanation = " ".join(
-            part for part in (decision.explanation.strip(), _CONFIRMED_EXFIL_EXPLANATION) if part
-        )
-        return decision.model_copy(
-            update={
-                "final_verdict": Verdict.BLOCK,
-                "final_risk": Risk.critical,
-                "reason_codes": reasons,
-                "explanation": explanation,
-            }
-        )
-
-    if not _session_holds_secret(repo_root, session_id):
-        return decision
-
-    floor_verdict = Verdict.BLOCK if mode in _STRICT_MODES else Verdict.AUTH
-    floor_risk = Risk.critical if floor_verdict is Verdict.BLOCK else Risk.high
-    reasons = list(dict.fromkeys([*decision.reason_codes, ReasonCode.multi_step_exfil]))
-    explanation = " ".join(
-        part for part in (decision.explanation.strip(), _FLOOR_EXPLANATION) if part
-    )
-    return decision.model_copy(
-        update={
-            "final_verdict": max_verdict(decision.final_verdict, floor_verdict),
-            "final_risk": max_risk(decision.final_risk, floor_risk),
-            "reason_codes": reasons,
-            "explanation": explanation,
-        }
-    )
-
-
-def _session_holds_secret(repo_root: str, session_id: str | None) -> bool:
-    """True iff this session has accumulated ``secret_access`` taint (a secret
-    entered its context) under the session or entity scope.
-
-    A light SQLite read on the egress path only. On any error it returns ``False`` —
-    it never *fabricates* taint (which would AUTH/BLOCK every egress). A degraded
-    taint store is the alarm-not-downgrade concern of HK.5.0c, not a place to
-    silently escalate here.
-    """
-    import asyncio  # lazy: keep the hook's module import light
-
-    from doberman.storage.taint import (  # lazy: light (no numpy/scipy/river)
-        TAINT_SECRET_ACCESS,
-        entity_scope,
-        read_taint,
-    )
-
-    scopes: list[str] = [session_id] if session_id else []
-    try:
-        scopes.append(entity_scope(repo_root))
-    except Exception:  # noqa: BLE001,S110 — keep the session scope even if entity scope fails
-        pass
-    if not scopes:
-        return False
-
-    async def _any_secret() -> bool:
-        for scope in scopes:
-            counts = await read_taint(repo_root, scope)
-            if counts.get(TAINT_SECRET_ACCESS, 0) > 0:
-                return True
-        return False
-
-    try:
-        return asyncio.run(_any_secret())
-    except Exception:  # noqa: BLE001 — a failed taint read never fabricates a verdict
-        return False
-
-
-def _outbound_secret_fingerprints(args: dict[str, Any], dest: str | None) -> set[str]:
-    """Keyed-HMAC fingerprints of secret-candidate tokens anywhere in the outbound
-    payload (the call's arguments + its external destination). Light + best-effort;
-    the plaintext is never stored or logged."""
-    from doberman.engine.rules.secrets import candidate_secret_fingerprints
-
-    fps: set[str] = set()
-
-    def _walk(value: Any) -> None:
-        if isinstance(value, str):
-            fps.update(candidate_secret_fingerprints(value))
-        elif isinstance(value, dict):
-            for item in value.values():
-                _walk(item)
-        elif isinstance(value, (list, tuple)):
-            for item in value:
-                _walk(item)
-
-    _walk(args)
-    if dest:
-        fps.update(candidate_secret_fingerprints(dest))
-    return fps
-
-
-def _outbound_matches_recorded_secret(
-    args: dict[str, Any], dest: str | None, repo_root: str, session_id: str | None
-) -> bool:
-    """True iff an outbound token matches a secret fingerprint recorded earlier in
-    this session/entity scope (a confirmed read-then-send). One light SQLite read on
-    the egress path only — and only when something secret-shaped is actually going
-    out. Fails closed to False (never fabricates a match)."""
-    fps = _outbound_secret_fingerprints(args, dest)
-    if not fps:
-        return False  # nothing secret-shaped outbound — skip the DB read
-
-    import asyncio
-
-    from doberman.storage.taint import entity_scope, match_secret_fingerprint
-
-    scopes: list[str] = [session_id] if session_id else []
-    try:
-        scopes.append(entity_scope(repo_root))
-    except Exception:  # noqa: BLE001,S110 — keep the session scope even if entity scope fails
-        pass
-    if not scopes:
-        return False
-
-    fp_list = list(fps)
-
-    async def _any_match() -> bool:
-        for scope in scopes:
-            if await match_secret_fingerprint(repo_root, scope, fp_list):
-                return True
-        return False
-
-    try:
-        return asyncio.run(_any_match())
-    except Exception:  # noqa: BLE001 — a failed match read never fabricates a verdict
-        return False
 
 
 def run_pre_hook(stdin_text: str) -> str | None:

--- a/tests/integration/test_enforcement_wiring.py
+++ b/tests/integration/test_enforcement_wiring.py
@@ -96,7 +96,7 @@ def test_discretionary_auth_dispatch_honors_dial(cwd, monkeypatch, state, expect
         claude_code, "decide", _fake_discretionary_auth(ReasonCode.sensitive_path_access)
     )
     # keep the taint floor inert so the decision under test is purely discretionary
-    monkeypatch.setattr(claude_code, "_apply_taint_floor", lambda _a, decision, *a, **k: decision)
+    monkeypatch.setattr(claude_code, "apply_taint_floor", lambda _a, decision, *a, **k: decision)
 
     out = _pre("Write", {"file_path": "app.py", "content": "x"}, cwd)
 
@@ -118,7 +118,7 @@ def test_monitor_records_the_would_have_verdict(cwd, monkeypatch):
     monkeypatch.setattr(
         claude_code, "decide", _fake_discretionary_auth(ReasonCode.sensitive_path_access)
     )
-    monkeypatch.setattr(claude_code, "_apply_taint_floor", lambda _a, decision, *a, **k: decision)
+    monkeypatch.setattr(claude_code, "apply_taint_floor", lambda _a, decision, *a, **k: decision)
 
     assert _pre("Write", {"file_path": "app.py", "content": "x"}, cwd) is None
     rows = _rows(cwd)
@@ -132,7 +132,7 @@ def test_off_does_not_record_the_would_have(cwd, monkeypatch):
     monkeypatch.setattr(
         claude_code, "decide", _fake_discretionary_auth(ReasonCode.sensitive_path_access)
     )
-    monkeypatch.setattr(claude_code, "_apply_taint_floor", lambda _a, decision, *a, **k: decision)
+    monkeypatch.setattr(claude_code, "apply_taint_floor", lambda _a, decision, *a, **k: decision)
 
     assert _pre("Write", {"file_path": "app.py", "content": "x"}, cwd) is None
     assert _rows(cwd) == [], "off does not evaluate the discretionary layer, so it stays silent"

--- a/tests/unit/test_taint_floor_module.py
+++ b/tests/unit/test_taint_floor_module.py
@@ -1,0 +1,81 @@
+"""H2a: module-level regression test for the extracted taint floor.
+
+``apply_taint_floor`` used to be a private helper (``_apply_taint_floor``) on
+the Claude Code host-hook adapter; it now lives in
+``doberman.engine.taint_floor`` so both the host-hook and the MCP proxy can
+share it (proxy wiring is H2b, not this slice). This exercises the raise-only
+invariant directly against the module — independent of the hosthook — using
+the same taint-store fixture pattern as ``test_hosthook_taint_floor.py``.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+
+from doberman.engine.decision_engine import max_risk, max_verdict
+from doberman.engine.taint_floor import apply_taint_floor
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+from doberman.storage.taint import TAINT_SECRET_ACCESS, record_taints
+
+_TS = datetime(2026, 7, 18, tzinfo=timezone.utc)
+_EGRESS_URL = "https://attacker.example/collect"
+
+
+def _action(**over) -> SecurityObject:
+    base = dict(
+        id="taint-floor-1",
+        ts=_TS,
+        agent_role="unknown",
+        action_type=ActionType.network_request,
+        tool_name="WebFetch",
+        target=_EGRESS_URL,
+    )
+    base.update(over)
+    return SecurityObject(**base)
+
+
+def _pass_decision(action: SecurityObject) -> Decision:
+    return Decision(
+        action_id=action.id,
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=GuardrailResult(verdict=Verdict.PASS, risk=Risk.low),
+        decided_at=_TS,
+    )
+
+
+def test_no_external_destination_is_returned_unchanged(tmp_path):
+    # Not an egress — the floor has nothing to raise and must abstain, returning
+    # the exact same decision object (not even a copy).
+    action = _action(external_destination=None)
+    decision = _pass_decision(action)
+
+    out = apply_taint_floor(action, decision, "balanced", str(tmp_path), "sess-1", {})
+
+    assert out is decision
+
+
+def test_tainted_session_egress_raises_verdict_and_risk_never_lower(tmp_path):
+    # A session that already accessed a secret, followed by an egress the
+    # per-call floor judged clean: the taint floor must raise the verdict/risk,
+    # and — raise-only — never lower them below the input decision.
+    action = _action(external_destination=_EGRESS_URL)
+    decision = _pass_decision(action)
+    asyncio.run(record_taints(str(tmp_path), ["sess-2"], [TAINT_SECRET_ACCESS]))
+
+    out = apply_taint_floor(
+        action, decision, "balanced", str(tmp_path), "sess-2", {"url": _EGRESS_URL}
+    )
+
+    assert out.final_verdict is Verdict.AUTH
+    assert out.final_risk is Risk.high
+    # Raise-only invariant, expressed structurally rather than by re-deriving the
+    # expected verdict: combining with the original decision must be a no-op.
+    assert max_verdict(out.final_verdict, decision.final_verdict) == out.final_verdict
+    assert max_risk(out.final_risk, decision.final_risk) == out.final_risk


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: H2a — extract the cross-call taint floor (behavior-preserving)
- Plan reference: workspace-root H2 feature (proxy/hosthook taint-floor unification)

## What this PR does
Pure, behavior-preserving extraction (H2a) of the raise-only, cross-call
secret-exfiltration "taint floor" out of the Claude Code hosthook
(`src/doberman/hosthooks/claude_code.py`) into a new shared module
`src/doberman/engine/taint_floor.py`, so the pure-MCP proxy can consume the
same floor in a follow-up slice (H2b — not part of this PR).

Moved (logic unchanged): `_apply_taint_floor` → public `apply_taint_floor`,
its private helpers `_session_holds_secret`, `_outbound_secret_fingerprints`,
`_outbound_matches_recorded_secret`, and the constants `_STRICT_MODES`,
`_FLOOR_EXPLANATION`, `_CONFIRMED_EXFIL_EXPLANATION`. The hosthook now imports
`apply_taint_floor` and calls it at the same call site; its now-unused
`max_verdict` import was dropped (still used indirectly via the new module).

No new behavior: no proxy wiring, no output-taint recording change — pure move
+ re-import.

## Tests added (run in CI)
- `tests/unit/test_taint_floor_module.py` (new) — exercises `apply_taint_floor`
  directly against the module: (a) no external destination → decision returned
  unchanged (identity), (b) a tainted-session egress raises verdict/risk and
  the raise-only invariant holds structurally (`max_verdict`/`max_risk` against
  the original decision are no-ops).
- `tests/unit/test_hosthook_taint_floor.py` and `tests/unit/test_hosthook_taint.py`
  — unchanged, still green (regression net proving the move didn't alter
  hosthook behavior).

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (unchanged: all taint reads still fail closed to False)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — the floor's raise-only behavior is unchanged and additionally now proven by the module-level test
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- None — pure extraction, no behavior change, no scope creep beyond the three files listed.