### PR TITLE
feat(proxy): apply cross-call taint floor + record output taint in decide_and_execute

### DIFF
--- a/src/doberman/engine/taint_floor.py
+++ b/src/doberman/engine/taint_floor.py
@@ -1,13 +1,17 @@
 """HK.5.2 / 5.2b — the cross-call, taint-primary multi-step exfiltration floor.
 
 Extracted (H2a, behavior-preserving) from the Claude Code host-hook adapter so
-both host-hook adapters and the pure-MCP proxy can share it (the proxy wiring
-itself is H2b — not this slice). See :func:`apply_taint_floor` for the
-mechanism.
+both host-hook adapters and the pure-MCP proxy (H2b) can share it. The proxy
+already runs inside a live event loop, so it awaits :func:`apply_taint_floor_async`
+directly; :func:`apply_taint_floor` is a thin sync wrapper (``asyncio.run``)
+kept for the sync host-hook call site — calling the sync wrapper from the
+async proxy would raise ``RuntimeError: asyncio.run() cannot be called from a
+running event loop``, so the two are deliberately not interchangeable.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from doberman.engine.decision_engine import max_risk, max_verdict
@@ -27,7 +31,7 @@ _CONFIRMED_EXFIL_EXPLANATION = (
 )
 
 
-def apply_taint_floor(
+async def apply_taint_floor_async(
     action: SecurityObject,
     decision: Decision,
     mode: str,
@@ -50,6 +54,9 @@ def apply_taint_floor(
     ``normalize`` recognises — WebFetch, network requests, domain/MCP egress tools).
     Deep Bash-command egress parsing is HK.5.6; entropy-on-egress and the read-vs-send
     fingerprint match (→ confirmatory BLOCK) are HK.5.2b.
+
+    Async so the MCP proxy — already inside a running event loop — can ``await``
+    this directly. See :func:`apply_taint_floor` for the sync host-hook wrapper.
     """
     if action.external_destination is None:
         return decision  # not an egress — nothing can leave through this action
