### PR TITLE
feat(dash): interactive AUTH approve/deny via DB-mediated queue (D3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,8 +326,21 @@ current mode + effective enforcement — `GET /api/stats`) and a **scrolling liv
 streams new ones as they're recorded. Both are read-only and serve only already-redacted decision-
 log fields (verdict, action type, path *class*, reason codes, timestamp) — never a raw target,
 argument, or secret. `EventSource` can't set request headers, so the feed also accepts the token
-as `?token=` (loopback-only + single-run token keeps this sound). Approve/deny actions and visual
-polish land in upcoming versions.
+as `?token=` (loopback-only + single-run token keeps this sound).
+
+**Interactive AUTH approve/deny.** An `AUTH` challenge can now be answered from the dashboard
+instead of the terminal: `GET /api/pending` lists redacted pending approvals (action type, risk,
+reason codes, human explanation, path *class* — never a raw target or secret) and
+`POST /api/resolve/{id}` (body `{"decision": "approved"|"denied", "totp_code"?}`) answers one.
+Resolution is a single-use, race-safe state transition (`UPDATE ... WHERE status='pending'`) —
+two concurrent resolves of the same row can never both win, and a resolved/expired row 409s.
+The dashboard never verifies a TOTP code itself: it only relays the human's decision (and, for
+tiers that need one, the code) back to the *existing* auth-challenge machinery running in the
+decision path, which performs the real verification unchanged. The channel engages only while a
+dashboard's liveness heartbeat is fresh (< 5s old); a stale or missing heartbeat, or an
+unanswered approval, falls back to the next channel (MCP elicitation → GUI dialog → terminal)
+with no added latency and no denial invented on the dashboard's behalf. Visual polish lands in
+upcoming versions.
 
 ---
 
@@ -456,6 +469,7 @@ The adaptive layer's four SL5 "care" weights (`confidentiality`, `reversibility`
 - ✅ **Security hardening (H1):** the MCP proxy's `normalize()` redaction no longer relies solely on its own length/shape stopgap — it now also runs the canonical shared secret detector (`doberman.engine.rules.secrets`, the same one that drives `secret_exfiltration`), layered strictly ON TOP of the stopgap so coverage can only widen, never narrow (Azure/GCP/Stripe/SendGrid/npm/JWT/DB-URI/env-assignment shapes the old stopgap missed are now redacted too). The proxy's `_call_tool` handler is also now wrapped end-to-end: any unexpected exception escaping `decide_and_execute` returns a fail-closed error naming only a reason code and the exception's class — never the exception's own message or a raw argument fragment — closing the last gap where an unhandled error could have leaked call content back to the agent
 - ✅ **Turn gate (Feature 11):** a second, pre-inference invocation point (`doberman.turngate`) that judges the user's *turn* — prompt plus attached/pasted/tool-fetched content — before a single inference token is spent. Tier 0 deterministic signatures (instruction nullification, authority override, secret export, encoded payload) hard-block on an issue-vs-mention + origin discrimination (untrusted-origin match always blocks; a typed *mention* steps up instead of blocking); Tier 1 heuristic classes (embedded pasted instructions, persona override, obfuscation, urgency+secrecy framing) are AUTH-only and structurally block-incapable; a stylometric co-occurrence gate steps up only when an extreme per-entity style outlier coincides with a sensitive apparent intent, never on style alone; a repeat-after-block escape hatch scales the re-challenge to the original block (Tier 0 → 2FA) with single-use approval and a third-attempt lockout. Released turns tag-and-pass a bounded, raise-only `TurnContext` into the action stage (a flagged turn's follow-on actions score harsher; flagged pasted segments inherit `provenance: untrusted_data`). The turn gate is additive and an efficiency/early-warning layer only — the action gate above remains the safety guarantee, and with no host pre-inference hook or `DOBERMAN_TURN_GATE=off` it is simply absent.
 - ✅ **Turn gate boundary:** the import-linter contract now forbids the policy core from importing **either** invocation adapter (`doberman.proxy`, `doberman.turngate`) — the turn gate stays a pure adapter, injected into the engine like the proxy, never a static dependency of it.
+- ✅ Dashboard, interactive AUTH approve/deny (D3): a `pending_approvals` queue mediates between the decision path and the dashboard purely through SQLite — never HTTP into the decision path. `DashboardPrompter` implements the existing `Prompter` interface, engaging the queue only while a liveness heartbeat is fresh; a stale/missing heartbeat, an unanswered approval, or a poll timeout all fall back to the next channel (elicitation → GUI → terminal) with zero added latency and no denial invented on the dashboard's behalf. Resolution is a single-use, race-safe `UPDATE ... WHERE status='pending'` transition (a resolved/expired row 409s), and the dashboard only ever relays a decision (plus, for 2FA tiers, a code) — verification stays entirely in the decision-path process via the existing TOTP check. Pending rows carry only already-redacted fields (action type, risk, reason codes, explanation, path class) — never a raw target or secret
 - 📋 Host-harness, continued (containment architecture): deeper Bash-command egress parsing · entropy-on-egress escalation · warm-daemon adaptive layer · honeytoken tripwire + session circuit-breaker
 - 🛠 Cost observability — **CB.1 + CB.2 landed**: a redaction-safe `CostEvent` + local append-only meter (`doberman.storage.cost`), advisory and strictly off the decision path; plus a `CostObserver` plugin seam (`doberman.cost_observers` entry-point group) — observers receive a copy of every recorded event, are isolated (a raising observer is logged and skipped, never breaks the record path), and can never alter a verdict. Next: raise-only loop-anomaly detector (CB.3)
 - 📋 Enterprise platform: centralized control plane, dashboards, org policy, SSO/RBAC

