### PR TITLE
CRITICAL: fix secret exposure in the interception log (proxy.log_action)

### DIFF
--- a/src/doberman/proxy/interception_log.py
+++ b/src/doberman/proxy/interception_log.py
@@ -1,13 +1,18 @@
 """Structured, redacted interception logging (one JSON line per action).
 
-Every action that reaches the chokepoint is recorded with its redacted
-:class:`SecurityObject` and verdict, keyed by the stable ``action.id`` so
-later features (decision log, audit) can correlate. Two hard rules:
+Every action that reaches the chokepoint is recorded — by a curated,
+redaction-safe field set, never the full :class:`SecurityObject` — and
+verdict, keyed by the stable ``action.id`` so later features (decision log,
+audit) can correlate. Two hard rules:
 
 1. Logging is best-effort and must NEVER raise into the execution path —
    a logging failure must not alter, block, or crash a decision.
-2. Only redacted material enters the log: the SecurityObject is already
-   redacted by ``normalize()``; nothing else from the raw call is logged.
+2. Only fields that are redaction-safe *by construction* enter the log
+   (ids, enum classifications, the redacted path class, safe metadata
+   scalars) — never ``raw_args_redacted``, the raw ``target``, or the raw
+   ``external_destination``. ``normalize()``'s heuristic redactor is a
+   stopgap, not a guarantee (see :func:`log_action`), so this sink cannot
+   rely on it.
 """
 
 import json
@@ -15,6 +20,7 @@ import logging
 from typing import Any
 
 from doberman.models import SecurityObject, Verdict
+from doberman.storage.log import _path_class
 
 LOGGER_NAME = "doberman.interception"
 
@@ -34,12 +40,33 @@ def log_action(action: SecurityObject, verdict: Verdict) -> None:
     cancellation (CancelledError), GeneratorExit, and interpreter shutdown
     must propagate — swallowing them here would break structured
     concurrency, and an unwind executes nothing downstream (fail closed).
