### PR TITLE
feat(dash): localhost dashboard skeleton with per-run token auth (D1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,19 @@ doberman scan   # discover local MCP capabilities and build a risk map
 
 Basic protection works immediately out of the box. Pick a strength mode to match your risk tolerance.
 
+### 6. Dashboard (preview)
+
+```bash
+pip install "doberman-core[dash]"   # optional extra: starlette + uvicorn
+doberman dash                       # prints a URL, e.g. http://127.0.0.1:8642/?token=...
+```
+
+A localhost-only web dashboard, off by default. Binds to `127.0.0.1` only (never a public
+interface) and generates a fresh, single-use token for that run — open the printed URL to
+connect; every API call is authenticated with that token. This preview slice is the serving
+skeleton only (an empty shell that confirms it's connected); the live decision feed, summary
+stats, and approve/deny actions land in upcoming versions.
+
 ---
 
 ## Verify it end-to-end (real downstream, no fakes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter", "textual", "hypothesis"]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff", "import-linter", "textual", "hypothesis", "starlette", "uvicorn", "httpx"]
 explain = ["anthropic"]
 tui = ["textual"]
+dash = ["starlette", "uvicorn"]
 
 [project.scripts]
 doberman = "doberman.cli.main:app"
@@ -100,7 +101,7 @@ include_external_packages = true
 name = "Policy core must not depend on an invocation adapter"
 type = "forbidden"
 source_modules = ["doberman.engine", "doberman.roles", "doberman.policy", "doberman.storage", "doberman.auth", "doberman.subjective"]
-forbidden_modules = ["doberman.proxy", "doberman.hosthooks"]
+forbidden_modules = ["doberman.proxy", "doberman.hosthooks", "doberman.dash"]
 
 # Cross-repo boundary: the public core must never import the private enterprise package.
 # NOTE: defense-in-depth only — enterprise is never installed in core CI, so this contract

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -10,6 +10,7 @@ import asyncio
 import importlib.util
 import json
 import logging
+import secrets
 import sys
 from datetime import datetime, timezone
 
@@ -649,6 +650,38 @@ def tui(
     from doberman.tui import run_tui
 
     run_tui(path)
+
+
+_DASH_HOST = "127.0.0.1"
+_DASH_DEFAULT_PORT = 8642
+
+
+@app.command()
+def dash(
+    port: int = typer.Option(_DASH_DEFAULT_PORT, "--port", help="Port to bind the dashboard to."),
+) -> None:
+    """Launch the local dashboard (preview) - a localhost-only control surface.
+
+    Binds to 127.0.0.1 only, never a public interface. A fresh, single-use
+    token is generated for this run and embedded in the printed URL; every API
+    route requires it as a bearer token, checked in constant time. Requires the
+    optional 'dash' extra; the live feed, stats, and approve/deny actions land
+    in later slices.
+    """
+    try:
+        import uvicorn
+
+        from doberman.dash import create_app
+    except ImportError as exc:
+        typer.echo(
+            'The dashboard requires the optional "dash" extra: pip install "doberman-core[dash]"',
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
+
+    token = secrets.token_urlsafe(32)
+    typer.echo(f"Dashboard: http://{_DASH_HOST}:{port}/?token={token}")
+    uvicorn.run(create_app(token), host=_DASH_HOST, port=port)
 
 
 @app.command()

--- a/src/doberman/dash/__init__.py
+++ b/src/doberman/dash/__init__.py
@@ -1,0 +1,15 @@
+"""Local dashboard (preview) - a localhost-only control surface for Doberman.
+
+D1 (this slice) is the serving skeleton: an app factory, bearer-token auth,
+and a single inline HTML shell. Later slices add the live decision feed
+(SSE), summary stats, and approve/deny actions.
+
+Only ever imported lazily, from the ``doberman dash`` CLI command - never at
+module scope elsewhere - so ``import doberman`` and the rest of the CLI keep
+working with the optional ``dash`` extra (``starlette``, ``uvicorn``) not
+installed.
+"""
+
+from doberman.dash.app import create_app
+
+__all__ = ["create_app"]

--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -1,0 +1,131 @@
+"""Starlette app factory for the local dashboard (D1: serving skeleton only).
+
+Binds to ``127.0.0.1`` only; the ``doberman dash`` CLI command hands in a
+per-run bearer token generated with ``secrets.token_urlsafe(32)``. ``GET /``
+(the inline HTML shell) carries no data and is served without auth; every
+``/api/*`` route requires ``Authorization: Bearer <token>``, checked with
+``hmac.compare_digest`` (constant-time, avoids a timing side-channel), else
+401. No cookies are ever set - there is no CSRF surface.
+
+This module (and the ``doberman.dash`` package) is only ever imported lazily
+from the ``dash`` CLI command, never at module scope elsewhere, so ``import
+doberman`` and the rest of the CLI keep working with the optional ``dash``
+extra (``starlette``, ``uvicorn``) not installed - see
+``tests/unit/test_dash_serve.py`` and the import-linter contract forbidding
+the policy core from importing ``doberman.dash``.
+
+Later slices add the live decision feed (SSE), summary stats, and
+approve/deny actions; D1 is the skeleton only.
+"""
+
+from __future__ import annotations
+
+import hmac
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse, Response
+from starlette.routing import Route
+
+_BEARER_PREFIX = "Bearer "
+
+# ponytail: one inline page, no build toolchain - real UI lands in a later slice.
+_HTML_SHELL = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Doberman Dashboard</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root { color-scheme: dark light; }
+  body {
+    margin: 0; padding: 2rem; min-height: 100vh; box-sizing: border-box;
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: #0b0d10; color: #e6e6e6;
+  }
+  @media (prefers-color-scheme: light) {
+    body { background: #f7f7f8; color: #111; }
+  }
+  h1 { font-size: 1.1rem; font-weight: 600; margin: 0 0 1rem; }
+  #status { display: inline-flex; align-items: center; gap: .5rem; font-size: .9rem; }
+  .dot { width: .6rem; height: .6rem; border-radius: 50%; background: #888; flex: none; }
+  .dot.ok { background: #3fb950; }
+  .dot.err { background: #f85149; }
+</style>
+</head>
+<body>
+  <h1>Doberman Dashboard (preview)</h1>
+  <div id="status"><span class="dot" id="dot"></span><span id="label">connecting...</span></div>
+  <script>
+    (function () {
+      var params = new URLSearchParams(window.location.search);
+      var token = params.get("token") || "";
+      // Strip the token from the URL/history immediately so it never lingers
+      // in browser history, a referrer header, or a screen share. It is kept
+      // only in this closure's memory for the life of the page.
+      params.delete("token");
+      var clean = window.location.pathname
+        + (params.toString() ? "?" + params.toString() : "");
+      window.history.replaceState({}, document.title, clean);
+
+      var dot = document.getElementById("dot");
+      var label = document.getElementById("label");
+
+      fetch("/api/health", { headers: { "Authorization": "Bearer " + token } })
+        .then(function (res) {
+          if (!res.ok) { throw new Error("status " + res.status); }
+          return res.json();
+        })
+        .then(function () {
+          dot.className = "dot ok";
+          label.textContent = "connected";
+        })
+        .catch(function () {
+          dot.className = "dot err";
+          label.textContent = "not connected";
+        });
+    })();
+  </script>
+</body>
+</html>
+"""
+
+
+def _unauthorized() -> JSONResponse:
+    return JSONResponse({"error": "unauthorized"}, status_code=401)
+
+
+def _token_matches(request: Request, token: str) -> bool:
+    header = request.headers.get("authorization", "")
+    if not header.startswith(_BEARER_PREFIX):
+        return False
+    supplied = header[len(_BEARER_PREFIX) :]
+    return hmac.compare_digest(supplied, token)
+
+
+async def _index(request: Request) -> Response:
+    # No auth: the shell carries no data, only the JS that reads the token
+    # back out of its own URL and calls the authenticated API routes.
+    return HTMLResponse(_HTML_SHELL)
+
+
+def _make_health_route(token: str) -> Route:
+    async def health(request: Request) -> Response:
+        if not _token_matches(request, token):
+            return _unauthorized()
+        return JSONResponse({"status": "ok"})
+
+    return Route("/api/health", health)
+
+
+def create_app(token: str) -> Starlette:
+    """Build the dashboard's Starlette app, bound to one per-run ``token``.
+
+    ``GET /`` is unauthenticated (no data). Every ``/api/*`` route requires
+    the bearer token, checked in constant time.
+    """
+    routes = [
+        Route("/", _index),
+        _make_health_route(token),
+    ]
+    return Starlette(routes=routes)

--- a/tests/unit/test_dash_serve.py
+++ b/tests/unit/test_dash_serve.py
@@ -1,0 +1,104 @@
+"""Unit tests for the D1 dashboard serving skeleton (``doberman.dash``).
+
+D1 is the serving skeleton only: an app factory, bearer-token auth, and the
+inline HTML shell (no feed/stats/approve-deny yet - those are later slices).
+Covers:
+
+* the lazy-import guarantee: importing ``doberman`` (and the CLI module)
+  never pulls in ``doberman.dash`` or ``starlette``;
+* API auth: missing token -> 401, wrong token -> 401, correct token -> 200;
+* the HTML shell (``GET /``) is served without auth and carries no token
+  value;
+* the CLI ``dash`` command's friendly install-hint + non-zero exit when the
+  optional 'dash' extra is missing;
+* the serve entry point binds to 127.0.0.1 only (no real socket is bound).
+"""
+
+import subprocess
+import sys
+
+import pytest
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_importing_doberman_never_pulls_in_dash_or_starlette():
+    # Run in a fresh interpreter: order-independent of every other test below,
+    # which legitimately imports doberman.dash / starlette for the app tests.
+    code = (
+        "import sys; "
+        "import doberman; "
+        "import doberman.cli.main; "
+        "assert 'doberman.dash' not in sys.modules; "
+        "assert 'starlette' not in sys.modules"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True, timeout=60)  # noqa: S603
+
+
+# --------------------------------------------------------------------------
+# Everything below imports doberman.dash / starlette directly - fine, this
+# process is not the one the lazy-import guarantee above is checking.
+# --------------------------------------------------------------------------
+
+from starlette.testclient import TestClient  # noqa: E402
+
+from doberman.dash.app import create_app  # noqa: E402
+
+_TOKEN = "test-dash-token-0123456789"  # noqa: S105 - fixture value, not a real secret
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(create_app(_TOKEN))
+
+
+def test_health_without_token_is_401(client: TestClient):
+    resp = client.get("/api/health")
+    assert resp.status_code == 401
+
+
+def test_health_with_wrong_token_is_401(client: TestClient):
+    resp = client.get("/api/health", headers={"Authorization": "Bearer nope"})
+    assert resp.status_code == 401
+
+
+def test_health_with_malformed_auth_header_is_401(client: TestClient):
+    # No "Bearer " prefix at all.
+    resp = client.get("/api/health", headers={"Authorization": _TOKEN})
+    assert resp.status_code == 401
+
+
+def test_health_with_correct_token_is_200(client: TestClient):
+    resp = client.get("/api/health", headers={"Authorization": f"Bearer {_TOKEN}"})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_index_serves_html_shell_without_auth(client: TestClient):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    # The shell carries no data - in particular, never the token value.
+    assert _TOKEN not in resp.text
+
+
+def test_cli_dash_missing_extra_exits_nonzero_with_install_hint(monkeypatch):
+    from doberman.cli.main import app as cli_app
+
+    # Simulate the optional 'dash' extra not being installed: a None entry in
+    # sys.modules makes any import of that dotted path raise ImportError.
+    monkeypatch.setitem(sys.modules, "doberman.dash", None)
+
+    result = runner.invoke(cli_app, ["dash"])
+
+    assert result.exit_code != 0
+    assert 'pip install "doberman-core[dash]"' in result.stderr
+
+
+def test_dash_binds_localhost_only():
+    from doberman.cli import main as cli_main
+
+    # Assert the constant the `dash` command passes to uvicorn.run - never
+    # actually bind a socket in a test.
+    assert cli_main._DASH_HOST == "127.0.0.1"


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: D1 — Dashboard MVP: serving skeleton + auth
- Plan reference: doberman_core_plan.md

## What this PR does

Adds the serving skeleton for the local (localhost-only) dashboard:
- `src/doberman/dash/app.py`: a Starlette app factory (`create_app(token)`), bearer-token
  auth checked with `hmac.compare_digest` on every `/api/*` route (D1 has just `/api/health`),
  and a single inline HTML shell (vanilla JS, no build toolchain, dark-friendly) served
  unauthenticated at `GET /` (it carries no data).
- `src/doberman/cli/main.py`: new `doberman dash [--port]` command. Binds `127.0.0.1` only,
  generates a per-run `secrets.token_urlsafe(32)` token, prints
  `http://127.0.0.1:<port>/?token=<token>`, and calls `uvicorn.run(...)`. Lazy-imports
  `doberman.dash`/`uvicorn` inside the function body; on `ImportError` prints an install hint
  (`pip install "doberman-core[dash]"`) and exits non-zero.
- `pyproject.toml`: new optional extra `dash = ["starlette", "uvicorn"]` (core install stays
  free of it); added `starlette`/`uvicorn`/`httpx` to `dev` so CI can exercise the app via
  Starlette TestClient; added `doberman.dash` to the existing import-linter forbidden
  contract (the policy core must not depend on it, alongside `doberman.proxy`/`doberman.hosthooks`).
- `README.md`: new "Dashboard (preview)" section (install extra, `doberman dash`,
  localhost-only + per-run token, feed/stats/approve-deny noted as landing later).

The inline JS reads the token from its own URL, strips it immediately via
`history.replaceState`, keeps it only in JS memory, and calls `/api/health` with it as a
bearer header to show a connected/not-connected state. No cookies are ever set, so there is
no CSRF surface.

## Tests added (run in CI)
- `tests/unit/test_dash_serve.py`:
  - `test_importing_doberman_never_pulls_in_dash_or_starlette` (subprocess check that
    `import doberman` / `import doberman.cli.main` never import `doberman.dash` or `starlette`)
  - `test_health_without_token_is_401`, `test_health_with_wrong_token_is_401`,
    `test_health_with_malformed_auth_header_is_401`, `test_health_with_correct_token_is_200`
    (API auth via Starlette TestClient)
  - `test_index_serves_html_shell_without_auth` (`GET /` needs no auth and never contains
    the token value)
  - `test_cli_dash_missing_extra_exits_nonzero_with_install_hint` (simulates the `dash`
    extra missing via `sys.modules["doberman.dash"] = None`, using Typer CliRunner; asserts
    non-zero exit and the install hint on stderr)
  - `test_dash_binds_localhost_only` (asserts the 127.0.0.1 host constant, no real bind)
- Existing `tests/unit/test_core_is_standalone.py` re-run unchanged (still green).

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code (starlette/uvicorn are permissively licensed)
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (missing/wrong/malformed token gives 401; a missing extra exits 1, never a traceback)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — N/A, no guardrail/learning logic in this slice
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — N/A, this slice is dashboard serving/auth, not a decision-path guardrail
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Edge cases: missing bearer header, wrong token, malformed header (no "Bearer " prefix), HTML shell containing no token value, CLI missing the optional extra.
- Deviations: none from the D1 design brief.
- Risks / notes: Starlette TestClient currently emits a deprecation warning recommending an
  alternate httpx-compatible package for testing; non-fatal, all tests pass; flagged for a
  future dependency bump, out of scope for D1. No browser auto-open is implemented (the CLI
  only prints the URL); kept minimal per the D1 brief.
