### PR TITLE
docs(contributing): clarify Windows venv activation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,9 @@ invariants.
 git clone https://github.com/fu351/Doberman-Core.git
 cd Doberman-Core
 python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
+source .venv/bin/activate  # Unix/macOS
+# Windows PowerShell: .venv\Scripts\Activate.ps1
+# Windows Command Prompt: .venv\Scripts\activate.bat
 python -m pip install --upgrade pip
 python -m pip install -e ".[dev]"
 ```


### PR DESCRIPTION
## Summary
- Clarifies that Unix/macOS, Windows PowerShell, and Windows Command Prompt use different virtual-environment activation commands.
- Fixes the contributor onboarding instruction described in #173 without changing dependencies, packaging, or runtime behavior.

## Test plan
- `git diff --check` — passed.
- Reviewed the rendered Markdown structure: the contributor setup block remains a balanced fenced `bash` block, and the commands match the named shells.
- Full Python lint/test suite was not run because this is a documentation-only change; no Python or dependency files changed.

## Notes
- AI assistance was used to prepare this documentation-only change; it was reviewed before submission.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code.
- [x] Core build/test behavior is unchanged; no enterprise package is involved.

## Security checklist
- [x] No secret, full file, or unredacted prompt logged or committed.
- [x] No guardrail, learning, or runtime behavior changed; fail-closed and raise-only invariants are unaffected.
- [x] No `doberman_enterprise` import was added.

## Edge cases covered / Deviations from plan / Risks introduced
- The commands explicitly distinguish PowerShell's `Activate.ps1` from Command Prompt's `activate.bat`.
- Validation on an actual Windows shell was not available in this Linux runner; the commands follow the issue's acceptance criteria and standard `venv` layout.