@@ -60,7 +67,9 @@ def apply_taint_floor(
     # fingerprint was recorded when a secret entered this session is the SAME secret
     # leaving. A CONFIRMED exfil → hard BLOCK in EVERY mode (highest confidence; not
     # mode-gated like the taint floor below).
-    if _outbound_matches_recorded_secret(args, action.external_destination, repo_root, session_id):
+    if await _outbound_matches_recorded_secret(
+        args, action.external_destination, repo_root, session_id
+    ):
         reasons = list(dict.fromkeys([*decision.reason_codes, ReasonCode.confirmed_exfil]))
         explanation = " ".join(
             part for part in (decision.explanation.strip(), _CONFIRMED_EXFIL_EXPLANATION) if part
@@ -74,7 +83,7 @@ def apply_taint_floor(
             }
         )
 
-    if not _session_holds_secret(repo_root, session_id):
+    if not await _session_holds_secret(repo_root, session_id):
         return decision
 
     floor_verdict = Verdict.BLOCK if mode in _STRICT_MODES else Verdict.AUTH
@@ -93,7 +102,27 @@ def apply_taint_floor(
     )
 
 
-def _session_holds_secret(repo_root: str, session_id: str | None) -> bool:
+def apply_taint_floor(
+    action: SecurityObject,
+    decision: Decision,
+    mode: str,
+    repo_root: str,
+    session_id: str | None,
+    args: dict[str, Any],
+) -> Decision:
+    """Sync wrapper around :func:`apply_taint_floor_async` for the host-hook adapter.
+
+    The Claude Code host-hook's ``evaluate_pre``/``evaluate_post`` run outside any
+    event loop, so wrapping in ``asyncio.run`` here is safe and keeps that call site
+    unchanged. The MCP proxy runs INSIDE a live event loop and must await
+    ``apply_taint_floor_async`` directly — calling this sync wrapper there would
+    raise ``RuntimeError: asyncio.run() cannot be called from a running event loop``.
+    Signature and behavior are otherwise identical.
+    """
+    return asyncio.run(apply_taint_floor_async(action, decision, mode, repo_root, session_id, args))
+
+
+async def _session_holds_secret(repo_root: str, session_id: str | None) -> bool:
     """True iff this session has accumulated ``secret_access`` taint (a secret
     entered its context) under the session or entity scope.
 
@@ -102,8 +131,6 @@ def _session_holds_secret(repo_root: str, session_id: str | None) -> bool:
     taint store is the alarm-not-downgrade concern of HK.5.0c, not a place to
     silently escalate here.
     """
-    import asyncio  # lazy: keep this module's import light
-
     from doberman.storage.taint import (  # lazy: light (no numpy/scipy/river)
         TAINT_SECRET_ACCESS,
         entity_scope,
@@ -118,15 +145,12 @@ def _session_holds_secret(repo_root: str, session_id: str | None) -> bool:
     if not scopes:
         return False
 
-    async def _any_secret() -> bool:
+    try:
         for scope in scopes:
             counts = await read_taint(repo_root, scope)
             if counts.get(TAINT_SECRET_ACCESS, 0) > 0:
                 return True
         return False
-
-    try:
-        return asyncio.run(_any_secret())
     except Exception:  # noqa: BLE001 — a failed taint read never fabricates a verdict
         return False
 
@@ -155,7 +179,7 @@ def _outbound_secret_fingerprints(args: dict[str, Any], dest: str | None) -> set
     return fps
 
 
-def _outbound_matches_recorded_secret(
+async def _outbound_matches_recorded_secret(
     args: dict[str, Any], dest: str | None, repo_root: str, session_id: str | None
 ) -> bool:
     """True iff an outbound token matches a secret fingerprint recorded earlier in
@@ -165,8 +189,6 @@ def _outbound_matches_recorded_secret(
     fps = _outbound_secret_fingerprints(args, dest)
     if not fps:
         return False  # nothing secret-shaped outbound — skip the DB read
-
-    import asyncio
 
     from doberman.storage.taint import entity_scope, match_secret_fingerprint
 
@@ -180,13 +202,53 @@ def _outbound_matches_recorded_secret(
 
     fp_list = list(fps)
 
-    async def _any_match() -> bool:
+    try:
         for scope in scopes:
             if await match_secret_fingerprint(repo_root, scope, fp_list):
                 return True
         return False
-
-    try:
-        return asyncio.run(_any_match())
     except Exception:  # noqa: BLE001 — a failed match read never fabricates a verdict
         return False
+
+
+async def record_output_taint(
+    output_text: str, repo_root: str, session_id: str | None = None
+) -> None:
+    """Best-effort: record ``secret_access`` taint + keyed-HMAC fingerprints from a
+    forwarded tool result's output text, for the pure-MCP proxy.
+
+    Mirrors the host-hook's PostToolUse recording (``_record_taint`` /
+    ``_record_secret_fingerprints`` in ``hosthooks/claude_code.py``) so a secret read
+    through the proxy taints the session exactly like one read through the host-hook
+    — later feeding :func:`apply_taint_floor_async`'s cross-call check. The host-hook
+    gates recording on fired reason codes from its own evaluation; the proxy has no
+    such signal for a downstream RESULT, so presence is judged directly from the text
+    via ``candidate_secret_fingerprints``. Never raises — a recording failure must
+    never break the forward/return path — and never fabricates taint beyond what was
+    actually found in the text.
+    """
+    try:
+        from doberman.engine.rules.secrets import candidate_secret_fingerprints
+        from doberman.storage.taint import (
+            TAINT_SECRET_ACCESS,
+            entity_scope,
+            record_secret_fingerprints,
+            record_taints,
+        )
+
+        fps = candidate_secret_fingerprints(output_text)
+        if not fps:
+            return  # nothing secret-shaped in the output — record nothing
+
+        scopes: list[str] = [session_id] if session_id else []
+        try:
+            scopes.append(entity_scope(repo_root))
+        except Exception:  # noqa: BLE001,S110
+            pass
+        if not scopes:
+            return
+
+        await record_taints(repo_root, scopes, [TAINT_SECRET_ACCESS])
+        await record_secret_fingerprints(repo_root, scopes, list(fps))
+    except Exception:  # noqa: BLE001 — recording must never break the execution path
+        return

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -30,6 +30,7 @@ from doberman.config import load_active_role, load_enforcement, load_mode, load_
 from doberman.engine.decision_engine import Guardrail, decide
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.engine.subjective import SubjectiveGuardrail
+from doberman.engine.taint_floor import apply_taint_floor_async, record_output_taint
 from doberman.models import (
     ActionType,
     Decision,
@@ -282,6 +283,25 @@ async def _forward(
         return _denied_result(ReasonCode.downstream_error, type(exc).__name__, action.id)
 
 
+async def _record_result_taint(result: CallToolResult) -> None:
+    """Best-effort: feed a successful tool result's text to the taint floor.
+
+    Mirrors the host-hook's PostToolUse recording so a secret read through the
+    proxy taints the session for the next call's cross-call exfil check
+    (``apply_taint_floor_async``). Guards non-text content blocks; never raises —
+    ``record_output_taint`` is itself fail-closed/best-effort, but a malformed
+    result (e.g. a non-string ``.text``) must not break the forward/return path.
+    """
+    try:
+        output_text = "".join(
+            block.text for block in result.content if isinstance(block, TextContent)
+        )
+        if output_text:
+            await record_output_taint(output_text, REPO_ROOT, None)
+    except Exception:  # noqa: BLE001 — recording must never break the execution path
+        _engine_logger.warning("output taint recording failed; continuing")
+
+
 async def _consume_single_use(action: SecurityObject, grants: tuple, now: datetime) -> None:
     """Mark a single-use elevation spent after it released a forward (best-effort)."""
     grant = find_cover(action.target, grants, root=REPO_ROOT)
@@ -374,6 +394,7 @@ async def _handle_auth(
 
     result = await _forward(downstream, tool_name, arguments, action)
     if not result.isError:
+        await _record_result_taint(result)
         await _consume_single_use(action, grants, now)
         await _observe_allowed(action, eid, surprise_score)
     await _persist(decision, action, auth_result="approved", elevation_id=elevation_id, eid=eid)
@@ -405,6 +426,15 @@ async def decide_and_execute(
     decision = _safe_decide(
         action,
         _build_ctx(arguments, grants, score, budget_ok=budget_ok, eid=eid, scope_token=token),
+    )
+
+    # HK.5.2/5.2b cross-call exfil floor: raise-only, awaited directly (this
+    # function already runs inside a live event loop — see taint_floor.py's
+    # module docstring for why the sync `apply_taint_floor` must NOT be used here).
+    # `session_id=None`: the proxy has no session id of its own, so the floor falls
+    # back to the per-repo entity scope.
+    decision = await apply_taint_floor_async(
+        action, decision, load_mode(REPO_ROOT), REPO_ROOT, None, arguments or {}
     )
 
     # Record every intercepted action with its REAL verdict. Logged before the
@@ -439,6 +469,7 @@ async def decide_and_execute(
     softened = decision.final_verdict is not Verdict.PASS
     result = await _forward(downstream, tool_name, arguments, action)
     if not result.isError:
+        await _record_result_taint(result)
         await _consume_single_use(action, grants, now)
         if not softened:
             # Teach the baseline only on a GENUINE pass. A softened would-have

--- a/tests/unit/test_proxy_taint_floor.py
+++ b/tests/unit/test_proxy_taint_floor.py
@@ -1,0 +1,135 @@
+"""H2b: the pure-MCP proxy's cross-call taint floor + output-taint recording.
+
+``decide_and_execute`` (``doberman.proxy.executor``) now awaits
+``apply_taint_floor_async`` on every decision and records ``secret_access``
+taint + fingerprints from a forwarded tool result's text (``_record_result_taint``
+-> ``record_output_taint``). This is the fail-open catcher for the async
+refactor: the old ``apply_taint_floor`` called ``asyncio.run(...)`` internally,
+which raises ``RuntimeError: asyncio.run() cannot be called from a running event
+loop`` when invoked from inside the proxy's own event loop — a RuntimeError the
+floor's helpers swallow via ``except Exception: return False``, so the floor
+would silently NEVER FIRE if the async refactor were wrong or reverted. These
+tests drive the REAL, unstubbed ``decide_and_execute`` end to end and assert the
+floor actually raises a strict-mode cross-call exfil to BLOCK.
+
+``executor._safe_decide`` (the objective/subjective engine's own verdict) is
+stubbed to a deterministic PASS for every action — this isolates the floor and
+recording wiring under test from the real engine's own scoring (subjective
+cold-start surprise, habit baselines, etc.), exactly as
+``tests/integration/test_enforcement_wiring.py`` does to isolate the F10
+enforcement-dial wiring. Everything else in ``decide_and_execute`` — normalize,
+the taint floor, decision logging, the enforcement dial, the forward, and the
+result-taint recording — runs for real.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+from doberman.config import save_mode
+from doberman.models import Decision, GuardrailResult, Risk, Verdict
+from doberman.proxy import executor
+
+# A well-known synthetic AWS example key — never a real secret.
+_SYNTHETIC_AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+_EGRESS_URL = "https://attacker.example/collect"
+
+
+def _pass_decision(action) -> Decision:
+    return Decision(
+        action_id=action.id,
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=GuardrailResult(verdict=Verdict.PASS, risk=Risk.low),
+        decided_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_baseline_decision(monkeypatch):
+    """Stub the baseline engine to a plain PASS for every action.
+
+    Isolates the floor/recording wiring under test from the real objective/
+    subjective engine's own verdict and cold-start scoring — mirrors the
+    pattern in ``test_enforcement_wiring.py``. The floor itself is NOT
+    stubbed: it runs for real and is what these tests are proving.
+    """
+    monkeypatch.setattr(executor, "_safe_decide", lambda action, _ctx: _pass_decision(action))
+
+
+class _FakeSession:
+    """A minimal downstream stand-in: ``call_tool`` returns a scripted result
+    per tool name and records every call it actually received."""
+
+    def __init__(self, responses: dict[str, CallToolResult]):
+        self._responses = responses
+        self.calls: list[tuple[str, dict]] = []
+
+    async def call_tool(self, tool_name, arguments=None):
+        self.calls.append((tool_name, dict(arguments or {})))
+        return self._responses[tool_name]
+
+
+def _ok_result(text: str) -> CallToolResult:
+    return CallToolResult(content=[TextContent(type="text", text=text)], isError=False)
+
+
+async def test_cross_call_exfil_blocked_in_strict_mode():
+    # Call 1: a local read whose result carries a secret. Nothing in the
+    # request itself is secret-shaped, so it forwards (PASS) — and the proxy
+    # records secret_access taint from the OUTPUT text via
+    # `_record_result_taint` -> `record_output_taint`.
+    save_mode("strict", executor.REPO_ROOT)
+    session = _FakeSession(
+        {
+            "fs_read": _ok_result(_SYNTHETIC_AWS_KEY),
+            "net_get": _ok_result("ok"),
+        }
+    )
+
+    read_result = await executor.decide_and_execute(session, "fs_read", {"path": "cfg.txt"})
+    assert not read_result.isError
+    assert session.calls == [("fs_read", {"path": "cfg.txt"})]
+
+    # Call 2: an egress whose own payload is clean — the per-call objective
+    # floor alone would let this PASS. The cross-call taint floor must raise
+    # it to BLOCK in strict mode because this session already holds
+    # secret_access taint from call 1. This assertion is the fail-open
+    # catcher: if the async refactor silently no-ops, this call forwards.
+    egress_result = await executor.decide_and_execute(session, "net_get", {"url": _EGRESS_URL})
+    assert egress_result.isError
+    assert "blocked by policy" in egress_result.content[0].text
+    assert "multi_step_exfil" in egress_result.content[0].text
+    # The floor fired BEFORE the forward — the egress call never reached the
+    # downstream, and the secret itself never appears in the denial text.
+    assert session.calls == [("fs_read", {"path": "cfg.txt"})]
+    assert _SYNTHETIC_AWS_KEY not in egress_result.content[0].text
+
+
+async def test_clean_session_egress_not_blocked_by_floor():
+    # Raise-only / no-regression: with no prior taint anywhere in this
+    # session, a benign egress is NOT escalated by the floor — even in
+    # strict mode — and forwards normally.
+    save_mode("strict", executor.REPO_ROOT)
+    session = _FakeSession({"net_get": _ok_result("ok")})
+
+    result = await executor.decide_and_execute(session, "net_get", {"url": _EGRESS_URL})
+
+    assert not result.isError
+    assert session.calls == [("net_get", {"url": _EGRESS_URL})]
+
+
+async def test_output_taint_recording_failure_is_best_effort(monkeypatch):
+    # A recording failure (e.g. a degraded taint store) must never break the
+    # forward/return path — the tool result still comes back untouched.
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError("taint store unavailable")
+
+    monkeypatch.setattr(executor, "record_output_taint", _boom)
+    session = _FakeSession({"fs_read": _ok_result(_SYNTHETIC_AWS_KEY)})
+
+    result = await executor.decide_and_execute(session, "fs_read", {"path": "cfg.txt"})
+
+    assert not result.isError
+    assert result.content[0].text == _SYNTHETIC_AWS_KEY

--- a/tests/unit/test_taint_floor_module.py
+++ b/tests/unit/test_taint_floor_module.py
@@ -1,18 +1,28 @@
-"""H2a: module-level regression test for the extracted taint floor.
+"""H2a/H2b: module-level regression test for the extracted taint floor.
 
 ``apply_taint_floor`` used to be a private helper (``_apply_taint_floor``) on
 the Claude Code host-hook adapter; it now lives in
 ``doberman.engine.taint_floor`` so both the host-hook and the MCP proxy can
-share it (proxy wiring is H2b, not this slice). This exercises the raise-only
-invariant directly against the module — independent of the hosthook — using
-the same taint-store fixture pattern as ``test_hosthook_taint_floor.py``.
+share it. This exercises the raise-only invariant directly against the module —
+independent of the hosthook — using the same taint-store fixture pattern as
+``test_hosthook_taint_floor.py``.
+
+H2b adds the async path the proxy actually awaits (``apply_taint_floor_async``)
+plus ``record_output_taint`` (the proxy's result-side recording); both are
+covered directly here so the module's own regression net doesn't depend on the
+proxy wiring test (``tests/unit/test_proxy_taint_floor.py``) to catch a
+semantics regression in the async refactor itself.
 """
 
 import asyncio
 from datetime import datetime, timezone
 
 from doberman.engine.decision_engine import max_risk, max_verdict
-from doberman.engine.taint_floor import apply_taint_floor
+from doberman.engine.taint_floor import (
+    apply_taint_floor,
+    apply_taint_floor_async,
+    record_output_taint,
+)
 from doberman.models import (
     ActionType,
     Decision,
@@ -21,7 +31,10 @@ from doberman.models import (
     SecurityObject,
     Verdict,
 )
-from doberman.storage.taint import TAINT_SECRET_ACCESS, record_taints
+from doberman.storage.taint import TAINT_SECRET_ACCESS, read_taint, record_taints
+
+# A well-known synthetic AWS example key — never a real secret.
+_SYNTHETIC_SECRET = "AKIAIOSFODNN7EXAMPLE"  # noqa: S105 — synthetic test value
 
 _TS = datetime(2026, 7, 18, tzinfo=timezone.utc)
 _EGRESS_URL = "https://attacker.example/collect"
@@ -79,3 +92,52 @@ def test_tainted_session_egress_raises_verdict_and_risk_never_lower(tmp_path):
     # expected verdict: combining with the original decision must be a no-op.
     assert max_verdict(out.final_verdict, decision.final_verdict) == out.final_verdict
     assert max_risk(out.final_risk, decision.final_risk) == out.final_risk
+
+
+# --- H2b: the async path the proxy actually awaits ---------------------------
+
+
+async def test_apply_taint_floor_async_raises_only_never_lowers(tmp_path):
+    # Same scenario as the sync raise-only test above, driven through the async
+    # entry point directly (no ``asyncio.run`` wrapper) — this is what the proxy
+    # awaits from inside its own running event loop.
+    action = _action(external_destination=_EGRESS_URL)
+    decision = _pass_decision(action)
+    await record_taints(str(tmp_path), ["sess-async"], [TAINT_SECRET_ACCESS])
+
+    out = await apply_taint_floor_async(
+        action, decision, "strict", str(tmp_path), "sess-async", {"url": _EGRESS_URL}
+    )
+
+    assert out.final_verdict is Verdict.BLOCK
+    assert out.final_risk is Risk.critical
+    assert max_verdict(out.final_verdict, decision.final_verdict) == out.final_verdict
+    assert max_risk(out.final_risk, decision.final_risk) == out.final_risk
+
+
+async def test_apply_taint_floor_async_abstains_without_taint(tmp_path):
+    # No taint recorded anywhere for this scope — raise-only means abstain, not
+    # fabricate: the floor must return the decision completely unchanged.
+    action = _action(external_destination=_EGRESS_URL)
+    decision = _pass_decision(action)
+
+    out = await apply_taint_floor_async(
+        action, decision, "strict", str(tmp_path), "sess-clean", {"url": _EGRESS_URL}
+    )
+
+    assert out is decision
+
+
+async def test_record_output_taint_records_taint_and_fingerprint_for_secret_text(tmp_path):
+    await record_output_taint(_SYNTHETIC_SECRET, str(tmp_path), "sess-rec")
+
+    counts = await read_taint(str(tmp_path), "sess-rec")
+    assert counts.get(TAINT_SECRET_ACCESS, 0) > 0
+
+
+async def test_record_output_taint_records_nothing_for_benign_text(tmp_path):
+    benign = "just some ordinary log output, nothing secret here"
+    await record_output_taint(benign, str(tmp_path), "sess-benign")
+
+    counts = await read_taint(str(tmp_path), "sess-benign")
+    assert counts == {}


### PR DESCRIPTION
## Slice
- Feature / Slice: H2b — wire the cross-call taint floor into the pure-MCP proxy

**Stacked on #116** (H2a: extracted the sync taint floor to `engine/taint_floor.py`). Merge #116 first.

## What this PR does

The pure-MCP proxy (`doberman.proxy.executor.decide_and_execute`) had no cross-call exfil defense — HK.5.2/5.2b's taint floor only existed in the sync Claude Code host-hook adapter. Calling the existing sync `apply_taint_floor` from the proxy's own running event loop would have silently disabled it: `apply_taint_floor` calls `asyncio.run(...)` internally, which raises `RuntimeError: asyncio.run() cannot be called from a running event loop` inside the proxy — and that RuntimeError is swallowed by the floor's own `except Exception: return False`, so the floor would never fire and nothing would surface the failure.

- `engine/taint_floor.py`: added an async path (`apply_taint_floor_async`, plus async `_session_holds_secret` / `_outbound_matches_recorded_secret`) that the proxy awaits directly. The public sync `apply_taint_floor` is now a thin `asyncio.run(...)` wrapper around the async version — identical signature and behavior, so the host-hook's sync call site is untouched. Added `record_output_taint`, mirroring the host-hook's PostToolUse recording, so a secret surfaced in a forwarded tool *result* taints the session the same way a host-hook read does.
- `proxy/executor.py`: `decide_and_execute` now awaits `apply_taint_floor_async` right after `_safe_decide()` and before `log_action()`. A shared `_record_result_taint` helper awaits `record_output_taint` after every successful forward — both the plain PASS path and the AUTH-approval path in `_handle_auth`. Recording is best-effort and fail-closed: a taint-store failure never breaks the forward/return path and never fabricates taint.

## Tests added (run in CI)
- `tests/unit/test_proxy_taint_floor.py` (new) — drives the real, unstubbed `decide_and_execute` (only `_safe_decide` is stubbed to a deterministic PASS, matching the isolation pattern in `test_enforcement_wiring.py`) against a fake downstream session:
  - `test_cross_call_exfil_blocked_in_strict_mode` — the fail-open catcher: a strict-mode session that reads a secret in call 1 is BLOCKed on a clean-payload egress in call 2, and the egress never reaches the downstream (`session.calls` only shows call 1). This test fails if the async refactor silently no-ops.
  - `test_clean_session_egress_not_blocked_by_floor` — raise-only/no-regression: a benign egress in a clean session is not escalated by the floor, even in strict mode.
  - `test_output_taint_recording_failure_is_best_effort` — a monkeypatched `record_output_taint` failure never breaks the forward/return.
- `tests/unit/test_taint_floor_module.py` (updated) — direct async coverage independent of the proxy wiring test: `apply_taint_floor_async` raise-only invariant, and `record_output_taint` records taint+fingerprints for secret-bearing text and nothing for benign text.
- `tests/unit/test_hosthook_taint_floor.py` + `tests/unit/test_hosthook_taint.py` — unchanged, pass as-is, confirming the sync wrapper preserves the original host-hook behavior exactly.

All 26 tests in the scoped run pass (`ruff format --check .`, `ruff check .`, `lint-imports` all green; `pytest` 26 passed in 36.70s).

## Security checklist
- [x] Fails closed on error / uncertainty — every taint read/match/record wraps `except Exception` and returns `False`/no-op, never fabricating taint or a verdict.
- [x] No secret, full file, or unredacted prompt logged or committed — the BLOCK path's denial text never contains the synthetic secret (asserted in `test_cross_call_exfil_blocked_in_strict_mode`).
- [x] Any guardrail/learning change is raise-only (no silent loosening) — `apply_taint_floor_async` only ever raises verdict/risk via `max_verdict`/`max_risk`; asserted structurally in `test_taint_floor_module.py`.
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — `ReasonCode.multi_step_exfil` / `ReasonCode.confirmed_exfil` plus the existing explanation strings, unchanged from H2a.
- [x] doberman-core does not import doberman_enterprise — `lint-imports`: 2 contracts kept, 0 broken.

## Edge cases covered / Deviations from plan / Risks introduced
- Both the PASS-path and AUTH-approval-path (`_handle_auth`) recording sites are wired (nothing deferred) via one shared `_record_result_taint` helper, avoiding duplication.
- No deviations from the H2b task packet. No output-gating and no hosthook recording changes — out of scope for this slice.
- No known risks/tech debt introduced.