### PR TITLE
feat(dash): arm-then-confirm approve control

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -881,8 +881,7 @@ def dash(
     ``--path`` (default: the current repo), plus an interactive AUTH
     approve/deny queue: a challenge on the decision path engages this
     dashboard only while it is running (see the heartbeat below), and falls
-    back to the terminal/GUI otherwise. Requires the optional 'dash' extra;
-    polish lands in a later slice.
+    back to the terminal/GUI otherwise. Requires the optional 'dash' extra.
     """
     try:
         import uvicorn

--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -438,8 +438,19 @@ _HTML_SHELL = """<!doctype html>
           approveBtn.type = "button";
           approveBtn.className = "approve";
           approveBtn.textContent = "Approve";
+          var armTimer = null;
           approveBtn.addEventListener("click", function () {
-            resolveApproval(row.id, "approved", totpInput ? totpInput.value : null, li);
+            if (approveBtn.dataset.armed === "1") {
+              clearTimeout(armTimer);
+              resolveApproval(row.id, "approved", totpInput ? totpInput.value : null, li);
+              return;
+            }
+            approveBtn.dataset.armed = "1";
+            approveBtn.textContent = "Confirm approve";
+            armTimer = setTimeout(function () {
+              approveBtn.dataset.armed = "";
+              approveBtn.textContent = "Approve";
+            }, 3000);
           });
           li.appendChild(approveBtn);
 

--- a/tests/unit/test_dash_serve.py
+++ b/tests/unit/test_dash_serve.py
@@ -113,6 +113,11 @@ def test_shell_totp_input_has_aria_label():
     assert 'totpInput.setAttribute("aria-label", "TOTP code")' in app_module._HTML_SHELL
 
 
+def test_shell_approve_requires_arm_then_confirm():
+    assert "Confirm approve" in app_module._HTML_SHELL
+    assert "armTimer" in app_module._HTML_SHELL
+
+
 def test_shell_has_no_side_stripe():
     assert "border-left: 3px" not in app_module._HTML_SHELL
 


### PR DESCRIPTION
## Summary
- The dash pending-card Approve button is now arm-then-confirm: the first click arms it ("Confirm approve"), a second click within 3 seconds resolves, and the timer disarms it back to "Approve". Deny stays single-click - denying is the safe direction, so it earns no friction.
- Client-side only: the arming lives in `_HTML_SHELL`'s render loop (one timer per card); server-side approval semantics are untouched.
- Rides along: the `dash` command docstring dropped its stale "polish lands in a later slice" promise - the polish has landed.

## Tests
- `test_shell_approve_requires_arm_then_confirm` (red-green cycle confirmed before implementation)
- `ruff` / `lint-imports` (2 contracts kept) / `test_dash_serve.py` green locally

**Repo:** core. No enterprise references; dash HTML shell and one CLI docstring only.

Part of the 2026-08-05 UX fix wave (critique: approving an AUTH challenge is the highest-stakes click in the product and had zero slip protection).
