### PR TITLE
feat(cost): loop-anomaly detector over the cost ledger (CB.3)

### DIFF
--- a/src/doberman/storage/cost.py
+++ b/src/doberman/storage/cost.py
@@ -3,7 +3,8 @@
 Persists redaction-safe :class:`~doberman.models.CostEvent` rows to the
 append-only ``cost_events`` ledger and reads them back as aggregate totals —
 the raw material for the third boundary (a budget ceiling, platform-side) and
-for the CB.3 loop-anomaly detector.
+for the :func:`detect_loop_anomaly` loop-anomaly detector (CB.3), an advisory
+read over the same ledger that flags a runaway/looping token or tool-call burn.
 
 Two non-negotiables, mirrored from the decision log:
 
@@ -26,6 +27,8 @@ This module is policy-core storage and must never import ``doberman.proxy``.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Protocol, runtime_checkable
 
 from doberman.models import CostEvent, CostKind
@@ -167,3 +170,185 @@ async def read_breakdown(repo_root: str, *, entity_id: str | None = None) -> dic
     except Exception:  # noqa: BLE001 — a meter read must never break a caller
         logger.warning("cost meter breakdown read failed; reporting empty")
         return {}
+
+
+# --- Loop-anomaly detector (CB.3) --------------------------------------------
+
+#: Advisory default thresholds for the loop-anomaly readout, over a rolling
+#: window. A runaway agent stuck in a tool-call loop shows up as an abnormal
+#: number of actions (``call_burst``) or an abnormal token burn (``token_burst``)
+#: in a short span; a human-paced session does not. These are deliberately
+#: conservative (few false positives) and fully overridable per call — the
+#: readout is advisory, so a caller can tune freely without ever touching a
+#: safety verdict.
+_DEFAULT_WINDOW_SECONDS = 60
+_DEFAULT_MAX_CALLS = 40
+_DEFAULT_MAX_UNITS = 200_000
+
+#: Hard cap on rows pulled for a single readout, so a pathologically large
+#: ledger can never make an advisory read expensive. Recent rows are read first.
+_ANOMALY_ROW_CAP = 5000
+
+
+@dataclass(frozen=True)
+class LoopAnomaly:
+    """Advisory read of the cost ledger: is an entity in a runaway/looping burn?
+
+    Redaction-safe by construction — it holds **counts and a coarse signal label
+    only**, never a raw role/path (``entity_id`` is already a keyed HMAC upstream
+    and is not echoed here) and never any payload. Crucially this is **not a
+    verdict**: the cost layer is off the decision path, so a ``LoopAnomaly`` can
+    flag a runaway loop for a human, a dashboard, or a ``CostObserver`` — but it
+    can never itself block, step up, or otherwise alter a PASS/AUTH/BLOCK.
+    """
+
+    #: True when the window's activity crossed an advisory threshold.
+    is_anomaly: bool
+    #: Which signal tripped: ``""`` (none), ``"call_burst"``, or ``"token_burst"``.
+    signal: str
+    #: The rolling window examined, in seconds.
+    window_seconds: int
+    #: Tool-call cost events observed in the window (the loop signal).
+    calls: int
+    #: Summed token units (``tokens_in`` + ``tokens_out``) observed in the window.
+    units: int
+    #: One-line, redaction-safe human explanation (counts + classes only).
+    explanation: str
+
+
+def _calm(window_seconds: int) -> LoopAnomaly:
+    """A benign (no-anomaly) readout — the fail-safe and empty-ledger result."""
+    return LoopAnomaly(
+        is_anomaly=False,
+        signal="",
+        window_seconds=window_seconds,
+        calls=0,
+        units=0,
+        explanation="No runaway cost pattern in the recent window.",
+    )
+
+
+async def detect_loop_anomaly(
+    repo_root: str,
+    *,
+    entity_id: str | None = None,
+    now: datetime | None = None,
+    window_seconds: int = _DEFAULT_WINDOW_SECONDS,
+    max_calls: int = _DEFAULT_MAX_CALLS,
+    max_units: int = _DEFAULT_MAX_UNITS,
+) -> LoopAnomaly:
+    """Advisory: does the cost ledger show a runaway/looping burn for an entity?
+
+    Reads the cost events in ``[now - window_seconds, now]`` (optionally scoped to
+    one ``entity_id``) and flags a ``call_burst`` when the number of **tool-call**
+    events exceeds ``max_calls`` or a ``token_burst`` when the summed **token**
+    units (``tokens_in`` + ``tokens_out``) exceed ``max_units`` (a call burst takes
+    precedence in the label). Counting only tool-call rows and summing only token
+    units keeps each signal a single, well-defined quantity — one agent action
+    emits several ``CostEvent`` rows of different kinds, so counting every row (or
+    summing mixed units) would mis-calibrate both thresholds.
+
+    ``now`` defaults to the current UTC time; pass it explicitly for a
+    deterministic/historical read.
+
+    **Off the decision path and fail-safe:** the result is advisory only, and any
+    read/parse error, an empty ledger, or a non-tz-aware ``now`` yields a calm,
+    no-anomaly readout — this detector must never raise into, or gate, the caller.
+    """
+    if window_seconds <= 0:
+        return _calm(window_seconds)
+    if now is None:
+        now = datetime.now(timezone.utc)
+    # Fail-safe on a naive `now`: the ledger stores tz-aware ISO timestamps, so a
+    # naive cutoff would raise TypeError on the ``ts`` comparison below. The
+    # detector's contract is that it never raises into its caller, so a naive
+    # `now` (the natural mistake of passing a bare ``datetime.now()``) returns a
+    # calm readout instead of crashing.
+    if now.tzinfo is None:
+        return _calm(window_seconds)
+    cutoff = now - timedelta(seconds=window_seconds)
+
+    where = " WHERE entity_id = ?" if entity_id is not None else ""
+    params: list[object] = [entity_id] if entity_id is not None else []
+    try:
+        async with open_db(repo_root) as conn:
+            async with conn.execute(
+                # Order by the monotonic AUTOINCREMENT PK (part of idx_cost_events),
+                # not the TEXT ``ts``: "most recently recorded first, capped" is then
+                # an indexed read, not a full scan + string sort, and is immune to
+                # mixed UTC offsets in stored timestamps. This suits the detector's
+                # live "is this entity looping right now" use; for a far-historical
+                # ``now`` on a ledger with more than the cap of newer rows, in-window
+                # rows can be crowded out — an accepted under-count for an advisory
+                # readout. The precise window filter runs in Python below.
+                f"SELECT kind, ts, units FROM cost_events{where} ORDER BY id DESC LIMIT ?",  # noqa: S608 — fixed clause, params bound
+                [*params, _ANOMALY_ROW_CAP],
+            ) as cur:
+                rows = await cur.fetchall()
+    except Exception:  # noqa: BLE001 — an advisory read must never break a caller
+        logger.warning("loop-anomaly read failed; reporting calm")
+        return _calm(window_seconds)
+
+    _TOKEN_KINDS = (CostKind.tokens_in.value, CostKind.tokens_out.value)
+    calls = 0
+    units = 0
+    for kind_raw, ts_raw, unit_raw in rows:
+        try:
+            ts = datetime.fromisoformat(ts_raw)
+        except (TypeError, ValueError):
+            continue  # unparseable row — skip, never crash the readout
+        # A legacy/malformed row carrying a *naive* timestamp cannot be compared
+        # with the aware cutoff (TypeError) — skip it rather than let the whole
+        # read raise. (Current writers always store aware timestamps; this guards
+        # a hand-written or pre-migration row.)
+        if ts.tzinfo is None:
+            continue
+        if ts < cutoff or ts > now:
+            continue
+        # A loop is a burst of *tool calls*; the token burn is measured only on
+        # *token* kinds. Other kinds contribute to neither signal.
+        if kind_raw == CostKind.tool_call.value:
+            calls += 1
+        elif kind_raw in _TOKEN_KINDS:
+            try:
+                units += max(0, int(unit_raw))
+            except (TypeError, ValueError):
+                continue
+
+    # Ceiling (known, and deliberately named before anything depends on it): the
+    # burst signals are scoped per ``entity_id``, so a caller that can rotate the
+    # entity id between actions resets the counter and evades the burst. Harmless
+    # while this detector is advisory with no production caller; a real wiring
+    # (the CB.3 seam in #143) must bound entity rotation before relying on it.
+    if calls > max_calls:
+        return LoopAnomaly(
+            is_anomaly=True,
+            signal="call_burst",
+            window_seconds=window_seconds,
+            calls=calls,
+            units=units,
+            explanation=(
+                f"{calls} tool calls in {window_seconds}s exceed the advisory "
+                f"limit of {max_calls}; possible runaway tool-call loop."
+            ),
+        )
+    if units > max_units:
+        return LoopAnomaly(
+            is_anomaly=True,
+            signal="token_burst",
+            window_seconds=window_seconds,
+            calls=calls,
+            units=units,
+            explanation=(
+                f"{units} tokens in {window_seconds}s exceed the advisory limit of "
+                f"{max_units}; possible runaway token burn."
+            ),
+        )
+    return LoopAnomaly(
+        is_anomaly=False,
+        signal="",
+        window_seconds=window_seconds,
+        calls=calls,
+        units=units,
+        explanation="No runaway cost pattern in the recent window.",
+    )

