### PR TITLE
cli: pin scan --json over --quiet with test and docs

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -23,6 +23,8 @@ Entry point: `doberman` (Typer). All commands accept `--help`.
 |------|----------|-------|
 | `--json` | `scan`, `doctor`, `policy-history` | One JSON document on stdout |
 | `--quiet` / `-q` | `scan` | No human map; exit code preserved |
+
+When both are passed, `--json` wins over `--quiet`: machine-readable JSON is still emitted.
 | `--path` / `-p` | most commands | Repository root (default `.`) |
 
 ### `doberman scan --json` schema

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -23,9 +23,9 @@ Entry point: `doberman` (Typer). All commands accept `--help`.
 |------|----------|-------|
 | `--json` | `scan`, `doctor`, `policy-history` | One JSON document on stdout |
 | `--quiet` / `-q` | `scan` | No human map; exit code preserved |
+| `--path` / `-p` | most commands | Repository root (default `.`) |
 
 When both are passed, `--json` wins over `--quiet`: machine-readable JSON is still emitted.
-| `--path` / `-p` | most commands | Repository root (default `.`) |
 
 ### `doberman scan --json` schema
 

--- a/tests/unit/test_cli_scan_json.py
+++ b/tests/unit/test_cli_scan_json.py
@@ -81,6 +81,7 @@ def test_scan_default_not_json(tmp_path):
     else:
         raise AssertionError("default scan should not be raw JSON")
 
+
 def test_scan_json_wins_over_quiet(tmp_path):
     """`--json` still prints JSON when combined with `--quiet` (#225)."""
     with (
@@ -96,4 +97,3 @@ def test_scan_json_wins_over_quiet(tmp_path):
     # Quiet must not suppress machine-readable output.
     assert both.stdout.strip() != ""
     assert json.loads(both.stdout) == json.loads(json_only.stdout)
-

--- a/tests/unit/test_cli_scan_json.py
+++ b/tests/unit/test_cli_scan_json.py
@@ -80,3 +80,20 @@ def test_scan_default_not_json(tmp_path):
         pass
     else:
         raise AssertionError("default scan should not be raw JSON")
+
+def test_scan_json_wins_over_quiet(tmp_path):
+    """`--json` still prints JSON when combined with `--quiet` (#225)."""
+    with (
+        patch("doberman.cli.main.enumerate_capabilities", return_value=_caps()),
+        patch("doberman.cli.main.rate_capabilities", side_effect=lambda c: c),
+    ):
+        both = runner.invoke(app, ["scan", "--path", str(tmp_path), "--json", "--quiet"])
+        json_only = runner.invoke(app, ["scan", "--path", str(tmp_path), "--json"])
+    assert both.exit_code == json_only.exit_code == 0
+    payload = json.loads(both.stdout)
+    assert payload["version"] == 1
+    assert isinstance(payload["capabilities"], list)
+    # Quiet must not suppress machine-readable output.
+    assert both.stdout.strip() != ""
+    assert json.loads(both.stdout) == json.loads(json_only.stdout)
+


### PR DESCRIPTION
## Summary
`doberman scan --json --quiet` already prints JSON because the JSON branch returns before the quiet check. That precedence is sensible but was untested and undocumented.

- Add a regression test that `--json --quiet` still emits valid JSON with the same exit code as `--json` alone
- Document in `docs/CLI.md` that `--json` wins over `--quiet`

Fixes #225