### PR TITLE
fix(proxy): guard auth-challenge + single-use consumption (defense-in-depth, fail-closed)

### DIFF
--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -283,10 +283,23 @@ async def _forward(
 
 
 async def _consume_single_use(action: SecurityObject, grants: tuple, now: datetime) -> None:
-    """Mark a single-use elevation spent after it released a forward (best-effort)."""
-    grant = find_cover(action.target, grants, root=REPO_ROOT)
-    if grant is not None and grant.single_use:
-        await mark_used(REPO_ROOT, grant.id)
+    """Mark a single-use elevation spent after it released a forward (best-effort).
+
+    Wrapped so a failure here can never turn an already-successful forward into
+    an error result. On failure the grant may remain active until its TTL
+    expires; that residual is surfaced via a warning rather than crashing the
+    response for an action that has already, legitimately, been forwarded.
+    """
+    try:
+        grant = find_cover(action.target, grants, root=REPO_ROOT)
+        if grant is not None and grant.single_use:
+            await mark_used(REPO_ROOT, grant.id)
+    except Exception:  # noqa: BLE001 — must never break an already-successful forward
+        _engine_logger.warning(
+            "single-use elevation consumption failed (action %s); grant may remain active "
+            "until its TTL expires",
+            action.id,
+        )
 
 
 async def _persist(
@@ -331,11 +344,16 @@ async def _handle_auth(
     # Off the event loop: the challenge blocks for a human, and an elicitation
     # answer arrives over the very session this loop services — waiting in-loop
     # would deadlock it (and freeze the proxy during GUI/TTY prompts too).
-    auth_result = await asyncio.to_thread(
-        run_auth_challenge, decision, action, prompter=AUTH_PROMPTER
-    )
-    # Approval is bound to THIS action id — never honor a result for another call.
-    approved = auth_result.approved and auth_result.action_id == action.id
+    try:
+        auth_result = await asyncio.to_thread(
+            run_auth_challenge, decision, action, prompter=AUTH_PROMPTER
+        )
+    except Exception:  # noqa: BLE001 — a challenge failure must fail closed, not crash/leak
+        _engine_logger.warning("auth challenge raised; failing closed (action %s)", action.id)
+        approved = False
+    else:
+        # Approval is bound to THIS action id — never honor a result for another call.
+        approved = auth_result.approved and auth_result.action_id == action.id
     await _learn_from_auth(action, decision, approved, eid)
     if not approved:
         await _persist(decision, action, auth_result="denied", eid=eid)

--- a/tests/integration/test_auth_release.py
+++ b/tests/integration/test_auth_release.py
@@ -1,5 +1,6 @@
 """Slice 7.5 — actions are released only after a successful, bound auth."""
 
+import logging
 from datetime import datetime, timezone
 
 from doberman.auth.challenge import AuthResult, AuthTier
@@ -180,3 +181,56 @@ async def test_destructive_elevation_is_single_use(monkeypatch, isolated_executo
         r2 = await agent.call_tool("fs_delete", {"path": "backend/api.ts"})
         assert not r2.isError
         assert calls["n"] == 2
+
+
+async def test_auth_challenge_raising_fails_closed_and_sanitized(monkeypatch):
+    """A `run_auth_challenge` crash must deny — never crash the proxy or leak."""
+    monkeypatch.setattr(executor, "DEFAULT_OBJECTIVE", _AUTHING)
+
+    def boom(decision, action, *, prompter=None, at=None):
+        raise RuntimeError("challenge backend exploded: leaked-internal-detail")
+
+    monkeypatch.setattr(executor, "run_auth_challenge", boom)
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("fs_write", {"path": "a.txt", "content": "x"})
+        # Fail-closed denial, shaped exactly like an ordinary AUTH denial.
+        assert result.isError
+        text = result.content[0].text
+        assert "authentication required" in text
+        # The raw exception must never reach the agent — sanitized like every
+        # other error path in the proxy.
+        assert "leaked-internal-detail" not in text
+        assert "RuntimeError" not in text
+        # Nothing was forwarded — the challenge failed before release.
+        assert fake.calls == []
+
+
+async def test_mark_used_failure_does_not_corrupt_successful_forward(
+    monkeypatch, isolated_executor_repo_root, caplog
+):
+    """A `mark_used` crash after a successful forward must not turn it into an error."""
+    _write_role(isolated_executor_repo_root)
+
+    def approve_elev(decision, action, *, prompter=None, at=None):
+        return AuthResult(
+            approved=True,
+            tier=AuthTier.role_elevation,
+            method="test",
+            at=datetime.now(timezone.utc),
+            action_id=action.id,
+        )
+
+    def boom_mark_used(repo_root, elevation_id):
+        raise RuntimeError("db exploded")
+
+    monkeypatch.setattr(executor, "run_auth_challenge", approve_elev)
+    monkeypatch.setattr(executor, "mark_used", boom_mark_used)
+    with caplog.at_level(logging.WARNING, logger="doberman.proxy.engine"):
+        async with proxied_session() as (fake, agent):
+            result = await agent.call_tool("fs_delete", {"path": "backend/api.ts"})
+    # The downstream delete already succeeded — a broken mark_used must not
+    # turn that real success into an isError result.
+    assert not result.isError
+    assert fake.calls == [("fs_delete", {"path": "backend/api.ts"})]
+    # The residual (grant may still be marked unused) is surfaced, not silent.
+    assert any("single-use elevation consumption failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Slice
- Feature / Slice: proxy hardening — defense-in-depth on two unguarded exception paths in `proxy/executor.py`

## What this PR does
`proxy/executor.py` is the MCP proxy chokepoint and is thoroughly fail-closed, except two unguarded exception paths in the auth / post-forward flow. Neither is an active bypass today (the decision engine already fails closed, and the MCP SDK's outer catch-all backstops any leak), but both are hardened to be self-contained and fail-closed like the rest of the proxy (`_forward`, the host-hook's `_resolve_auth`). Both changes are raise-only — success-path behavior is unchanged; only fail-closed handling was added on the exception paths.

1. **`_handle_auth`** — the `run_auth_challenge` call (run via `asyncio.to_thread`) is now wrapped in `try/except`. Any exception is treated exactly like an ordinary auth denial (`approved = False`), so the agent receives the same sanitized AUTH-denied response it would for a real decline — never the raw exception text — and nothing is forwarded to the downstream tool.
2. **`_consume_single_use`** — `find_cover`/`mark_used` are now wrapped in `try/except`. A failure here (previously unguarded — `mark_used` in `storage/db.py` only catches `aiosqlite.Error`/`OSError` internally, not every exception type) can no longer turn an already-successful forward into an `isError` result. The residual (a single-use grant that may not be marked spent, staying active until its ~15-min TTL) is surfaced via a `logger.warning` instead of being silently swallowed or crashing the response.

No new `ReasonCode` was needed — both fixes reuse existing denial shapes (the ordinary AUTH-denied response, and a warning log matching the pattern used elsewhere in this file).

## Tests added (run in CI)
- `tests/integration/test_auth_release.py::test_auth_challenge_raising_fails_closed_and_sanitized` — `run_auth_challenge` monkeypatched to raise → the proxy returns a fail-closed, sanitized AUTH-denied result (raw exception text absent), and the fake downstream records no call.
- `tests/integration/test_auth_release.py::test_mark_used_failure_does_not_corrupt_successful_forward` — `mark_used` monkeypatched to raise after a real role-elevation-approved `fs_delete` forward succeeds → the result is still non-error, the downstream call is still recorded, and a warning is logged for the residual.
- All 8 tests in `test_auth_release.py` pass (6 pre-existing + 2 new).

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — this PR changes no decision logic at all
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged — reuses the existing AUTH-denied path)

## Edge cases covered / Deviations from plan / Risks introduced
- Covered: auth-challenge exception mid-flow (before any elevation grant or forward); single-use consumption failure after a legitimate successful forward.
- Deviations: none.
- Risks / tech debt: none introduced — this narrows an existing gap rather than adding new surface.