### PR TITLE
feat(dash): light-mode AA verdict colors, live-region pending queue, labeled TOTP input

### DIFF
--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -104,11 +104,11 @@ _HTML_SHELL = """<!doctype html>
   }
   @media (prefers-color-scheme: light) {
     :root {
-      --bg: #f7f7f8;
-      --surface: #ffffff;
-      --border: #dde1e6;
-      --ink: #111;
-      --ink-dim: #5b6572;
+      --bg: #f7f7f8; --surface: #ffffff; --border: #dde1e6; --ink: #111; --ink-dim: #5b6572;
+      --pass: #1a7f37;  --pass-bg: rgba(26, 127, 55, .12);
+      --auth: #9a6700;  --auth-bg: rgba(154, 103, 0, .12);
+      --block: #cf222e; --block-bg: rgba(207, 34, 46, .12);
+      --neutral: #57606a; --neutral-bg: rgba(87, 96, 106, .12);
     }
   }
   * { box-sizing: border-box; }
@@ -164,9 +164,9 @@ _HTML_SHELL = """<!doctype html>
   #pending-list .badge { font-size: .76rem; padding: .25rem .55rem; }
   #pending-list li {
     padding: 1rem 1.1rem; margin-bottom: .7rem;
-    border: 1px solid var(--auth); border-left: 3px solid var(--auth);
+    border: 1px solid var(--auth);
     border-radius: 8px; background: var(--surface); font-size: .85rem;
-    box-shadow: 0 0 0 1px rgba(210, 153, 34, .07), 0 10px 28px -14px rgba(210, 153, 34, .55);
+    box-shadow: 0 4px 8px -4px rgba(210, 153, 34, .4);
     animation: pending-arrive .28s ease-out both;
   }
   @keyframes pending-arrive {
@@ -208,7 +208,7 @@ _HTML_SHELL = """<!doctype html>
   </div>
   <div id="stats">stats loading...</div>
   <h2>Pending approvals</h2>
-  <ul id="pending-list"></ul>
+  <ul id="pending-list" aria-live="polite"></ul>
   <div id="pending-empty" class="empty-state">No pending approvals right now.</div>
   <h2>Recent decisions</h2>
   <ul id="feed"></ul>
@@ -404,6 +404,11 @@ _HTML_SHELL = """<!doctype html>
           summary.textContent = row.action_type +
             " " + (row.target_path_class || "-") + " (tier: " + row.tier + ")";
           header.appendChild(summary);
+
+          var expiry = document.createElement("span");
+          expiry.className = "detail";
+          expiry.textContent = "expires " + (String(row.expires_at || "").slice(11, 19) || "-") + " UTC";
+          header.appendChild(expiry);
           li.appendChild(header);
 
           var reasons = document.createElement("div");
@@ -425,6 +430,7 @@ _HTML_SHELL = """<!doctype html>
             totpInput.inputMode = "numeric";
             totpInput.placeholder = "TOTP code";
             totpInput.autocomplete = "off";
+            totpInput.setAttribute("aria-label", "TOTP code");
             li.appendChild(totpInput);
           }
 
@@ -448,6 +454,7 @@ _HTML_SHELL = """<!doctype html>
 
           pendingList.appendChild(li);
         });
+        document.title = (rows.length ? "(" + rows.length + ") " : "") + "Doberman Dashboard";
       }
 
       function refreshPending() {

--- a/tests/unit/test_dash_serve.py
+++ b/tests/unit/test_dash_serve.py
@@ -43,6 +43,7 @@ def test_importing_doberman_never_pulls_in_dash_or_starlette():
 
 from starlette.testclient import TestClient  # noqa: E402
 
+from doberman.dash import app as app_module  # noqa: E402
 from doberman.dash.app import create_app  # noqa: E402
 
 _TOKEN = "test-dash-token-0123456789"  # noqa: S105 - fixture value, not a real secret
@@ -102,3 +103,30 @@ def test_dash_binds_localhost_only():
     # Assert the constant the `dash` command passes to uvicorn.run - never
     # actually bind a socket in a test.
     assert cli_main._DASH_HOST == "127.0.0.1"
+
+
+def test_shell_pending_list_is_polite_live_region():
+    assert 'id="pending-list" aria-live="polite"' in app_module._HTML_SHELL
+
+
+def test_shell_totp_input_has_aria_label():
+    assert 'totpInput.setAttribute("aria-label", "TOTP code")' in app_module._HTML_SHELL
+
+
+def test_shell_has_no_side_stripe():
+    assert "border-left: 3px" not in app_module._HTML_SHELL
+
+
+def test_shell_light_mode_retunes_verdict_colors():
+    # the light block must override the verdict tokens, not just bg/ink
+    light = app_module._HTML_SHELL.split("prefers-color-scheme: light", 1)[1].split("}")[0]
+    for var in ("--pass:", "--auth:", "--block:", "--neutral:"):
+        assert var in light
+
+
+def test_shell_titles_pending_count():
+    assert "document.title = (rows.length" in app_module._HTML_SHELL
+
+
+def test_shell_renders_pending_expiry():
+    assert "expires " in app_module._HTML_SHELL


### PR DESCRIPTION
## Slice
- UX fix wave / UX.2 - dash a11y + honest light mode (2026-08-05 audit P1s)

## What this PR does
The dash declared `color-scheme: dark light` but light mode never re-tuned the verdict tokens, so PASS/AUTH/BLOCK badges computed ~2.2-2.5:1 on light backgrounds. Light mode now carries its own AA-passing verdict and neutral values. The pending-approval queue - the one surface a human must notice - becomes perceivable beyond eyesight-on-tab: `aria-live="polite"` on the list, a pending count in the tab title, and each card shows its expiry time. The TOTP input gains an accessible name, and the card loses its 3px side-stripe + wide glow in favor of the existing 1px amber border and a tight shadow.

## Tests added (run in CI)
- `tests/unit/test_dash_serve.py`: six new shell assertions - live region present, TOTP aria-label present, no side-stripe, light block re-tunes all four signal tokens, title carries the pending count, expiry rendered. Each fails against the previous shell.

## Security checklist
- [x] Fails closed on error / uncertainty (no auth/decision-path changes)
- [x] No secret, full file, or unredacted prompt logged or committed (expiry is a timestamp already serialized by /api/pending)
- [x] Any guardrail/learning change is raise-only (presentation-only)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged)

## Edge cases covered / Deviations from plan / Risks introduced
- Title count resets when the queue empties (update sits past the rebuild-skip guard, which fires on any set change).
- aria-live is on the pending list only - the decision feed stays silent by design (it would be chatty).