### PR TITLE
perf(ci): run the test suite in parallel with pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - run: ruff format --check .
       - name: Architecture & repo boundaries
         run: lint-imports
-      - run: pytest --cov=doberman --cov-report=term-missing --cov-fail-under=80
+      - run: pytest -n auto --cov=doberman --cov-report=term-missing --cov-fail-under=80
   package-smoke-test:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio", "pytest-cov", "ruff>=0.15,<0.16", "import-linter", "textual", "hypothesis", "starlette", "uvicorn", "httpx"]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-xdist", "ruff>=0.15,<0.16", "import-linter", "textual", "hypothesis", "starlette", "uvicorn", "httpx"]
 explain = ["anthropic"]
 tui = ["textual"]
 dash = ["starlette", "uvicorn"]


### PR DESCRIPTION
## What this PR does

Runs the CI test suite under `pytest-xdist` (`-n auto`). No test, source, or coverage-gate change.

Measured on a 5-way experiment matrix (run `30797096752`, branch `chore/ci-timing-experiment`), pytest step only:

| Job | pytest step | vs baseline |
|---|---|---|
| `win-cov-serial` (baseline) | 1531s (25.5 min) | — |
| `win-nocov-serial` | 1130s (18.8 min) | −401s |
| **`win-cov-xdist`** | **877s (14.6 min)** | **−654s, 1.75x** |
| `ubu-cov-serial` (baseline) | 1057s (17.6 min) | — |
| **`ubu-cov-xdist`** | **535s (8.9 min)** | **−522s, 1.98x** |

Slowest leg goes from ~25.5 min to ~14.6 min, so roughly **11 minutes off every PR**.

### Why not just drop `--cov` on Windows

That was the cheaper-looking option. The matrix rules it out: dropping coverage saves 401s, while xdist saves 654s **and keeps the coverage gate**. xdist strictly dominates it.

### Worker safety

Both xdist jobs passed with `--cov-fail-under=80` enforced, on Windows and Ubuntu. `pytest-cov` merges xdist worker coverage natively, so the gate is unchanged and still raise-only. The suite was already well-suited to this: per-test `tmp_path` isolation, zero `sleep()` calls, and only 7 subprocess-spawning tests.

Windows gains less than Ubuntu (1.75x vs 1.98x), which is expected — parallel filesystem work is costlier there.

`-n auto` is set in CI only, deliberately not in `addopts`, so local single-file runs and `pdb` debugging are unaffected.

## Tests added (run in CI)
- None. No behavior change; this alters how the existing 2256 tests are executed, not what they assert.

## Security checklist
- [x] Fails closed on error / uncertainty — N/A, CI config only
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — coverage gate unchanged at 80, still enforced on every leg
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — N/A