### PR TITLE
fix(subjective): flag a frozen-high belief as entrenched (martingale zero-variance blind spot)

### DIFF
--- a/src/doberman/subjective/martingale.py
+++ b/src/doberman/subjective/martingale.py
@@ -120,6 +120,16 @@ def martingale_score(beliefs: list[float] | tuple[float, ...]) -> MartingaleResu
     x_centered = prior - prior.mean()
     sxx = float(np.dot(x_centered, x_centered))
     if sxx < 1e-12:
+        # A literally-invariant belief window is entrenchment's extreme case:
+        # the belief stopped updating entirely, which OLS can't express (no
+        # regressor variance to regress on) so it would otherwise score "no
+        # signal". Flag it directly — but ONLY when the frozen belief is HIGH
+        # (the dangerous "stopped escalating / desensitized" case, which
+        # run_monitor routes to the raise-safe baseline refresh). A frozen LOW
+        # belief stays unflagged, exactly as before (raise-only: never
+        # auto-refreshes a cautious baseline).
+        if float(prior.mean()) >= SAFE_BELIEF:
+            return MartingaleResult(beta=1.0, p_value=0.0, n=n)
         return MartingaleResult(beta=0.0, p_value=1.0, n=n)
     beta = float(np.dot(x_centered, delta - delta.mean()) / sxx)
     intercept = float(delta.mean() - beta * prior.mean())

--- a/tests/unit/test_martingale.py
+++ b/tests/unit/test_martingale.py
@@ -92,10 +92,29 @@ def test_mean_reversion_is_over_correction_not_entrenchment():
 
 def test_short_and_degenerate_windows_never_flag():
     assert not martingale_score(_entrenched_stream(start=0.3, n=10)).entrenched  # too short
-    constant = [0.7] * (MIN_WINDOW + 5)
-    result = martingale_score(constant)  # constant prior: nothing to regress on
+    # A constant window BELOW SAFE_BELIEF: nothing to regress on, and not the
+    # dangerous frozen-HIGH case, so it stays unflagged (see
+    # test_frozen_high_belief_is_flagged_entrenched below for the HIGH side).
+    constant = [0.5] * (MIN_WINDOW + 5)
+    result = martingale_score(constant)
     assert result.beta == 0.0
     assert result.p_value == 1.0
+
+
+def test_frozen_high_belief_is_flagged_entrenched():
+    # A belief window that stopped updating entirely at a HIGH (safe) value is
+    # entrenchment's most extreme case — the zero-variance OLS blind spot.
+    result = martingale_score([0.9] * (MIN_WINDOW + 2))
+    assert result.beta > 0
+    assert result.p_value < 0.05
+    assert result.entrenched
+
+
+def test_frozen_low_belief_not_flagged():
+    # A frozen LOW (cautious) belief is unchanged behavior: raise-only means
+    # this never auto-refreshes toward a warmer baseline.
+    result = martingale_score([0.3] * (MIN_WINDOW + 2))
+    assert not result.entrenched
 
 
 # --- the monitor ----------------------------------------------------------------
@@ -166,6 +185,23 @@ async def test_entrenched_toward_risky_is_surfaced_and_protection_held(tmp_path)
     assert await read_beliefs(_EID, repo_root=root)  # beliefs NOT wiped: held, not refreshed
 
 
+async def test_frozen_high_stream_persists_to_refresh(tmp_path):
+    root = str(tmp_path)
+    await _seed_beliefs(root, [0.9] * (MIN_WINDOW + 2))
+    first = await run_monitor(_EID, repo_root=root, now=_NOW)
+    assert first is None  # one flagged window is not yet actionable
+    second = await run_monitor(_EID, repo_root=root, now=_NOW)
+    assert second == "refresh"  # persistence reached; frozen HIGH belief is the safe/dangerous case
+
+
+async def test_frozen_low_stream_never_refreshes(tmp_path):
+    root = str(tmp_path)
+    eid = "hmac:martingale-frozen-low-test"
+    await _seed_beliefs(root, [0.3] * (MIN_WINDOW + 2), eid=eid)
+    for _ in range(2):
+        assert await run_monitor(eid, repo_root=root, now=_NOW) is None
+
+
 async def test_rational_stream_never_triggers_an_action(tmp_path):
     root = str(tmp_path)
     await _seed_beliefs(root, _rational_stream())
