### PR TITLE
fix(dash): stop the 2s poll from wiping the TOTP field, and mask it

### DIFF
--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -183,7 +183,7 @@ _HTML_SHELL = """<!doctype html>
     color: var(--auth); font-family: var(--mono); font-size: .84rem; font-weight: 600;
   }
   #pending-list .row-explanation { margin: .45rem 0 .8rem; color: var(--ink); opacity: .82; max-width: 68ch; }
-  #pending-list input[type="text"] {
+  #pending-list input {
     font-family: var(--mono); font-size: .95rem; padding: .45rem .6rem; margin-right: .5rem;
     letter-spacing: .12em; width: 9rem; background: var(--bg); color: var(--ink); border: 1px solid var(--border); border-radius: 4px;
   }
@@ -369,7 +369,20 @@ _HTML_SHELL = """<!doctype html>
         }).catch(function () { /* network hiccup — next poll retries */ });
       }
 
+      var lastPendingKey = null;
+
       function renderPending(rows) {
+        // A queued approval is IMMUTABLE once written (id / tier / risk / reason
+        // codes are fixed at write time and `/api/pending` re-serializes the same
+        // allow-list), so only the SET can change - a row arrives or it leaves.
+        // Rebuilding an unchanged set on every poll destroyed and recreated the
+        // TOTP <input>, throwing away focus and any digits already typed. At a 2s
+        // poll that makes a 6-digit code effectively impossible to enter, and the
+        // approval TTL is only 120s. Skip the rebuild when the id set is identical.
+        var key = rows.map(function (row) { return row.id; }).join(",");
+        if (key === lastPendingKey) { return; }
+        lastPendingKey = key;
+
         // The empty state is CSS-only (`#pending-list:not(:empty) ~
         // #pending-empty`) - clearing to no children is enough to reveal it.
         pendingList.textContent = "";
@@ -406,7 +419,10 @@ _HTML_SHELL = """<!doctype html>
           var totpInput = null;
           if (row.needs_totp) {
             totpInput = document.createElement("input");
-            totpInput.type = "text";
+            // A masked field: this is a live second factor, and the dashboard is
+            // exactly the screen that gets screen-shared and recorded.
+            totpInput.type = "password";
+            totpInput.inputMode = "numeric";
             totpInput.placeholder = "TOTP code";
             totpInput.autocomplete = "off";
             li.appendChild(totpInput);

--- a/tests/unit/test_dash_polish.py
+++ b/tests/unit/test_dash_polish.py
@@ -120,3 +120,23 @@ def test_feed_timestamp_renders_compact_not_full_iso(tmp_path):
     # in `doberman log` / the TUI.
     assert ".slice(11, 19)" in html
     assert '" @ " + row.ts;' not in html
+
+
+def test_pending_list_is_not_rebuilt_when_the_queue_is_unchanged(tmp_path):
+    """The 2s poll used to rebuild every card, destroying the focused TOTP input
+    and any digits already typed. A queued approval is immutable once written, so
+    an unchanged id set must short-circuit before the list is cleared."""
+    html = _index_html(tmp_path)
+    assert "lastPendingKey" in html
+    assert 'var key = rows.map(function (row) { return row.id; }).join(",");' in html
+    # The guard must come BEFORE the clear, or it does nothing.
+    assert html.index("if (key === lastPendingKey) { return; }") < html.index(
+        'pendingList.textContent = "";'
+    )
+
+
+def test_the_totp_field_is_masked(tmp_path):
+    """It is a live second factor and this screen gets shared and recorded."""
+    html = _index_html(tmp_path)
+    assert 'totpInput.type = "password";' in html
+    assert 'totpInput.type = "text";' not in html


### PR DESCRIPTION
## Slice
- Feature / Slice: dashboard approval card — TOTP input usability + masking
- Found: live dry run of the demo recording (2026-07-27)

## The bug

`renderPending` cleared and rebuilt the **entire** pending list on every 2 s poll. That destroyed and recreated the TOTP `<input>` mid-typing, discarding focus and any digits already entered.

At a 2 s cadence a 6-digit code essentially cannot be completed by hand. This is not cosmetic — it made **the one interactive control in the product unusable**, and the approval TTL is only 120 s (`DEFAULT_APPROVAL_TTL_S`).

It had already been observed once and worked around rather than fixed: an automated capture logged

```
attempt 1: TOTP field was cleared by a pending-list refresh; refilling
```

## Why the fix is correct, not a heuristic

A queued approval is **immutable once written** — `id`, `tier`, `risk`, `action_type` and `reason_codes` are fixed at write time, and `/api/pending` re-serializes the same hard allow-list (`dash/app.py`) on every poll.

So only the **set** can change: a row arrives, or it leaves. Comparing the joined id set and returning early when unchanged therefore cannot miss an in-place mutation — there is no such mutation. Arrivals and departures still trigger a full re-render, and the CSS-only empty state is unaffected.

## Also: the TOTP field is now masked

`type="password"` (plus `inputMode="numeric"`). It carries a **live second factor**, and the dashboard is precisely the screen that gets screen-shared and recorded.

The CSS keyed off `input[type="text"]`, which the mask would have **silently broken** — the field would have lost its styling with no test failing. Selector relaxed to `#pending-list input`.

## Tests added (run in CI)

`tests/unit/test_dash_polish.py`:
- the id-set guard exists
- **the guard precedes the clear** — a guard placed after `pendingList.textContent = ""` would do nothing, so ordering is asserted explicitly
- the field is `password` and no longer `text`

All 51 tests across the four `test_dash_*.py` files pass.

## Security checklist
- [x] Fails closed on error / uncertainty — unchanged, no decision-path code touched
- [x] No secret, full file, or unredacted prompt logged or committed — this **reduces** exposure by masking a live second factor
- [x] Any guardrail change is raise-only — N/A, no guardrail logic changed
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — unchanged
- [x] `doberman-core` does not import `doberman_enterprise`

## Public-release safety (doberman-core)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed

## Risks
Low. Presentation-layer only: no API, DOM contract, or decision-path change. The one behavioural change is that an unchanged queue no longer re-renders — which is the fix.