--- a/tests/unit/test_cost_loop_anomaly.py
+++ b/tests/unit/test_cost_loop_anomaly.py
@@ -1,0 +1,281 @@
+"""Feature CB.3 — loop-anomaly detector over the cost ledger.
+
+Covers:
+* empty ledger / calm window -> no anomaly
+* a call burst over the window threshold -> ``call_burst``
+* a token burst over the window threshold -> ``token_burst``
+* events outside the rolling window are ignored
+* the exact threshold boundary (calls == max_calls is NOT an anomaly)
+* per-entity scoping: one entity's burst never flags another
+* the readout is advisory (never a verdict) and fail-safe: a broken DB, a naive
+  ``now``, and a legacy naive-timestamp row all report calm and never raise
+* the explanation is redaction-safe: counts/classes only, no raw entity id
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from doberman.models import CostEvent, CostKind
+from doberman.storage.cost import (
+    LoopAnomaly,
+    detect_loop_anomaly,
+    record_cost_event,
+)
+from doberman.storage.db import open_db
+
+_NOW = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def _event(units: int, *, ts: datetime, kind: CostKind = CostKind.tool_call, entity_id="e1"):
+    return CostEvent(action_id="a1", ts=ts, kind=kind, units=units, entity_id=entity_id)
+
+
+async def _seed(root, events):
+    for ev in events:
+        await record_cost_event(ev, repo_root=root)
+
+
+# --- empty / calm ------------------------------------------------------------
+
+
+async def test_empty_ledger_is_calm(tmp_path):
+    result = await detect_loop_anomaly(str(tmp_path), entity_id="e1", now=_NOW)
+    assert isinstance(result, LoopAnomaly)
+    assert result.is_anomaly is False
+    assert result.signal == ""
+    assert result.calls == 0 and result.units == 0
+
+
+async def test_activity_below_threshold_is_calm(tmp_path):
+    root = str(tmp_path)
+    await _seed(root, [_event(10, ts=_NOW - timedelta(seconds=i)) for i in range(5)])
+    result = await detect_loop_anomaly(root, entity_id="e1", now=_NOW, max_calls=40)
+    assert result.is_anomaly is False
+    assert result.calls == 5
+
+
+# --- call burst --------------------------------------------------------------
+
+
+async def test_call_burst_over_threshold_flags(tmp_path):
+    root = str(tmp_path)
+    # 30 events inside a 60s window, threshold 20 -> call_burst.
+    await _seed(root, [_event(1, ts=_NOW - timedelta(seconds=i % 60)) for i in range(30)])
+    result = await detect_loop_anomaly(root, entity_id="e1", now=_NOW, max_calls=20)
+    assert result.is_anomaly is True
+    assert result.signal == "call_burst"
+    assert result.calls == 30
+
+
+# --- exact threshold boundary ------------------------------------------------
+
+
+async def test_exact_threshold_is_not_an_anomaly(tmp_path):
+    root = str(tmp_path)
+    # calls == max_calls must NOT flag: the predicate is strictly ``> max_calls``.
+    await _seed(root, [_event(1, ts=_NOW - timedelta(seconds=i % 60)) for i in range(20)])
+    at_limit = await detect_loop_anomaly(root, entity_id="e1", now=_NOW, max_calls=20)
+    assert at_limit.calls == 20
+    assert at_limit.is_anomaly is False
+
+    # One more event crosses it.
+    await _seed(root, [_event(1, ts=_NOW)])
+    over = await detect_loop_anomaly(root, entity_id="e1", now=_NOW, max_calls=20)
+    assert over.calls == 21
+    assert over.is_anomaly is True
+    assert over.signal == "call_burst"
+
+
+# --- token burst -------------------------------------------------------------
+
+
+async def test_token_burst_over_threshold_flags(tmp_path):
+    root = str(tmp_path)
+    # Few calls, but huge token burn -> token_burst (not a call burst).
+    await _seed(
+        root,
+        [_event(50_000, ts=_NOW - timedelta(seconds=i), kind=CostKind.tokens_in) for i in range(4)],
+    )
+    result = await detect_loop_anomaly(
+        root, entity_id="e1", now=_NOW, max_calls=40, max_units=100_000
+    )
+    assert result.is_anomaly is True
+    assert result.signal == "token_burst"
+    assert result.units == 200_000
+    assert result.calls == 0  # token rows are not tool calls
+
+
+async def test_call_burst_takes_precedence_over_token_burst(tmp_path):
+    root = str(tmp_path)
+    # Genuinely cross BOTH thresholds: 30 tool calls (> max_calls) AND 200k tokens
+    # (> max_units). The label must be the call burst.
+    await _seed(root, [_event(1, ts=_NOW - timedelta(seconds=i % 30)) for i in range(30)])
+    await _seed(
+        root,
+        [
+            _event(10_000, ts=_NOW - timedelta(seconds=i % 30), kind=CostKind.tokens_in)
+            for i in range(20)
+        ],
+    )
+    result = await detect_loop_anomaly(
+        root, entity_id="e1", now=_NOW, max_calls=20, max_units=100_000
+    )
+    assert result.is_anomaly is True
+    assert result.signal == "call_burst"
+    assert result.calls == 30
+    assert result.units == 200_000
+
+
+# --- signal calibration: which kinds feed which signal -----------------------
+
+
+async def test_token_kinds_do_not_count_as_tool_calls(tmp_path):
+    root = str(tmp_path)
+    # 30 token rows, but zero tool calls -> no call_burst (calls stays 0).
+    await _seed(
+        root,
+        [
+            _event(1, ts=_NOW - timedelta(seconds=i % 60), kind=CostKind.tokens_in)
+            for i in range(30)
+        ],
+    )
+    result = await detect_loop_anomaly(
+        root, entity_id="e1", now=_NOW, max_calls=20, max_units=10_000_000
+    )
+    assert result.calls == 0
+    assert result.is_anomaly is False
+
+
+async def test_tool_call_units_do_not_count_as_token_burn(tmp_path):
+    root = str(tmp_path)
+    # tool_call rows carrying large `units` must NOT be summed as token burn.
+    await _seed(root, [_event(50_000, ts=_NOW - timedelta(seconds=i)) for i in range(4)])
+    result = await detect_loop_anomaly(
+        root, entity_id="e1", now=_NOW, max_calls=40, max_units=100_000
+    )
+    assert result.units == 0  # tool_call units are not token units
+    assert result.is_anomaly is False
+
+
+async def test_now_defaults_to_current_utc_time(tmp_path):
+    # Omitting `now` must not raise (default = current UTC). Rows dated far in the
+    # past fall outside the default window -> calm, no exception.
+    root = str(tmp_path)
+    await _seed(root, [_event(1, ts=_NOW - timedelta(days=365)) for _ in range(30)])
+    result = await detect_loop_anomaly(root, entity_id="e1", max_calls=20)
+    assert isinstance(result, LoopAnomaly)
+    assert result.is_anomaly is False
+
+
+# --- window boundary ---------------------------------------------------------
+
+
+async def test_events_outside_window_are_ignored(tmp_path):
+    root = str(tmp_path)
+    # 30 events, but all older than the 60s window -> calm.
+    await _seed(root, [_event(1, ts=_NOW - timedelta(seconds=300 + i)) for i in range(30)])
+    result = await detect_loop_anomaly(
+        root, entity_id="e1", now=_NOW, window_seconds=60, max_calls=20
+    )
+    assert result.is_anomaly is False
+    assert result.calls == 0
+
+
+async def test_future_events_are_ignored(tmp_path):
+    root = str(tmp_path)
+    await _seed(root, [_event(1, ts=_NOW + timedelta(seconds=10 + i)) for i in range(30)])
+    result = await detect_loop_anomaly(root, entity_id="e1", now=_NOW, max_calls=20)
+    assert result.is_anomaly is False
+    assert result.calls == 0
+
+
+async def test_nonpositive_window_is_calm(tmp_path):
+    root = str(tmp_path)
+    await _seed(root, [_event(1, ts=_NOW) for _ in range(30)])
+    result = await detect_loop_anomaly(root, entity_id="e1", now=_NOW, window_seconds=0)
+    assert result.is_anomaly is False
+
+
+# --- per-entity scoping ------------------------------------------------------
+
+
+async def test_burst_is_scoped_to_its_entity(tmp_path):
+    root = str(tmp_path)
+    await _seed(
+        root, [_event(1, ts=_NOW - timedelta(seconds=i % 60), entity_id="e1") for i in range(30)]
+    )
+    # e2 did nothing; its readout is calm even though e1 is bursting.
+    result = await detect_loop_anomaly(root, entity_id="e2", now=_NOW, max_calls=20)
+    assert result.is_anomaly is False
+    assert result.calls == 0
+    # e1's own readout flags.
+    hot = await detect_loop_anomaly(root, entity_id="e1", now=_NOW, max_calls=20)
+    assert hot.is_anomaly is True
+
+
+# --- advisory + fail-safe ----------------------------------------------------
+
+
+def test_loop_anomaly_is_not_a_verdict():
+    # Structural guard: the advisory readout carries no verdict/risk field, so it
+    # cannot be mistaken for (or wired into) a decision.
+    fields = LoopAnomaly.__dataclass_fields__
+    assert "verdict" not in fields and "risk" not in fields
+
+
+async def test_broken_db_reports_calm_and_never_raises(tmp_path, monkeypatch):
+    import doberman.storage.cost as cost_mod
+
+    def _boom(*args, **kwargs):
+        raise OSError("disk gone")
+
+    monkeypatch.setattr(cost_mod, "open_db", _boom)
+    result = await detect_loop_anomaly(str(tmp_path), entity_id="e1", now=_NOW)
+    assert result.is_anomaly is False
+    assert result.signal == ""
+
+
+async def test_naive_now_reports_calm_and_never_raises(tmp_path):
+    # A caller passing a bare (tz-naive) datetime.now() must not trigger a
+    # TypeError against the ledger's aware timestamps — it reports calm instead.
+    root = str(tmp_path)
+    await _seed(root, [_event(1, ts=_NOW - timedelta(seconds=i % 60)) for i in range(30)])
+    naive_now = datetime(2026, 1, 1, 12, 0)  # no tzinfo
+    result = await detect_loop_anomaly(root, entity_id="e1", now=naive_now, max_calls=20)
+    assert result.is_anomaly is False
+    assert result.calls == 0
+
+
+async def test_legacy_naive_row_is_skipped_not_raised(tmp_path):
+    # A hand-written / pre-migration row with a NAIVE iso timestamp must not crash
+    # the readout (aware-vs-naive comparison would TypeError). It is skipped.
+    root = str(tmp_path)
+    # A valid, in-window aware row so there is something to count.
+    await _seed(root, [_event(1, ts=_NOW)])
+    # Inject a naive-timestamp row directly, bypassing the aware-only model.
+    async with open_db(root) as conn:
+        await conn.execute(
+            "INSERT INTO cost_events (ts, action_id, kind, units, model, entity_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("2026-01-01T12:00:00", "legacy", CostKind.tool_call.value, 1, None, "e1"),
+        )
+        await conn.commit()
+    result = await detect_loop_anomaly(root, entity_id="e1", now=_NOW, max_calls=0)
+    # Did not raise; the naive row was skipped, only the one aware row counted.
+    assert result.calls == 1
+
+
+# --- redaction ---------------------------------------------------------------
+
+
+async def test_explanation_is_redaction_safe(tmp_path):
+    root = str(tmp_path)
+    distinctive = "hmac:super-distinctive-entity-fingerprint"
+    await _seed(
+        root,
+        [_event(1, ts=_NOW - timedelta(seconds=i % 60), entity_id=distinctive) for i in range(30)],
+    )
+    result = await detect_loop_anomaly(root, entity_id=distinctive, now=_NOW, max_calls=20)
+    assert result.is_anomaly is True
+    # The raw entity fingerprint never appears in the human explanation.
+    assert "super-distinctive-entity-fingerprint" not in result.explanation
+    assert distinctive not in result.explanation


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: CB.3 — loop-anomaly detector over the cost ledger (part of #143)
- Plan reference: doberman_implementation_plan.md (Slice CB.3)

## What this PR does

Rebased onto current `main` and **narrowed to the two net-new files** — the CI/CD-config glob work is already carried forward in #203, so `paths.py` / `README.md` / `CHANGELOG.md` are dropped here.

Adds `detect_loop_anomaly()` over the append-only `cost_events` ledger. Over a rolling window (optionally scoped to one `entity_id`) it flags a runaway/looping burn:
- **`call_burst`** — number of `tool_call` events exceeds `max_calls`
- **`token_burst`** — summed token units (`tokens_in` + `tokens_out`) exceed `max_units`

It returns an advisory `LoopAnomaly` (counts + a coarse signal label + a redaction-safe explanation). **Infra-first slice:** `detect_loop_anomaly` / `LoopAnomaly` are not wired into any caller yet — the `CostObserver` seam that gives it a home is #143.

### Review feedback addressed (from the earlier pass on this PR)
- **The `TypeError` in the "never raises" path is fixed.** A tz-naive `now` (or a legacy naive-timestamp row) compared against the ledger's aware timestamps used to raise outside the failure boundary. Now: a naive `now` returns calm up front, `now` is optional (defaults to `datetime.now(timezone.utc)`) so omitting it can't raise, and naive rows are skipped in-loop.
- **Signals calibrated to single, well-defined quantities.** One agent action emits several `CostEvent` rows, so `call_burst` now counts only `tool_call` rows and `token_burst` sums only token-kind units (previously it counted all rows / summed mixed units).
- **Bounded read is a real indexed scan.** Capped by the monotonic `id` PK (part of `idx_cost_events`) instead of the unindexed TEXT `ts`, which also removes the mixed-UTC-offset string-ordering hazard.
- **Kept** the parameterized SQL (`# noqa: S608` justified), the `_ANOMALY_ROW_CAP` DoS bound, the broken-DB fail-safe test, the not-a-verdict structural test, and the redaction test.
- **Named the per-`entity_id` burst-scoping ceiling** in a comment so it's on record before anything depends on it.

## Tests added (run in CI)
- `tests/unit/test_cost_loop_anomaly.py` — 18 tests: empty/calm, call_burst, token_burst, precedence, window/future boundaries, **exact `calls == max_calls` boundary**, per-entity scoping, kind-scoping of each signal, **`now` default**, **naive `now`**, **legacy naive DB row**, broken-DB fail-safe, not-a-verdict, and explanation redaction.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty — every error path (bad `now`, unparseable/naive row, DB failure) returns a calm readout; the detector never raises into its caller
- [x] No secret, full file, or unredacted prompt logged or committed — `LoopAnomaly` holds counts + a coarse label only; a test asserts the raw `entity_id` never appears in the explanation
- [x] Any guardrail/learning change is raise-only (no silent loosening) — N/A: this is advisory and **off the decision path**; `test_loop_anomaly_is_not_a_verdict` asserts it structurally
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — N/A: emits no verdict
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- **Deviation (agreed on the thread):** landed as the advisory **detector half** of #143; the sliding-window/tag/AUTH wiring belongs to the `CostObserver` seam and is deferred to #143.
- **Known ceiling (commented):** burst signals are per-`entity_id`, so a caller able to rotate the entity id resets the counter — harmless while advisory with no production caller; the #143 wiring must bound it.
- **Known limitation (commented):** the `id`-ordered row cap suits the live "is this entity looping now" read; a far-historical `now` on a ledger with more than the cap of newer rows can under-count — an accepted trade-off for an advisory readout.
