### PR TITLE
feat(cli): rename the SessionStart panel to session-summary, keep dashboard as alias

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -240,7 +240,7 @@ The proxy above protects the tools you route *through* Doberman. To make Doberma
     ],
     "SessionStart": [
       {
-        "hooks": [{ "type": "command", "command": "doberman dashboard" }]
+        "hooks": [{ "type": "command", "command": "doberman session-summary" }]
       }
     ]
   }
@@ -270,7 +270,7 @@ doberman uninstall-hooks          # remove only Doberman's entries (leaves your 
 
 [OpenClaw](https://docs.openclaw.ai) agents route through Doberman via a small local plugin instead of a hook-pack (OpenClaw's `before_tool_call` event is only reachable from a typed plugin hook). It spawns `doberman hook openclaw` per call — same fail-closed, deterministic objective floor as the Claude Code hook — and maps the verdict to OpenClaw's own primitives: `allow` is a no-op, `block` is terminal, and `auth` delegates to OpenClaw's own `/approve` flow (the gateway has no interactive terminal of its own for Doberman's local challenge dialog). See [`adapters/openclaw/README.md`](../adapters/openclaw/README.md) for install steps and the mandatory "verify it's live" canary check — OpenClaw has shipped bugs where plugin hooks silently never fire, so that check isn't optional.
 
-**Session dashboard.** `install-hooks` also wires a `SessionStart` hook that runs `doberman dashboard` — a print-and-exit (never interactive, never blocking) summary of a **device-global, lifetime rollup**: every decision Doberman makes, across every repo and session on this machine, increments a tiny counter at `~/.doberman/metrics.db` (verdict class + count only — no path, no reason code, no per-action detail). It shows total interceptions and the PASS/AUTH/BLOCK split:
+**Session summary.** `install-hooks` also wires a `SessionStart` hook that runs `doberman session-summary` — a print-and-exit (never interactive, never blocking) summary of a **device-global, lifetime rollup**: every decision Doberman makes, across every repo and session on this machine, increments a tiny counter at `~/.doberman/metrics.db` (verdict class + count only — no path, no reason code, no per-action detail). The former `doberman dashboard` command remains as a hidden compatibility alias. It shows total interceptions and the PASS/AUTH/BLOCK split:
 
 ```
 +------------------------------------------+
@@ -284,7 +284,7 @@ doberman uninstall-hooks          # remove only Doberman's entries (leaves your 
 +------------------------------------------+
 ```
 
-Run it any time with `doberman dashboard`. Output is plain ASCII (no box-drawing runes or emoji) so it always renders on a legacy Windows console, and the command always exits `0` and never raises — a dashboard must never break a session start.
+Run it any time with `doberman session-summary`. Output is plain ASCII (no box-drawing runes or emoji) so it always renders on a legacy Windows console, and the command always exits `0` and never raises — a session summary must never break a session start.
 
 **Decision-transparency TUI.** `doberman log` prints the raw redacted rows; `doberman tui` browses the same rows interactively and adds a plain-language "why" for whichever row is highlighted — the verdict, the decided layer, and its reason codes turned into a sentence, using only that row's already-redacted data (never a raw path, argument, or secret). Arrow keys navigate, `r` reloads, `q` quits:
 

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1319,9 +1319,11 @@ def setup(
     )
 
 
-@app.command()
-def dashboard() -> None:
+@app.command("session-summary")
+def session_summary() -> None:
     """Print the device-global session-guard summary and exit.
+
+    Formerly ``doberman dashboard``.
 
     Reads the lifetime rollup at ``~/.doberman/metrics.db`` (every decision on
     this device, across all repos/sessions, increments it - see
@@ -1337,6 +1339,12 @@ def dashboard() -> None:
     except Exception:  # noqa: BLE001, S110 — a dashboard must never break session start
         pass
     raise typer.Exit(0)
+
+
+@app.command("dashboard", hidden=True)
+def dashboard() -> None:
+    """Run the deprecated alias for ``doberman session-summary``."""
+    session_summary()
 
 
 @app.command()

--- a/src/doberman/hosthooks/install.py
+++ b/src/doberman/hosthooks/install.py
@@ -28,15 +28,16 @@ POST_MATCHER = "Bash|Edit|Write|NotebookEdit|WebFetch|WebSearch|Read|Glob|Grep|m
 #: Command registered as the PostToolUse hook.
 POST_COMMAND = "doberman hook post"
 
-#: Command registered as the SessionStart hook (prints the session dashboard).
-DASHBOARD_COMMAND = "doberman dashboard"
+#: Command registered as the SessionStart hook (prints the session summary).
+DASHBOARD_COMMAND = "doberman session-summary"
 
 #: Sentinel substring used to detect Doberman-owned hook entries.
 _DOBERMAN_MARKER = "doberman hook "
 
 #: SessionStart entries use a different command shape (`doberman hook `
-#: doesn't match `doberman dashboard`), so they need their own marker.
+#: doesn't match the summary commands), so they need their own markers.
 _DASHBOARD_MARKER = "doberman dashboard"
+_SESSION_SUMMARY_MARKER = "doberman session-summary"
 
 _PRE_ENTRY: dict[str, Any] = {
     "matcher": PRE_MATCHER,
@@ -64,7 +65,9 @@ def _is_doberman_group(group: dict[str, Any]) -> bool:
     """Return True if *any* hook command in this matcher group belongs to Doberman."""
     for h in group.get("hooks", []):
         cmd = h.get("command", "")
-        if isinstance(cmd, str) and (_DOBERMAN_MARKER in cmd or _DASHBOARD_MARKER in cmd):
+        if isinstance(cmd, str) and (
+            _DOBERMAN_MARKER in cmd or _DASHBOARD_MARKER in cmd or _SESSION_SUMMARY_MARKER in cmd
+        ):
             return True
     return False
 

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -32,6 +32,7 @@ CLI_HELP_TARGETS = (
     ("install-hooks",),
     ("uninstall-hooks",),
     ("setup",),
+    ("session-summary",),
     ("dashboard",),
     ("version",),
     ("2fa",),
@@ -85,3 +86,10 @@ def test_cli_help_renders_without_a_traceback(command_path):
     assert result.exit_code == 0, result.output
     assert _expected_usage(command_path) in normalized_output
     assert "Traceback" not in result.output
+
+
+def test_dashboard_alias_is_hidden_from_root_help():
+    root_command = get_command(app)
+
+    assert root_command.commands["session-summary"].hidden is False
+    assert root_command.commands["dashboard"].hidden is True

--- a/tests/unit/test_device_metrics.py
+++ b/tests/unit/test_device_metrics.py
@@ -176,7 +176,12 @@ class TestRecordDecisionRollupWiring:
 
 
 class TestDashboardCLI:
-    def test_exits_zero_on_empty_store(self):
+    def test_session_summary_exits_zero_and_prints_panel(self):
+        result = runner.invoke(cli_module.app, ["session-summary"])
+        assert result.exit_code == 0, result.output
+        assert "No activity" in result.output
+
+    def test_dashboard_alias_exits_zero_on_empty_store(self):
         result = runner.invoke(cli_module.app, ["dashboard"])
         assert result.exit_code == 0, result.output
         assert "No activity" in result.output

--- a/tests/unit/test_install_hooks.py
+++ b/tests/unit/test_install_hooks.py
@@ -79,9 +79,9 @@ class TestMergeDobermanHooks:
         assert PRE_COMMAND in _pre_commands(result)
         assert POST_COMMAND in _post_commands(result)
 
-    def test_session_start_dashboard_entry_added(self):
+    def test_session_start_session_summary_entry_added(self):
         result = merge_doberman_hooks({})
-        assert DASHBOARD_COMMAND in _session_start_commands(result)
+        assert _session_start_commands(result) == ["doberman session-summary"]
 
     def test_session_start_idempotent_no_duplicates(self):
         once = merge_doberman_hooks({})
@@ -173,6 +173,20 @@ class TestRemoveDobermanHooks:
         assert _count_doberman(result, "PreToolUse") == 0
         assert _count_doberman(result, "PostToolUse") == 0
         assert _count_doberman(result, "SessionStart") == 0
+
+    def test_removes_old_and_new_session_start_entries(self):
+        settings = {
+            "hooks": {
+                "SessionStart": [
+                    {"hooks": [{"type": "command", "command": "doberman dashboard"}]},
+                    {"hooks": [{"type": "command", "command": "doberman session-summary"}]},
+                ]
+            }
+        }
+
+        result = remove_doberman_hooks(settings)
+
+        assert "hooks" not in result
 
     def test_preserves_model_key(self):
         settings = self._settings_with_both_and_other()


### PR DESCRIPTION
## Summary
- `doberman dashboard` is renamed `session-summary` - the old name collided with `doberman dash` (the web dashboard) and misdescribed a print-and-exit panel.
- `dashboard` survives as a hidden, permanent alias: existing installs' settings.json invoke that literal string at SessionStart, and breaking it breaks session start.
- `install-hooks` writes `doberman session-summary` going forward; `remove_doberman_hooks` recognizes and removes both old- and new-style SessionStart groups, so no install is left stranded on either name.
- `docs/SETUP.md` updated; README had no references to the old name.

## Tests
- `session-summary` appears in `--help`; `dashboard` is hidden from it
- Both invocations print the panel and exit 0
- Fresh `merge_doberman_hooks` writes the new command string
- `remove_doberman_hooks` strips a legacy `doberman dashboard` group
- `ruff` / `lint-imports` (2 contracts kept) / targeted pytest green locally

**Repo:** core. No enterprise references; CLI command registration and hook-string plumbing only.

Part of the 2026-08-05 UX fix wave (audit: two commands both named "dashboard" was the top findability confusion).
