### PR TITLE
ci: add package-smoke-test job to catch wheel packaging bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
           /tmp/wheel-env/bin/pip install dist/*.whl
       - name: Smoke test — CLI entry point works standalone
         run: /tmp/wheel-env/bin/doberman --version
+      # `--version` only proves the modules shipped: it never reads package DATA.
+      # builtin_roles.yaml is loaded lazily (roles.py), so dropping it from the
+      # wheel would leave the check above green while every role lookup crashes.
+      - name: Smoke test — bundled package data ships in the wheel
+        run: >
+          /tmp/wheel-env/bin/python -c
+          "from doberman.roles.roles import load_builtin_roles;
+          assert load_builtin_roles(), 'builtin_roles.yaml missing from the wheel'"
   secret-scan:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,22 @@ jobs:
       - name: Architecture & repo boundaries
         run: lint-imports
       - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+  package-smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install --upgrade pip build
+      - run: python -m build
+      - name: Install wheel into a clean environment
+        run: |
+          python -m venv /tmp/wheel-env
+          /tmp/wheel-env/bin/pip install dist/*.whl
+      - name: Smoke test — CLI entry point works standalone
+        run: /tmp/wheel-env/bin/doberman --version
   secret-scan:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core | doberman-enterprise
- Feature / Slice: #196 — ci: add a packaging smoke-test job (build + install the wheel)
- Plan reference: doberman_implementation_plan.md

## What this PR does
CI only ever ran pip install -e ".[dev]" (editable install). A missing packages entry in [tool.hatch.build.targets.wheel], a broken [project.scripts] entry, or a file that only exists via the editable symlink would pass all CI checks and ship in a release undetected.
Adds a new package-smoke-test job that builds the real wheel with python -m build, installs it into a clean venv (no editable install, no dev extras), and runs doberman --version to prove the packaged CLI entry point works standalone. The existing test job is untouched. Closes #196.

## Tests added (run in CI)
- The package-smoke-test job is itself the verification — it fails the build if the wheel doesn't build, install cleanly, or run. No new test file is needed for a CI-plumbing change.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- build installed inline in the CI step only, not added to pyproject.toml dependencies
- Job runs ubuntu-latest / Python 3.12 only — packaging bugs aren't Python-version-specific
- Standalone-guarantee check, secret-scan job, and full test matrix are all untouched