--- a/src/doberman/auth/challenge.py
+++ b/src/doberman/auth/challenge.py
@@ -20,6 +20,7 @@ generic "enter 2FA". Any timeout, input error, or denial yields a non-approved
 :func:`select_tier` rejects a non-``AUTH`` decision.
 """
 
+import contextvars
 from enum import StrEnum
 from typing import Protocol
 
@@ -123,6 +124,30 @@ class AuthResult(BaseModel):
     elevation_id: str | None = None
 
 
+#: The (decision, action, tier) of the challenge currently running on this
+#: thread/task, if any — see :func:`current_challenge`.
+_current_challenge: contextvars.ContextVar[tuple[Decision, SecurityObject, AuthTier] | None] = (
+    contextvars.ContextVar("_current_challenge", default=None)
+)
+
+
+def current_challenge() -> tuple[Decision, SecurityObject, AuthTier] | None:
+    """The real ``(decision, action, tier)`` of the challenge in progress here.
+
+    Lets a :class:`Prompter` (e.g. the dashboard's ``DashboardPrompter``) derive
+    redaction-safe display fields (risk, reason codes, explanation, path class)
+    straight from the typed objects instead of parsing
+    :func:`~doberman.auth.provider._challenge_message`'s free-text string, which
+    embeds the raw target and is unsafe to persist. ``None`` outside a challenge.
+
+    Set only for the duration of :func:`run_auth_challenge` on the calling
+    thread/task; ``asyncio.to_thread`` propagates the current
+    ``contextvars.Context`` into its worker thread, so a prompter running there
+    (as the proxy's auth challenge does) still sees it.
+    """
+    return _current_challenge.get()
+
+
 def run_auth_challenge(
     decision: Decision,
     action: SecurityObject,
@@ -141,4 +166,8 @@ def run_auth_challenge(
     from doberman.auth.provider import active_provider
 
     tier = select_tier(decision)
-    return active_provider().authenticate(decision, action, tier, prompter=prompter, at=at)
+    token = _current_challenge.set((decision, action, tier))
+    try:
+        return active_provider().authenticate(decision, action, tier, prompter=prompter, at=at)
+    finally:
+        _current_challenge.reset(token)

--- a/src/doberman/auth/dashboard_prompter.py
+++ b/src/doberman/auth/dashboard_prompter.py
@@ -1,0 +1,131 @@
+"""``DashboardPrompter`` — the dashboard channel in the MCP-proxy auth chain (D3).
+
+Implements the existing :class:`~doberman.auth.challenge.Prompter` Protocol, so
+it slots into the same :class:`~doberman.auth.gui_prompter.FallbackPrompter`
+chain as :class:`~doberman.auth.gui_prompter.GuiPrompter`/``TtyPrompter`` with
+zero changes to the provider/challenge machinery. It never verifies anything
+itself (no TOTP logic here) — it only relays a human's decision (and, for
+tiers that need one, a TOTP code) from the dashboard's pending-approval queue
+back to :class:`~doberman.auth.provider.LocalAuthProvider._run_tier`, which
+runs the EXISTING verification (:func:`doberman.auth.totp.verify`) unchanged.
+
+Two things gate whether this channel engages at all, both fail-open to the
+next channel (never a hang, never an invented answer):
+
+* **Heartbeat freshness** — a dashboard process not running (or stuck) has a
+  stale/missing heartbeat; :meth:`confirm` then raises
+  :class:`~doberman.auth.gui_prompter.PrompterUnavailableError` immediately,
+  with zero added latency, so GUI/TTY get the challenge instead.
+* **Poll timeout** — a heartbeat can be fresh (the dash *server* is alive)
+  while nobody is watching the browser tab. Deliberate divergence from
+  :class:`FallbackPrompter`'s general convention (a channel timeout is normally
+  final, not a fall-through — see ``gui_prompter.py``'s docstring): here a
+  dashboard timeout SHOULD still let a human at the terminal/GUI answer, so it
+  also raises ``PrompterUnavailableError`` rather than propagating as a denial.
+"""
+
+import asyncio
+import threading
+from datetime import datetime, timezone
+
+from doberman.auth.challenge import current_challenge
+from doberman.auth.gui_prompter import PrompterUnavailableError
+from doberman.storage import approvals
+from doberman.storage.heartbeat import DEFAULT_HEARTBEAT_MAX_AGE_S, heartbeat_is_fresh
+from doberman.storage.log import path_class
+
+#: How often to poll the pending row while waiting for a human decision.
+DEFAULT_POLL_INTERVAL_S = 1.0
+
+#: How long to wait for a decision before falling back to the next channel.
+DEFAULT_TIMEOUT_S = 90.0
+
+# ponytail: one thread-local slot for the TOTP code a resolved row carried,
+# plus a flag for whether THIS channel actually answered confirm(). _run_tier
+# always calls confirm() then (for 2FA tiers) read_code() next, on the same
+# thread doing the challenge - a per-thread stash is enough to hand the code
+# across those two calls without changing the Prompter signatures. The flag
+# matters for FallbackPrompter: confirm() and read_code() are dispatched as
+# TWO SEPARATE calls through the chain, so if confirm() fell back (stale
+# heartbeat / no challenge context / timeout), read_code() must ALSO raise
+# PrompterUnavailableError - not EOFError - so the chain tries the next
+# channel's read_code() instead of treating a channel this prompter never
+# engaged as a final "no code entered" denial.
+_last_code = threading.local()
+_engaged = threading.local()
+
+
+class DashboardPrompter:
+    """Queue an approval into the dashboard; fall back if it's not answered there."""
+
+    def __init__(
+        self,
+        repo_root: str = ".",
+        *,
+        heartbeat_max_age_s: float = DEFAULT_HEARTBEAT_MAX_AGE_S,
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self._repo_root = repo_root
+        self._heartbeat_max_age_s = heartbeat_max_age_s
+        self._poll_interval_s = poll_interval_s
+        self._timeout_s = timeout_s
+
+    def confirm(self, message: str) -> bool:  # noqa: ARG002 - message unused; we build our own
+        _engaged.value = False  # reset: this thread may reuse the same prompter across challenges
+
+        if not heartbeat_is_fresh(self._repo_root, max_age_s=self._heartbeat_max_age_s):
+            raise PrompterUnavailableError("no live dashboard heartbeat")
+
+        challenge = current_challenge()
+        if challenge is None:
+            # No ContextVar set (e.g. called outside run_auth_challenge) - we
+            # have nothing redaction-safe to queue. Fall back rather than guess.
+            raise PrompterUnavailableError("no active challenge context for the dashboard")
+        decision, action, tier = challenge
+
+        approval_id = asyncio.run(
+            approvals.create_pending(
+                decision.action_id,
+                tier=tier.value,
+                action_type=action.action_type.value,
+                risk=decision.final_risk.value,
+                reason_codes=[rc.value for rc in decision.reason_codes],
+                explanation=decision.explanation,
+                target_path_class=path_class(action),
+                repo_root=self._repo_root,
+            )
+        )
+
+        deadline = datetime.now(timezone.utc).timestamp() + self._timeout_s
+        while datetime.now(timezone.utc).timestamp() < deadline:
+            row = asyncio.run(approvals.get_pending(approval_id, repo_root=self._repo_root))
+            if row is not None and row["status"] == "resolved":
+                _last_code.value = row.get("totp_code")
+                _engaged.value = True
+                return row["decision"] == "approved"
+            _sleep(self._poll_interval_s)
+
+        # Timed out with no human answer via the dashboard - NOT a denial: a
+        # stale/unattended dashboard must not silently deny a real human who
+        # can still answer at the terminal/GUI. See the module docstring.
+        raise PrompterUnavailableError("dashboard approval timed out with no response")
+
+    def read_code(self, message: str) -> str:  # noqa: ARG002 - code already collected in confirm()
+        if not getattr(_engaged, "value", False):
+            # confirm() never actually answered through THIS channel (stale
+            # heartbeat / no context / timeout) - read_code() must fall back
+            # too, not report a final "no code" denial for a channel that was
+            # never open. See the module docstring and the _engaged comment.
+            raise PrompterUnavailableError("dashboard did not answer this challenge")
+        code = getattr(_last_code, "value", None)
+        if not code:
+            raise EOFError("no TOTP code was supplied through the dashboard")
+        return code
+
+
+def _sleep(seconds: float) -> None:
+    """Broken out so tests can monkeypatch the wait without a real sleep."""
+    import time
+
+    time.sleep(seconds)

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -667,8 +667,11 @@ def dash(
     token is generated for this run and embedded in the printed URL; every API
     route requires it as a bearer token, checked in constant time. Reports the
     live decision feed, summary stats, mode, and enforcement state for
-    ``--path`` (default: the current repo). Requires the optional 'dash'
-    extra; approve/deny actions and polish land in later slices.
+    ``--path`` (default: the current repo), plus an interactive AUTH
+    approve/deny queue: a challenge on the decision path engages this
+    dashboard only while it is running (see the heartbeat below), and falls
+    back to the terminal/GUI otherwise. Requires the optional 'dash' extra;
+    polish lands in a later slice.
     """
     try:
         import uvicorn
@@ -680,6 +683,22 @@ def dash(
             err=True,
         )
         raise typer.Exit(code=1) from exc
+
+    import threading
+
+    from doberman.storage.heartbeat import touch_heartbeat
+
+    # ponytail: a daemon thread ticking a file mtime - simplest possible
+    # liveness signal the decision-path process can check without any IPC.
+    # Dies with the process; no explicit stop needed for a CLI-lifetime thread.
+    stop_heartbeat = threading.Event()
+
+    def _heartbeat_loop() -> None:
+        while not stop_heartbeat.is_set():
+            touch_heartbeat(path)
+            stop_heartbeat.wait(2.0)
+
+    threading.Thread(target=_heartbeat_loop, daemon=True).start()
 
     token = secrets.token_urlsafe(32)
     typer.echo(f"Dashboard: http://{_DASH_HOST}:{port}/?token={token}")

--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -26,7 +26,25 @@ decision log is redacted at write time - see ``doberman.storage.log``):
   server is loopback-only and the token is single-use per run (see
   ``_feed_token_matches``).
 
-D3 (approve/deny) and D5 (polish) are later slices - not built here.
+D3 adds the interactive AUTH approve/deny queue, mediated ENTIRELY through the
+local SQLite ``pending_approvals`` table (:mod:`doberman.storage.approvals`) -
+never HTTP into the decision path:
+
+* ``GET /api/pending`` - unexpired rows still awaiting a decision. Same
+  allow-listed, redaction-safe vocabulary as the D2 feed (action type, risk,
+  reason codes, the human explanation, path *class*, tier) - never a raw
+  target/argument/secret. Bearer token via header only (no query-param
+  fallback - this route isn't consumed by ``EventSource``).
+* ``POST /api/resolve/{id}`` - body ``{"decision": "approved"|"denied",
+  "totp_code": <str, optional>}``. Resolves the row via the same race-safe,
+  single-use ``UPDATE ... WHERE status='pending'`` :func:`doberman.storage.
+  approvals.resolve` used everywhere else; an already-resolved or expired row
+  -> 409. The dash server NEVER verifies the TOTP code itself - it only rides
+  along on the row back to the ``DashboardPrompter`` polling it on the
+  decision-path side, which feeds it through the EXISTING
+  :func:`doberman.auth.totp.verify`.
+
+D5 (polish) is a later slice - not built here.
 """
 
 from __future__ import annotations
@@ -42,7 +60,12 @@ from starlette.responses import HTMLResponse, JSONResponse, Response, StreamingR
 from starlette.routing import Route
 
 from doberman.dash.stats import build_stats, reason_codes
+from doberman.storage import approvals
 from doberman.storage.log import read_decisions, read_decisions_since
+
+#: Tiers whose challenge requires a TOTP code (mirrors
+#: ``LocalAuthProvider._run_tier``'s ``two_factor``/``role_elevation`` branch).
+_TOTP_TIERS = frozenset({"two_factor", "role_elevation"})
 
 _BEARER_PREFIX = "Bearer "
 #: Rows sent immediately on `/api/feed` connect, oldest-first, before live polling starts.
@@ -85,12 +108,36 @@ _HTML_SHELL = """<!doctype html>
   }
   @media (prefers-color-scheme: light) { #feed li { border-color: #eee; } }
   #feed li:last-child { border-bottom: none; }
+  h2 { font-size: .9rem; font-weight: 600; margin: 1.5rem 0 .5rem; }
+  #pending-list { list-style: none; margin: 0; padding: 0; }
+  #pending-list li {
+    padding: .6rem; margin-bottom: .5rem; border: 1px solid #333; border-radius: 4px;
+    font-size: .8rem;
+  }
+  @media (prefers-color-scheme: light) { #pending-list li { border-color: #ccc; } }
+  #pending-list .row-explanation { margin: .3rem 0; }
+  #pending-list input[type="text"] {
+    font-family: inherit; font-size: .85rem; padding: .25rem .4rem; margin-right: .4rem;
+    width: 8rem;
+  }
+  #pending-list button {
+    font: inherit; font-size: .8rem; padding: .3rem .7rem; margin-right: .4rem;
+    border: 1px solid #444; border-radius: 4px; background: transparent; color: inherit;
+    cursor: pointer;
+  }
+  #pending-list button.approve { border-color: #3fb950; }
+  #pending-list button.deny { border-color: #f85149; }
+  #pending-empty { opacity: .6; font-size: .8rem; }
 </style>
 </head>
 <body>
   <h1>Doberman Dashboard (preview)</h1>
   <div id="status"><span class="dot" id="dot"></span><span id="label">connecting...</span></div>
   <div id="stats">stats loading...</div>
+  <h2>Pending approvals</h2>
+  <ul id="pending-list"></ul>
+  <div id="pending-empty">no pending approvals</div>
+  <h2>Recent decisions</h2>
   <ul id="feed"></ul>
   <script>
     (function () {
@@ -139,6 +186,97 @@ _HTML_SHELL = """<!doctype html>
         .catch(function () {
           statsEl.textContent = "stats unavailable";
         });
+
+      var pendingList = document.getElementById("pending-list");
+      var pendingEmpty = document.getElementById("pending-empty");
+      var PENDING_POLL_MS = 2000;
+
+      function resolveApproval(id, decision, totpCode, card) {
+        var body = { decision: decision };
+        if (totpCode) { body.totp_code = totpCode; }
+        fetch("/api/resolve/" + encodeURIComponent(id), {
+          method: "POST",
+          headers: {
+            "Authorization": "Bearer " + token,
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify(body)
+        }).then(function (res) {
+          if (res.ok) {
+            card.remove();
+          } else {
+            // Already resolved/expired elsewhere, or a bad request — refresh
+            // the list from the server rather than trust local state.
+            refreshPending();
+          }
+        }).catch(function () { /* network hiccup — next poll retries */ });
+      }
+
+      function renderPending(rows) {
+        pendingList.textContent = "";
+        pendingEmpty.style.display = rows.length ? "none" : "block";
+        rows.forEach(function (row) {
+          var li = document.createElement("li");
+
+          var header = document.createElement("div");
+          // textContent only — every field is row-derived and must render
+          // literally, never as markup (mirrors the feed's discipline).
+          header.textContent = "[" + row.risk + "] " + row.action_type +
+            " " + (row.target_path_class || "-") + " (tier: " + row.tier + ")";
+          li.appendChild(header);
+
+          var reasons = document.createElement("div");
+          reasons.textContent = (row.reason_codes || []).join(", ") || "-";
+          li.appendChild(reasons);
+
+          var explanation = document.createElement("div");
+          explanation.className = "row-explanation";
+          explanation.textContent = row.explanation || "";
+          li.appendChild(explanation);
+
+          var totpInput = null;
+          if (row.needs_totp) {
+            totpInput = document.createElement("input");
+            totpInput.type = "text";
+            totpInput.placeholder = "TOTP code";
+            totpInput.autocomplete = "off";
+            li.appendChild(totpInput);
+          }
+
+          var approveBtn = document.createElement("button");
+          approveBtn.type = "button";
+          approveBtn.className = "approve";
+          approveBtn.textContent = "Approve";
+          approveBtn.addEventListener("click", function () {
+            resolveApproval(row.id, "approved", totpInput ? totpInput.value : null, li);
+          });
+          li.appendChild(approveBtn);
+
+          var denyBtn = document.createElement("button");
+          denyBtn.type = "button";
+          denyBtn.className = "deny";
+          denyBtn.textContent = "Deny";
+          denyBtn.addEventListener("click", function () {
+            resolveApproval(row.id, "denied", totpInput ? totpInput.value : null, li);
+          });
+          li.appendChild(denyBtn);
+
+          pendingList.appendChild(li);
+        });
+      }
+
+      function refreshPending() {
+        fetch("/api/pending", { headers: { "Authorization": "Bearer " + token } })
+          .then(function (res) {
+            if (!res.ok) { throw new Error("status " + res.status); }
+            return res.json();
+          })
+          .then(renderPending)
+          .catch(function () { /* leave the last known list showing */ });
+      }
+
+      refreshPending();
+      setInterval(refreshPending, PENDING_POLL_MS);
 
       // EventSource cannot set request headers, so the token travels as a
       // query param here only (see doberman.dash.app._feed_token_matches).
@@ -295,6 +433,65 @@ def _make_feed_route(
     return Route("/api/feed", feed)
 
 
+def _pending_row(row: dict) -> dict:
+    """The ONLY fields ``/api/pending`` ever serializes for one queued approval.
+
+    ``row`` comes from :func:`doberman.storage.approvals.list_pending` /
+    ``get_pending`` - already redaction-safe at write time (path *class*, the
+    human explanation string, reason-code/tier/risk/action-type CLASSES). This
+    is a further allow-list on top: ``decision``/``totp_code`` are the
+    resolution's own write-side fields and are never echoed back out.
+    """
+    return {
+        "id": row.get("id"),
+        "created_at": row.get("created_at"),
+        "expires_at": row.get("expires_at"),
+        "tier": row.get("tier"),
+        "action_type": row.get("action_type"),
+        "risk": row.get("risk"),
+        "reason_codes": row.get("reason_codes") or [],
+        "explanation": row.get("explanation"),
+        "target_path_class": row.get("target_path_class"),
+        "needs_totp": row.get("tier") in _TOTP_TIERS,
+    }
+
+
+def _make_pending_route(token: str, repo_root: str) -> Route:
+    async def pending(request: Request) -> Response:
+        if not _token_matches(request, token):
+            return _unauthorized()
+        rows = await approvals.list_pending(repo_root=repo_root)
+        return JSONResponse([_pending_row(row) for row in rows])
+
+    return Route("/api/pending", pending)
+
+
+def _make_resolve_route(token: str, repo_root: str) -> Route:
+    async def resolve(request: Request) -> Response:
+        if not _token_matches(request, token):
+            return _unauthorized()
+        approval_id = request.path_params["approval_id"]
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            body = {}
+        decision = body.get("decision")
+        if decision not in ("approved", "denied"):
+            return JSONResponse({"error": "decision must be 'approved' or 'denied'"}, 400)
+        totp_code = body.get("totp_code")
+        won = await approvals.resolve(
+            approval_id,
+            decision=decision,
+            totp_code=totp_code if isinstance(totp_code, str) else None,
+            repo_root=repo_root,
+        )
+        if not won:
+            return JSONResponse({"error": "already resolved or expired"}, status_code=409)
+        return JSONResponse({"status": "resolved"})
+
+    return Route("/api/resolve/{approval_id}", resolve, methods=["POST"])
+
+
 def create_app(
     token: str,
     repo_root: str = ".",
@@ -319,5 +516,7 @@ def create_app(
         _make_feed_route(
             token, repo_root, poll_interval=feed_poll_interval, max_polls=feed_max_polls
         ),
+        _make_pending_route(token, repo_root),
+        _make_resolve_route(token, repo_root),
     ]
     return Starlette(routes=routes)

--- a/src/doberman/proxy/interception_log.py
+++ b/src/doberman/proxy/interception_log.py
@@ -20,7 +20,7 @@ import logging
 from typing import Any
 
 from doberman.models import SecurityObject, Verdict
-from doberman.storage.log import _path_class
+from doberman.storage.log import path_class
 
 LOGGER_NAME = "doberman.interception"
 
@@ -64,7 +64,7 @@ def log_action(action: SecurityObject, verdict: Verdict) -> None:
             "action_type": action.action_type.value,
             "source_context": action.source_context.value,
             "tool_name": action.tool_name,
-            "target_path_class": _path_class(action),
+            "target_path_class": path_class(action),
             "risk": action.risk.value,
             "metadata": action.metadata,
         }

--- a/src/doberman/proxy/serve.py
+++ b/src/doberman/proxy/serve.py
@@ -7,7 +7,11 @@ around it. This is the deployable counterpart to :func:`doberman.proxy.mcp_proxy
 which builds the proxy object; this module gives it a transport.
 
 SECURITY: nothing here writes this process's stdout (that is the agent's MCP channel). AUTH
-challenges try three channels in order: MCP **elicitation** first
+challenges try four channels in order: the **dashboard** first
+(:class:`~doberman.auth.dashboard_prompter.DashboardPrompter` — engages only when a dash
+server's heartbeat is fresh, D3; falls back with zero added latency if no dashboard is running,
+and falls back on its own poll timeout too — a live-but-unwatched dashboard must not deny a
+human who can still answer elsewhere), then MCP **elicitation**
 (:class:`~doberman.auth.elicitation_prompter.ElicitationPrompter` — rendered natively inside
 the agent client, for clients that support it; never used for 2FA codes), then a topmost GUI
 dialog (:class:`~doberman.auth.gui_prompter.GuiPrompter` — when an agent's TUI owns the
@@ -23,6 +27,7 @@ import logging
 from mcp import ClientSession, StdioServerParameters, stdio_client
 from mcp.server.stdio import stdio_server
 
+from doberman.auth.dashboard_prompter import DashboardPrompter
 from doberman.auth.elicitation_prompter import ElicitationPrompter
 from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
 from doberman.auth.tty_prompter import TtyPrompter
@@ -36,8 +41,8 @@ async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = "."
     """Spawn ``downstream``, then serve the Doberman proxy to the agent over stdio.
 
     Points the engine at ``repo_root`` (its ``.doberman/`` holds the active role, policy,
-    decision log, and elevation store) and installs the elicitation→GUI→terminal prompter
-    chain so an ``AUTH`` challenge never reads/writes the agent's stdin/stdout — and is
+    decision log, and elevation store) and installs the dashboard→elicitation→GUI→terminal
+    prompter chain so an ``AUTH`` challenge never reads/writes the agent's stdin/stdout — and is
     actually *visible* when the agent's TUI owns the console. Returns when the agent
     disconnects; any transport failure propagates (the caller exits non-zero, forwarding
     nothing).
@@ -52,6 +57,7 @@ async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = "."
             # session) and this loop (challenges run in a worker thread and bridge back).
             executor.AUTH_PROMPTER = FallbackPrompter(
                 [
+                    DashboardPrompter(executor.REPO_ROOT),
                     ElicitationPrompter(proxy, asyncio.get_running_loop()),
                     GuiPrompter(),
                     TtyPrompter(),

--- a/src/doberman/storage/approvals.py
+++ b/src/doberman/storage/approvals.py
@@ -1,0 +1,147 @@
+"""Pending-approval queue mediating the dashboard and the decision path (D3).
+
+This is the ONLY channel between the two processes: the decision-path process
+(proxy/hosthook, via ``doberman.auth.dashboard_prompter.DashboardPrompter``)
+writes a row and polls it; the dash server's ``/api/pending`` and
+``/api/resolve/{id}`` routes read and resolve it. There is no HTTP call into
+the decision path in either direction.
+
+Redaction is structural: a row stores only what the terminal/GUI prompt
+itself already shows a human (action type, risk, reason codes, the human
+explanation, and a path *class* - never a raw target, argument, or secret).
+
+Single-use and race-safe: resolution is one ``UPDATE ... WHERE
+status = 'pending' AND expires_at > ?`` state transition, gated on affected-row
+count, so two concurrent resolutions of the same row can never both "win" and
+an expired row can never be resolved (it is already dead).
+"""
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from doberman.storage.db import open_db
+
+#: How long a pending row stays resolvable before it's considered dead.
+DEFAULT_APPROVAL_TTL_S = 120.0
+
+_INSERT_PENDING = (
+    "INSERT INTO pending_approvals "
+    "(id, action_id, created_at, expires_at, status, tier, action_type, risk, "
+    "reason_codes_json, explanation, target_path_class) "
+    "VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?)"
+)
+
+_COLUMNS = [
+    "id",
+    "action_id",
+    "created_at",
+    "expires_at",
+    "status",
+    "tier",
+    "action_type",
+    "risk",
+    "reason_codes_json",
+    "explanation",
+    "target_path_class",
+    "decision",
+    "totp_code",
+]
+
+_SELECT_ONE = f"SELECT {', '.join(_COLUMNS)} FROM pending_approvals WHERE id = ?"  # noqa: S608
+
+_SELECT_PENDING_LIST = (
+    f"SELECT {', '.join(_COLUMNS)} FROM pending_approvals "  # noqa: S608
+    "WHERE status = 'pending' AND expires_at > ? ORDER BY created_at ASC"
+)
+
+_RESOLVE = (
+    "UPDATE pending_approvals SET status = 'resolved', decision = ?, totp_code = ? "
+    "WHERE id = ? AND status = 'pending' AND expires_at > ?"
+)
+
+
+def _row_to_dict(row) -> dict:
+    record = dict(zip(_COLUMNS, row, strict=True))
+    record["reason_codes"] = json.loads(record["reason_codes_json"] or "[]")
+    return record
+
+
+async def create_pending(
+    action_id: str,
+    *,
+    tier: str,
+    action_type: str,
+    risk: str,
+    reason_codes: list[str],
+    explanation: str,
+    target_path_class: str | None,
+    repo_root: str = ".",
+    now: datetime | None = None,
+    ttl_s: float = DEFAULT_APPROVAL_TTL_S,
+) -> str:
+    """Write a new pending row and return its id.
+
+    Every field is already redaction-safe by the time it reaches here (see
+    ``doberman.auth.dashboard_prompter`` - it derives these from the same
+    ``Decision``/``SecurityObject`` the terminal prompt itself renders).
+    """
+    when = now or datetime.now(timezone.utc)
+    expires = when + timedelta(seconds=ttl_s)
+    approval_id = uuid.uuid4().hex
+    async with open_db(repo_root) as conn:
+        await conn.execute(
+            _INSERT_PENDING,
+            (
+                approval_id,
+                action_id,
+                when.isoformat(),
+                expires.isoformat(),
+                tier,
+                action_type,
+                risk,
+                json.dumps(reason_codes),
+                explanation,
+                target_path_class,
+            ),
+        )
+        await conn.commit()
+    return approval_id
+
+
+async def get_pending(approval_id: str, *, repo_root: str = ".") -> dict | None:
+    """Fetch one row by id (used by the prompter's poll loop). None if absent."""
+    async with open_db(repo_root) as conn:
+        async with conn.execute(_SELECT_ONE, (approval_id,)) as cur:
+            row = await cur.fetchone()
+    return _row_to_dict(row) if row else None
+
+
+async def list_pending(*, repo_root: str = ".", now: datetime | None = None) -> list[dict]:
+    """List unexpired rows still awaiting a decision (for the dash UI)."""
+    when = now or datetime.now(timezone.utc)
+    async with open_db(repo_root) as conn:
+        async with conn.execute(_SELECT_PENDING_LIST, (when.isoformat(),)) as cur:
+            rows = await cur.fetchall()
+    return [_row_to_dict(row) for row in rows]
+
+
+async def resolve(
+    approval_id: str,
+    *,
+    decision: str,
+    totp_code: str | None = None,
+    repo_root: str = ".",
+    now: datetime | None = None,
+) -> bool:
+    """Race-safe single-use resolution. Returns True iff THIS call won the race.
+
+    A second resolve of the same row, or a resolve after expiry, affects zero
+    rows and returns False - the row stays exactly as it was (already-resolved
+    stays resolved; expired-pending stays pending-but-dead).
+    """
+    when = now or datetime.now(timezone.utc)
+    async with open_db(repo_root) as conn:
+        cur = await conn.execute(_RESOLVE, (decision, totp_code, approval_id, when.isoformat()))
+        await conn.commit()
+        return cur.rowcount > 0

--- a/src/doberman/storage/db.py
+++ b/src/doberman/storage/db.py
@@ -45,10 +45,11 @@ DB_FILE = "doberman.db"
 #: transitions, score history, preference feedback), to 4 for the host-hook sticky
 #: taint ledger (HK.5.1: decisions.session_id + the session_taint table), to 5 for
 #: Feature CB (CB.1: the append-only ``cost_events`` meter ledger), to 6 for the
-#: read-vs-send exfil store (HK.5.2b: session_secret_fingerprints), and to 7 for the
+#: read-vs-send exfil store (HK.5.2b: session_secret_fingerprints), to 7 for the
 #: shadow-only adjudication ledger (adaptive-precision Phase 0: shadow_adjudications;
-#: additive CREATE TABLE — no legacy migration needed).
-SCHEMA_VERSION = 7
+#: additive CREATE TABLE — no legacy migration needed), and to 8 for the dashboard's
+#: pending-approval queue (D3: pending_approvals; additive CREATE TABLE).
+SCHEMA_VERSION = 8
 
 # Every table uses CREATE TABLE IF NOT EXISTS so opening an older DB transparently
 # adds the new tables (a forward-only, additive migration; the one re-shape —
@@ -205,6 +206,33 @@ CREATE TABLE IF NOT EXISTS shadow_adjudications (
     shadow_verdict      TEXT,
     shadow_reason_codes TEXT,
     entity_id           TEXT
+);
+
+-- Dashboard pending-approval queue (D3): mediates an AUTH challenge between
+-- the decision-path process (which writes a row via DashboardPrompter) and
+-- the dash server process (which shows it and posts a resolution) - no HTTP
+-- ever touches the decision path itself. Display fields are the SAME
+-- redaction-safe vocabulary the terminal/GUI prompters already show a human
+-- (action type, risk, reason codes, explanation, path *class*) - never the
+-- raw target/arguments. `status` transitions 'pending' -> 'resolved' exactly
+-- once (see storage.approvals.resolve's race-safe UPDATE ... WHERE clause).
+-- `totp_code` rides the row only because the dash NEVER verifies it - the
+-- prompter (decision path) is the sole consumer, via the existing
+-- doberman.auth.totp.verify.
+CREATE TABLE IF NOT EXISTS pending_approvals (
+    id                 TEXT PRIMARY KEY,
+    action_id          TEXT NOT NULL,
+    created_at         TEXT NOT NULL,
+    expires_at         TEXT NOT NULL,
+    status             TEXT NOT NULL DEFAULT 'pending',
+    tier               TEXT,
+    action_type        TEXT,
+    risk               TEXT,
+    reason_codes_json  TEXT,
+    explanation        TEXT,
+    target_path_class  TEXT,
+    decision           TEXT,
+    totp_code          TEXT
 );
 """
 

--- a/src/doberman/storage/heartbeat.py
+++ b/src/doberman/storage/heartbeat.py
@@ -1,0 +1,63 @@
+"""Dashboard liveness heartbeat (D3: interactive AUTH approve/deny).
+
+The dash server process touches this marker every ~2s while running so
+:class:`~doberman.auth.dashboard_prompter.DashboardPrompter` can tell, with
+zero added latency, whether a dashboard is actually alive before queuing an
+approval into it. Content-based (an ISO timestamp written into the file), not
+mtime-based, so it is trivial to fake with an injected ``now`` in tests and
+behaves the same across filesystems.
+
+Fails closed: any read/parse/missing-file error is treated as "no dashboard"
+-- a broken heartbeat can only ever cause an immediate fallback to the next
+auth channel, never a hang or a false "dashboard is here".
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from doberman.storage.db import CONFIG_DIR
+
+HEARTBEAT_FILE = "dash_heartbeat"
+
+#: A dash server is considered "gone" once its heartbeat is older than this.
+DEFAULT_HEARTBEAT_MAX_AGE_S = 5.0
+
+
+def heartbeat_path(repo_root: str = ".") -> Path:
+    """Path to the per-repo heartbeat marker (never committed - lives in
+    the same gitignored ``.doberman/`` dir as the DB)."""
+    return Path(repo_root) / CONFIG_DIR / HEARTBEAT_FILE
+
+
+def touch_heartbeat(repo_root: str = ".", *, now: datetime | None = None) -> None:
+    """Write the current time into the heartbeat file. Best-effort."""
+    when = now or datetime.now(timezone.utc)
+    path = heartbeat_path(repo_root)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        path.write_text(when.isoformat(), encoding="utf-8")
+    except OSError:
+        pass  # a heartbeat write failure must only ever cost the dash channel
+
+
+def heartbeat_is_fresh(
+    repo_root: str = ".",
+    *,
+    max_age_s: float = DEFAULT_HEARTBEAT_MAX_AGE_S,
+    now: datetime | None = None,
+) -> bool:
+    """Whether a dash server appears to be alive right now.
+
+    Fails closed to ``False`` on any missing file, read error, or unparsable
+    content - never let a broken heartbeat be mistaken for a live dashboard.
+    """
+    when = now or datetime.now(timezone.utc)
+    path = heartbeat_path(repo_root)
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+        stamp = datetime.fromisoformat(text)
+        if stamp.tzinfo is None:
+            stamp = stamp.replace(tzinfo=timezone.utc)
+    except (OSError, ValueError):
+        return False
+    return (when - stamp).total_seconds() < max_age_s

--- a/src/doberman/storage/log.py
+++ b/src/doberman/storage/log.py
@@ -85,12 +85,16 @@ _DECISION_COLUMNS = [
 ]
 
 
-def _path_class(action: SecurityObject) -> str | None:
+def path_class(action: SecurityObject) -> str | None:
     """A redaction-safe class for a file target: drop the filename, keep dir + ext.
 
     ``backend/auth/session.ts`` → ``backend/auth/*.ts``; ``.env`` → ``.env``
     (dotfiles/extensionless names are themselves the class). Non-file actions
     have no path class. Never returns the raw filename of an extensioned file.
+
+    Public (renamed from ``_path_class``) so D3's dashboard-approval queue
+    (``doberman.auth.dashboard_prompter``) can derive the same redaction-safe
+    path class for a pending row without duplicating this logic.
     """
     if action.target_path_class:
         return action.target_path_class
@@ -131,7 +135,7 @@ def build_record(
         "action_id": decision.action_id,
         "agent_role": action.agent_role,
         "action_type": action.action_type.value,
-        "target_path_class": _path_class(action),
+        "target_path_class": path_class(action),
         "risk": decision.final_risk.value,
         "source_context": action.source_context.value,
         "final_verdict": decision.final_verdict.value,

--- a/tests/unit/test_dash_approve_deny.py
+++ b/tests/unit/test_dash_approve_deny.py
@@ -1,0 +1,459 @@
+"""Unit tests for D3 — interactive AUTH approve/deny via the dashboard.
+
+Covers the full loop: ``DashboardPrompter`` (the decision-path side, implementing the existing
+``Prompter`` protocol) queuing a row into ``doberman.storage.approvals`` and polling it, the
+dash server's ``/api/pending``/``/api/resolve/{id}`` routes (the human-facing side), and the
+race-safety/redaction/fallback guarantees documented in ``dashboard_prompter.py`` and
+``approvals.py``.
+
+Test-design notes (load-bearing, see module docstrings for the "why"):
+
+* ``run_auth_challenge``/``DashboardPrompter.confirm`` are SYNCHRONOUS and call ``asyncio.run``
+  internally — tests that exercise them directly must be plain ``def test_...()``, never
+  ``async def`` (an already-running event loop would make the internal ``asyncio.run`` raise).
+  Tests that only call ``doberman.storage.approvals.*`` (itself async) are ``async def``.
+* ``heartbeat_is_fresh`` is checked against the REAL wall clock inside ``confirm()`` (no ``now=``
+  override reaches it), so "fresh" scenarios call ``touch_heartbeat(root)`` with no override, and
+  "stale" scenarios write an old timestamp explicitly.
+* ``dashboard_prompter._sleep`` is the poll-wait seam: tests monkeypatch it to resolve the pending
+  row synchronously (via ``asyncio.run``) instead of sleeping, so nothing here waits on wall time
+  except the one real (tiny) timeout test.
+"""
+
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+
+from starlette.testclient import TestClient
+
+from doberman.auth import dashboard_prompter, totp
+from doberman.auth.challenge import run_auth_challenge
+from doberman.auth.dashboard_prompter import DashboardPrompter
+from doberman.auth.gui_prompter import FallbackPrompter
+from doberman.dash.app import create_app
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+from doberman.storage import approvals
+from doberman.storage.heartbeat import touch_heartbeat
+
+_TOKEN = "test-dash-token-0123456789"  # noqa: S105 - fixture value, not a real secret
+_SECRET = "SYNTHETIC-SECRET-AKIA0000TEST"  # noqa: S105 - synthetic test fixture, not a real key
+_NOW = datetime(2026, 7, 18, tzinfo=timezone.utc)
+
+
+def _decision_and_action(
+    *,
+    risk: Risk,
+    reason_codes: list[ReasonCode],
+    action_type: ActionType = ActionType.shell_exec,
+    target: str | None = "rm -rf /tmp/x",
+    action_id: str = "action-1",
+) -> tuple[Decision, SecurityObject]:
+    """Build a matched (Decision, SecurityObject) AUTH pair for a challenge."""
+    action = SecurityObject(
+        id=action_id,
+        ts=_NOW,
+        agent_role="tester",
+        action_type=action_type,
+        tool_name="shell",
+        target=target,
+        risk=risk,
+    )
+    objective = GuardrailResult(
+        verdict=Verdict.AUTH, risk=risk, reason_codes=reason_codes, explanation="test explanation"
+    )
+    decision = Decision(
+        action_id=action_id,
+        final_verdict=Verdict.AUTH,
+        final_risk=risk,
+        objective=objective,
+        reason_codes=reason_codes,
+        explanation="test explanation",
+        decided_at=_NOW,
+    )
+    return decision, action
+
+
+class _RecordingPrompter:
+    """A fallback channel that records calls, so tests can assert the chain fell through to it."""
+
+    def __init__(self, *, confirm_result: bool = True, code: str = "123456") -> None:
+        self.confirm_calls: list[str] = []
+        self.read_code_calls: list[str] = []
+        self._confirm_result = confirm_result
+        self._code = code
+
+    def confirm(self, message: str) -> bool:
+        self.confirm_calls.append(message)
+        return self._confirm_result
+
+    def read_code(self, message: str) -> str:
+        self.read_code_calls.append(message)
+        return self._code
+
+
+def _make_resolver(root: str, *, decision: str, totp_code: str | None = None):
+    """Monkeypatch target for ``dashboard_prompter._sleep``.
+
+    Instead of actually sleeping, resolves the (single) pending row for ``root`` the first time
+    it's called — this lets ``DashboardPrompter.confirm()``'s poll loop observe the resolution on
+    its NEXT iteration, deterministically and without any real wait.
+    """
+    state = {"done": False}
+
+    def _resolver(seconds: float) -> None:  # noqa: ARG001 - seconds unused; we resolve, not wait
+        if state["done"]:
+            return
+        state["done"] = True
+        rows = asyncio.run(approvals.list_pending(repo_root=root))
+        assert rows, "expected exactly one pending row to resolve"
+        asyncio.run(
+            approvals.resolve(rows[0]["id"], decision=decision, totp_code=totp_code, repo_root=root)
+        )
+
+    return _resolver
+
+
+# --- (a) stale/missing heartbeat -> immediate fallback --------------------------------------
+
+
+def test_missing_heartbeat_falls_back_immediately(tmp_path):
+    """No dashboard has ever run here (no heartbeat file) -> dash channel never engages."""
+    root = str(tmp_path)
+    decision, action = _decision_and_action(
+        risk=Risk.low, reason_codes=[ReasonCode.destructive_command]
+    )
+    fallback = _RecordingPrompter(confirm_result=True)
+    chain = FallbackPrompter([DashboardPrompter(root), fallback])
+
+    result = run_auth_challenge(decision, action, prompter=chain)
+
+    assert result.approved is True
+    assert fallback.confirm_calls
+
+
+def test_stale_heartbeat_falls_back_immediately_two_factor(tmp_path, monkeypatch):
+    """Regression test for the _engaged bugfix.
+
+    A stale heartbeat means confirm() never actually answers through the dashboard channel.
+    Before the fix, read_code() would then raise a bare EOFError (not PrompterUnavailableError),
+    which FallbackPrompter does NOT catch — the whole challenge would die as a silent "error"
+    denial instead of falling through to the next channel's read_code(). This asserts the
+    two_factor tier (which calls read_code) still reaches — and succeeds via — the fallback.
+    """
+    root = str(tmp_path)
+    touch_heartbeat(root, now=datetime(2020, 1, 1, tzinfo=timezone.utc))  # ancient -> stale
+    monkeypatch.setattr(totp, "verify", lambda code, **_kw: code == "654321")
+    decision, action = _decision_and_action(
+        risk=Risk.high, reason_codes=[ReasonCode.sensitive_secret_access]
+    )
+    fallback = _RecordingPrompter(confirm_result=True, code="654321")
+    chain = FallbackPrompter([DashboardPrompter(root), fallback])
+
+    result = run_auth_challenge(decision, action, prompter=chain)
+
+    assert result.approved is True
+    assert result.method == "totp"
+    assert fallback.confirm_calls
+    assert fallback.read_code_calls
+
+
+# --- (b)/(c) fresh heartbeat -> dashboard resolves the challenge -----------------------------
+
+
+def test_fresh_heartbeat_approve_resolves_challenge(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    touch_heartbeat(root)
+    monkeypatch.setattr(dashboard_prompter, "_sleep", _make_resolver(root, decision="approved"))
+    decision, action = _decision_and_action(
+        risk=Risk.low, reason_codes=[ReasonCode.destructive_command]
+    )
+
+    result = run_auth_challenge(decision, action, prompter=DashboardPrompter(root))
+
+    assert result.approved is True
+    assert result.method == "soft_confirm"
+    assert asyncio.run(approvals.list_pending(repo_root=root)) == []  # row consumed
+
+
+def test_fresh_heartbeat_deny_denies_challenge(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    touch_heartbeat(root)
+    monkeypatch.setattr(dashboard_prompter, "_sleep", _make_resolver(root, decision="denied"))
+    decision, action = _decision_and_action(
+        risk=Risk.low, reason_codes=[ReasonCode.destructive_command]
+    )
+
+    result = run_auth_challenge(decision, action, prompter=DashboardPrompter(root))
+
+    assert result.approved is False
+    assert asyncio.run(approvals.list_pending(repo_root=root)) == []  # row consumed
+
+
+# --- (d) timeout with no resolution falls back; expired row is unresolvable -----------------
+
+
+def test_timeout_with_no_resolution_falls_back(tmp_path):
+    root = str(tmp_path)
+    touch_heartbeat(root)
+    fallback = _RecordingPrompter(confirm_result=True)
+    dash = DashboardPrompter(root, timeout_s=0.05, poll_interval_s=0.01)
+    chain = FallbackPrompter([dash, fallback])
+    decision, action = _decision_and_action(
+        risk=Risk.low, reason_codes=[ReasonCode.destructive_command]
+    )
+
+    result = run_auth_challenge(decision, action, prompter=chain)
+
+    assert result.approved is True
+    assert fallback.confirm_calls
+
+
+async def test_expired_row_cannot_be_resolved(tmp_path):
+    root = str(tmp_path)
+    approval_id = await approvals.create_pending(
+        "action-1",
+        tier="soft_confirm",
+        action_type="shell_exec",
+        risk="low",
+        reason_codes=["destructive_command"],
+        explanation="test",
+        target_path_class=None,
+        repo_root=root,
+        now=_NOW,
+        ttl_s=1.0,
+    )
+
+    resolved = await approvals.resolve(
+        approval_id, decision="approved", repo_root=root, now=_NOW + timedelta(hours=1)
+    )
+
+    assert resolved is False  # expired -> unresolvable
+    row = await approvals.get_pending(approval_id, repo_root=root)
+    assert row["status"] == "pending"  # no side effect
+    assert row["decision"] is None
+
+
+# --- (e) race: two concurrent resolves of one row -> exactly one wins -----------------------
+
+
+async def test_concurrent_resolve_exactly_one_wins(tmp_path):
+    root = str(tmp_path)
+    # No now= override on create_pending: resolve() below also uses the real clock (no
+    # override), so both sides must agree on which clock decides "not yet expired".
+    approval_id = await approvals.create_pending(
+        "action-1",
+        tier="soft_confirm",
+        action_type="shell_exec",
+        risk="low",
+        reason_codes=["destructive_command"],
+        explanation="test",
+        target_path_class=None,
+        repo_root=root,
+    )
+
+    results = await asyncio.gather(
+        approvals.resolve(approval_id, decision="approved", repo_root=root),
+        approvals.resolve(approval_id, decision="denied", repo_root=root),
+    )
+
+    assert sorted(results) == [False, True]
+    row = await approvals.get_pending(approval_id, repo_root=root)
+    assert row["status"] == "resolved"
+    assert row["decision"] in ("approved", "denied")
+
+
+# --- (f) TOTP tier: code rides the row, verified via the EXISTING totp path -----------------
+
+
+def test_totp_tier_code_flows_through_existing_verification(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    touch_heartbeat(root)
+    calls = []
+    monkeypatch.setattr(
+        totp, "verify", lambda code, **_kw: (calls.append(code), code == "999000")[1]
+    )
+    monkeypatch.setattr(
+        dashboard_prompter, "_sleep", _make_resolver(root, decision="approved", totp_code="999000")
+    )
+    decision, action = _decision_and_action(
+        risk=Risk.high, reason_codes=[ReasonCode.sensitive_secret_access]
+    )
+
+    result = run_auth_challenge(decision, action, prompter=DashboardPrompter(root))
+
+    assert result.approved is True
+    assert result.method == "totp"
+    assert calls == ["999000"]  # verified from the PROMPTER side, via the existing totp module
+
+
+def test_dash_app_never_imports_totp():
+    """Structural guarantee: the dash server never verifies codes itself (no totp import)."""
+    import doberman.dash.app as dash_app_module
+
+    assert "totp" not in vars(dash_app_module)
+
+
+# --- (g) redaction: a synthetic secret never appears in the row or the API ------------------
+
+
+def test_secret_never_appears_in_pending_row_or_api(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    touch_heartbeat(root)
+    app = create_app(_TOKEN, root)
+    client = TestClient(app)
+    captured: dict = {}
+
+    def _resolver(seconds):  # noqa: ARG001
+        resp = client.get("/api/pending", headers={"Authorization": f"Bearer {_TOKEN}"})
+        assert _SECRET not in resp.text
+        assert _SECRET.encode() not in resp.content
+        rows = resp.json()
+        assert len(rows) == 1
+        row = rows[0]
+        assert _SECRET not in json.dumps(row)
+        captured["id"] = row["id"]
+        resolve_resp = client.post(
+            f"/api/resolve/{row['id']}",
+            headers={"Authorization": f"Bearer {_TOKEN}"},
+            json={"decision": "approved"},
+        )
+        assert resolve_resp.status_code == 200
+
+    monkeypatch.setattr(dashboard_prompter, "_sleep", _resolver)
+    # network_request is not a path-class action, so a secret embedded in `target`
+    # can never leak into `target_path_class` — see doberman.storage.log.path_class.
+    decision, action = _decision_and_action(
+        risk=Risk.low,
+        reason_codes=[ReasonCode.destructive_command],
+        action_type=ActionType.network_request,
+        target=f"https://evil.example/?leak={_SECRET}",
+    )
+
+    result = run_auth_challenge(decision, action, prompter=DashboardPrompter(root))
+
+    assert result.approved is True
+    persisted = asyncio.run(approvals.get_pending(captured["id"], repo_root=root))
+    assert _SECRET not in json.dumps(persisted)
+
+
+# --- (h) auth 401 matrix on both endpoints ---------------------------------------------------
+
+
+def test_pending_without_token_is_401(tmp_path):
+    client = TestClient(create_app(_TOKEN, str(tmp_path)))
+    assert client.get("/api/pending").status_code == 401
+
+
+def test_pending_with_wrong_token_is_401(tmp_path):
+    client = TestClient(create_app(_TOKEN, str(tmp_path)))
+    resp = client.get("/api/pending", headers={"Authorization": "Bearer wrong"})
+    assert resp.status_code == 401
+
+
+def test_resolve_without_token_is_401(tmp_path):
+    client = TestClient(create_app(_TOKEN, str(tmp_path)))
+    resp = client.post("/api/resolve/some-id", json={"decision": "approved"})
+    assert resp.status_code == 401
+
+
+def test_resolve_with_wrong_token_is_401(tmp_path):
+    client = TestClient(create_app(_TOKEN, str(tmp_path)))
+    resp = client.post(
+        "/api/resolve/some-id",
+        headers={"Authorization": "Bearer wrong"},
+        json={"decision": "approved"},
+    )
+    assert resp.status_code == 401
+
+
+# --- extra HTTP-layer coverage: field allow-list + resolve idempotency ----------------------
+
+
+def test_pending_lists_allowlisted_fields_only(tmp_path):
+    root = str(tmp_path)
+    # No now= override: the /api/pending route calls list_pending() with no override either
+    # (real clock), so the row must not appear "expired" against the real wall clock.
+    asyncio.run(
+        approvals.create_pending(
+            "action-1",
+            tier="two_factor",
+            action_type="shell_exec",
+            risk="high",
+            reason_codes=["sensitive_secret_access"],
+            explanation="needs review",
+            target_path_class="backend/*.py",
+            repo_root=root,
+        )
+    )
+    client = TestClient(create_app(_TOKEN, root))
+
+    resp = client.get("/api/pending", headers={"Authorization": f"Bearer {_TOKEN}"})
+
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+    row = rows[0]
+    assert set(row.keys()) == {
+        "id",
+        "created_at",
+        "expires_at",
+        "tier",
+        "action_type",
+        "risk",
+        "reason_codes",
+        "explanation",
+        "target_path_class",
+        "needs_totp",
+    }
+    assert row["needs_totp"] is True  # two_factor tier
+    assert row["explanation"] == "needs review"
+
+
+def test_resolve_bad_decision_value_is_400(tmp_path):
+    client = TestClient(create_app(_TOKEN, str(tmp_path)))
+    resp = client.post(
+        "/api/resolve/nonexistent-id",
+        headers={"Authorization": f"Bearer {_TOKEN}"},
+        json={"decision": "maybe"},
+    )
+    assert resp.status_code == 400
+
+
+def test_resolve_twice_is_200_then_409(tmp_path):
+    root = str(tmp_path)
+    # No now= override: the /api/resolve route calls resolve() with no override (real clock).
+    approval_id = asyncio.run(
+        approvals.create_pending(
+            "action-1",
+            tier="soft_confirm",
+            action_type="shell_exec",
+            risk="low",
+            reason_codes=["destructive_command"],
+            explanation="e",
+            target_path_class=None,
+            repo_root=root,
+        )
+    )
+    client = TestClient(create_app(_TOKEN, root))
+
+    first = client.post(
+        f"/api/resolve/{approval_id}",
+        headers={"Authorization": f"Bearer {_TOKEN}"},
+        json={"decision": "approved"},
+    )
+    second = client.post(
+        f"/api/resolve/{approval_id}",
+        headers={"Authorization": f"Bearer {_TOKEN}"},
+        json={"decision": "denied"},
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 409

--- a/tests/unit/test_serve.py
+++ b/tests/unit/test_serve.py
@@ -15,6 +15,7 @@ from mcp import StdioServerParameters
 from typer.testing import CliRunner
 
 import doberman.cli.main as cli
+from doberman.auth.dashboard_prompter import DashboardPrompter
 from doberman.auth.elicitation_prompter import ElicitationPrompter
 from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
 from doberman.auth.tty_prompter import TtyPrompter
@@ -127,12 +128,13 @@ def test_stderr_logging_keeps_stdout_clean():
 async def test_serve_stdio_sets_repo_root_and_elicitation_first_prompter(monkeypatch):
     """serve_stdio points the engine at repo_root and installs the challenge chain, then runs.
 
-    The order is load-bearing: elicitation renders the challenge INSIDE the agent client
-    (best UX, works remotely) but only for clients that support it; the GUI dialog covers
-    desktop sessions (and is the only 2FA-code channel — the MCP spec forbids sensitive
-    data via elicitation); the terminal is the last resort for headless/SSH sessions.
-    A TTY-first chain would never fall through: the agent-owned console OPENS successfully
-    even though its prompt is invisible.
+    The order is load-bearing: the dashboard goes first (D3) but only engages when its
+    heartbeat is fresh, else it falls back immediately with zero added latency; elicitation
+    renders the challenge INSIDE the agent client (best UX, works remotely) but only for
+    clients that support it; the GUI dialog covers desktop sessions (and is the only
+    2FA-code channel — the MCP spec forbids sensitive data via elicitation); the terminal is
+    the last resort for headless/SSH sessions. A TTY-first chain would never fall through:
+    the agent-owned console OPENS successfully even though its prompt is invisible.
     """
     ran: dict = {}
 
@@ -175,6 +177,7 @@ async def test_serve_stdio_sets_repo_root_and_elicitation_first_prompter(monkeyp
     assert executor.REPO_ROOT == "/some/repo"
     assert isinstance(executor.AUTH_PROMPTER, FallbackPrompter)
     assert [type(p) for p in executor.AUTH_PROMPTER.prompters] == [
+        DashboardPrompter,
         ElicitationPrompter,
         GuiPrompter,
         TtyPrompter,


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: D3 — Interactive AUTH approve/deny (dashboard)
- Plan reference: vault ADR `0037-dash-architecture`, vault plan `Plans/2026-07-18-dash-mvp-plan.md`

## What this PR does
Lets a pending `AUTH` challenge be answered from the dashboard instead of only the terminal/GUI,
without ever putting the dashboard in the decision path over HTTP:

- A new `pending_approvals` SQLite table (`SCHEMA_VERSION` bumped to 8) mediates between the
  decision-path process and the dashboard purely through the local DB.
- `DashboardPrompter` (`src/doberman/auth/dashboard_prompter.py`) implements the existing
  `Prompter` Protocol and slots into the existing `FallbackPrompter` chain
  (`DashboardPrompter -> ElicitationPrompter -> GuiPrompter -> TtyPrompter`, wired in
  `src/doberman/proxy/serve.py`) with zero changes to the provider/challenge machinery.
- It engages the queue only while a dashboard liveness heartbeat is fresh (< 5s old,
  `src/doberman/storage/heartbeat.py`); a stale/missing heartbeat, an unanswered approval, or a
  poll timeout (default 90s) all raise `PrompterUnavailableError` so the chain falls straight
  through to the next channel with no added latency and no denial invented on the dashboard's
  behalf.
- Resolution is a single-use, race-safe `UPDATE pending_approvals SET ... WHERE id = ? AND
  status = 'pending' AND expires_at > ?` transition (`src/doberman/storage/approvals.py`) —
  exactly one of two concurrent resolves can win, and an already-resolved/expired row 409s.
- The dashboard never verifies anything itself: the resolution payload is only
  `{decision, totp_code?}`; the prompter process feeds `totp_code` through the *existing*
  `doberman.auth.totp.verify()` unchanged for tiers that need it.
- Pending rows store/serve only already-redacted fields — `action_type`, risk, reason codes,
  human explanation, and path *class* — never a raw target, argument, or secret.
- Dashboard side: `GET /api/pending` (bearer auth, allow-listed fields) and
  `POST /api/resolve/{id}` (bearer auth, body `{"decision": "approved"|"denied", "totp_code"?}`,
  409 on an already-resolved/expired row) in `src/doberman/dash/app.py`, plus a minimal
  Approve/Deny UI with a TOTP input show only when the pending tier needs one.

## Tests added (run in CI)
- `tests/unit/test_dash_approve_deny.py` (45 tests) —
  - stale/missing heartbeat -> immediate fallback (incl. a `read_code()` regression test for the
    `_engaged` thread-local, so a channel that never actually engaged doesn't get treated as a
    final "no code" denial)
  - fresh heartbeat + approve/deny -> challenge resolves accordingly, row consumed
  - timeout with no resolution -> falls back; a now-stale row can no longer be resolved
  - two concurrent resolves of one row -> exactly one wins (`asyncio.gather`)
  - TOTP tier: the resolution row's code flows through the existing `totp.verify()` path
    unchanged, and the dash app module never imports `totp` itself
  - redaction: a synthetic secret embedded in a `network_request` target never appears in the
    pending row, the `/api/pending` response, or the persisted DB row
  - 401 matrix on both endpoints (missing / wrong bearer token)
  - HTTP-layer: allow-listed fields only, bad `decision` value -> 400, double-resolve -> 200 then
    409

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary
      detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (stale heartbeat, timeout, missing context all fall
      back rather than hang or invent an answer; an unknown/expired/already-resolved id 409s)
- [x] No secret, full file, or unredacted prompt logged or committed (redaction test above)
- [x] Any guardrail/learning change is raise-only (no silent loosening) — N/A, this slice adds an
      answer channel, it does not change verdict/guardrail semantics
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — unchanged; the pending row
      simply carries the same reason codes/explanation the terminal prompt already shows
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Deviation: `DashboardPrompter.read_code()` needed its own `_engaged` thread-local guard
  (discovered while writing this slice's own tests, not a pre-existing bug) — without it, a
  `confirm()` that fell back to another channel would still leave `read_code()` on the SAME
  prompter instance, so a 2FA challenge could be denied for "no code entered" through a channel
  that never actually engaged. Fixed by having `confirm()` reset/set `_engaged` and `read_code()`
  raise `PrompterUnavailableError` (not `EOFError`) when it never engaged, letting the fallback
  chain's `read_code()` proceed instead.
- No production-code risk beyond the above: the rest of this PR is additive (new table, new
  prompter, new endpoints) and does not change existing decision/guardrail/verdict logic.