+
+    Only a curated, redaction-safe field set is emitted — never
+    ``action.model_dump()`` / ``raw_args_redacted`` / the raw ``target`` or
+    ``external_destination``. ``normalize()``'s redactor is a length- and
+    shape-based heuristic stopgap (see ``proxy/normalize.py``), not a
+    guarantee: an unshaped, short secret under a non-sensitive argument key
+    (e.g. ``content="db_password=Tr0ub4dor&3"``) passes through
+    ``raw_args_redacted`` untouched. So this sink must never depend on that
+    redaction — it emits only fields that are safe *by construction*: ids,
+    enum classifications, the redacted path **class** (mirrors
+    ``storage/log.py::build_record``), and ``action.metadata`` (populated
+    only by ``normalize()`` with safe scalars — ``target_count`` / a reason
+    code list — never raw call content).
     """
     try:
         record: dict[str, Any] = {
             "event": "tool_call_intercepted",
-            "action": action.model_dump(mode="json"),
             "verdict": verdict.value,
+            "id": action.id,
+            "ts": action.ts.isoformat(),
+            "agent_role": action.agent_role,
+            "action_type": action.action_type.value,
+            "source_context": action.source_context.value,
+            "tool_name": action.tool_name,
+            "target_path_class": _path_class(action),
+            "risk": action.risk.value,
+            "metadata": action.metadata,
         }
         logger.info(json.dumps(record, default=str, ensure_ascii=False))
     except Exception:  # noqa: BLE001 — logging must never break execution

--- a/tests/integration/test_interception_log.py
+++ b/tests/integration/test_interception_log.py
@@ -30,10 +30,14 @@ async def test_one_valid_json_line_per_call_with_action_id(caplog):
     for record in records:
         assert record["event"] == "tool_call_intercepted"
         assert record["verdict"] == "PASS"
-        assert record["action"]["id"]  # stable id for correlation
-    assert records[0]["action"]["tool_name"] == "fs_write"
-    assert records[0]["action"]["action_type"] == "file_write"
-    assert records[1]["action"]["target"] == "echo hi"
+        assert record["id"]  # stable id for correlation
+    assert records[0]["tool_name"] == "fs_write"
+    assert records[0]["action_type"] == "file_write"
+    assert records[0]["target_path_class"] == "*.txt"
+    # shell_exec has no path class, and the raw command text is never logged
+    # (the sink only ever emits the redaction-safe field set — see log_action).
+    assert records[1]["target_path_class"] is None
+    assert "echo hi" not in caplog.text
 
 
 async def test_synthetic_secret_never_appears_in_log(caplog):
@@ -88,8 +92,54 @@ async def test_failed_calls_are_still_logged_and_ids_correlate(caplog):
     assert result.isError
     records = _log_records(caplog)
     assert len(records) == 1
-    logged_id = records[0]["action"]["id"]
+    logged_id = records[0]["id"]
     # The denial the agent sees carries the same action id as the log line.
     match = re.search(r"action id: ([0-9a-f]+)", result.content[0].text)
     assert match is not None
     assert match.group(1) == logged_id
+
+
+def test_short_unshaped_secret_under_non_sensitive_key_never_logged(caplog):
+    """The critical proof: log_action must not depend on normalize()'s redactor.
+
+    normalize()'s ``_redact_value`` is a length/shape heuristic stopgap — a
+    short, unshaped secret under a non-sensitive argument key (e.g.
+    ``content="db_password=..."``) passes through ``raw_args_redacted``
+    completely unredacted. Before this fix, ``log_action`` logged
+    ``action.model_dump()`` (which includes ``raw_args_redacted``), so a
+    routine PASS could write that secret to the interception log in
+    cleartext. This test fails on the old code and passes on the new.
+    """
+    caplog.set_level(logging.INFO, logger=LOGGER_NAME)
+    secret_value = "db_password=Tr0ub4dor&3"  # noqa: S105 — synthetic test value
+    action = normalize("write_file", {"content": secret_value, "path": "config.env"})
+    # Sanity-check the premise: the heuristic redactor really did let this
+    # secret through unredacted (otherwise this test would prove nothing).
+    assert action.raw_args_redacted["content"] == secret_value
+
+    interception_log.log_action(action, Verdict.PASS)
+
+    assert "db_password" not in caplog.text
+    assert "Tr0ub4dor" not in caplog.text
+
+    records = _log_records(caplog)
+    assert len(records) == 1
+    record = records[0]
+    assert record["event"] == "tool_call_intercepted"
+    assert record["verdict"] == "PASS"
+    assert record["action_type"] == "file_write"
+    assert record["tool_name"] == "write_file"
+    assert record["target_path_class"] == "*.env"
+    assert "raw_args_redacted" not in record
+    assert "target" not in record
+
+
+def test_secret_shaped_value_never_logged(caplog):
+    """Regression guard: a secret-SHAPED value is also absent from the log."""
+    caplog.set_level(logging.INFO, logger=LOGGER_NAME)
+    secret_value = "AKIA" + "1234567890ABCDEF"  # noqa: S105 — synthetic test value
+    action = normalize("write_file", {"token": secret_value, "path": "a.txt"})
+
+    interception_log.log_action(action, Verdict.PASS)
+
+    assert secret_value not in caplog.text


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: security fix (out-of-band) — interception-log secret exposure
- Plan reference: n/a (Prime Directive #3 violation found in existing code, not a plan slice)

## What this PR does

**CRITICAL — Prime Directive #3 (never expose secrets).** `proxy/interception_log.py::log_action`
logged `action.model_dump(mode="json")` — the **full** `SecurityObject`, including
`raw_args_redacted` and the raw `target` — for **every** intercepted tool call, on every
verdict including a plain `PASS`.

`normalize()`'s redactor (`proxy/normalize.py::_redact_value`) is a length/shape heuristic
stopgap, not a guarantee: a string value that (a) isn't under a sensitive-looking key name,
(b) is under 256 chars, and (c) doesn't match one of five narrow secret shapes (AWS/GH/PEM/
sk-/long-unbroken-token) passes through **unchanged**. So a routine call like
`write_file(content="db_password=Tr0ub4dor&3", path="config.env")` put the secret straight
into `raw_args_redacted["content"]`, and `log_action` wrote it to the `doberman.interception`
log **in cleartext** — no error, no attacker required, just normal use.

### The fix
`log_action` no longer dumps the whole `SecurityObject`. It now emits a curated,
redaction-safe field set only — mirroring `storage/log.py::build_record`'s discipline:
`event`, `verdict`, `id`, `ts`, `agent_role`, `action_type`, `source_context`, `tool_name`,
the redacted path **class** (via `storage.log._path_class`, reused rather than
reimplemented so the two log sinks can't drift apart), `risk`, and `action.metadata`
(confirmed, by auditing every `SecurityObject(...)` construction site, to only ever hold
safe scalars — `target_count` / a reason-code list — never raw call content; note this is
a *different* dict from `EvalContext.metadata["raw_arguments"]`, which is explicitly
in-memory-only and never logged).

**Never included:** `raw_args_redacted`, the raw `target`, the raw `external_destination`.

This is a pure narrowing of what gets logged — raise-only, no behavior change to any
decision/verdict path.

## Tests added (run in CI)
- `tests/integration/test_interception_log.py::test_short_unshaped_secret_under_non_sensitive_key_never_logged` —
  **the critical proof.** Builds a realistic action via `normalize("write_file", {"content": "db_password=Tr0ub4dor&3", "path": "config.env"})`,
  asserts the premise (the heuristic redactor really did let it through unredacted in
  `raw_args_redacted`), then calls `log_action(..., Verdict.PASS)` and asserts neither
  `"db_password"` nor `"Tr0ub4dor"` appear anywhere in the captured log text. Confirmed to
  **fail on the pre-fix code** (reverted locally and re-ran: it fails, logging the secret in
  cleartext) and **pass on the fix**.
- `tests/integration/test_interception_log.py::test_secret_shaped_value_never_logged` —
  regression guard for a shape-matched secret (`AKIA...`).
- `tests/integration/test_interception_log.py::test_one_valid_json_line_per_call_with_action_id` —
  reconciled: the old assertions read the leaky `record["action"][...]` nested shape
  (including asserting the *raw* shell command `"echo hi"` was logged as `target`); updated
  to the new flat, redaction-safe shape, and **strengthened** the shell_exec case to assert
  the raw command text is *absent* from the log (it has no path class either).
- `test_failed_calls_are_still_logged_and_ids_correlate` — reconciled `record["action"]["id"]` to `record["id"]`.

No other test in the repo references `log_action`'s output shape (checked via a project-wide
grep for `model_dump`/`tool_call_intercepted`/`log_action`/`raw_args_redacted`).

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed (no enterprise touched)

## Security checklist
- [x] Fails closed on error / uncertainty (unchanged: `log_action`'s existing best-effort try/except + `_LOG_FAILED_LINE` fallback preserved as-is)
- [x] No secret, full file, or unredacted prompt logged or committed — this PR's entire purpose
- [x] Raise-only (this PR only *removes* over-exposed fields from the log; no field newly added is unsafe)
- [x] N/A — this sink doesn't carry reason codes/explanations (that's the decision log, `storage/log.py`, already redaction-safe and untouched)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- **Path deviation from the original task packet:** the packet referenced `tests/unit/test_interception_log.py`;
  the actual (only) file by that name lives at `tests/integration/test_interception_log.py` — confirmed via
  repo-wide search, and its content/assertions matched the packet's description exactly (nested `record["action"][...]`
  shape). Edited that file in place rather than creating a redundant `tests/unit/` copy.
- **`action.target_path_class` is not pre-populated:** `normalize()` never sets it (always `None` on a
  freshly normalized action) — the actual redacted-class computation lives in `storage/log.py::_path_class`,
  which falls back to computing the class from `action.target` + `action.action_type`. Reused that function
  (import, no modification to `storage/log.py`) rather than reimplementing the same logic a second time, to
  avoid the two log sinks silently drifting apart in what counts as "redacted."
- **`action.metadata` inclusion:** audited every `SecurityObject(...)` construction (only in `normalize.py`)
  to confirm it only ever holds `{}`, `{"target_count": int}`, or `{"reason_codes": [...]}` — never raw
  argument content — before including it in the safe field set.
- Risk / tech debt: none introduced. The underlying heuristic redactor gap in `normalize()` is untouched
  (separate, larger fix — tracked as a follow-up: harden the redactor / wire the real secret-detection rule
  as the actual root cause; this PR fixes the sink that was writing the leak to disk).
