### PR TITLE
docs: add troubleshooting for PATH-shadowed Doberman installations

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -7,6 +7,7 @@ agent, verify it, and explore the health check, dashboard, and TUI. New here? Th
 **Contents**
 
 - [Install](#1-install)
+- [Troubleshooting: wrong or stale `doberman` on PATH](#path-troubleshooting)
 - [MCP proxy - wrap any tool server](#mcp-proxy) - Claude Desktop, Cursor, Codex, any MCP client
 - [Claude Code hooks](#claude-code-hooks) - gate every tool call, no MCP reconfig
 - [OpenClaw](#openclaw)
@@ -40,6 +41,128 @@ pip install -e ".[dev]"
 ```
 
 Either way you get the `doberman` CLI on your PATH. (Maintainers: see [`RELEASING.md`](../RELEASING.md).)
+
+<a name="path-troubleshooting"></a>
+
+### Troubleshooting: wrong or stale `doberman` on PATH
+
+If `doberman` behaves unexpectedly — missing a command you just added, using an
+old version, or ignoring changes from your dev install — the shell may be
+resolving a *different* `doberman` executable than the one in your active
+virtual environment. This is common when you have more than one installation
+method in play (global `pip`, `pipx`, and one or more venvs).
+
+This section only lists and compares what's already on your PATH. It does not
+modify PATH, uninstall anything, or touch your environments.
+
+**List every `doberman` executable currently resolvable.**
+
+Run the command for your shell. Each one lists **all** matches, not just the
+first — this matters because the *first* result is the one actually being run.
+
+```powershell
+# PowerShell
+Get-Command -All doberman
+```
+
+```cmd
+:: Command Prompt (cmd.exe)
+where.exe doberman
+```
+
+```bash
+# Unix-like shells (bash/zsh/etc.)
+which -a doberman
+# or, more portable:
+command -v doberman
+```
+
+If more than one path is listed, the first one in the output is the one your
+shell will actually invoke when you type `doberman`.
+
+**Compare the resolved executable against your active virtual environment.**
+
+With your intended venv activated, check where Python thinks it's installed
+and compare it to what step 1 found.
+
+```bash
+# Unix-like shells
+python -c "import sys; print(sys.prefix)"
+command -v doberman
+```
+
+```powershell
+# PowerShell / Command Prompt
+python -c "import sys; print(sys.prefix)"
+Get-Command doberman
+```
+
+If `sys.prefix` doesn't match the directory the resolved `doberman` lives in
+(e.g. it's not under `.venv/bin` or `.venv/Scripts`), a different install is
+shadowing your venv's copy.
+
+**Inspect common install locations safely.**
+
+These only report information — they don't remove or modify anything.
+
+```bash
+# Check a pip-installed copy inside a venv (Unix-like shells)
+.venv/bin/pip show doberman-core
+```
+
+```powershell
+# Same, on Windows
+.venv\Scripts\pip show doberman-core
+```
+
+```bash
+# Check a pipx-installed copy (any shell with pipx on PATH)
+pipx list
+```
+
+`pipx list` shows every pipx-managed package and the interpreter it's pinned
+to, including any global `doberman` install that could be shadowing your venv.
+
+```bash
+# See which python/pip your shell defaults to (Unix-like shells)
+which -a python python3 pip pip3
+```
+
+```powershell
+# PowerShell
+Get-Command -All python, pip
+```
+
+```cmd
+:: Command Prompt
+where.exe python
+where.exe pip
+```
+
+**Remediation (non-destructive).**
+
+Pick whichever fits your workflow — none of these require editing PATH or
+removing anything:
+
+- **Re-activate the intended virtual environment** in the current shell
+  session, then re-run step 1 to confirm it now resolves first:
+
+  ```bash
+  source .venv/bin/activate        # Unix-like shells
+  .venv\Scripts\activate           # Windows (cmd or PowerShell)
+  ```
+
+- **Invoke the venv's executable explicitly**, bypassing PATH resolution
+  entirely:
+
+  ```bash
+  ./.venv/bin/doberman --version        # Unix-like shells
+  .venv\Scripts\doberman.exe --version  # Windows
+  ```
+
+- **Open a new shell/terminal window** if you recently activated or
+  deactivated an environment — some shells cache the resolved path for the
+  current session (`hash -r` in bash clears this without restarting).
 
 <a name="mcp-proxy"></a>
 


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: #174 — docs: add troubleshooting for PATH-shadowed Doberman installations
- Plan reference: N/A (docs fix from a filed issue, not part of the implementation plan)

## What this PR does
Adds a "Troubleshooting: wrong or stale `doberman` on PATH" section to
docs/SETUP.md, right after the Install step. Covers how to list every
resolved `doberman` executable (PowerShell, Command Prompt, and Unix-like
shells), how to compare the resolved executable against the active virtual
environment, how to safely inspect pip/pipx/venv installs, and non-destructive
remediation options (re-activating the intended venv, invoking its executable
explicitly, or opening a fresh shell). No code changes.

Closes #174.

*Formatted and refined with AI assistance.*

## Tests added (run in CI)
- N/A — documentation-only change, no code paths affected. Ran the existing
  suite locally (`ruff check .`, `ruff format --check .`, `lint-imports`,
  `pytest --cov=doberman ...`) to confirm nothing broke; all commands in the
  new section were tested manually in their respective shells.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty — N/A (no runtime behavior changed; doc only)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — N/A, no guardrail logic touched
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — N/A, no decision-engine code touched
- [x] doberman-core does not import doberman_enterprise — N/A, no imports added

## Edge cases covered / Deviations from plan / Risks introduced
- Deliberately out of scope, per the issue: no PATH editing, no deleting
  environments, no uninstalling packages on the contributor's behalf, no
  changes to the installer/packaging config.
- No risks introduced — this is a documentation-only change with zero effect
  on runtime behavior, the decision engine, or CI.