### PR TITLE
fix(serve): say what the proxy is waiting for instead of looking hung

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -64,6 +64,10 @@ doberman serve --path ~/my-project -- npx -y @modelcontextprotocol/server-filesy
 
 Doberman communicates over **stdio** — it spawns your tool server as a managed subprocess and speaks standard MCP. Your agent sees one server entry; the real tool server runs silently behind it.
 
+> **You don't run `doberman serve` yourself, and it doesn't start your agent** — your agent's MCP
+> client spawns it, using the config in step 3. Typed bare into a terminal it just blocks on stdin
+> waiting for a client to speak MCP, which looks like a hang; it prints one line saying so.
+
 ### 3. Point your agent at Doberman
 
 Replace your agent's existing MCP server entry with the Doberman-wrapped version.

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -138,6 +138,25 @@ def _configure_stderr_logging(level: int = logging.INFO) -> None:
         root.addHandler(logging.StreamHandler(sys.stderr))
 
 
+#: Shown once, only to a human at a terminal, before `serve` blocks on stdin.
+#: Run bare, the proxy logs two lines and then goes silent forever waiting for a
+#: client's JSON-RPC — indistinguishable from a hang, and easy to read as "serve
+#: is supposed to start my agent and didn't". It starts nothing: an MCP client
+#: spawns *it*. Never write this to stdout; stdout IS the MCP channel.
+_SERVE_WAITING_HINT = (
+    "waiting for an MCP client to connect on stdin - this command does not start your agent. "
+    "Register it once (`claude mcp add doberman -- doberman serve -- <your tool server>`), then "
+    "start the agent separately. For Claude Code, `doberman setup` instead wires hooks that gate "
+    "every tool call with no MCP reconfig."
+)
+
+
+def _stderr_is_tty() -> bool:
+    """Whether a human is watching stderr. A seam: a CLI test runner replaces
+    ``sys.stderr`` with a non-tty capture, so this is the patch point."""
+    return sys.stderr.isatty()
+
+
 @app.command(
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
     help="Run Doberman as an MCP proxy in front of a downstream MCP tool server.",
@@ -156,6 +175,9 @@ def serve(
 
     Point your agent's MCP config at this instead of the real server. AUTH prompts appear on
     your terminal; with no terminal attached (headless) an AUTH action is denied (fail closed).
+
+    This does not launch your agent - the agent's MCP client spawns this process. Run bare in a
+    terminal it just waits on stdin for a client.
     """
     # Imported here, not at module scope, so non-serve CLI commands (`--help`,
     # `log`, `status`, `scan`, ...) don't pay the cost of loading the subjective
@@ -171,6 +193,8 @@ def serve(
         raise typer.Exit(code=2)
     params = StdioServerParameters(command=downstream_argv[0], args=downstream_argv[1:])
     _configure_stderr_logging()
+    if _stderr_is_tty():  # a human ran it; a client-spawned process gets a pipe
+        typer.echo(f"doberman: {_SERVE_WAITING_HINT}", err=True)
     try:
         asyncio.run(serve_stdio(params, repo_root=path))
     except Exception as exc:  # noqa: BLE001 - surface a clean stderr error, never a raw traceback

--- a/src/doberman/proxy/serve.py
+++ b/src/doberman/proxy/serve.py
@@ -64,5 +64,7 @@ async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = "."
                 ]
             )
             async with stdio_server() as (agent_read, agent_write):
-                logger.info("ready — proxying tool calls to the agent over stdio")
+                # ASCII only: this line lands in whatever stderr the client gave us, and a
+                # non-UTF-8 capture turns the em-dash into a replacement char in their log.
+                logger.info("ready - proxying tool calls to the agent over stdio")
                 await proxy.run(agent_read, agent_write, proxy.create_initialization_options())

--- a/tests/unit/test_serve_startup_hint.py
+++ b/tests/unit/test_serve_startup_hint.py
@@ -1,0 +1,62 @@
+"""`doberman serve` must not look like a hang, and must never say so on stdout.
+
+Run bare in a terminal the proxy blocks on stdin waiting for a client and prints
+nothing further, which reads as a hang - or as "serve was supposed to start my
+agent". One stderr line fixes that, but stdout is the MCP channel, so the fix
+must be provably invisible to a client that spawned the process on a pipe.
+"""
+
+import pytest
+from typer.testing import CliRunner
+
+import doberman.cli.main as cli
+from doberman.proxy import serve as serve_mod
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def _stub_serve(monkeypatch):
+    """Keep `serve` from actually spawning a downstream or touching global logging."""
+    monkeypatch.setattr(cli, "_configure_stderr_logging", lambda *a, **k: None)
+
+    async def _spy(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(serve_mod, "serve_stdio", _spy)
+
+
+def test_hint_says_it_starts_nothing_and_names_both_wiring_paths():
+    hint = cli._SERVE_WAITING_HINT
+    assert "does not start your agent" in hint
+    assert "claude mcp add doberman" in hint  # the MCP-proxy path
+    assert "doberman setup" in hint  # the hooks path, recommended for Claude Code
+    assert "stdin" in hint  # names what it is actually waiting for
+
+
+def test_hint_is_ascii_only():
+    """It goes to whatever stderr the caller gave us; a non-UTF-8 capture would
+    mangle an em-dash into a replacement character in their log."""
+    cli._SERVE_WAITING_HINT.encode("ascii")
+
+
+def test_piped_stderr_gets_no_hint_and_stdout_stays_empty(_stub_serve):
+    """A client-spawned process gets pipes, not a tty: the hint is for humans, and
+    stdout must carry nothing but MCP frames."""
+    result = runner.invoke(cli.app, ["serve", "--", "mytool"])
+
+    assert result.exit_code == 0
+    assert result.stdout == ""
+    assert "does not start your agent" not in result.stderr
+
+
+def test_a_terminal_gets_the_hint_on_stderr(monkeypatch, _stub_serve):
+    written: list[str] = []
+    monkeypatch.setattr(cli, "_stderr_is_tty", lambda: True)
+    monkeypatch.setattr(cli.typer, "echo", lambda msg, **kw: written.append(f"{kw}:{msg}"))
+
+    runner.invoke(cli.app, ["serve", "--", "mytool"])
+
+    hinted = [line for line in written if "does not start your agent" in line]
+    assert hinted, written
+    assert "'err': True" in hinted[0]  # stderr only - never the MCP channel


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Fix: "`doberman serve` does not start Claude properly" — diagnosed as a UX/discoverability defect, not a proxy bug.

## What this PR does

The proxy itself is healthy: an end-to-end MCP client drove the installed `doberman serve` through `initialize` + `tools/list` successfully, and stdout carries pure JSON-RPC with no banner, BOM, or log contamination.

The defect is what a human sees. `doberman serve -- <tool server>` logs two lines and then blocks on stdin forever waiting for a client's JSON-RPC — in a terminal that is indistinguishable from a hang, and it invites the wrong conclusion: that `serve` is the command that launches your agent and it failed to. It launches nothing; the agent's MCP client spawns *this* process.

Emits one stderr line naming both facts — what it is waiting for, and that it starts no agent — plus the two real wiring paths: `claude mcp add` for the proxy, or `doberman setup` for the Claude Code hook path (recommended, no MCP reconfig). Gated on `stderr.isatty()` so it reaches the human who ran it bare and stays out of a client's logs. Never stdout: that IS the MCP channel.

Also makes the "ready" line ASCII — its em-dash decoded as a replacement character through a non-UTF-8 stderr pipe, and every real client captures stderr that way.

## Tests added (run in CI)
- `tests/unit/test_serve_startup_hint.py` (4 tests) — the hint names stdin, "does not start your agent", and both wiring commands; it is ASCII-only; a piped run emits **nothing on stdout** and no hint on stderr; a tty run emits it with `err=True`.

The tty branch sits behind a `_stderr_is_tty()` seam: a CLI test runner replaces `sys.stderr` with a non-tty capture, leaving the branch otherwise unreachable, and an untested branch guarding the MCP channel is not one to ship.

## Security checklist
- [x] Fails closed on error / uncertainty — unchanged; no decision-path code touched
- [x] No secret, full file, or unredacted prompt logged or committed — the hint is a static string
- [x] Any guardrail/learning change is raise-only — n/a
- [x] doberman-core does not import doberman_enterprise
- [x] stdout stays byte-for-byte an MCP channel — pinned by a test asserting empty stdout in the piped case

## Edge cases covered
Client-spawned (piped stderr, no hint) · human-run (tty, hint on stderr) · missing downstream argv still exits 2 · non-UTF-8 stderr capture.

## Risks / tech debt
The positive tty case is proven through the seam rather than a real pty (no pty on the Windows dev box). `SETUP.md` now states outright that you don't run `serve` yourself.
