### PR TITLE
fix(hosthook): enforce agent role boundaries (F4) on the decision path

### DIFF
--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -44,7 +44,7 @@ from typing import TYPE_CHECKING, Any
 
 from doberman.branding import DOG
 from doberman.config import load_active_role, load_mode, resolve_enforcement_sync
-from doberman.engine.decision_engine import PASS_STUB, decide, max_risk, max_verdict
+from doberman.engine.decision_engine import PASS_STUB, decide, max_risk
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.engine.taint_floor import apply_taint_floor
 from doberman.models import Decision, EvalContext, ReasonCode, Risk, SecurityObject, Verdict

--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -43,8 +43,8 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from doberman.branding import DOG
-from doberman.config import load_mode, resolve_enforcement_sync
-from doberman.engine.decision_engine import PASS_STUB, decide, max_risk
+from doberman.config import load_active_role, load_mode, resolve_enforcement_sync
+from doberman.engine.decision_engine import PASS_STUB, decide, max_risk, max_verdict
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.engine.taint_floor import apply_taint_floor
 from doberman.models import Decision, EvalContext, ReasonCode, Risk, SecurityObject, Verdict
@@ -333,11 +333,11 @@ def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
         canonical, args = to_normalize_input(tool_name, tool_input)
         action = normalize(canonical, args)
         # The objective rules inspect the UN-redacted call via metadata['raw_arguments']
-        # (in-memory only, never logged). role=None ⇒ role-boundary rule no-ops; the
-        # deterministic floor (paths, destructive commands, destinations, secrets,
-        # token channels) is what fires here.
+        # (in-memory only, never logged). This is the real tool-call decision path, so
+        # the active role rides along too (parity with proxy.executor._build_ctx) — a
+        # repo with no .doberman/role.yaml still gets role=None (no-op, opt-in only).
         ctx = EvalContext(
-            role=None,
+            role=load_active_role(repo_root),
             mode=mode,
             metadata={"raw_arguments": args, "repo_root": repo_root},
         )
@@ -554,6 +554,9 @@ def evaluate_post(payload: dict[str, Any]) -> dict[str, Any] | None:
             scan_args["tool_output"] = output_text
 
             action = normalize(canonical, scan_args)
