### PR TITLE
docs(contributing): add contributor onboarding guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to Doberman
+
+Doberman is an Apache-2.0 project for AI-agent runtime authorization. This guide
+gets you from a fresh clone to the same checks CI runs. `AGENTS.md` and
+`CLAUDE.md` remain the operating manual and source of truth for project
+invariants.
+
+## Local setup
+
+```bash
+git clone https://github.com/fu351/Doberman-Core.git
+cd Doberman-Core
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev]"
+```
+
+## Run the checks
+
+Run these before opening a PR:
+
+```bash
+ruff check .
+ruff format --check .
+lint-imports
+pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+```
+
+CI also verifies that `doberman-core` builds and tests without the private
+enterprise package installed, then runs the same ruff, import-linter, pytest,
+and secret-scan workflow.
+
+## Architecture in five lines
+
+1. A tool call enters Doberman through the MCP proxy or host-hook path.
+2. The call is normalized into a `SecurityObject`.
+3. The decision engine runs objective and adaptive guardrails.
+4. Guardrail verdicts merge through raise-only `combine()`.
+5. The execution gate returns PASS / AUTH / BLOCK: allow, authenticate, or block.
+
+## Invariants
+
+Every change must preserve these two safety properties:
+
+- **Fail closed** - on any error, uncertainty, or unhandled case, deny or
+  `BLOCK`; a protected agent must not reach a tool around Doberman.
+- **Raise-only** - guardrails may auto-tighten, but may never silently loosen.
+  Any permanent weakening goes through the human-gated policy path.
+
+Also keep secrets out of commits, logs, fixtures, and PR examples. Redacted
+metadata, classifications, and fingerprints are fine; raw secrets are not.
+
+## Workflow
+
+- Start from current `main` and make one focused slice per PR.
+- Use the existing branch pattern: `feat/<feature>/<slice>`, `fix/...`, or
+  `chore/...`.
+- Use Conventional Commits, such as `fix(hosthooks): block control-plane writes`
+  or `docs(contributing): add onboarding guide`.
+- Tests travel with the code, and docs or README updates travel with behavior
+  changes.
+- Fill out the PR template, including the public-release safety and security
+  checklists.
+- Note any AI assistance in the PR description.
+
+## Pick a first task
+
+Start with the
+[`good first issue`](https://github.com/fu351/Doberman-Core/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+or
+[`help wanted`](https://github.com/fu351/Doberman-Core/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+labels. Good first PRs are usually narrow docs, tests, or guardrail hardening
+changes with a clear issue to close.

--- a/README.md
+++ b/README.md
@@ -431,6 +431,13 @@ Doberman is **defense-in-depth, not airtight** — no single rule is a guarantee
 
 ---
 
+## Contributing
+
+Start with [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, CI checks, project
+invariants, and the PR workflow.
+
+---
+
 ## License
 
 Apache-2.0. The core is genuinely standalone — no proprietary dependency, ever (CI-enforced).


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: #90 - contributor onboarding docs
- Plan reference: #90

## What this PR does
- Adds a root `CONTRIBUTING.md` distilled from `AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTORS.md`, `pyproject.toml`, and CI.
- Covers clone-to-green setup, CI-equivalent local checks, the short architecture tour, fail-closed / raise-only invariants, PR workflow, and first-task labels.
- Links the guide from the README.

Closes #90.

## Tests added (run in CI)
- None; docs-only change.
- Local validation run:
  - `.venv/bin/python -m pip install -e ".[dev]"`
  - `git diff --check`
  - `.venv/bin/ruff check .`
  - `.venv/bin/ruff format --check .`
  - `.venv/bin/lint-imports`
  - `.venv/bin/pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80` (1599 passed, 2 skipped, 91.38% coverage)

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (docs-only; no runtime decision path changed)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (docs-only; no guardrail or learning behavior changed)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (docs-only; no BLOCK/AUTH rendering changed)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Edge cases covered: README now links the guide; the guide names the exact local setup, CI checks, invariants, branch/commit workflow, and first-task labels requested in #90.
- Deviations from plan: none.
- Risks introduced: none expected; documentation-only.

AI assistance disclosure: prepared with AI assistance from Codex.