### PR TITLE
fix(rules): exempt identifier and relative-path shapes from the weak entropy path (AN-2)

### DIFF
--- a/src/doberman/engine/rules/secrets.py
+++ b/src/doberman/engine/rules/secrets.py
@@ -251,6 +251,28 @@ _ENTROPY_TOKEN = re.compile(r"^[A-Za-z0-9+/=_\-]+$")
 # that does fire is still fingerprinted.
 _HASH_LIKE_HEX = re.compile(r"[0-9a-fA-F]{40,}")
 
+# An identifier or relative path — ``DEFAULT_CHALLENGE_TIMEOUT_S``,
+# ``migrations/0002_add_last_login``, ``fix/auth/challenge-deadline-fail-closed``
+# — is a run of ordinary words joined by separators. It clears the length floor
+# and, because the separators add symbol variety, the entropy floor too, so the
+# WEAK path flagged it as a possible secret. Measured in the field at roughly a
+# 6:1 false-positive ratio, which is the click-through-fatigue failure mode: it
+# trains a human to approve without reading and so devalues every GENUINE prompt.
+#
+# Relief for this already existed but was conditioned on a LEADING ``/`` (see
+# ``_token_looks_like_weak_secret``), which is an arbitrary line — a relative
+# path is exactly as non-credential as an absolute one, and a bare identifier
+# has no slash at all.
+#
+# The discriminator is SHAPE, not a threshold: a token is exempt only when it
+# decomposes entirely into short, purely-alphabetic or purely-numeric segments.
+# A credential does not have that shape. Base64/base64url/hex/JWT segments are
+# long and mix letters with digits, so they fail ``_WORD_SEGMENT`` and are still
+# judged whole — no secret can be fragmented below the length floor and dropped.
+_WORD_SEGMENT = re.compile(r"^(?:[A-Za-z]+|[0-9]+)$")
+_SEGMENT_SPLIT = re.compile(r"[/_.\-]")
+_MAX_WORD_SEGMENT_LEN = 20
+
 # Bounds for the encoded-exfil decoder: avoid decode bombs / runaway recursion.
 # One decode layer only (no recursive base64 peeling), bounded token count/size.
 _DECODE_MAX_TOKENS = 64  # at most N candidate tokens decoded per scan
@@ -330,6 +352,19 @@ def contains_strong_secret(text: str) -> bool:
     return bool(text) and _strong_secret_in_text(text)
 
 
+def _looks_like_identifier_or_path(token: str) -> bool:
+    """Is this token a separator-joined run of ordinary words (not a credential)?
+
+    Requires at least two segments and EVERY segment to be short and either
+    all-alphabetic or all-numeric. ``a3f5-9c2e-...`` (hex, mixed classes) and a
+    base64 blob both fail, so this only ever exempts identifier/path shapes.
+    """
+    segments = [seg for seg in _SEGMENT_SPLIT.split(token) if seg]
+    if len(segments) < 2:
+        return False
+    return all(len(seg) <= _MAX_WORD_SEGMENT_LEN and _WORD_SEGMENT.match(seg) for seg in segments)
+
+
 def _token_looks_like_weak_secret(token: str) -> bool:
     """Judge a single candidate token for the high-entropy heuristic.
 
@@ -361,6 +396,8 @@ def _token_looks_like_weak_secret(token: str) -> bool:
         # value (after the last '='), so a high-entropy RHS is still caught.
         return _token_looks_like_weak_secret(token.rsplit("=", 1)[-1])
     if _is_benign_fixture_token(token):
+        return False
+    if _looks_like_identifier_or_path(token):
         return False
     if token.startswith("/"):
         return any(_looks_high_entropy_secret(segment) for segment in token.split("/"))

--- a/src/doberman/engine/rules/secrets.py
+++ b/src/doberman/engine/rules/secrets.py
@@ -365,7 +365,7 @@ def _looks_like_identifier_or_path(token: str) -> bool:
     return all(len(seg) <= _MAX_WORD_SEGMENT_LEN and _WORD_SEGMENT.match(seg) for seg in segments)
 
 
-def _token_looks_like_weak_secret(token: str) -> bool:
+def _token_looks_like_weak_secret(token: str, *, exempt_identifiers: bool = True) -> bool:
     """Judge a single candidate token for the high-entropy heuristic.
 
     ``/`` is a base64 value char, so an *absolute* filesystem path
