### PR TITLE
test: extend ASCII-only guarantee to 2fa remove and setup mode errors (#254)

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -745,7 +745,7 @@ def twofa_remove() -> None:
     if not password.is_enrolled():
         typer.echo(
             "warning: no possession factor is enrolled now, so every policy weakening "
-            "will be denied — run `doberman password set` (or `doberman 2fa setup`) to "
+            "will be denied - run `doberman password set` (or `doberman 2fa setup`) to "
             "restore one.",
             err=True,
         )

--- a/src/doberman/hosthooks/setup.py
+++ b/src/doberman/hosthooks/setup.py
@@ -46,7 +46,7 @@ def parse_mode_choice(raw: str) -> SecurityMode:
         if 0 <= idx < len(modes):
             return modes[idx]
         raise ValueError(
-            f"choose 1–{len(modes)} or type a mode name "
+            f"choose 1-{len(modes)} or type a mode name "
             f"({', '.join(m.value for m in SecurityMode)})"
         )
     # Named

--- a/tests/unit/test_cli_encode_safe.py
+++ b/tests/unit/test_cli_encode_safe.py
@@ -12,11 +12,20 @@ a box-drawing rule, an emoji) there raised ``UnicodeEncodeError`` and crashed
 import io
 import sys
 
+import pyotp
 from typer.testing import CliRunner
 
+from doberman.auth import totp
 from doberman.cli.main import _ensure_encode_safe_stdio, app
 
 runner = CliRunner()
+
+
+def _current_code() -> str:
+    """A code for the live enrollment on the real clock (same as test_2fa_remove)."""
+    secret = totp._read_secret()
+    assert secret is not None
+    return pyotp.TOTP(secret).now()
 
 
 def test_encode_safe_stdio_prevents_cp1252_crash(monkeypatch):
@@ -51,3 +60,29 @@ def test_setup_yes_output_is_ascii_and_cp1252_safe(tmp_path):
     assert result.exit_code == 0, result.output
     assert result.output.isascii(), f"non-ASCII in setup output: {result.output!r}"
     result.output.encode("cp1252")
+
+
+def test_2fa_remove_warning_is_ascii_and_cp1252_safe():
+    # The 2fa remove path warns when no possession factor remains; that warning
+    # used an em-dash and must stay ASCII like the rest of onboarding.
+    totp.enroll()
+
+    result = runner.invoke(app, ["2fa", "remove"], input=f"y\n{_current_code()}\n")
+
+    assert result.exit_code == 0, result.output
+    assert "will be denied" in result.stderr
+    output = result.output + result.stderr
+    assert output.isascii(), f"non-ASCII in 2fa remove output: {output!r}"
+    output.encode("cp1252")  # raises if any char is not cp1252-encodable
+
+
+def test_setup_bad_mode_choice_error_is_ascii_and_cp1252_safe(tmp_path):
+    # An out-of-range numeric mode choice surfaces parse_mode_choice's error
+    # message (which used an en-dash); it must be ASCII too.
+    result = runner.invoke(app, ["setup", "--path", str(tmp_path)], input="9\n")
+
+    assert result.exit_code == 2
+    assert "choose 1-4" in result.stderr
+    output = result.output + result.stderr
+    assert output.isascii(), f"non-ASCII in setup error output: {output!r}"
+    output.encode("cp1252")  # raises if any char is not cp1252-encodable


### PR DESCRIPTION
## What this PR does

Fixes issue #254: two user-facing CLI messages slipped non-ASCII dashes past the cp1252-safe onboarding guarantee.

- \src/doberman/cli/main.py\: the \2fa remove\ warning used an em-dash (U+2014)
- \src/doberman/hosthooks/setup.py\: \parse_mode_choice\ error used an en-dash (U+2013)

Both replaced with plain hyphens.

## Tests added (run in CI)

Extended \	ests/unit/test_cli_encode_safe.py\ so the ASCII guarantee covers the two paths that slipped through:

- \	est_2fa_remove_warning_is_ascii_and_cp1252_safe\ - drives \2fa remove\ to the no-possession-factor warning and asserts ASCII + cp1252 safety
- \	est_setup_bad_mode_choice_error_is_ascii_and_cp1252_safe\ - drives a bad numeric mode choice through the wizard and asserts ASCII + cp1252 safety

Verified both new tests FAIL when the character fixes are reverted. \uff check\, \uff format --check\ and all unit tests in the touched files pass.

## Edge cases covered / Deviations from plan / Risks introduced

None - behavior and public API unchanged; only two user-facing strings and the tests covering them.