### PR TITLE
fix(dash): keep the dashboard authenticated across a reload

### DIFF
--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -219,11 +219,25 @@ _HTML_SHELL = """<!doctype html>
         off: "badge badge-block"
       };
 
+      var TOKEN_KEY = "doberman-dash-token";
       var params = new URLSearchParams(window.location.search);
       var token = params.get("token") || "";
+      // The token is stripped from the address bar below, so a reload re-fetches
+      // a URL that no longer carries it. Hand it to sessionStorage (per-tab,
+      // dies with the tab) so refreshing this tab doesn't strand the page
+      // permanently unauthenticated with no way back but restarting the CLI.
+      // Wrapped because sessionStorage throws outright in some privacy modes -
+      // there we simply degrade to the old memory-only behavior.
+      try {
+        if (token) {
+          window.sessionStorage.setItem(TOKEN_KEY, token);
+        } else {
+          token = window.sessionStorage.getItem(TOKEN_KEY) || "";
+        }
+      } catch (e) { /* no storage: this page load still works, a reload won't */ }
       // Strip the token from the URL/history immediately so it never lingers
-      // in browser history, a referrer header, or a screen share. It is kept
-      // only in this closure's memory for the life of the page.
+      // in browser history, a referrer header, or a screen share. A brand-new
+      // tab has no sessionStorage of its own, so it still needs the printed link.
       params.delete("token");
       var clean = window.location.pathname
         + (params.toString() ? "?" + params.toString() : "");
@@ -239,16 +253,29 @@ _HTML_SHELL = """<!doctype html>
 
       fetch("/api/health", { headers: { "Authorization": "Bearer " + token } })
         .then(function (res) {
-          if (!res.ok) { throw new Error("status " + res.status); }
+          if (!res.ok) {
+            var httpError = new Error("status " + res.status);
+            httpError.status = res.status;
+            throw httpError;
+          }
           return res.json();
         })
         .then(function () {
           dot.className = "dot ok";
           label.textContent = "connected";
         })
-        .catch(function () {
+        .catch(function (err) {
           dot.className = "dot err";
-          label.textContent = "not connected";
+          // A rejected token is the one failure a human can actually fix, and
+          // only by reopening the link THIS run printed - so say that instead
+          // of a dead-end "not connected", and drop the stale token so the next
+          // load doesn't silently retry it.
+          if (err && err.status === 401) {
+            try { window.sessionStorage.removeItem(TOKEN_KEY); } catch (e) {}
+            label.textContent = "not authorized - reopen the link printed by doberman dash";
+          } else {
+            label.textContent = "not connected";
+          }
         });
 
       function renderStats(s) {

--- a/tests/unit/test_dash_token_reload.py
+++ b/tests/unit/test_dash_token_reload.py
@@ -1,0 +1,55 @@
+"""The dashboard's session token must survive a reload of its own tab.
+
+The page strips the token out of the address bar on load (so it can't leak via
+history, a referrer, or a screen share), which means a refresh re-fetches a URL
+that no longer carries it. These tests pin the two halves that have to hold at
+once: the token is recoverable for *this tab*, and it is still never left in the
+URL, the HTML, or anywhere that outlives the tab.
+
+Assertions are on the served markup because the logic is inline JS with no
+browser in the test suite - so they guard the contract, not the runtime.
+"""
+
+import pytest
+from starlette.testclient import TestClient
+
+from doberman.dash.app import create_app
+
+_TOKEN = "test-dash-token-0123456789"  # noqa: S105 - fixture value, not a real secret
+
+
+@pytest.fixture()
+def shell() -> str:
+    with TestClient(create_app(_TOKEN)) as client:
+        resp = client.get("/")
+    assert resp.status_code == 200
+    return resp.text
+
+
+def test_token_is_stashed_and_read_back_for_a_reload(shell: str):
+    assert "sessionStorage.setItem(TOKEN_KEY" in shell
+    assert "sessionStorage.getItem(TOKEN_KEY" in shell
+
+
+def test_token_is_still_stripped_from_the_url(shell: str):
+    """The privacy property the stripping exists for must survive the fix."""
+    assert 'params.delete("token")' in shell
+    assert "window.history.replaceState" in shell
+
+
+def test_token_never_outlives_the_tab(shell: str):
+    """sessionStorage (per-tab, cleared on close), never localStorage - a
+    dashboard token must not persist after the tab is gone."""
+    assert "localStorage" not in shell
+
+
+def test_shell_never_embeds_the_token_value(shell: str):
+    assert _TOKEN not in shell
+
+
+def test_a_rejected_token_is_dropped_and_explains_the_way_back(shell: str):
+    """A stale token must not be retried silently on every reload, and the dead
+    end has to name its own fix."""
+    assert "removeItem(TOKEN_KEY)" in shell
+    assert "err.status === 401" in shell
+    assert "reopen the link printed by doberman dash" in shell


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Fix: "the dashboard is not connecting properly" — reproduced and root-caused.

## What this PR does

The page read its bearer token from `?token=` and then stripped it from the address bar — correct, so it cannot linger in history, a referrer, or a screen share — but kept the only copy in closure memory. So the URL the browser would reload **already had no token**: one refresh (F5, crash restore, reopening the tab) re-ran the script with `token = ""`, every `/api/*` call 401'd, and the status dot read `not connected` permanently. Nothing but restarting `doberman dash` could recover it, since the running process cannot reissue the token it already printed.

The token now goes to `sessionStorage` on the load that carries it and is read back when the URL has none. **sessionStorage, not localStorage** — it is per-tab and dies with the tab, so the token still cannot outlive its session, and a brand-new tab has no copy and still needs the freshly printed link. The write is wrapped because sessionStorage throws outright in some privacy modes; there it degrades to exactly the old memory-only behavior.

Second half of the same complaint: a 401 now clears the stored token and says `reopen the link printed by doberman dash` instead of a dead-end `not connected`, so a genuinely stale token from a previous CLI run explains its own fix.

## Tests added (run in CI)
- `tests/unit/test_dash_token_reload.py` (5 tests) — the token is stashed and read back; it is **still** stripped from the URL and absent from the served HTML; `localStorage` appears nowhere (a dashboard token must not outlive the tab); a 401 drops the stored token and names the recovery.

Assertions are on the served markup because the logic is inline JS with no browser in the suite. Behavior itself was verified separately by running the extracted block against a stubbed `window`: link load → token present, reload with no query → token recovered, fresh tab with no link → empty.

## Security checklist
- [x] Fails closed on error / uncertainty — a rejected token still 401s; nothing about server-side auth changed
- [x] No secret, full file, or unredacted prompt logged or committed — a test pins that the shell never embeds the token value
- [x] Any guardrail/learning change is raise-only — n/a, no decision-path change
- [x] doberman-core does not import doberman_enterprise
- [x] No new exposure: an XSS on this page could already read the in-memory token, and sessionStorage is origin-scoped and per-tab

## Edge cases covered
Reload of the same tab · fresh tab with no link · sessionStorage unavailable (privacy mode) · a stale token from a previous `doberman dash` run · opening a new link in a tab that already holds an old token (the URL wins).

## Risks / tech debt
No browser runs in CI, so the tests guard the contract, not the runtime.
