### PR TITLE
chore(ci): run one workflow per push instead of two

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: ["feat/**", "fix/**", "chore/**", "main"]
+    branches: ["main"]
   pull_request:
     branches: ["main"]
 permissions:


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: chore — single CI run per push
- Plan reference: N/A (CI infra fix)

## What this PR does
`ci.yml` previously triggered on both `push` (branches `feat/**`, `fix/**`, `chore/**`, `main`) and
`pull_request` (branches `main`). For any branch with an open PR, every push therefore spawned two
complete duplicate workflow runs (one `push` event, one `pull_request` event) — 8 checks instead of 4
(3-job test matrix + secret-scan, doubled). Confirmed by direct observation: commit `2491c81` produced
both a `pull_request` run and a `push` run for the same commit.

Fix: narrow the `push` trigger to `branches: ["main"]` only. Feature branches get their CI from the
`pull_request` trigger (which re-runs on every push to a branch with an open PR); `main` keeps its
post-merge CI via `push`.

**Behavioral change worth calling out:** a push to a `feat/**`/`fix/**`/`chore/**` branch with **no open
PR yet** will no longer trigger CI until a PR is opened. This is the intended tradeoff — CI now runs once
per push instead of twice, at the cost of not running before a PR exists.

## Tests added (run in CI)
- None — this is a CI-workflow-only change; validated locally via `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` (YAML parses) and by observing this PR's own CI runs below.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (N/A — no runtime/decision-path code touched)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) (N/A — no guardrail code touched)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (N/A — no guardrail code touched)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Risk: a `feat/**` branch push with no open PR yet won't get CI until the PR is opened (see behavioral-change note above). No other workflow behavior (matrix, Windows leg, permissions, job steps, concurrency) changed.