@@ -394,17 +394,19 @@ def _token_looks_like_weak_secret(token: str) -> bool:
         # trailing-only) is not a single secret — the name part inflates entropy and
         # over-flags benign config like ``cfg_path=/usr/local/bin`` (#56). Judge the
         # value (after the last '='), so a high-entropy RHS is still caught.
-        return _token_looks_like_weak_secret(token.rsplit("=", 1)[-1])
+        return _token_looks_like_weak_secret(
+            token.rsplit("=", 1)[-1], exempt_identifiers=exempt_identifiers
+        )
     if _is_benign_fixture_token(token):
         return False
-    if _looks_like_identifier_or_path(token):
+    if exempt_identifiers and _looks_like_identifier_or_path(token):
         return False
     if token.startswith("/"):
         return any(_looks_high_entropy_secret(segment) for segment in token.split("/"))
     return _looks_high_entropy_secret(token)
 
 
-def _weak_secret_in_text(text: str) -> bool:
+def _weak_secret_in_text(text: str, *, exempt_identifiers: bool = True) -> bool:
     """Low-confidence signal: a long, token-shaped, high-entropy string.
 
     "Weak" evidence can step up to AUTH but NEVER drives a BLOCK by itself — a
@@ -415,7 +417,7 @@ def _weak_secret_in_text(text: str) -> bool:
         return False
     sample = text[:_SCAN_MAX_CHARS]
     for token in re.findall(r"[A-Za-z0-9+/=_\-]{%d,}" % _ENTROPY_MIN_LEN, sample):
-        if _token_looks_like_weak_secret(token):
+        if _token_looks_like_weak_secret(token, exempt_identifiers=exempt_identifiers):
             return True
     return False
 
@@ -560,9 +562,21 @@ def _strong_secret_present(strings: Iterable[str]) -> bool:
     return False
 
 
-def _weak_secret_present(strings: Iterable[str]) -> bool:
-    """Any WEAK secret signal (AUTH only, never BLOCK): a high-entropy token."""
-    return any(_weak_secret_in_text(text) for text in strings)
+def _weak_secret_present(strings: Iterable[str], *, exempt_identifiers: bool = True) -> bool:
+    """Any WEAK secret signal (AUTH only, never BLOCK): a high-entropy token.
+
+    ``exempt_identifiers`` MUST be ``False`` for an action that sends data out.
+    The identifier/path exemption exists to stop ordinary shell and file work
+    from prompting; on an egress path the same shape is a plausible payload
+    (a hyphen- or underscore-joined passphrase or recovery phrase), and
+    ``ExternalDestinationRule`` explicitly delegates that case here — in
+    balanced mode it PASSes a merely-unknown host precisely because "a secret
+    leaving to any host is still a hard block via the secrets rule". Exempting
+    identifiers on egress would leave BOTH rules covering nothing.
+    """
+    return any(
+        _weak_secret_in_text(text, exempt_identifiers=exempt_identifiers) for text in strings
+    )
 
 
 #: Cap on how many detected secret tokens we fingerprint per action.
@@ -731,7 +745,7 @@ class SecretLeakageRule:
         #    base64 fragments, so the host-hook output scan treats this code as
         #    pass-through (still recorded + tainted), never a hard block of a read.
         #    The engine step-up (proxy / pre-hook egress) is unchanged.
-        if _weak_secret_present(strings):
+        if _weak_secret_present(strings, exempt_identifiers=not going_external):
             return GuardrailResult(
                 verdict=Verdict.AUTH,
                 risk=Risk.high,

--- a/tests/unit/test_secrets_identifier_fp.py
+++ b/tests/unit/test_secrets_identifier_fp.py
@@ -113,3 +113,55 @@ def test_the_compensating_control_a_named_credential_is_still_caught(text):
     and the STRONG path catches it regardless of the value's shape. Only a bare,
     unnamed, word-shaped token loses its AUTH step-up."""
     assert _strong_secret_in_text(text) is True
