### PR TITLE
docs(examples): add a custom Guardrail plugin tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,25 @@ It reports two plugin profiles — `builtins_only` and `with_plugins` (built-ins
 
 ---
 
+## Write a custom Guardrail (plugin)
+
+Third-party rules register through the **`doberman.rules`** entry-point group. Core never imports your package by name — install it, and `discover_rules()` / the objective guardrail pick it up automatically.
+
+A five-minute worked example lives at [`examples/plugin-guardrail/`](examples/plugin-guardrail/) (from a git checkout):
+
+```bash
+pip install -e ".[dev]"
+pip install -e examples/plugin-guardrail
+pytest examples/plugin-guardrail/tests -q
+pip uninstall -y doberman-example-plugin-guardrail   # optional: restore core-only discovery
+```
+
+The tutorial rule steps up a write to `SECRETS_TODO.md` to AUTH, stays raise-only, and never puts the path or payload into its explanation. Copy the package when you need a real custom rule of your own.
+
+> While the example is installed, core's "no plugins registered" checks will see it — that is expected. Uninstall before re-running the full core suite if you want a clean standalone environment.
+
+---
+
 ## Tune to your risk tolerance
 
 Set a mode in `.doberman/policies.yaml` or via `doberman mode <mode>`. Every mode change made this way — the CLI dial or the setup wizard — is recorded in the append-only policy-change ledger (view it with `doberman policy-history`). Lowering strictness (paranoid → strict → balanced → light) is a **weaken** and requires confirmation plus a possession factor: **TOTP if enrolled, otherwise the local Doberman password**. If neither exists, the lowering fails closed; confirmation alone never suffices. Raising stays frictionless and auto-applies:
@@ -471,6 +490,7 @@ The adaptive layer's four SL5 "care" weights (`confidentiality`, `reversibility`
 
 - ✅ Tool mediation · decision engine · objective guardrail (paths, commands, destinations, secrets, **smuggled-token channels**) · subjective guardrail (adaptive behavioral baselines, **OOD/homoglyph token signals**) · roles & boundaries · capability discovery · tiered auth (confirm → TOTP → scoped elevation) · audit log · policy-drift & poisoning defense (classify strengthen/weaken, possession-factor-gated permanent weakening, append-only ledger, **enforce/monitor/off enforcement dial — now consumed by the decision path (discretionary verdicts soften; the objective floor stays live), softening now gated behind the same possession-factor check as a policy weakening (TOTP if enrolled else password, fails closed with neither — no confirm-only fallback) + a ledger-verified tamper clamp**, **strictness `mode` and SL5 `prefs` now use the corrected 2FA-or-password gate: password is the minimum factor, optional TOTP takes precedence when enrolled, neither enrolled fails closed, and raising stays frictionless**) · universal subjective layer (SL1–SL9)
 - ✅ Benchmark harness (suite-agnostic ASR/FPR over labeled actions; `builtins_only` vs `with_plugins`; deterministic synthetic gate; external-suite adapters via `tests/benchmarks/`)
+- ✅ Tutorial custom Guardrail plugin package ([`examples/plugin-guardrail/`](examples/plugin-guardrail/)) — installable via the `doberman.rules` entry-point group with a worked discovery + AUTH demo
 - ✅ Host-harness integration: Claude Code `PreToolUse` + `PostToolUse` hooks (`doberman hook pre`/`post`) gate every built-in *and* MCP tool call — and scan tool **output** for leaked secrets — with no MCP reconfig; fail-closed, import-light, surfacing an in-session approval dialog (confirm / TOTP 2FA) on a sensitive action, and recording a local redacted history
 - ✅ One-command onboarding: `doberman setup` (alertness + guardrails + auto-wires the hooks) · `install-hooks`/`uninstall-hooks` · `doberman doctor` (read-only health self-check: hooks / config / DB / 2FA / enforcement dial / fingerprint key; non-zero exit on any critical failure)
 - ✅ Host-harness self-protection: an agent cannot disable the hooks by editing `.claude/settings.json` — the hook-install file is a blocked control-plane path (like `.doberman/`)

--- a/examples/plugin-guardrail/README.md
+++ b/examples/plugin-guardrail/README.md
@@ -1,0 +1,121 @@
+# Tutorial: custom Guardrail plugin
+
+Doberman discovers third-party rules through the **`doberman.rules`** Python
+entry-point group (`RULE_GROUP` in `src/doberman/engine/registry.py`). Core never
+imports your package by name — install the package, and
+`discover_rules()` / `ObjectiveGuardrail()` pick it up automatically.
+
+This mini-package is a five-minute copy template.
+
+## What it does
+
+`ExampleRule` steps up a **file write** whose canonical basename is
+`SECRETS_TODO.md` to **AUTH** (reason code `sensitive_path_access`). Everything
+else abstains (`PASS`).
+
+Invariants this example preserves:
+
+| Invariant | How |
+|-----------|-----|
+| **Raise-only** | Returns only PASS or AUTH; never lowers another rule's verdict (`combine()` is max-severity). |
+| **No payload in logs/explanations** | `explanation` names the *rule*, never the raw path or file contents. |
+| **Fail-closed core unchanged** | A broken plugin is isolated by core; this package does not catch-and-swallow errors to PASS. |
+| **No core patch** | Registration is entirely via this package's `pyproject.toml`. |
+
+## Round trip (from a Doberman-Core checkout)
+
+```bash
+# 1. Install core (dev extras optional for running tests)
+pip install -e ".[dev]"
+
+# 2. Install this tutorial plugin (editable)
+pip install -e examples/plugin-guardrail
+
+# 3. Prove discovery + the rule fires
+pytest examples/plugin-guardrail/tests -q
+```
+
+Expected: all tests pass, including `test_entry_point_is_discoverable_after_install`
+and `test_plugin_fires_inside_objective_guardrail`.
+
+### Manual smoke (optional)
+
+```python
+from doberman.engine.registry import discover_rules
+from doberman.engine.objective import ObjectiveGuardrail
+from doberman.models import (
+    ActionType, EvalContext, SecurityObject, Verdict,
+)
+from datetime import datetime, timezone
+from example_plugin.rules import ExampleRule
+
+assert any(isinstance(r, ExampleRule) for r in discover_rules())
+
+g = ObjectiveGuardrail()
+action = SecurityObject(
+    id="demo",
+    ts=datetime.now(timezone.utc),
+    agent_role="unknown",
+    action_type=ActionType.file_write,
+    tool_name="write_file",
+    target="notes/SECRETS_TODO.md",
+)
+ctx = EvalContext(metadata={"raw_arguments": {"path": "notes/SECRETS_TODO.md"}})
+assert g.evaluate(action, ctx).verdict is Verdict.AUTH
+```
+
+Uninstall when finished so other local experiments are not affected:
+
+```bash
+pip uninstall -y doberman-example-plugin-guardrail
+```
+
+> **Important:** while this package is installed, core's "no plugins installed"
+> standalone checks (`discover_rules() == []`) will fail — that is expected.
+> Uninstall before re-running the full core suite. Default CI does **not**
+> install this package; it only path-imports the rule class for evaluate/raise-only
+> checks.
+
+## How registration works
+
+```toml
+# examples/plugin-guardrail/pyproject.toml
+[project.entry-points."doberman.rules"]
+example_rule = "example_plugin.rules:ExampleRule"
+```
+
+At runtime:
+
+1. `ObjectiveGuardrail(load_plugins=True)` calls `discover_rules()`.
+2. `discover_rules()` selects entry points in group `doberman.rules`.
+3. Each entry point is loaded and instantiated; non-`Guardrail`-shaped objects are skipped.
+4. Built-in rules **and** plugins are reduced with raise-only `combine()`.
+
+## Layout
+
+```text
+examples/plugin-guardrail/
+  pyproject.toml          # package metadata + doberman.rules entry point
+  README.md               # this file
+  src/example_plugin/
+    __init__.py
+    rules.py              # ExampleRule (Guardrail protocol)
+  tests/
+    test_example_rule.py  # discovery + evaluation + raise-only + redaction
+```
+
+## Copy checklist for your own rule
+
+1. New package with `requires-python = ">=3.11"` and `dependencies = ["doberman-core"]` (install against a local editable core checkout, not a stale PyPI wheel, while developing).
+2. Implement `evaluate(self, action, ctx) -> GuardrailResult` (same contract as built-ins).
+3. Register under `[project.entry-points."doberman.rules"]`.
+4. Prefer `ReasonCode` values from `doberman.models` (do not invent free-form codes).
+5. Canonicalize paths with `doberman.canonical.canonicalize` before matching; normalize `\\` → `/` if you accept agent-supplied path strings.
+6. Prefer `ctx.metadata["raw_arguments"]` for path matching when present (redacted `action.target` can hide the real path).
+7. Never put secrets, full paths, or request payloads into `explanation` or logs.
+8. Only return PASS / AUTH / BLOCK results that *raise* risk for your signal; abstain otherwise.
+9. Do **not** re-implement repo-root confinement unless you mean to — escapes should stay the built-in path rule's job so a solo plugin does not invent a weaker story.
+
+Use `src/doberman/engine/rules/paths.py` as the reference built-in template.
+
+This tutorial only steps up **writes** (not deletes/reads) of the marker file — keep demo scope minimal.

--- a/examples/plugin-guardrail/pyproject.toml
+++ b/examples/plugin-guardrail/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "doberman-example-plugin-guardrail"
+version = "0.1.0"
+description = "Tutorial: a minimal custom Guardrail registered via the doberman.rules entry-point group."
+requires-python = ">=3.11"
+dependencies = ["doberman-core"]
+
+# This is the whole extensibility contract: core discovers the group at runtime
+# via importlib.metadata and never imports this package by name.
+[project.entry-points."doberman.rules"]
+example_rule = "example_plugin.rules:ExampleRule"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/example_plugin"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+extend-select = ["I", "B", "S"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101"]

