### PR TITLE
chore(release): v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Shipped history for Doberman. Planned work lives on the [roadmap](README.md#roadmap) and the
 [project board](https://github.com/users/fu351/projects/5); exact per-commit detail is in the
 [git log](https://github.com/fu351/Doberman-Core/commits/main) and
-[releases](https://github.com/fu351/Doberman-Core/releases) (latest: **v0.16.0**, adds raise-only static egress classification).
+[releases](https://github.com/fu351/Doberman-Core/releases) (latest: **v0.17.0**, adds the runtime egress broker — enforcement-gated egress PASS, velocity signals, and post-fetch artifact verification).
 
 ## Shipped
 - Tool mediation · decision engine · objective guardrail (paths, commands, destinations, secrets, **smuggled-token channels**) · subjective guardrail (adaptive behavioral baselines, **OOD/homoglyph token signals**) · roles & boundaries · capability discovery · tiered auth (confirm → TOTP → scoped elevation) · audit log · policy-drift & poisoning defense (classify strengthen/weaken, possession-factor-gated permanent weakening, append-only ledger, **enforce/monitor/off enforcement dial — now consumed by the decision path (discretionary verdicts soften; the objective floor stays live), softening now gated behind the same possession-factor check as a policy weakening (TOTP if enrolled else password, fails closed with neither — no confirm-only fallback) + a ledger-verified tamper clamp**, **strictness `mode` and SL5 `prefs` now use the corrected 2FA-or-password gate: password is the minimum factor, optional TOTP takes precedence when enrolled, neither enrolled fails closed, and raising stays frictionless**) · universal subjective layer (SL1–SL9)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doberman-core"
-version = "0.16.0"
+version = "0.17.0"
 description = "Adaptive authorization layer for coding agents (open core)"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Slice
- Release cut: **v0.17.0**

## What this PR does
Bumps the single-sourced version (`pyproject.toml`) from 0.16.0 to 0.17.0 and updates the CHANGELOG's "latest release" pointer. No code changes.

**Why 0.17.0 and not 0.16.1:** 28 commits landed since v0.16.0, including new public API surface — the `doberman.egress` package, the `doberman.egress_brokers` plugin entry-point group, the `doberman 2fa remove` CLI command, and the `doberman.render` module. That is a minor bump under semver, not a patch.

Headline contents since v0.16.0:
- Runtime egress broker RB.1-RB.7 (broker seam, default-deny allowlist, forcing forward proxy, retrospective reconciliation, enforcement-gated PASS, mode-gated posture, velocity signal, artifact digest verification)
- Security fix: bounded AUTH challenges so an unanswered prompt denies instead of hanging (AN-4, #166)
- Security fix: raw socket/shell egress verb classification (CRIT-1, #151)
- Security fix: trailing dot/space path canonicalization (#214)
- CI/CD-config protection beyond GitHub Actions (#203) and the devops role-boundary fix (#215)

## Tests added (run in CI)
None — release-metadata-only change. Existing suite verified green on this tree: 2199 collected / 0 failed, 91% coverage, `lint-imports` 2/2 contracts kept, `twine check` clean, and the sdist/wheel public-release safety scan found no vault, plan, key, or enterprise content.

## Security checklist
- [x] Fails closed on error / uncertainty — unchanged, no logic touched
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — no guardrail change
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — unchanged

## Edge cases covered / Deviations from plan / Risks introduced
- Version is single-sourced per ADR 0041, so `__version__` derives from distribution metadata and needs no edit.
- PyPI publish is immutable; the version number was deliberately chosen as a minor bump before cutting.