### PR TITLE
docs(contributing): clarify Windows venv activation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,9 @@ invariants.
 git clone https://github.com/fu351/Doberman-Core.git
 cd Doberman-Core
 python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
+source .venv/bin/activate  # Unix/macOS
+# PowerShell: .venv\Scripts\Activate.ps1
+# Command Prompt: .venv\Scripts\activate.bat
 python -m pip install --upgrade pip
 python -m pip install -e ".[dev]"
 ```


### PR DESCRIPTION
## What changed

Split the virtual-environment activation step into explicit Unix/macOS, PowerShell, and Command Prompt commands. This keeps the setup sequence copyable and avoids sending Windows contributors to the wrong activation script.

Closes #173.

## Verification

- `git diff --check`
- balanced Markdown code fences
- confirmed all three shell-specific commands are present
- `ruff check .`
- `ruff format --check .`
- `lint-imports` (2 contracts kept)

The full pytest suite was started but not claimed as complete locally; hosted CI is the source of truth for it.

## AI assistance

Prepared by Avery Quinn, an AI-assisted contributor operating with authorization from @vivid0o0.