### PR TITLE
fix(auth): route TOTP rotation proof through the rate-limited verify()

### DIFF
--- a/src/doberman/auth/totp.py
+++ b/src/doberman/auth/totp.py
@@ -99,17 +99,10 @@ def enroll(
             raise RuntimeError(
                 "TOTP is already enrolled; pass force=True to deliberately rotate the secret"
             )
-        existing_secret = _read_secret()
-        try:
-            verified = (
-                existing_secret is not None
-                and current_code is not None
-                and pyotp.TOTP(existing_secret).verify(
-                    str(current_code), valid_window=_VALID_WINDOW
-                )
-            )
-        except Exception:  # noqa: BLE001 — any proof error refuses rotation
-            verified = False
+        # Route the rotation proof through the rate-limited verify() (not a direct
+        # pyotp check) so repeated wrong-code rotation attempts trip the same
+        # _failures lockout as a normal auth attempt — symmetric with password.py.
+        verified = current_code is not None and verify(str(current_code))
         if not verified:
             raise RuntimeError("a valid current 2FA code is required to rotate TOTP")
 

--- a/tests/unit/test_totp.py
+++ b/tests/unit/test_totp.py
@@ -92,6 +92,47 @@ def test_enroll_rotation_accepts_current_code_without_logging_credentials(caplog
         assert sensitive_value not in caplog.text
 
 
+def test_enroll_rotation_wrong_code_shares_rate_limiter():
+    """H5a: rotation's current_code proof must route through verify()'s
+    _failures lockout, not a direct un-rate-limited pyotp check."""
+    totp.enroll()
+    correct = _current_code(_T0)
+    for _ in range(5):
+        with pytest.raises(RuntimeError, match="current 2FA code"):
+            totp.enroll(force=True, current_code="000000")
+    # 5 wrong rotation attempts tripped the same limiter a normal verify() uses.
+    assert totp.verify(correct, at=_T0) is False
+
+
+def test_enroll_rotation_correct_code_succeeds_and_resets_counter():
+    # enroll()'s rotation proof checks the CURRENT wall clock (no `at` injection
+    # point), so prove it with `.now()` like the existing rotation test does.
+    totp.enroll()
+    first = totp._read_secret()
+    correct = pyotp.TOTP(first).now()
+
+    rotated_uri = totp.enroll(force=True, current_code=correct)
+
+    assert rotated_uri.startswith("otpauth://")
+    rotated = totp._read_secret()
+    assert rotated is not None and rotated != first
+    # Counter reset by the successful verify(): a fresh wrong attempt is just one failure.
+    assert totp.verify("000000", at=_T0) is False
+    assert totp.verify(pyotp.TOTP(rotated).at(_T0), at=_T0) is True
+
+
+def test_enroll_rotation_blocked_while_locked_out():
+    totp.enroll()
+    first = totp._read_secret()
+    correct = pyotp.TOTP(first).now()
+    for _ in range(5):
+        assert totp.verify("000000", at=_T0) is False
+    # Locked out: even the CORRECT current code must not rotate the secret.
+    with pytest.raises(RuntimeError, match="current 2FA code"):
+        totp.enroll(force=True, current_code=correct)
+    assert totp._read_secret() == first
+
+
 def test_secret_file_is_owner_only(isolated_totp_secret):
     import os
     import stat


### PR DESCRIPTION
## Slice
- Feature / Slice: H5a — TOTP rotation rate-limit bypass fix

## What this PR does
Closes an un-rate-limited brute-force bypass in `src/doberman/auth/totp.py`. `enroll(force=True, current_code=...)` (secret rotation) proved the current code by calling `pyotp.TOTP(existing_secret).verify(...)` **directly**, bypassing the rate-limited `verify()` wrapper and its `_failures` lockout. An attacker could repeatedly call `enroll(force=True, current_code=<guess>)` without ever tripping the lockout, brute-force the current code, then rotate the secret to attacker control — full 2FA takeover.

The fix routes the rotation proof through the module's own rate-limited `verify()` instead of a direct `pyotp` check. At rotation time the existing secret is still the one on disk (the new secret is written only after the proof succeeds), so `verify(str(current_code))` reads and checks against it, applies the `_failures` lockout, increments on a wrong code, and resets on success. This makes TOTP rotation symmetric with `auth/password.py`, which already routes its equivalent proof through its own rate limiter.

## Tests added (run in CI)
- `tests/unit/test_totp.py::test_enroll_rotation_wrong_code_shares_rate_limiter` — 5 wrong rotation attempts trip the same `_failures` lockout a normal `verify()` attempt would, proving rotation is no longer a bypass path.
- `tests/unit/test_totp.py::test_enroll_rotation_correct_code_succeeds_and_resets_counter` — a correct current code still rotates the secret successfully and resets the failure counter.
- `tests/unit/test_totp.py::test_enroll_rotation_blocked_while_locked_out` — once already locked out, rotation is refused even with the objectively correct current code (proves the bypass is fully closed, not just rate-limited).
- All 13 existing/updated tests in `tests/unit/test_totp.py` remain green.

## Security checklist
- [x] Fails closed on error / uncertainty (unchanged `RuntimeError` on any non-`True` proof)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Raise-only tightening: closes a bypass, does not loosen any existing guardrail
- [x] N/A — no BLOCK/AUTH verdict change here (this is an auth-provider proof, not a decision-engine verdict)

## Edge cases covered / Deviations from plan / Risks introduced
- Edge case: rotation attempted while already locked out (from prior normal `verify()` failures) is now also blocked — previously only rotation-specific brute force was unlimited, but this closes the whole class.
- No deviations from the H5a scope in the task packet: 3-line swap in `enroll()`, only `src/doberman/auth/totp.py` + `tests/unit/test_totp.py` touched.
- Known residual risk (documented in the commit body): the `_failures` counter is in-memory only, so a process restart clears lockout state. Full cross-restart brute-force resistance needs `_failures` persistence — tracked separately as H5b, held for a design decision on lockout recovery (e.g. what resets it, how long a lockout persists).