### PR TITLE
fix(ci): add a Windows CI leg and fix cross-drive key-path test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,25 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    # Windows runners default `run:` to PowerShell; pin bash (Git Bash ships on
+    # GitHub's Windows images) so the shell-scripted steps below — the `grep`-based
+    # standalone-guarantee check in particular — behave identically on every OS.
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
+        os: ["ubuntu-latest"]
         python-version: ["3.11", "3.12"]
+        # Doberman is a local-first tool that runs on developer machines of every
+        # OS, and it carries OS-specific code (e.g. the Windows O_BINARY key-write
+        # path in storage/fingerprint.py). Guard that surface with one Windows leg
+        # so cross-platform regressions surface in CI, not on a contributor's box.
+        include:
+          - os: "windows-latest"
+            python-version: "3.12"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/tests/unit/test_fingerprint.py
+++ b/tests/unit/test_fingerprint.py
@@ -110,8 +110,16 @@ def test_default_key_path_is_outside_any_repo(monkeypatch):
     monkeypatch.delenv(KEY_FILE_ENV, raising=False)
     path = fp_mod._default_key_path()
     assert "doberman" in str(path).lower()
-    # It must not resolve inside the current working directory (the repo).
-    assert os.path.commonpath([str(path.resolve()), os.getcwd()]) != os.getcwd()
+    # It must not resolve inside the current working directory (the repo). On
+    # Windows the per-user config dir and the repo can sit on different drives
+    # (e.g. key under C:\Users\...\AppData while the checkout is on D:\); there
+    # commonpath raises ValueError, which is itself proof the key is outside the
+    # repo — the exact property this test guards. Treat it as a pass.
+    try:
+        common = os.path.commonpath([str(path.resolve()), os.getcwd()])
+    except ValueError:
+        common = None  # no shared path at all -> definitively outside the repo
+    assert common != os.getcwd()
 
 
 def test_fingerprint_module_exposes_no_plaintext_key(key_path):


### PR DESCRIPTION
The default fingerprint key path and the repo can live on different Windows drives (e.g. key under C:\Users\...\AppData, checkout on D:\), where os.path.commonpath raises ValueError — the only failing test on multi-drive Windows. Treat a cross-drive result as proof the key is outside the repo.

Also add one windows-latest CI leg (guarding OS-specific code like the O_BINARY key-write path) and pin the job shell to bash so the grep-based standalone-guarantee step behaves identically on Windows.

# Pull Request

## Slice
- Repo: doberman-core | doberman-enterprise
- Feature / Slice: <id> — <title>
- Plan reference: doberman_implementation_plan.md

## What this PR does

## Tests added (run in CI)
-

## Public-release safety (doberman-core only)
- [ ] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [ ] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [ ] Fails closed on error / uncertainty
- [ ] No secret, full file, or unredacted prompt logged or committed
- [ ] Any guardrail/learning change is raise-only (no silent loosening)
- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
- [ ] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
-