+
+
+# --- the composition guard (ADR 0049) -------------------------------------
+# The identifier exemption is scoped to NON-egress actions. `ExternalDestination
+# Rule` PASSes a merely-unknown host in balanced mode and justifies that by
+# delegating to this rule ("a secret leaving to any host is still a hard block
+# via the secrets rule"). Exempting identifier shapes on an egress path would
+# leave BOTH rules covering nothing — a hole neither loosening opened alone.
+# Caught by tests/integration/test_benchmark_synthetic_gate.py (ASR 0.0 -> 0.333).
+
+# Only tokens that clear the 3.6 bits/char entropy floor are in scope here — the
+# exemption is the ONLY thing this change controls.
+IDENTIFIER_SHAPED_PAYLOADS = [
+    "correct-horse-battery-staple-nine",  # entropy 3.662
+    "BENCHMARK_PAYLOAD_MARKER_DO_NOT_LEAK",  # entropy 3.774
+]
+
+
+@pytest.mark.parametrize("payload", IDENTIFIER_SHAPED_PAYLOADS)
+def test_identifier_shapes_are_NOT_exempt_on_an_egress_path(payload):
+    """On the way out, a word-shaped token is a plausible payload, not a path."""
+    assert _weak_secret_in_text(payload, exempt_identifiers=False) is True
+
+
+@pytest.mark.parametrize("payload", IDENTIFIER_SHAPED_PAYLOADS)
+def test_identifier_shapes_are_exempt_off_the_egress_path(payload):
+    """...but the same shape in ordinary shell/file work must not prompt."""
+    assert _weak_secret_in_text(payload, exempt_identifiers=True) is False
+
+
+def test_preexisting_limit_a_low_entropy_passphrase_is_missed_by_the_FLOOR():
+    """Not introduced here, and not fixable by the exemption: a word-shaped token
+    below the 3.6 bits/char floor was never on the weak path at all — on `main`
+    or on this branch. Recorded so the exemption is not blamed for it, and so
+    the real remaining gap stays visible."""
+    # Named `sample`, not `token`: ruff S105 flags the latter as a hardcoded
+    # password on this very string — a third detector agreeing the shape is
+    # credential-ish in SOME context, which is exactly why the fix is scoping.
+    sample = "MY_RECOVERY_PASSPHRASE_VALUE_HERE"  # entropy 3.559
+    assert _weak_secret_in_text(sample, exempt_identifiers=False) is False
+
+
+def test_the_exemption_defaults_to_on_but_the_rule_disables_it_for_egress():
+    """Guard the wiring, not just the helper: `SecretLeakageRule.evaluate` must
+    pass `exempt_identifiers=not going_external`. If someone drops that argument
+    the default (True) silently reopens the hole, so assert on the source."""
+    import inspect
+
+    from doberman.engine.rules import secrets as mod
+
+    src = inspect.getsource(mod.SecretLeakageRule.evaluate)
+    assert "_weak_secret_present(strings, exempt_identifiers=not going_external)" in src

