### PR TITLE
feat(cli): route every verdict surface through the shared render layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ Doberman now reviews every tool call your agent makes. Confirm it with `doberman
 real verdicts with `doberman demo`. Everything else - MCP-proxy wiring, the dashboard, TUI, scan,
 and 2FA - is in the **[Setup Guide](docs/SETUP.md)**.
 
-Verdicts are colour-coded in a terminal (`BLOCK` red, `AUTH` amber, `PASS` green) and explanations
-wrap to your terminal width. Colour is dropped automatically when output is piped or redirected, and
-honours [`NO_COLOR`](https://no-color.org) when that variable is set to a non-empty value.
+Verdicts are colour-coded everywhere they're shown (`BLOCK` red, `AUTH` amber, `PASS` green) —
+`review`, `status`, `log`, the TUI, and `demo`, which also wraps its explanations to your terminal
+width. Colour is dropped automatically when output is piped or redirected, and honours
+[`NO_COLOR`](https://no-color.org) when that variable is set to a non-empty value.
 
 ---
 

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -41,6 +41,7 @@ from doberman.policy.drift import (
 )
 from doberman.policy.modes import SecurityMode, resolve_mode
 from doberman.policy.preferences import DIMENSIONS, preset_name
+from doberman.render import verdict_label, verdict_label_str
 from doberman.storage.db import active_elevations, revoke_elevation
 from doberman.storage.log import memory_summary, read_decisions
 from doberman.storage.taint import entity_scope, read_taint
@@ -271,7 +272,7 @@ def review(
         if not item.applicable:
             tags.append("N/A - capability absent")
         suffix = f"  ({', '.join(tags)})" if tags else ""
-        typer.echo(f"{box} {item.verdict.value:<5} {item.id}{suffix}")
+        typer.echo(f"{box} {verdict_label(item.verdict)} {item.id}{suffix}")
     typer.echo(f"\nMode: {doc.mode}")
 
     if yes:
@@ -523,7 +524,7 @@ def status(
     else:
         for row in rows:
             reasons = ", ".join(json.loads(row["reason_codes_json"] or "[]")) or "-"
-            typer.echo(f"  {row['ts']}  {row['final_verdict']:<5}  {reasons}")
+            typer.echo(f"  {row['ts']}  {verdict_label_str(row['final_verdict'])}  {reasons}")
 
 
 @app.command()
@@ -819,7 +820,7 @@ def log(
         reasons = ", ".join(json.loads(row["reason_codes_json"] or "[]")) or "-"
         auth = f"; auth={row['auth_result']}" if row["auth_result"] else ""
         typer.echo(
-            f"{row['ts']}  {row['final_verdict']:<5} {row['action_type']:<13} "
+            f"{row['ts']}  {verdict_label_str(row['final_verdict'])} {row['action_type']:<13} "
             f"{target}  [{reasons}]{auth}"
         )
 

--- a/src/doberman/render.py
+++ b/src/doberman/render.py
@@ -64,6 +64,19 @@ def verdict_label(verdict: Verdict) -> str:
     return typer.style(padded, **_VERDICT_STYLES.get(verdict, {}))
 
 
+def verdict_label_str(value: str) -> str:
+    """Like :func:`verdict_label`, but for a verdict already read back as a plain string
+    (e.g. a DB row's ``final_verdict``).
+
+    An unrecognized value (corrupt row, future verdict) never raises — it is padded to
+    the same fixed width and returned uncolored, so a log/status viewer can't crash on it.
+    """
+    try:
+        return verdict_label(Verdict(value))
+    except ValueError:
+        return f"{value:<{_LABEL_WIDTH}}"
+
+
 def wrap_detail(text: str, indent: int = 4, width: int | None = None) -> list[str]:
     """Wrap ``text`` to a sane terminal width, indented ``indent`` spaces.
 

--- a/src/doberman/tui.py
+++ b/src/doberman/tui.py
@@ -39,6 +39,13 @@ from doberman.storage.log import read_decisions
 
 _EMPTY_PLACEHOLDER = "(no decisions recorded yet)"
 _COLUMNS = ("ts", "verdict", "action_type", "target_path_class", "reason codes")
+#: Verdict cell color, matching doberman.render's palette. Unknown/corrupt values
+#: (not a real Verdict) get no style rather than raising.
+_VERDICT_STYLES = {
+    "BLOCK": "bold red",
+    "AUTH": "bold yellow",
+    "PASS": "green",
+}
 #: Debounce before the (possibly network-bound) enrichment worker starts, so
 #: holding an arrow key skims rows without firing a request per keypress.
 _EXPLAIN_DEBOUNCE_S = 0.3
@@ -118,10 +125,13 @@ class DecisionExplainerApp(App[None]):
             return
         for row in self._rows:
             # Text() cells render literally — no Rich-markup interpretation of
-            # row-derived strings.
+            # row-derived strings. The style= kwarg is applied structurally by
+            # Rich, not parsed out of the string, so a crafted value still can't
+            # spoof a color it wasn't assigned.
+            verdict_str = str(row.get("final_verdict") or "-")
             table.add_row(
                 Text(str(row.get("ts") or "-")),
-                Text(str(row.get("final_verdict") or "-")),
+                Text(verdict_str, style=_VERDICT_STYLES.get(verdict_str)),
                 Text(str(row.get("action_type") or "-")),
                 Text(str(row.get("target_path_class") or "-")),
                 Text(_reason_codes_text(row)),

--- a/tests/unit/test_cli_verdict_render.py
+++ b/tests/unit/test_cli_verdict_render.py
@@ -1,0 +1,49 @@
+"""Slice: every verdict-printing CLI surface routes through ``doberman.render``.
+
+Covers ``verdict_label_str`` (the string-keyed wrapper used where a verdict is
+read back from storage as a plain string, e.g. ``row['final_verdict']``) and the
+TUI's verdict-cell style mapping. The color/wrap primitives themselves are
+already covered by ``test_render.py``.
+"""
+
+import pytest
+
+import doberman.render as render
+
+
+def test_verdict_label_str_known_verdict_colored_when_forced(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr(render, "supports_color", lambda: True)
+    colored = render.verdict_label_str("BLOCK")
+    assert colored != f"{'BLOCK':<5}"  # carries ANSI styling
+    assert "BLOCK" in colored
+
+
+def test_verdict_label_str_known_verdict_plain_with_no_color(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert render.verdict_label_str("AUTH") == f"{'AUTH':<5}"
+
+
+def test_verdict_label_str_unknown_value_padded_plain_no_exception(monkeypatch):
+    # Corrupt/legacy row value -- must never raise, and is never colored even
+    # when color would otherwise apply.
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr(render, "supports_color", lambda: True)
+    assert render.verdict_label_str("ALLOW") == f"{'ALLOW':<5}"
+
+
+def test_verdict_label_str_plain_output_byte_identical_to_old_format(monkeypatch):
+    # Alignment invariant: the pre-render.py hand-rolled f"{v:<5}" lines must
+    # still line up exactly when color is off (redirected output, NO_COLOR, CI logs).
+    monkeypatch.setenv("NO_COLOR", "1")
+    for value in ("BLOCK", "AUTH", "PASS"):
+        assert render.verdict_label_str(value) == f"{value:<5}"
+
+
+def test_tui_verdict_style_mapping_covers_exactly_pass_auth_block():
+    # doberman.tui imports textual at module scope (by design -- see its
+    # docstring); skip cleanly in the standalone dev venv, same as test_tui.py.
+    pytest.importorskip("textual")
+    from doberman.tui import _VERDICT_STYLES as tui_verdict_styles
+
+    assert set(tui_verdict_styles) == {"PASS", "AUTH", "BLOCK"}


### PR DESCRIPTION
## Slice
- UX fix wave / slice 1 - verdict-render unification (audit 2026-08-05, action #1)

## What this PR does
`render.py` was built for ADR 0044 but only `demo` used it: `review`, `status`, `log`, and the TUI printed verdicts unstyled and unwrapped. This routes all of them through the shared layer: a new `verdict_label_str` helper colors a stored verdict string and pads unknown values instead of raising, and the TUI styles its verdict cell with the same palette. The README claim about colour-coding is now true everywhere verdicts appear, and its wording now scopes explanation-wrapping to `demo`, which is what ships.

## Tests added (run in CI)
- `tests/unit/test_cli_verdict_render.py` - colored when forced, plain under NO_COLOR, unknown value pads without raising, plain output byte-identical to the old `:<5` format (alignment invariant), TUI style map covers exactly PASS/AUTH/BLOCK.

## Security checklist
- [x] Fails closed on error / uncertainty (unknown verdict renders plain, never raises)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (presentation-only change)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged)

## Edge cases covered / Deviations from plan / Risks introduced
- Non-TTY / NO_COLOR / piped output is byte-identical to before - no downstream parser breaks.
- `policy-history` was named in the audit but prints classification + approval status, not a verdict - deliberately left unchanged.