### PR TITLE
test(cli): smoke-test help for every command

### DIFF
--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -1,0 +1,87 @@
+"""Smoke-test help rendering for every public CLI command and group."""
+
+import re
+
+import pytest
+from typer.main import get_command
+from typer.testing import CliRunner
+
+from doberman.cli.main import app
+
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+# Keep this explicit matrix synchronized with every public command and group,
+# including dynamically discovered commands that are absent from `.commands`.
+CLI_HELP_TARGETS = (
+    (),
+    ("serve",),
+    ("scan",),
+    ("review",),
+    ("mode",),
+    ("enforcement",),
+    ("prefs",),
+    ("status",),
+    ("doctor",),
+    ("revoke",),
+    ("log",),
+    ("tui",),
+    ("dash",),
+    ("demo",),
+    ("memory",),
+    ("policy-history",),
+    ("install-hooks",),
+    ("uninstall-hooks",),
+    ("setup",),
+    ("dashboard",),
+    ("version",),
+    ("2fa",),
+    ("2fa", "setup"),
+    ("2fa", "remove"),
+    ("password",),
+    ("password", "set"),
+    ("hook",),
+    ("hook", "pre"),
+    ("hook", "post"),
+    ("hook", "openclaw"),
+)
+
+runner = CliRunner()
+
+
+def _eager_command_paths(command, prefix=()):
+    yield prefix
+    for name, child in getattr(command, "commands", {}).items():
+        yield from _eager_command_paths(child, (*prefix, name))
+
+
+def _target_id(command_path):
+    return "root" if not command_path else " ".join(command_path)
+
+
+def _expected_usage(command_path):
+    return "Usage: root" + "".join(f" {name}" for name in command_path)
+
+
+def _normalize_help_output(output):
+    return " ".join(ANSI_ESCAPE.sub("", output).split())
+
+
+def test_cli_help_targets_cover_every_eager_command_and_group():
+    registered = set(_eager_command_paths(get_command(app)))
+
+    assert len(CLI_HELP_TARGETS) == len(set(CLI_HELP_TARGETS))
+    assert registered <= set(CLI_HELP_TARGETS)
+
+
+@pytest.mark.parametrize("command_path", CLI_HELP_TARGETS, ids=_target_id)
+def test_cli_help_renders_without_a_traceback(command_path):
+    result = runner.invoke(
+        app,
+        [*command_path, "--help"],
+        env={"FORCE_COLOR": "1"},
+    )
+    normalized_output = _normalize_help_output(result.output)
+
+    assert result.exit_code == 0, result.output
+    assert _expected_usage(command_path) in normalized_output
+    assert "Traceback" not in result.output


### PR DESCRIPTION
## Slice

- Repo: doberman-core
- Feature / Slice: #176 — Smoke-test `--help` for every Typer command and group
- Plan reference: Issue #176

## What this PR does

- adds an explicit matrix for the root app and every public command and command group
- invokes each target with `--help` and verifies exit code 0, the complete usage path, and no traceback
- automatically requires every eager registration while documenting how dynamic commands stay synchronized
- preserves the existing startup guard against importing optional scientific and enterprise packages

Closes #176

## Tests added (run in CI)

- `pytest tests/unit/test_cli_help.py -q`: 31 passed
- CLI-pattern unit suite: passed with 2 skipped
- `ruff check .`
- `ruff format --check .`
- `lint-imports`: 2 contracts kept, 0 broken
- `pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80`: 2161 passed, 5 skipped; 91.97% coverage

## Public-release safety (doberman-core only)

- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist

- [x] Fails closed on error / uncertainty (runtime behavior is unchanged)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no guardrail or learning behavior changed)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (not affected)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced

- The matrix is intentionally explicit so dynamically discovered commands can be listed without invoking option callbacks, prompts, network access, or persistent state during discovery.
- The eager-registration guard rejects missing ordinary commands and duplicate matrix entries.
- Usage-path validation catches stale nested targets even when Click's eager `--help` handling exits successfully at a parent command.
- Whitespace normalization keeps wrapped Rich help output deterministic for long valid command paths.
- This is a test-only change; runtime behavior and public CLI text are unchanged.

## AI assistance

AI assistance disclosure: This PR was developed with assistance from OpenAI Codex.