--- a/tests/unit/test_secrets_identifier_fp.py
+++ b/tests/unit/test_secrets_identifier_fp.py
@@ -1,0 +1,115 @@
+"""Regression tests for the identifier/relative-path false positive (AN-2).
+
+The WEAK high-entropy path used to flag any >=24-char run of
+``[A-Za-z0-9+/=_-]`` — which is the shape of an ordinary identifier
+(``DEFAULT_CHALLENGE_TIMEOUT_S``) or relative path
+(``migrations/0002_add_last_login``). Measured at roughly a 6:1 false-positive
+ratio in real sessions.
+
+These tests exist in three parts, and the third matters as much as the first:
+
+1. the false positives stay suppressed;
+2. real credential shapes still fire — this is the raise-only guard, and it must
+   fail loudly if the exemption is ever widened into a threshold tweak;
+3. the *documented cost* of the trade is pinned, so nobody later mistakes it for
+   a free lunch or silently extends it.
+
+See ADR 0049.
+"""
+
+import pytest
+
+from doberman.engine.rules.secrets import (
+    _looks_like_identifier_or_path,
+    _strong_secret_in_text,
+    _weak_secret_in_text,
+)
+
+# Every one of these was measured firing a spurious AUTH before the fix. The
+# last four are this repo's OWN mandated conventions — `feat/<slug>/<slug>`
+# branches and SCREAMING_SNAKE constants generate the trigger by design.
+BENIGN_COMMANDS = [
+    "python migrations/0002_add_last_login.py",
+    "git checkout -b fix/auth/challenge-deadline-fail-closed",
+    "grep -n DEFAULT_CHALLENGE_TIMEOUT_S src/doberman/auth/challenge.py",
+    "pytest tests/unit/test_auth_challenge_timeout.py",
+    "cat src/doberman/engine/rules/subjective_baseline_store.py",
+    "ls src/doberman/proxy/interception_log_redaction.py",
+]
+
+
+@pytest.mark.parametrize("command", BENIGN_COMMANDS)
+def test_ordinary_identifiers_and_paths_do_not_trip_the_weak_path(command):
+    assert _weak_secret_in_text(command) is False
+
+
+# The raise-only guard. If a future change turns the shape exemption into a
+# threshold tweak, these break.
+REAL_SECRET_TEXTS = [
+    "aws_secret=wJalrXUtnFEMIKbPxRfiCYEXAMPLEKEYzz",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0",
+    "ghp_16C7e42F292c6912E7710c838347Ae178B4a",
+    "curl -H 'Auth: Bmn3xQ7vKp2LsW9zTr4YhJ6dNc8FgV5aXe1'",
+    "svctok-2451234567-2451234567890-AbCdEfGhIjKlMnOpQrStUvWx",
+    "dGhpc2lzYXNlY3JldHZhbHVlZm9ydGVzdGluZzEyMw==",
+]
+# NOTE: the `svctok-` prefix above is deliberately NOT a real vendor prefix.
+# An earlier draft used a Slack-shaped `xoxb-` fixture and GitHub push
+# protection correctly rejected the push. The property under test is the
+# SHAPE (mixed alnum segments must never be mistaken for an identifier), which
+# does not need a recognisable vendor format to exercise.
+
+
+@pytest.mark.parametrize("text", REAL_SECRET_TEXTS)
+def test_real_secret_shapes_still_fire(text):
+    assert _weak_secret_in_text(text) is True
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "wJalrXUtnFEMIKbPxRfiCYEXAMPLEKEY",  # base64-ish, no separators
+        "svctok-2451234567-2451234567890-AbCdEfGhIjKlMnOpQrStUvWx",  # mixed segments
+        "550e8400-e29b-41d4-a716-446655440000",  # hex segments, not word-shaped
+        "AbCdEfGhIjKlMnOpQrStUvWxYz012345",
+    ],
+)
+def test_credential_shapes_are_never_treated_as_identifiers(token):
+    """A segment that mixes letters and digits is not a word — so no credential
+    can be fragmented below the length floor and silently dropped."""
+    assert _looks_like_identifier_or_path(token) is False
+
+
+def test_a_single_long_token_is_never_exempt():
+    """The exemption requires >=2 segments; a bare token is always judged whole."""
+    assert _looks_like_identifier_or_path("supersecretvaluewithnoseparators") is False
+
+
+def test_a_long_random_path_segment_still_fires():
+    """A path is only exempt when EVERY segment is word-shaped."""
+    assert _weak_secret_in_text("cp /tmp/wJalrXUtnFEMIKbPxRfiCYEXAMPLEKEY/out") is True
+
+
+# --- the documented cost of this trade (ADR 0049) -------------------------
+# A word-shaped passphrase is structurally IDENTICAL to a branch name, so the
+# shape exemption cannot keep one and drop the other. These tests pin the loss
+# deliberately: they are not describing desirable behavior, they are recording
+# the price so it stays visible and cannot widen unnoticed.
+
+
+def test_documented_cost_a_bare_word_shaped_passphrase_no_longer_steps_up():
+    assert _weak_secret_in_text("correct-horse-battery-staple-nine") is False
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "PASSWORD=correct-horse-battery-staple-nine",
+        "export SECRET_KEY=correct-horse-battery",
+    ],
+)
+def test_the_compensating_control_a_named_credential_is_still_caught(text):
+    """The cost above is bounded by this: give the passphrase a credential NAME
+    and the STRONG path catches it regardless of the value's shape. Only a bare,
+    unnamed, word-shaped token loses its AUTH step-up."""
+    assert _strong_secret_in_text(text) is True


### PR DESCRIPTION
## Slice
- Feature / Slice: AN-2 — `possible_high_entropy_secret` false positives
- Plan reference: `doberman-vault/TODO.md` item 2 · **ADR 0049**

> ⚠️ **Deliberate, human-authorised loosening.** Prime Directive 2 is raise-only, so this is not a quiet threshold tweak — fu351 authorised it explicitly, and ADR 0049 records what was traded for what.

## The problem

The weak high-entropy path flagged any ≥24-char run of `[A-Za-z0-9+/=_-]` clearing 3.6 bits/char — the shape of an ordinary identifier or relative path, not just a credential:

| token | why it cleared the floors |
|---|---|
| `DEFAULT_CHALLENGE_TIMEOUT_S` | 27 chars; `_` adds symbol variety |
| `migrations/0002_add_last_login` | 30 chars; mixed letters/digits/`_`/`/` |
| `fix/auth/challenge-deadline-fail-closed` | 39 chars; `/` and `-` |

Roughly a **6:1 false-positive ratio** (one session: 15 AUTH prompts, 13 of them this). Three further samples were collected when the rule gated this repo's own `git`, `grep` and `pytest` calls. **Note the self-reference:** the project mandates `feat/<slug>/<slice-slug>` branches and `SCREAMING_SNAKE` constants — its own conventions manufacture the trigger.