+            # role=None is intentional here (not the parity gap fixed elsewhere in this
+            # module): this action is synthetic, built to scan tool OUTPUT for secrets,
+            # not the real call target. Role-boundary is meaningless against scan text.
             ctx = EvalContext(
                 role=None,
                 mode=mode,
@@ -606,12 +609,15 @@ def _record_post_history(
     Wrapped in a broad except — must never raise or affect any verdict. ``mode`` is
     the strictness mode already resolved by the caller (#51) so the history row uses
     the same safe mode as the live decision, never a re-derived ``load_mode(".")``.
+    This is also the ONLY decision computed for pure-read tools (Read/Glob/Grep are
+    gated here but never in evaluate_pre), so the active role rides along too — same
+    real-input action as evaluate_pre, just recomputed post-execution for the log.
     """
     try:
         canonical, args = to_normalize_input(tool_name, tool_input)
         action = normalize(canonical, args)
         ctx = EvalContext(
-            role=None,
+            role=load_active_role(repo_root),
             mode=mode,
             metadata={"raw_arguments": args, "repo_root": repo_root},
         )

--- a/tests/unit/test_hosthook_claude_pre.py
+++ b/tests/unit/test_hosthook_claude_pre.py
@@ -16,6 +16,7 @@ import pytest
 from doberman.hosthooks import claude_code
 from doberman.hosthooks.claude_code import (
     GATED_BUILTINS,
+    evaluate_post,
     evaluate_pre,
     run_pre_hook,
     to_normalize_input,
@@ -26,6 +27,23 @@ from doberman.storage.log import read_decisions
 @pytest.fixture
 def cwd(tmp_path):
     """An isolated repo root so the test never inherits a real ``.doberman`` policy."""
+    return str(tmp_path)
+
+
+@pytest.fixture
+def role_cwd(tmp_path):
+    """An isolated repo root with an active role policy scoped to ``frontend/**``.
+
+    Modeled on test_auth_release.py's ``_write_role`` fixture pattern. Used to prove
+    the hosthook parity fix (F4 role-boundary enforcement) actually engages once a
+    role policy exists.
+    """
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir(parents=True, exist_ok=True)
+    (cfg / "role.yaml").write_text(
+        'name: webdev\nallowed:\n  - "frontend/**"\n',
+        encoding="utf-8",
+    )
     return str(tmp_path)
 
 
@@ -355,3 +373,52 @@ def test_pre_hook_block_never_logs_raw_secret(cwd):
     rows = asyncio.run(read_decisions(cwd))
     assert rows
     assert secret not in repr(rows[0])
+
+
+# --- role-boundary parity (F4 hosthook/proxy gap) ------------------------------
+#
+# The Claude Code hosthook used to build EvalContext with role=None on every path,
+# so an active role policy never got checked for hosthook-mediated tool calls
+# (unlike the MCP proxy, which always wires the active role). "random/notes.txt"
+# is used as the out-of-scope target rather than a backend/auth/** path — that
+# path independently triggers AUTH(sensitive_path_access) from the unrelated
+# path-sensitivity rule, which would confound a test meant to isolate the
+# role-boundary parity fix.
+
+_OUT_OF_SCOPE_EDIT = (
+    "Edit",
+    {"file_path": "random/notes.txt", "old_string": "a", "new_string": "b"},
+)
+
+
+def test_pre_hook_enforces_role_boundary_when_role_policy_is_active(role_cwd, monkeypatch):
+    # Before the fix: role=None → RoleBoundaryRule always abstains → PASS.
+    # After the fix: the active role (allowed=["frontend/**"]) rides into EvalContext,
+    # "random/notes.txt" is unmatched-by-allowed → suspicious → AUTH(role_out_of_scope)
+    # in balanced mode (the default; escalate_out_of_scope=True).
+    monkeypatch.setattr(claude_code, "AUTH_PROMPTER", _Decline())
+    out = _pre(*_OUT_OF_SCOPE_EDIT, role_cwd)
+    assert _permission(out) == "deny"
+    assert "role_out_of_scope" in _reason(out)
+
+
+def test_pre_hook_role_boundary_is_a_noop_with_no_role_policy(cwd):
+    # Parity/no-regression: a repo with no .doberman/role.yaml still abstains on the
+    # same out-of-scope path — load_active_role() returns None, RoleBoundaryRule
+    # abstains, and nothing else escalates a plain notes file.
+    assert _pre(*_OUT_OF_SCOPE_EDIT, cwd) is None
+
+
+def test_evaluate_post_output_scan_stays_role_free_with_active_role_policy(role_cwd):
+    # The evaluate_post output-scan EvalContext intentionally stays role=None (the
+    # action there is synthetic — built from tool OUTPUT to scan for secrets, not
+    # the real call target). Confirms an active role policy does not make the
+    # output scan spuriously fire role_out_of_scope on benign output text.
+    payload = {
+        "tool_name": "Read",
+        "tool_input": {"file_path": "random/notes.txt"},
+        "tool_response": "just some benign notes, nothing sensitive here",
+        "cwd": role_cwd,
+    }
+    result = evaluate_post(payload)
+    assert result is None


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: F4 parity fix — enforce role boundaries in the Claude Code hosthook
- Plan reference: parity audit Finding 2 (hosthook <-> proxy defense-parity audit)

## What this PR does
Closes a cross-adapter parity gap: the Claude Code hosthook (`src/doberman/hosthooks/claude_code.py`)
built every `EvalContext` with `role=None`, so an active `.doberman/role.yaml` was silently unenforced
for hosthook-mediated tool calls — while the MCP proxy (`proxy/executor.py`'s `_build_ctx`) always wired
the active role. This is **raise-only**: a role that was never checked can only start being checked.

Two real-tool-**input** decision sites now wire `role=load_active_role(repo_root)`, matching the proxy's
pattern:
- `evaluate_pre` — the PreToolUse decision path.
- `_record_post_history` — the best-effort decision computed for history recording, and the *only*
  decision ever computed for pure-read tools (Read/Glob/Grep are gated here, never in `evaluate_pre`).

One site deliberately stays `role=None`, with a comment explaining why: the `evaluate_post` output-scan
site builds a **synthetic** action from tool *output* text (to hunt for leaked secrets), not a real call
target — role-boundary is meaningless against scan text, and wiring role there risked spuriously firing
`role_out_of_scope` on benign output.

Behavior change: repos **with** an active role policy now get `AUTH`/`BLOCK` (`role_out_of_scope` /
`role_blocked_target`) on hosthook tool calls outside that role's scope, where before they silently
passed. Repos with **no** role policy are completely unaffected (`load_active_role` returns `None`, a
no-op).

## Tests added (run in CI)
- `tests/unit/test_hosthook_claude_pre.py`:
  - `role_cwd` fixture — an isolated repo with an inline custom role (`allowed: ["frontend/**"]`).
  - `test_pre_hook_enforces_role_boundary_when_role_policy_is_active` — an Edit to an out-of-scope path
    (`random/notes.txt`, deliberately not under `backend/auth/**`, which independently triggers an
    unrelated sensitive-path rule) now denies with `role_out_of_scope` in the reason.
  - `test_pre_hook_role_boundary_is_a_noop_with_no_role_policy` — the same call with no role policy still
    abstains (no-regression for policy-less repos).
  - `test_evaluate_post_output_scan_stays_role_free_with_active_role_policy` — confirms the output-scan
    site's `role=None` stays inert (no spurious `role_out_of_scope`) even with an active role policy.
- All 37 tests in `test_hosthook_claude_pre.py` pass; the 23 tests in `test_hosthook_claude_post.py` are
  unaffected (unchanged, still green).

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Edge case: chose `random/notes.txt` (not a `backend/auth/**` path) as the out-of-scope test target,
  since `backend/auth/**` is already a `DEFAULT_SENSITIVE_GLOBS` entry in `engine/rules/paths.py` and would
  have confounded the test with an unrelated AUTH trigger.
- No deviations from the assigned scope.
- No new risks/tech debt: this only enables dormant F4 enforcement; it does not change any objective rule,
  the decision engine, or the auth-challenge flow.