### PR TITLE
docs(contributors): add the eight contributors missing from the list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ testing, or ideas. Thank you. 🐕
 
 In alphabetical order by handle (ordering is not a ranking):
 
+- [@AshSgDe29071999](https://github.com/AshSgDe29071999)
 - [@averyquinnhq](https://github.com/averyquinnhq)
 - [@Bestpart-Irene](https://github.com/Bestpart-Irene)
 - [@harshitagrawal2O](https://github.com/harshitagrawal2O)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,8 +12,16 @@ testing, or ideas. Thank you. 🐕
 
 In alphabetical order by handle (ordering is not a ranking):
 
+- [@averyquinnhq](https://github.com/averyquinnhq)
 - [@Bestpart-Irene](https://github.com/Bestpart-Irene)
+- [@harshitagrawal2O](https://github.com/harshitagrawal2O)
+- [@jasperdingg](https://github.com/jasperdingg)
 - **Lee Sang Hoon** — [@leemeo3](https://github.com/leemeo3)
+- [@navaneethsankar07](https://github.com/navaneethsankar07)
+- [@QY-25123](https://github.com/QY-25123)
+- [@Shihasz](https://github.com/Shihasz)
+- [@snowyukitty](https://github.com/snowyukitty)
+- [@stevenmini2019](https://github.com/stevenmini2019)
 - [@Tian-Tan](https://github.com/Tian-Tan)
 
 The living list of everyone who has landed a commit is always on the


### PR DESCRIPTION
## What this PR does

`CONTRIBUTORS.md` listed three people, while ten non-maintainer contributors have landed merged PRs. This adds the eight who were missing and keeps the list alphabetical by handle.

Added, with the merged work that qualified them:

| Handle | Merged work |
|---|---|
| [@averyquinnhq](https://github.com/averyquinnhq) | #181 — Windows venv activation in CONTRIBUTING |
| [@harshitagrawal2O](https://github.com/harshitagrawal2O) | #152 — Windows CI leg + cross-drive key fix |
| [@jasperdingg](https://github.com/jasperdingg) | #221 — exhaustive raise-only reduction test |
| [@navaneethsankar07](https://github.com/navaneethsankar07) | #216 — targeted test-selection guide |
| [@QY-25123](https://github.com/QY-25123) | #102 — `CostObserver` plugin seam; #220 — package smoke test |
| [@Shihasz](https://github.com/Shihasz) | #183 — PATH-shadowing troubleshooting; #219 — ReasonCode drift test |
| [@snowyukitty](https://github.com/snowyukitty) | #132 — custom Guardrail tutorial; #184 — help smoke test |
| [@stevenmini2019](https://github.com/stevenmini2019) | #99 — Azure & GCP service-account key patterns |

Every one of these is a merged PR that changed behavior, added a real test, added a CI check, or documented a guarantee — the bar in `CLAUDE.md` §8b step 6.

`@leemeo3` and `@Tian-Tan` stay as they are; the file credits review, testing and ideas as well as code.

## Tests added (run in CI)
- None. Documentation only, no behavior change.

## Security checklist
- [x] Fails closed on error / uncertainty — N/A, docs only
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — N/A
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — N/A