### PR TITLE
test(objective): assert reduction loop is exhaustively raise only

### DIFF
--- a/tests/unit/test_objective_guardrail.py
+++ b/tests/unit/test_objective_guardrail.py
@@ -7,10 +7,13 @@ raises; and the documented combination cases (secret-exfil BLOCK beats a path
 AUTH, etc.).
 """
 
+import itertools
 from datetime import datetime, timezone
 
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.models import (
+    RISK_ORDER,
+    VERDICT_ORDER,
     ActionType,
     EvalContext,
     GuardrailResult,
@@ -159,3 +162,33 @@ def test_extra_rules_are_run_alongside_builtins():
     action = _action(ActionType.file_write, target="frontend/Button.tsx")
     # The benign edit would PASS on built-ins, but the extra rule raises it.
     assert g.evaluate(action, _ctx(path="frontend/Button.tsx")).verdict is Verdict.AUTH
+
+
+# Exhaustive raise only sweep of reduction loop, issue #188
+def _fixed_result(verdict, risk):
+    if verdict is Verdict.PASS:
+        return GuardrailResult(verdict=verdict, risk=risk)
+    return GuardrailResult(
+        verdict=verdict,
+        risk=risk,
+        reason_codes=[ReasonCode.unknown_tool],
+        explanation=f"{verdict} stub for testing.",
+    )
+
+
+_ALL_RESULTS = [_fixed_result(v, r) for v in Verdict for r in Risk]
+
+
+def test_reduction_loop_is_exhaustively_raise_only():
+    action, ctx = _action(), _ctx()
+    for length in (1, 2, 3):
+        for combo in itertools.product(_ALL_RESULTS, repeat=length):
+            guardrail = ObjectiveGuardrail(
+                rules=[FixedRule(result) for result in combo], load_plugins=False
+            )
+            out = guardrail.evaluate(action, ctx)
+            combo_desc = [(r.verdict, r.risk) for r in combo]
+            max_verdict_rank = max(VERDICT_ORDER[r.verdict] for r in combo)
+            max_risk_rank = max(RISK_ORDER[r.risk] for r in combo)
+            assert VERDICT_ORDER[out.verdict] >= max_verdict_rank, combo_desc
+            assert RISK_ORDER[out.risk] >= max_risk_rank, combo_desc


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: 3.7 - ObjectiveGuardrail
- Plan reference: na, issue #188 

## What this PR does
Adds a test that sweeps every stub rule combination for rule-lists of length 1-3 through ObjectiveGuardrail.evaluate(), asserting the combined verdict/risk is never lower than the max of the inputs. Closes #188. 

## Tests added (run in CI)
- tests/unit/test_objective_guardrail.py::test_reduction_loop_is_exhaustively_raise_only

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Rule-list lengths 1-3 cover chaining, empty rule list is tested elsewhere.
- Broke the loop locally to confirm if test fails, then reverted
I drafted it with some AI assistance.