--- a/examples/plugin-guardrail/src/example_plugin/__init__.py
+++ b/examples/plugin-guardrail/src/example_plugin/__init__.py
@@ -1,0 +1,21 @@
+"""Tutorial custom Guardrail plugin for Doberman (issue #91).
+
+Install with ``pip install -e examples/plugin-guardrail`` from a Doberman-Core
+checkout (after installing ``doberman-core`` itself). Core discovers this package
+through the ``doberman.rules`` entry-point group — no core import of this
+package is required.
+
+The entry point loads ``example_plugin.rules:ExampleRule`` directly; this
+``__init__`` deliberately avoids an eager re-export so package import stays free
+of import-time side effects.
+"""
+
+__all__ = ["ExampleRule"]
+
+
+def __getattr__(name: str):
+    if name == "ExampleRule":
+        from example_plugin.rules import ExampleRule
+
+        return ExampleRule
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/examples/plugin-guardrail/src/example_plugin/rules.py
+++ b/examples/plugin-guardrail/src/example_plugin/rules.py
@@ -1,0 +1,142 @@
+"""Minimal custom Guardrail: step up writes to ``SECRETS_TODO.md``.
+
+This is the worked example from issue #91. It intentionally mirrors the style of
+``doberman.engine.rules.paths.ProtectedPathRule``:
+
+* match the **canonical** basename (lower-cased, ``..``/symlink resolved);
+* prefer the raw (un-redacted) path from ``ctx.metadata["raw_arguments"]`` when
+  present, so a length-redacted ``action.target`` cannot bypass the check;
+* return only ``PASS`` / ``AUTH`` / ``BLOCK`` shaped results (here: PASS or AUTH);
+* never put the raw path, file contents, or any payload into ``explanation``.
+
+Raise-only: this rule only ever abstains (PASS) or steps up (AUTH). The
+objective guardrail combines results with ``combine()``, so a plugin cannot
+lower another rule's verdict.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from doberman.canonical import canonicalize
+from doberman.models import (
+    ActionType,
+    EvalContext,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+
+#: Basename this tutorial rule cares about (matched against lower-cased
+#: ``CanonicalPath.relposix``). Harmless demo marker, not a real secret store.
+_MARKER_BASENAME = "secrets_todo.md"
+
+#: Keys that may carry a raw path in un-redacted call arguments — same priority
+#: order as the built-in path rule (kept local so this package does not import
+#: ``doberman.proxy``).
+_RAW_PATH_KEYS: tuple[str, ...] = ("path", "file", "filename", "target")
+
+_DEFAULT_ROOT = "."
+
+
+def _abstain() -> GuardrailResult:
+    """Fresh PASS/low — no shared mutable result object for callers to alias."""
+    return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+
+
+def _raw_path_candidates(raw_arguments: Mapping[str, object]) -> list[str]:
+    """Extract path candidate(s) from raw call arguments (match only, never log)."""
+    for key in _RAW_PATH_KEYS:
+        value = raw_arguments.get(key)
+        if isinstance(value, str) and value:
+            return [value]
+        if isinstance(value, (list, tuple)) and value:
+            candidates = [str(v) for v in value if isinstance(v, str) and v]
+            if candidates:
+                return candidates
+    return []
+
+
+def _candidate_paths(action: SecurityObject) -> list[str]:
+    """Fallback path candidates from the (possibly redacted) SecurityObject."""
+    raw_paths = action.metadata.get("raw_paths") if isinstance(action.metadata, dict) else None
+    if isinstance(raw_paths, (list, tuple)) and raw_paths:
+        return [str(p) for p in raw_paths if isinstance(p, str) and p]
+    if action.target:
+        return [action.target]
+    return []
+
+
+def _paths_for(action: SecurityObject, ctx: EvalContext) -> list[str]:
+    """Prefer raw_arguments paths, then the normalized action target."""
+    raw_arguments = None
+    if isinstance(ctx.metadata, dict):
+        raw_arguments = ctx.metadata.get("raw_arguments")
+    if isinstance(raw_arguments, dict):
+        paths = _raw_path_candidates(raw_arguments)
+        if paths:
+            return paths
+    return _candidate_paths(action)
+
+
+def _repo_root(ctx: EvalContext) -> str:
+    if isinstance(ctx.metadata, dict):
+        return str(ctx.metadata.get("repo_root") or _DEFAULT_ROOT)
+    return _DEFAULT_ROOT
+
+
+def _basename_matches_marker(raw_path: str, root: str) -> bool:
+    """True when the canonical basename is ``SECRETS_TODO.md`` (any case).
+
+    Backslashes are normalized to forward slashes before canonicalization so a
+    Windows-style path string still matches on POSIX hosts (agents sometimes
+    emit ``notes\\SECRETS_TODO.md`` even when the engine runs on Linux).
+    """
+    # Mirror the control-plane helper in paths.py: normalize separators first.
+    normalized = (raw_path or "").replace("\\", "/")
+    canonical = canonicalize(normalized, root=root)
+    # Escapes are the built-in path rule's job; this tutorial rule abstains so
+    # it never invents a second, weaker confinement story.
+    if canonical.escapes_root:
+        return False
+    # relposix is lower-cased and uses forward slashes.
+    basename = canonical.relposix.rsplit("/", 1)[-1]
+    return basename == _MARKER_BASENAME
+
+
+class ExampleRule:
+    """Step up authentication when writing a file named ``SECRETS_TODO.md``.
+
+    Implements the :class:`~doberman.engine.decision_engine.Guardrail` protocol
+    (one method: ``evaluate``). Registered via::
+
+        [project.entry-points."doberman.rules"]
+        example_rule = "example_plugin.rules:ExampleRule"
+    """
+
+    def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:
+        # Scope: only file writes. Reads of the marker file are not stepped up
+        # by this tutorial rule (keep the demo obvious and minimal).
+        if action.action_type is not ActionType.file_write:
+            return _abstain()
+
+        paths = _paths_for(action, ctx)
+        if not paths:
+            return _abstain()
+
+        root = _repo_root(ctx)
+        for raw_path in paths:
+            if _basename_matches_marker(raw_path, root):
+                return GuardrailResult(
+                    verdict=Verdict.AUTH,
+                    risk=Risk.medium,
+                    reason_codes=[ReasonCode.sensitive_path_access],
+                    # Names the *rule*, never the raw path or file contents.
+                    explanation=(
+                        "Write targets a secrets-todo marker file; "
+                        "authentication required before proceeding."
+                    ),
+                )
+        return _abstain()

--- a/examples/plugin-guardrail/tests/test_example_rule.py
+++ b/examples/plugin-guardrail/tests/test_example_rule.py
@@ -1,0 +1,145 @@
+"""Prove the tutorial plugin discovers, evaluates, and stays fail-closed/raise-only.
+
+Run after installing core + this package (from the Doberman-Core checkout)::
+
+    pip install -e .
+    pip install -e examples/plugin-guardrail
+    pytest examples/plugin-guardrail/tests -q
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from doberman.engine.objective import ObjectiveGuardrail
+from doberman.engine.registry import RULE_GROUP, discover_rules
+from doberman.models import (
+    ActionType,
+    EvalContext,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+
+from example_plugin.rules import ExampleRule
+
+
+def _write(target: str) -> SecurityObject:
+    return SecurityObject(
+        id="example-plugin-1",
+        ts=datetime(2026, 7, 19, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.file_write,
+        tool_name="write_file",
+        target=target,
+    )
+
+
+def _ctx(path: str, *, root: str = ".") -> EvalContext:
+    return EvalContext(metadata={"repo_root": root, "raw_arguments": {"path": path}})
+
+
+def test_entry_point_is_discoverable_after_install():
+    """``pip install -e`` registers the entry point; discover_rules finds it."""
+    rules = discover_rules()
+    assert any(isinstance(rule, ExampleRule) for rule in rules), (
+        f"ExampleRule not discovered via {RULE_GROUP!r}; "
+        "install with: pip install -e examples/plugin-guardrail"
+    )
+
+
+def test_write_to_secrets_todo_steps_up_to_auth():
+    rule = ExampleRule()
+    result = rule.evaluate(_write("docs/SECRETS_TODO.md"), _ctx("docs/SECRETS_TODO.md"))
+    assert result.verdict is Verdict.AUTH
+    assert result.risk is Risk.medium
+    assert ReasonCode.sensitive_path_access in result.reason_codes
+
+
+def test_case_and_windows_separators_still_match():
+    """Canonical matching is case-insensitive; backslashes normalize on any OS."""
+    rule = ExampleRule()
+    result = rule.evaluate(
+        _write(r"notes\Secrets_Todo.md"),
+        _ctx(r"notes\Secrets_Todo.md"),
+    )
+    assert result.verdict is Verdict.AUTH
+
+
+def test_redacted_target_still_fires_via_raw_arguments():
+    """Prefer raw_arguments so a length-redacted target cannot bypass the rule."""
+    action = _write("<redacted>")
+    ctx = EvalContext(metadata={"raw_arguments": {"path": "docs/SECRETS_TODO.md"}})
+    assert ExampleRule().evaluate(action, ctx).verdict is Verdict.AUTH
+
+
+def test_target_only_fallback_without_raw_arguments():
+    assert ExampleRule().evaluate(_write("SECRETS_TODO.md"), EvalContext()).verdict is Verdict.AUTH
+
+
+def test_unrelated_write_abstains():
+    rule = ExampleRule()
+    result = rule.evaluate(_write("src/components/Button.tsx"), _ctx("src/components/Button.tsx"))
+    assert result.verdict is Verdict.PASS
+
+
+def test_read_of_marker_abstains():
+    """Tutorial scope is write-only; reads are left to other rules."""
+    action = SecurityObject(
+        id="example-plugin-read",
+        ts=datetime(2026, 7, 19, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.file_read,
+        tool_name="read_file",
+        target="SECRETS_TODO.md",
+    )
+    result = ExampleRule().evaluate(action, _ctx("SECRETS_TODO.md"))
+    assert result.verdict is Verdict.PASS
+
+
+def test_explanation_never_echoes_path_or_payload():
+    """SECURITY: explanation names the rule, never the path or contents."""
+    sensitive_path = "team/private/SECRETS_TODO.md"
+    result = ExampleRule().evaluate(_write(sensitive_path), _ctx(sensitive_path))
+    assert result.verdict is Verdict.AUTH
+    assert sensitive_path not in result.explanation
+    assert "SECRETS_TODO.md" not in result.explanation
+    assert "private" not in result.explanation
+
+
+def test_plugin_fires_inside_objective_guardrail():
+    """With the package installed, ObjectiveGuardrail discovers and runs it."""
+    guardrail = ObjectiveGuardrail()  # load_plugins=True (default)
+    # Benign-looking path for built-ins; only the tutorial plugin steps up.
+    result = guardrail.evaluate(
+        _write("notes/SECRETS_TODO.md"),
+        _ctx("notes/SECRETS_TODO.md"),
+    )
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.sensitive_path_access in result.reason_codes
+
+
+def test_plugin_cannot_lower_a_builtin_block():
+    """Raise-only: PASS from the tutorial rule cannot weaken a built-in BLOCK."""
+    guardrail = ObjectiveGuardrail()
+    action = _write(".env")  # built-in ProtectedPathRule blocks this
+    result = guardrail.evaluate(action, _ctx(".env"))
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+def test_direct_evaluate_never_raises_on_empty_target():
+    """No path → abstain (PASS); evaluate itself must not raise."""
+    action = SecurityObject(
+        id="example-plugin-empty",
+        ts=datetime(2026, 7, 19, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.file_write,
+        tool_name="write_file",
+        target="",
+    )
+    result = ExampleRule().evaluate(action, EvalContext())
+    assert isinstance(result, GuardrailResult)
+    assert result.verdict is Verdict.PASS

--- a/tests/unit/test_examples_plugin_guardrail.py
+++ b/tests/unit/test_examples_plugin_guardrail.py
@@ -1,0 +1,189 @@
+"""CI-visible checks for the tutorial plugin under examples/plugin-guardrail (#91).
+
+The example package is **opt-in** (``pip install -e examples/plugin-guardrail``).
+These tests never install its entry point into the active environment — that would
+pollute every ``ObjectiveGuardrail(load_plugins=True)`` call in the suite.
+
+They do prove:
+
+* the package layout and ``doberman.rules`` entry-point declaration are correct;
+* ``ExampleRule`` evaluates as documented (AUTH on SECRETS_TODO.md write);
+* explanations never echo the path/payload;
+* when injected like a discovered plugin, raise-only still holds with built-ins.
+
+Full entry-point discovery after a real install is covered by the example's own
+tests (``examples/plugin-guardrail/tests/``) and documented in its README.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from doberman.engine import registry
+from doberman.engine.objective import ObjectiveGuardrail
+from doberman.models import (
+    ActionType,
+    EvalContext,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLE_ROOT = _REPO_ROOT / "examples" / "plugin-guardrail"
+_EXAMPLE_SRC = _EXAMPLE_ROOT / "src"
+_EXAMPLE_PYPROJECT = _EXAMPLE_ROOT / "pyproject.toml"
+
+
+@pytest.fixture(scope="module")
+def example_rule_cls():
+    """Import ExampleRule from the checkout without installing the package."""
+    assert _EXAMPLE_SRC.is_dir(), f"missing tutorial package at {_EXAMPLE_SRC}"
+    inserted = str(_EXAMPLE_SRC)
+    sys.path.insert(0, inserted)
+    try:
+        # Fresh import in case a prior test left a stub.
+        sys.modules.pop("example_plugin", None)
+        sys.modules.pop("example_plugin.rules", None)
+        module = importlib.import_module("example_plugin.rules")
+        return module.ExampleRule
+    finally:
+        # Leave the module importable for the rest of this module's tests, but
+        # drop the path entry so we do not permanently shadow site-packages.
+        if sys.path and sys.path[0] == inserted:
+            sys.path.pop(0)
+
+
+def _write(target: str) -> SecurityObject:
+    return SecurityObject(
+        id="ex-plugin-ci-1",
+        ts=datetime(2026, 7, 19, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.file_write,
+        tool_name="write_file",
+        target=target,
+    )
+
+
+def _ctx(path: str) -> EvalContext:
+    return EvalContext(metadata={"raw_arguments": {"path": path}})
+
+
+def test_example_package_layout_exists():
+    assert (_EXAMPLE_ROOT / "README.md").is_file()
+    assert (_EXAMPLE_SRC / "example_plugin" / "rules.py").is_file()
+    assert (_EXAMPLE_ROOT / "tests" / "test_example_rule.py").is_file()
+    assert _EXAMPLE_PYPROJECT.is_file()
+
+
+def test_example_pyproject_declares_doberman_rules_entry_point():
+    data = tomllib.loads(_EXAMPLE_PYPROJECT.read_text(encoding="utf-8"))
+    eps = data["project"]["entry-points"]["doberman.rules"]
+    assert eps["example_rule"] == "example_plugin.rules:ExampleRule"
+    # Mirror the core package name so ``pip install -e`` resolves against this repo.
+    assert "doberman-core" in data["project"]["dependencies"]
+
+
+def test_example_rule_steps_up_marker_write(example_rule_cls):
+    result = example_rule_cls().evaluate(
+        _write("docs/SECRETS_TODO.md"),
+        _ctx("docs/SECRETS_TODO.md"),
+    )
+    assert result.verdict is Verdict.AUTH
+    assert result.risk is Risk.medium
+    assert ReasonCode.sensitive_path_access in result.reason_codes
+
+
+def test_example_rule_prefers_raw_arguments_over_redacted_target(example_rule_cls):
+    """Redacted action.target must not hide a marker write (mirrors paths.py)."""
+    action = _write("<redacted>")
+    ctx = EvalContext(metadata={"raw_arguments": {"path": "docs/SECRETS_TODO.md"}})
+    result = example_rule_cls().evaluate(action, ctx)
+    assert result.verdict is Verdict.AUTH
+
+
+def test_example_rule_falls_back_to_action_target(example_rule_cls):
+    """With no raw_arguments, the (possibly already-safe) target is still matched."""
+    result = example_rule_cls().evaluate(_write("SECRETS_TODO.md"), EvalContext())
+    assert result.verdict is Verdict.AUTH
+
+
+def test_example_rule_case_insensitive_basename(example_rule_cls):
+    result = example_rule_cls().evaluate(
+        _write("notes/Secrets_Todo.md"),
+        _ctx("notes/Secrets_Todo.md"),
+    )
+    assert result.verdict is Verdict.AUTH
+
+
+def test_example_rule_normalizes_backslash_separators(example_rule_cls):
+    """Windows-style separators must match even when the host is POSIX."""
+    result = example_rule_cls().evaluate(
+        _write(r"notes\Secrets_Todo.md"),
+        _ctx(r"notes\Secrets_Todo.md"),
+    )
+    assert result.verdict is Verdict.AUTH
+
+
+def test_example_rule_near_miss_basename_abstains(example_rule_cls):
+    for path in (
+        "docs/SECRETS_TODO.mdx",
+        "docs/not_SECRETS_TODO.md",
+        "docs/SECRETS_TODO.md.bak",
+    ):
+        result = example_rule_cls().evaluate(_write(path), _ctx(path))
+        assert result.verdict is Verdict.PASS, path
+
+
+def test_example_rule_abstains_on_unrelated_write(example_rule_cls):
+    result = example_rule_cls().evaluate(
+        _write("src/components/Button.tsx"),
+        _ctx("src/components/Button.tsx"),
+    )
+    assert result.verdict is Verdict.PASS
+
+
+def test_example_rule_explanation_omits_path_payload(example_rule_cls):
+    path = "team/private/SECRETS_TODO.md"
+    result = example_rule_cls().evaluate(_write(path), _ctx(path))
+    assert result.verdict is Verdict.AUTH
+    assert path not in result.explanation
+    assert "SECRETS_TODO.md" not in result.explanation
+    assert "private" not in result.explanation
+
+
+def test_example_rule_injected_into_objective_guardrail(example_rule_cls):
+    """Simulate discovery by injecting the real class as an extra rule."""
+    guardrail = ObjectiveGuardrail(load_plugins=False, extra_rules=[example_rule_cls()])
+    result = guardrail.evaluate(
+        _write("notes/SECRETS_TODO.md"),
+        _ctx("notes/SECRETS_TODO.md"),
+    )
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.sensitive_path_access in result.reason_codes
+
+
+def test_example_rule_cannot_lower_builtin_block(example_rule_cls):
+    guardrail = ObjectiveGuardrail(load_plugins=False, extra_rules=[example_rule_cls()])
+    result = guardrail.evaluate(_write(".env"), _ctx(".env"))
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+def test_example_rule_is_guardrail_shaped(example_rule_cls):
+    from doberman.engine.decision_engine import Guardrail
+
+    instance = example_rule_cls()
+    assert isinstance(instance, Guardrail)
+
+
+def test_registry_group_constant_matches_example_declaration():
+    """Tutorial pyproject must use the same group name core discovers."""
+    assert registry.RULE_GROUP == "doberman.rules"


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: #91 — tutorial custom Guardrail plugin package
- Plan reference: https://github.com/fu351/Doberman-Core/issues/91

## What this PR does

Doberman’s extensibility story is that third parties can ship rules without core importing them — via the `doberman.rules` entry-point group. Until now there was no worked example to copy.

This PR adds a small, opt-in tutorial package at `examples/plugin-guardrail/` that shows the full round trip:

1. implement a minimal `Guardrail` (`ExampleRule`)
2. register it in the package’s own `pyproject.toml`
3. `pip install -e` → the rule appears in `discover_rules()` / `ObjectiveGuardrail`
4. prove it with focused tests

**Demo behavior:** a `file_write` whose canonical basename is `SECRETS_TODO.md` steps up to **AUTH** (`sensitive_path_access`). Everything else abstains (`PASS`). Harmless on purpose — easy to read in five minutes.

Closes #91.

### What the example teaches

- The real entry-point contract (`doberman.rules`), not a hypothetical API
- Path matching that mirrors `ProtectedPathRule` (prefer `raw_arguments`, canonicalize, normalize `\` → `/`)
- Raise-only discipline: the plugin only ever abstains or steps *up*
- Explanations that name the *rule*, never the raw path or payload

### Why this is isolated and safe

- **No core engine change** — discovery stays in `registry.discover_rules()` as today
- **Opt-in** — default CI does *not* install the package, so standalone / empty-registry checks stay green
- CI unit tests path-import the rule and inject it with `ObjectiveGuardrail(load_plugins=False, extra_rules=[…])`
- Real entry-point discovery is covered by the package’s own tests after editable install (documented uninstall afterward)
- No new production dependency on core; no secrets, network, or payload logging

## Tests added (run in CI)

- `tests/unit/test_examples_plugin_guardrail.py` — layout, entry-point declaration, AUTH/PASS behavior, redacted-target + raw path, backslash normalize, near-miss basenames, explanation redaction, raise-only vs built-in `.env` BLOCK, Guardrail shape
- `examples/plugin-guardrail/tests/test_example_rule.py` — install-time discovery + objective-guardrail fire (run after `pip install -e examples/plugin-guardrail`; not in default `testpaths` by design)

**Local validation** (Python 3.12, rebased on current `main`):

- `ruff check .` / `ruff format --check .` — clean
- `lint-imports` — both contracts kept
- `pytest tests/unit/test_examples_plugin_guardrail.py tests/unit/test_core_is_standalone.py -q` — green
- `pip install -e examples/plugin-guardrail && pytest examples/plugin-guardrail/tests -q` — green (11)
- uninstall → standalone still green

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (example has no fail-open catch-to-PASS; core isolation unchanged)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — tutorial returns only PASS/AUTH; cannot lower a built-in BLOCK
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced

**Covered:** case-insensitive basename; Windows-style separators on any OS; redacted `action.target` with raw path; target-only fallback; near-miss basenames; read/empty abstain; explanation omits path; raise-only vs `.env`.

**Deviations:** none material vs #91. CI unit tests were added so default pytest covers evaluate/raise-only *without* registering the entry point (avoids polluting `discover_rules() == []`).

**Risks / notes:**
- While the example package is installed, core “no plugins registered” assertions fail — expected; README shows uninstall.
- `examples/` is git-checkout oriented (not added to the locked core sdist include list).
- Root README links the tutorial and reminds readers to uninstall for a clean core-only env.

AI assistance was used during implementation and review. The contributor independently verified the design, complete diff, and reported test results.