@@ -199,3 +235,10 @@ def test_guard_blocks_entrenched_and_insufficient_allows_rational():
 
     allowed = guard_self_update(_rational_stream())
     assert allowed.allowed
+
+
+def test_frozen_high_stream_blocks_self_update():
+    # Tightens the self-improvement guard too: a fully frozen HIGH belief
+    # stream is entrenched, so a proposed self-update driven by it is blocked.
+    blocked = guard_self_update([0.9] * (MIN_WINDOW + 2))
+    assert not blocked.allowed


### PR DESCRIPTION
## Slice
- Feature / Slice: SL8.1 fix — martingale zero-variance blind spot

## What this PR does
`martingale_score`'s zero-variance branch (a belief window that stopped updating entirely — the constant-prior case OLS can't regress on) unconditionally scored `entrenched=False`. That's exactly backwards for a belief frozen HIGH: a baseline that locked into "operating normally" and stopped escalating is the most extreme form of the desensitization SL8 exists to catch, and it passed through silently.

Fix: when the frozen belief's mean is `>= SAFE_BELIEF` (0.7), the zero-variance branch now returns an entrenched result (`beta=1.0, p_value=0.0`), which flows through the existing `run_monitor` persistence gate into the already-raise-safe baseline refresh path. A frozen LOW belief is unchanged — still scores not-entrenched, never auto-refreshed. Also tightens `guard_self_update`, which shares the same scoring function.

## Tests added (run in CI)
- `tests/unit/test_martingale.py::test_frozen_high_belief_is_flagged_entrenched` — a fully frozen HIGH belief window (`[0.9]*32`) is flagged entrenched.
- `tests/unit/test_martingale.py::test_frozen_low_belief_not_flagged` — a fully frozen LOW belief window (`[0.3]*32`) stays unflagged (raise-only guarantee).
- `tests/unit/test_martingale.py::test_frozen_high_stream_blocks_self_update` — `guard_self_update` blocks a proposed self-update driven by a frozen-HIGH stream.
- `tests/unit/test_martingale.py::test_frozen_high_stream_persists_to_refresh` — a persisted frozen-HIGH stream reaches persistence and `run_monitor` returns `"refresh"`.
- `tests/unit/test_martingale.py::test_frozen_low_stream_never_refreshes` — a persisted frozen-LOW stream never triggers an action.
- Updated `test_short_and_degenerate_windows_never_flag`'s constant fixture from `0.7` (which coincidentally equalled `SAFE_BELIEF`) to `0.5`, since `0.7` now correctly triggers the new frozen-high flag. No assertion was weakened — the test still asserts a degenerate/constant window below the safe threshold produces `(beta=0, p=1)`.

## Security checklist
- [x] Fails closed on error / uncertainty (unchanged — `run_monitor`/`guard_self_update` still catch-all and never raise)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — this only ADDS a detection path for frozen-HIGH; frozen-LOW behavior is unchanged, and the target action (`refresh_baseline`) was already the existing, more-conservative refresh path
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unaffected — no reason-code surface change)

## Edge cases covered / Deviations from plan / Risks introduced
- Frozen belief exactly at `SAFE_BELIEF` (0.7) is treated as the dangerous/safe case (`>=`), consistent with `run_monitor`'s existing `mean_belief >= SAFE_BELIEF` check.
- No deviations from plan.
- No new risk: only reachable code path is the existing `refresh_baseline` call already gated by `PERSISTENCE` consecutive flagged windows.