### PR TITLE
chore(build): anchor sdist include patterns to the project root

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,13 +61,18 @@ packages = ["src/doberman"]
 
 # Lock down exactly what ships in the sdist so no local/runtime files (graphify-out,
 # .doberman/, *.db, key files, dev plans) can ever leak into a published artifact.
+# Patterns are gitignore-style: the leading "/" anchors each one to the project root,
+# so an unrelated nested copy of the tree (e.g. a stray git worktree inside the
+# checkout) can never match and leak into the artifact.
+# "/tools" ships explicitly because [tool.pytest.ini_options] testpaths lists it.
 [tool.hatch.build.targets.sdist]
 include = [
-    "src/doberman",
-    "tests",
-    "README.md",
-    "LICENSE",
-    "pyproject.toml",
+    "/src/doberman",
+    "/tests",
+    "/tools",
+    "/README.md",
+    "/LICENSE",
+    "/pyproject.toml",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: release hygiene follow-up (v0.15.0 pre-tag sanity finding)
- Plan reference: BUILD-LOG 2026-07-19 (local sdist worktree pollution)

## What this PR does
Anchors every [tool.hatch.build.targets.sdist] include pattern with a leading slash (gitignore-style root anchor) so a stray nested tree inside the checkout (e.g. a git worktree) can never leak duplicate copies into a built sdist. Makes tools/ inclusion explicit since pytest testpaths references it (previously it shipped only partially via accidental unanchored matches).

CI-built artifacts were never affected (fresh checkout contains no nested trees) - this is defense-in-depth for any contaminated build environment.

## Tests added (run in CI)
- None (build-config only). Verified locally: a fake nested tree (.wt-fake/ with tests/, README.md, pyproject.toml) no longer ships; top-level sdist contents unchanged plus complete tools/.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the not-allowed list
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (N/A - build config)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (N/A)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (N/A)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Tightens the artifact surface only; sdist content for a clean checkout is unchanged except tools/ now ships completely instead of partially.