### PR TITLE
fix(dash): refresh stats on an interval and compact feed timestamps

### DIFF
--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -285,15 +285,22 @@ _HTML_SHELL = """<!doctype html>
         enforcementBadge.className = ENFORCEMENT_BADGE_CLASS[s.enforcement] || "badge badge-neutral";
       }
 
-      fetch("/api/stats", { headers: { "Authorization": "Bearer " + token } })
-        .then(function (res) {
-          if (!res.ok) { throw new Error("status " + res.status); }
-          return res.json();
-        })
-        .then(renderStats)
-        .catch(function () {
-          statsEl.textContent = "stats unavailable";
-        });
+      // Stats refresh on an interval, not just at page load - otherwise the
+      // counters freeze at their load-time values while the live feed fills.
+      var STATS_REFRESH_MS = 5000;
+      function refreshStats() {
+        fetch("/api/stats", { headers: { "Authorization": "Bearer " + token } })
+          .then(function (res) {
+            if (!res.ok) { throw new Error("status " + res.status); }
+            return res.json();
+          })
+          .then(renderStats)
+          .catch(function () {
+            statsEl.textContent = "stats unavailable";
+          });
+      }
+      refreshStats();
+      setInterval(refreshStats, STATS_REFRESH_MS);
 
       var pendingList = document.getElementById("pending-list");
       var PENDING_POLL_MS = 2000;
@@ -419,10 +426,12 @@ _HTML_SHELL = """<!doctype html>
           detail.className = "detail";
           // textContent only - a row-derived string must render literally,
           // never as markup (mirrors the TUI's markup=False discipline).
+          // Compact HH:MM:SS (UTC) - the full ISO timestamp is noise at a glance
+          // and stays available in `doberman log` / the TUI.
           detail.textContent = row.action_type +
             " " + (row.target_path_class || "-") +
             " " + (row.reason_codes && row.reason_codes.length ? row.reason_codes.join(",") : "-") +
-            " @ " + row.ts;
+            " @ " + (String(row.ts || "").slice(11, 19) || "-");
           li.appendChild(detail);
 
           // The empty state is CSS-only (`#feed:not(:empty) ~ #feed-empty`) -

--- a/tests/unit/test_dash_polish.py
+++ b/tests/unit/test_dash_polish.py
@@ -104,3 +104,19 @@ def test_feed_and_pending_rows_still_use_textcontent_only(tmp_path):
     # (The word "innerHTML" legitimately appears in comments documenting this
     # discipline, so assert on the assignment form specifically.)
     assert ".innerHTML" not in html
+
+
+def test_stats_refresh_on_an_interval_not_just_at_load(tmp_path):
+    html = _index_html(tmp_path)
+    # Counters must track the live feed instead of freezing at their
+    # page-load values.
+    assert "function refreshStats()" in html
+    assert "setInterval(refreshStats, STATS_REFRESH_MS)" in html
+
+
+def test_feed_timestamp_renders_compact_not_full_iso(tmp_path):
+    html = _index_html(tmp_path)
+    # HH:MM:SS sliced from the ISO string; the full timestamp stays available
+    # in `doberman log` / the TUI.
+    assert ".slice(11, 19)" in html
+    assert '" @ " + row.ts;' not in html


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: dash polish follow-up (found while recording the README hero GIF)

## What this PR does
The stats row was fetched once at page load and froze at those values while the live feed kept filling - visibly wrong on camera (feed shows 7 decisions, counters read 0). Stats now refresh every 5s via the same authed GET. Feed timestamps render as compact HH:MM:SS sliced from the ISO string (full precision stays in doberman log / the TUI).

## Tests added (run in CI)
- tests/unit/test_dash_polish.py: stats-refresh interval present; compact timestamp form present and the old full-ISO render gone. Full dash suite: 58 passed.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the not-allowed list
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (stats fetch failure renders 'stats unavailable', nothing else changes)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (N/A - UI only)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (N/A)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- textContent-only rendering discipline unchanged (asserted by existing test); no new endpoints; missing/short ts renders '-'.