Relief already existed but was gated on a **leading `/`** — arbitrary, since a relative path is exactly as non-credential as an absolute one, and a bare identifier has no slash at all.

## The change

Exempt a token only when it decomposes entirely into **word-like segments** (≥2 segments, each ≤20 chars, purely alphabetic or purely numeric) — **and only for non-egress actions**.

**Shape, not threshold.** The entropy constants are untouched: moving a threshold weakens detection uniformly, whereas a shape test removes only a class that provably isn't credential-shaped. Base64/base64url/hex/JWT/UUID segments mix letters with digits, fail the test, and are still judged whole.

## The first cut was wrong — the benchmark caught it

Worth reading, because it is the substance of this PR.

CI initially went red: `test_benchmark_synthetic_gate` **ASR 0.0 → 0.333**, one of three attacks bypassing. The error was analysing this loosening **in isolation**.

`destinations.py:436-442` carries its own prior loosening — in *balanced* mode a merely-unknown host is `PASS` — and justifies it by delegating to this rule:

> *"a secret leaving to any host is still a hard block via the secrets rule + raise-only combine"*

So exempting identifier shapes on an **egress** path left *both* rules covering nothing: a hyphen- or underscore-joined passphrase could leave for an unknown host completely ungated. **Neither loosening opened that hole alone; the composition did.**

**Fix:** `evaluate` now passes `exempt_identifiers=not going_external`, reusing the `_has_external_destination` discriminator it already computed. That is the natural boundary anyway — every measured FP is on `shell_exec`/file-path actions; all the detection value is on egress. Benchmark back to ASR 0.0.

## Why the remaining loosening is safe

1. Weak path only ever produced **AUTH, never BLOCK** — a prompt, not a barrier.
2. **Nothing changes on an egress path** — the case the other rule depends on.
3. **Named credentials untouched** — the strong path keys off the *name*, not value entropy.
4. **Exfil fingerprint path untouched** (`_candidate_secret_tokens`) — read-then-send is still a hard BLOCK.
5. A signal wrong 6 times in 7 has *negative* value; it trains click-through.

## The cost — stated, not minimised

Still a real loosening, now bounded: **a word-shaped passphrase passed as a naked argument in ordinary shell/file work no longer produces an AUTH step-up.** A word-shaped token is structurally identical to a branch name — *context*, not shape, is what separates them, which is why scoping is the fix.

## Tests added (run in CI)

`tests/unit/test_secrets_identifier_fp.py` — 27 tests:

- FP suppression (six measured cases)
- **raise-only guard**: real credential shapes still fire; credential shapes never treated as identifiers; a single long token is never exempt; a long random path segment still fires
- **composition guard**: identifier shapes are NOT exempt on an egress path — plus a **source assertion on the call site**, because `exempt_identifiers` defaults to `True` and dropping it would reopen the hole without failing any behavioural test
- **documented cost**, pinned so the price stays visible
- a pre-existing floor limit recorded separately (`MY_RECOVERY_PASSPHRASE_VALUE_HERE`, entropy 3.559, was never on the weak path — on `main` or here)

Local: full suite exit 0, ruff clean, both import contracts kept.

## Security checklist

- [x] Fails closed on error / uncertainty — unchanged
- [x] No secret, full file, or unredacted prompt logged or committed
- [ ] Any guardrail change is raise-only — **NO: authorised loosening, ADR 0049.** Left unticked deliberately; ticking it would be false.
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — unchanged
- [x] `doberman-core` does not import `doberman_enterprise`

## Related finding — not fixed here

**AN-5:** on clean `main`, stripping `exfil-unknown-host`'s payload and re-running yields ASR 0.333 — `ExternalDestinationRule` never caught that case. Its ASR 0.0 came from an incidental entropy hit on the suite's *own* `BENCHMARK_PAYLOAD_MARKER_DO_NOT_LEAK`. The suite's stated contract is false for that case, so **the gate has been green for the wrong reason** and would not have caught a genuine destination-coverage regression. Filed in TODO; deliberately out of scope here, since "just swap the marker" would hide the real question.

## Notes

- An earlier draft used a Slack-shaped `xoxb-` fixture; GitHub push protection correctly rejected the push. Fixture changed rather than using the bypass URL.
- Rebased onto `65c6582`.
- No CHANGELOG entry — that file had concurrent edits from another session (since landed as `df2cb90`). Happy to add one.
