### PR TITLE
feat(auth): add non-blocking async challenge interface and InMemoryAsyncBackend (#144)

### DIFF
--- a/src/doberman/auth/async_challenge.py
+++ b/src/doberman/auth/async_challenge.py
@@ -1,0 +1,587 @@
+"""Non-blocking auth-challenge mechanism (Feature 7, issue #144).
+
+Today, :func:`~doberman.auth.challenge.run_auth_challenge` is **synchronous**: it
+blocks the calling path — proxy worker, host-hook, or CI pipeline — until a human
+decides.  For unattended runs, no human is present; the caller stalls indefinitely
+(or until the :data:`~doberman.auth.challenge.DEFAULT_CHALLENGE_TIMEOUT_S` wall-clock
+deadline fires and denies).
+
+This module adds an **async (non-blocking) alternative**: the caller issues a challenge
+and immediately receives a :class:`ChallengeHandle` — an opaque, action-bound token
+it can store or hand to a scheduler. Later, when the human has decided (via any
+delivery channel that the operator has wired — dashboard, Slack push, e-mail; the
+hosted channels are explicitly out of scope here), the caller resolves the handle and
+receives a normal :class:`~doberman.auth.challenge.AuthResult`.
+
+Design constraints (from the issue and project invariants)
+----------------------------------------------------------
+* **Fail closed** — an unresolved, expired, or error handle yields a non-approved
+  ``AuthResult``; it never silently passes.
+* **Single-use, action-bound** — a handle resolves exactly once and is permanently
+  tied to the ``action_id`` it was issued for.  A second resolve of the same handle
+  returns the first result; a handle cannot be used against a different action.
+* **No weakening of the existing guarantees** — tier selection, ``role_elevation``
+  semantics, and the audit trail are unchanged; the async path is an alternative
+  *entry point*, not a replacement of the core machinery.
+* **Decoupled from delivery channels** — this module knows nothing about how the
+  human is notified.  The "hosted delivery channels (Slack/push/email routing)" are
+  explicitly out of scope (see the issue).
+* **Entry-point registry** — callers wiring an alternative async backend register an
+  :class:`AsyncChallengeBackend` under the ``doberman.async_challenge_backends``
+  group; with nothing installed the in-process in-memory backend runs.
+* **Import-linter safe** — this module lives in ``doberman.auth`` and therefore must
+  not import ``doberman.proxy``, ``doberman.hosthooks``, ``doberman.dash``, or
+  ``doberman.turngate``.
+
+Quick-start for operators
+-------------------------
+1. Call :func:`issue_challenge` from your agent's tool-call path; store the returned
+   :class:`ChallengeHandle`.
+2. Deliver the challenge details to a human out-of-band (this module does not do that).
+3. When the human approves/denies, call :func:`resolve_challenge` with the handle
+   and the human's decision.
+4. Consume the :class:`~doberman.auth.challenge.AuthResult` from the handle's
+   ``result`` property (or ``await handle.wait()``).
+
+Thread / async safety
+---------------------
+:class:`InMemoryAsyncBackend` is thread-safe (uses :mod:`threading` primitives).
+All public functions are synchronous and safe to call from any thread; no event loop
+is required.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Protocol, runtime_checkable
+
+from pydantic import AwareDatetime
+
+from doberman.auth.challenge import (
+    AuthResult,
+    AuthTier,
+    select_tier,
+)
+from doberman.models import Decision, SecurityObject
+
+logger = logging.getLogger("doberman.auth.async_challenge")
+
+# ---------------------------------------------------------------------------
+# Default TTL for an unresolved handle (seconds).
+# Sized well above the worst-case deliberate-human latency for async delivery
+# (e.g. a Slack notification that arrives while the human is in a meeting) but
+# short enough that a forgotten handle does not accumulate indefinitely.
+# ---------------------------------------------------------------------------
+DEFAULT_HANDLE_TTL_S: float = 3600.0  # 1 hour
+
+#: ``AuthResult.method`` when the handle expired before any human resolved it.
+ASYNC_TIMEOUT_METHOD = "async_timeout"
+
+#: ``AuthResult.method`` when the handle was explicitly denied without TOTP.
+ASYNC_DENIED_METHOD = "async_denied"
+
+#: Entry-point group for alternative async backends (mirrors the constant in
+#: ``doberman.engine.registry.ASYNC_CHALLENGE_BACKEND_GROUP`` — kept here too
+#: so the auth layer can reference it without importing the engine layer, which
+#: would violate the import-linter policy-core contract).
+ASYNC_BACKEND_GROUP = "doberman.async_challenge_backends"
+
+
+# ---------------------------------------------------------------------------
+# ChallengeHandle — the opaque token returned to the caller
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ChallengeHandle:
+    """An opaque, action-bound token for a pending async challenge.
+
+    Attributes
+    ----------
+    handle_id:
+        Opaque unique identifier for this challenge instance.  Use it to correlate
+        the pending row in your delivery channel with the resolve call later.
+    action_id:
+        The ``SecurityObject.id`` this challenge was issued for.  A resolve call
+        MUST carry the same ``action_id`` (enforced by :func:`resolve_challenge`).
+    tier:
+        The :class:`~doberman.auth.challenge.AuthTier` the engine selected.  Pass
+        this to the delivery channel so the human knows what proof is expected.
+    issued_at:
+        Wall-clock UTC timestamp of the :func:`issue_challenge` call.
+    expires_at:
+        After this point the handle is considered dead; :func:`resolve_challenge`
+        returns a non-approved ``AuthResult`` with ``method = ASYNC_TIMEOUT_METHOD``.
+    _event:
+        Internal :class:`threading.Event`; set when the handle is resolved.
+    _result:
+        Internal slot; set (exactly once) when the handle is resolved.
+    _lock:
+        Guards the single-write invariant on ``_result``.
+    """
+
+    handle_id: str
+    action_id: str
+    tier: AuthTier
+    issued_at: AwareDatetime
+    expires_at: AwareDatetime
+
+    # --- internal, not part of the public API ---
+    _event: threading.Event = field(default_factory=threading.Event, repr=False)
+    _result: AuthResult | None = field(default=None, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def is_expired(self) -> bool:
+        """True if the wall-clock deadline has passed."""
+        return datetime.now(timezone.utc) >= self.expires_at
+
+    @property
+    def is_resolved(self) -> bool:
+        """True if a human (or the expiry path) has already resolved this handle."""
+        return self._event.is_set()
+
+    @property
+    def result(self) -> AuthResult | None:
+        """The ``AuthResult`` if resolved, else ``None``.
+
+        Prefer :meth:`wait` when you need the result and can afford to block.
+        """
+        return self._result
+
+    # ------------------------------------------------------------------
+    # Blocking wait (optional; callers that prefer polling use ``result``)
+    # ------------------------------------------------------------------
+
+    def wait(self, timeout: float | None = None) -> AuthResult:
+        """Block until the handle is resolved, then return the result.
+
+        If ``timeout`` is given and the handle is not resolved in time, the
+        method returns a synthesised non-approved result with
+        ``method = ASYNC_TIMEOUT_METHOD`` (it does NOT mark the handle as resolved —
+        a concurrent resolver can still settle it).
+
+        Parameters
+        ----------
+        timeout:
+            Maximum seconds to wait.  ``None`` waits until the expiry deadline
+            computed at issue time.
+        """
+        deadline_s: float | None
+        if timeout is not None:
+            deadline_s = timeout
+        else:
+            remaining = (self.expires_at - datetime.now(timezone.utc)).total_seconds()
+            deadline_s = max(remaining, 0.0)
+
+        self._event.wait(timeout=deadline_s)
+        if self._result is not None:
+            return self._result
+        # Timed out waiting — return a synthesised non-approved result.
+        return AuthResult(
+            approved=False,
+            tier=self.tier,
+            method=ASYNC_TIMEOUT_METHOD,
+            at=datetime.now(timezone.utc),
+            action_id=self.action_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal resolution (called by the backend, not by callers)
+    # ------------------------------------------------------------------
+
+    def _settle(self, result: AuthResult) -> bool:
+        """Record the result (exactly once) and wake any :meth:`wait` callers.
+
+        Returns ``True`` if THIS call was the one that settled the handle;
+        ``False`` if the handle was already resolved (idempotent, race-safe).
+        """
+        with self._lock:
+            if self._event.is_set():
+                return False  # already settled — idempotent
+            self._result = result
+            self._event.set()
+            return True
+
+
+# ---------------------------------------------------------------------------
+# AsyncChallengeBackend Protocol — the extension seam
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class AsyncChallengeBackend(Protocol):
+    """A backend that manages the lifecycle of async challenge handles.
+
+    Implementations live in core (:class:`InMemoryAsyncBackend`) or in installed
+    packages registered via ``doberman.async_challenge_backends``.
+
+    Security contract
+    -----------------
+    * ``issue`` must return a :class:`ChallengeHandle` whose ``action_id`` matches
+      ``action.id``.  The handle is single-use; a second :meth:`resolve` of the same
+      ``handle_id`` must be a no-op (return the first result).
+    * ``resolve`` must reject an ``action_id`` mismatch (fail closed).
+    * ``resolve`` called on an expired handle must return a non-approved result.
+    """
+
+    def issue(
+        self,
+        decision: Decision,
+        action: SecurityObject,
+        tier: AuthTier,
+        *,
+        ttl_s: float = DEFAULT_HANDLE_TTL_S,
+        at: datetime | None = None,
+    ) -> ChallengeHandle: ...
+
+    def resolve(
+        self,
+        handle: ChallengeHandle,
+        *,
+        approved: bool,
+        totp_code: str | None = None,
+        at: datetime | None = None,
+    ) -> AuthResult: ...
+
+    def expire_stale(self, *, now: datetime | None = None) -> int: ...
+
+
+# ---------------------------------------------------------------------------
+# Built-in in-process backend (no external dependencies)
+# ---------------------------------------------------------------------------
+
+
+class InMemoryAsyncBackend:
+    """In-process, thread-safe async challenge backend.
+
+    Handles live in a dictionary keyed by ``handle_id``.  Suitable for single-process
+    deployments (CLI, local proxy); a multi-process deployment (e.g. the dashboard
+    running in a separate server) should supply a database-backed backend registered
+    via the entry-point group.
+
+    This is intentionally the simplest correct backend — it demonstrates the interface
+    and serves as the default when nothing else is installed.
+    """
+
+    name = "in_memory"
+
+    def __init__(self) -> None:
+        self._handles: dict[str, ChallengeHandle] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # AsyncChallengeBackend implementation
+    # ------------------------------------------------------------------
+
+    def issue(
+        self,
+        decision: Decision,
+        action: SecurityObject,
+        tier: AuthTier,
+        *,
+        ttl_s: float = DEFAULT_HANDLE_TTL_S,
+        at: datetime | None = None,
+    ) -> ChallengeHandle:
+        """Register a new pending challenge and return the handle.
+
+        The handle is stored internally; pass it (or at least ``handle_id``) to
+        :func:`resolve_challenge` when the human decides.
+        """
+        when = at or datetime.now(timezone.utc)
+        from datetime import timedelta  # local import to keep the module header clean
+
+        handle = ChallengeHandle(
+            handle_id=uuid.uuid4().hex,
+            action_id=action.id,
+            tier=tier,
+            issued_at=when,
+            expires_at=when + timedelta(seconds=ttl_s),
+        )
+        with self._lock:
+            self._handles[handle.handle_id] = handle
+        logger.debug(
+            "async challenge issued: handle=%s action=%s tier=%s",
+            handle.handle_id,
+            action.id,
+            tier.value,
+        )
+        return handle
+
+    def resolve(
+        self,
+        handle: ChallengeHandle,
+        *,
+        approved: bool,
+        totp_code: str | None = None,
+        at: datetime | None = None,
+    ) -> AuthResult:
+        """Settle ``handle`` with the human's decision.
+
+        Returns the :class:`~doberman.auth.challenge.AuthResult` (same value on
+        repeated calls — idempotent once settled).
+
+        Raises
+        ------
+        KeyError
+            If ``handle.handle_id`` was never issued by this backend.
+        ValueError
+            If the handle's ``action_id`` does not match the stored record (tamper
+            protection — fail closed).
+        """
+        when = at or datetime.now(timezone.utc)
+
+        with self._lock:
+            stored = self._handles.get(handle.handle_id)
+            if stored is None:
+                raise KeyError(f"unknown handle: {handle.handle_id!r}")
+            if stored.action_id != handle.action_id:
+                # The caller supplied a handle that references a different action —
+                # this must never approve (fail closed).
+                raise ValueError(
+                    f"handle {handle.handle_id!r} is bound to action "
+                    f"{stored.action_id!r}, not {handle.action_id!r}"
+                )
+
+        # Check expiry AFTER the lock (avoids a race where we expire while
+        # still inside the critical section).
+        if stored.is_expired:
+            result = _timeout_result(stored, when)
+            stored._settle(result)  # mark resolved so expire_stale won't re-count it
+            return result
+
+        # Already resolved?  Return the first result (idempotent).
+        if stored.is_resolved and stored.result is not None:
+            return stored.result
+
+        # Determine the approval method.  Two-factor tiers require a TOTP code;
+        # we verify it here in-process.  A future backend may delegate this to a
+        # hosted TOTP service — that is intentionally out of scope for this module.
+        method: str
+        actual_approved: bool
+        if approved and handle.tier in (AuthTier.two_factor, AuthTier.role_elevation):
+            if not totp_code:
+                # Tier requires a code but none was supplied — deny (fail closed).
+                logger.warning(
+                    "async resolve for handle %s denied: 2FA tier but no TOTP code supplied",
+                    handle.handle_id,
+                )
+                actual_approved = False
+                method = "denied_no_code"
+            else:
+                from doberman.auth import totp as totp_mod  # lazy: avoids import cycle
+
+                code_ok = totp_mod.verify(totp_code)
+                actual_approved = code_ok
+                method = "totp" if handle.tier is AuthTier.two_factor else "totp+elevation"
+                if not code_ok:
+                    logger.warning(
+                        "async resolve for handle %s denied: TOTP verification failed",
+                        handle.handle_id,
+                    )
+        elif approved:
+            actual_approved = True
+            method = handle.tier.value
+        else:
+            actual_approved = False
+            method = ASYNC_DENIED_METHOD
+
+        result = AuthResult(
+            approved=actual_approved,
+            tier=handle.tier,
+            method=method,
+            at=when,
+            action_id=handle.action_id,
+        )
+        settled = stored._settle(result)
+        if not settled:
+            # Another thread resolved first — return what they stored.
+            return stored.result  # type: ignore[return-value]
+
+        logger.debug(
+            "async challenge resolved: handle=%s action=%s approved=%s method=%s",
+            handle.handle_id,
+            handle.action_id,
+            actual_approved,
+            method,
+        )
+        return result
+
+    def expire_stale(self, *, now: datetime | None = None) -> int:
+        """Settle all expired, unresolved handles with a timeout result.
+
+        Call periodically to reclaim memory and close out abandoned challenges.
+        Returns the number of handles that were expired by this call.
+        """
+        when = now or datetime.now(timezone.utc)
+        expired_count = 0
+        with self._lock:
+            stale = [h for h in self._handles.values() if h.is_expired and not h.is_resolved]
+        for handle in stale:
+            result = _timeout_result(handle, when)
+            if handle._settle(result):
+                expired_count += 1
+                logger.debug(
+                    "async challenge expired: handle=%s action=%s",
+                    handle.handle_id,
+                    handle.action_id,
+                )
+        return expired_count
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton and registry helpers
+# ---------------------------------------------------------------------------
+
+#: The built-in backend, constructed once at import time.
+IN_MEMORY_BACKEND = InMemoryAsyncBackend()
+
+
+def _looks_like_async_backend(obj: object) -> bool:
+    """Structural duck-type check (not just isinstance)."""
+    return callable(getattr(obj, "issue", None)) and callable(getattr(obj, "resolve", None))
+
+
+def active_async_backend() -> AsyncChallengeBackend:
+    """Return the active async backend: the first registered one, else in-memory.
+
+    Discovery uses the ``doberman.async_challenge_backends`` entry-point group
+    (consistent with the :func:`~doberman.auth.provider.active_provider` pattern).
+    With nothing installed, the in-memory backend runs and behaviour is identical
+    to core-only.
+    """
+    from doberman.engine.registry import (  # lazy: avoids import cycle at load time
+        _iter_entry_points,
+        _load_and_construct,
+    )
+
+    for entry_point in _iter_entry_points(ASYNC_BACKEND_GROUP):
+        candidate = _load_and_construct(entry_point)
+        if candidate is None:
+            continue
+        if _looks_like_async_backend(candidate):
+            return candidate  # type: ignore[return-value]
+        logger.warning(
+            "skipping async challenge backend %r: not backend-shaped",
+            getattr(entry_point, "name", "?"),
+        )
+    return IN_MEMORY_BACKEND
+
+
+# ---------------------------------------------------------------------------
+# Public convenience functions (the primary API surface)
+# ---------------------------------------------------------------------------
+
+
+def issue_challenge(
+    decision: Decision,
+    action: SecurityObject,
+    *,
+    ttl_s: float = DEFAULT_HANDLE_TTL_S,
+    at: datetime | None = None,
+    backend: AsyncChallengeBackend | None = None,
+) -> ChallengeHandle:
+    """Issue a non-blocking auth challenge and return a pending handle.
+
+    The calling path is **never** blocked: the tier is selected immediately and the
+    handle is registered with the active (or supplied) backend, but no prompt is
+    shown and no human interaction occurs here.  The caller is responsible for
+    delivering the challenge details to the human through whatever out-of-band
+    channel is appropriate.
+
+    Parameters
+    ----------
+    decision:
+        The ``AUTH`` decision from the engine.  ``select_tier`` will raise
+        ``ValueError`` if this is not an ``AUTH`` decision.
+    action:
+        The :class:`~doberman.models.SecurityObject` the challenge names.
+    ttl_s:
+        Lifetime (seconds) before the handle expires.  After expiry,
+        :func:`resolve_challenge` returns a non-approved timeout result.
+    at:
+        Override the issue timestamp (for testing / deterministic audit logs).
+    backend:
+        Override the active backend (for testing or DI).  Defaults to
+        :func:`active_async_backend()`.
+    """
+    tier = select_tier(decision)  # validates that decision is AUTH; raises ValueError otherwise
+    _backend = backend or active_async_backend()
+    handle = _backend.issue(decision, action, tier, ttl_s=ttl_s, at=at)
+    logger.info(
+        "async auth challenge issued: handle=%s action=%s tier=%s expires=%s",
+        handle.handle_id,
+        action.id,
+        tier.value,
+        handle.expires_at.isoformat(),
+    )
+    return handle
+
+
+def resolve_challenge(
+    handle: ChallengeHandle,
+    *,
+    approved: bool,
+    totp_code: str | None = None,
+    at: datetime | None = None,
+    backend: AsyncChallengeBackend | None = None,
+) -> AuthResult:
+    """Resolve a pending challenge handle with the human's decision.
+
+    This is idempotent: a second call for the same handle returns the original
+    result without re-running any verification logic.
+
+    Parameters
+    ----------
+    handle:
+        The :class:`ChallengeHandle` returned by :func:`issue_challenge`.
+    approved:
+        ``True`` if the human approved; ``False`` to deny.
+    totp_code:
+        Required for ``two_factor`` and ``role_elevation`` tiers.  Pass ``None``
+        for ``soft_confirm`` and ``local_auth``.
+    at:
+        Override the resolution timestamp.
+    backend:
+        Override the active backend (for testing or DI).
+
+    Returns
+    -------
+    AuthResult
+        The single-use, action-bound approval result.  ``approved`` may differ
+        from the ``approved`` parameter when TOTP verification fails.
+    """
+    _backend = backend or active_async_backend()
+    result = _backend.resolve(handle, approved=approved, totp_code=totp_code, at=at)
+    logger.info(
+        "async auth challenge resolved: handle=%s action=%s approved=%s method=%s",
+        handle.handle_id,
+        handle.action_id,
+        result.approved,
+        result.method,
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _timeout_result(handle: ChallengeHandle, at: datetime) -> AuthResult:
+    """Synthesise the canonical timeout result for an expired handle."""
+    return AuthResult(
+        approved=False,
+        tier=handle.tier,
+        method=ASYNC_TIMEOUT_METHOD,
+        at=at,
+        action_id=handle.action_id,
+    )

--- a/src/doberman/engine/registry.py
+++ b/src/doberman/engine/registry.py
@@ -66,6 +66,10 @@ ADJUDICATOR_GROUP = "doberman.adjudicators"
 #: long-lived proxy singleton opts in — see :func:`discover_egress_brokers`
 #: for the memoization that also keeps a repeated opted-in construction cheap.
 EGRESS_BROKER_GROUP = "doberman.egress_brokers"
+#: Async challenge backends (issue #144) register here; resolved by the auth layer.
+#: Lets hosted/push-based approval channels (Slack, e-mail, etc.) supply a custom
+#: backend without importing core's synchronous prompter chain.
+ASYNC_CHALLENGE_BACKEND_GROUP = "doberman.async_challenge_backends"
 
 
 def _iter_entry_points(group: str) -> Iterator[EntryPoint]:

--- a/tests/unit/test_async_challenge.py
+++ b/tests/unit/test_async_challenge.py
@@ -1,0 +1,507 @@
+"""Tests for the non-blocking async auth-challenge mechanism (issue #144).
+
+Contracts under test
+--------------------
+* :func:`issue_challenge` selects the correct tier and returns a
+  :class:`ChallengeHandle` without blocking; the handle is action-bound and
+  carries an expiry timestamp.
+* :func:`resolve_challenge` records a human decision exactly once (single-use,
+  race-safe); a second resolve returns the FIRST result unchanged.
+* Expiry: a handle past its ``expires_at`` resolves to a non-approved result
+  tagged ``ASYNC_TIMEOUT_METHOD`` even when ``approved=True`` is passed.
+* Tier enforcement: ``two_factor`` and ``role_elevation`` tiers require a TOTP
+  code; omitting it denies (fail closed) regardless of the ``approved`` flag.
+* TOTP path: a valid code on a two-factor handle approves; an invalid code
+  denies (fail closed).
+* Fail-closed: :func:`issue_challenge` raises ``ValueError`` when ``decision``
+  is not an ``AUTH`` (mirrors :func:`select_tier`).
+* Action-ID binding: :func:`resolve_challenge` raises ``ValueError`` when the
+  handle's stored ``action_id`` does not match the record (tamper protection).
+* :meth:`ChallengeHandle.wait` blocks until resolved and returns the result.
+* :meth:`ChallengeHandle.wait` with a short timeout returns a synthesised
+  timeout result without marking the handle resolved.
+* :meth:`InMemoryAsyncBackend.expire_stale` settles unresolved expired handles
+  and returns an accurate count; already-resolved handles are left untouched.
+* The ``active_async_backend`` registry falls back to the built-in in-memory
+  backend when no entry-point is installed.
+* A registered custom backend is preferred over the built-in (registry seam).
+* A non-backend-shaped registration is skipped (defensive loading).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+import pyotp
+import pytest
+
+from doberman.auth import totp as totp_mod
+from doberman.auth.async_challenge import (
+    ASYNC_DENIED_METHOD,
+    ASYNC_TIMEOUT_METHOD,
+    ChallengeHandle,
+    InMemoryAsyncBackend,
+    active_async_backend,
+    issue_challenge,
+    resolve_challenge,
+)
+from doberman.auth.challenge import AuthTier
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _action(action_id: str = "act-async-1", target: str = "src/main.py") -> SecurityObject:
+    return SecurityObject(
+        id=action_id,
+        ts=_NOW,
+        agent_role="dev",
+        action_type=ActionType.file_write,
+        tool_name="fs_write",
+        target=target,
+    )
+
+
+def _auth_decision(
+    action_id: str = "act-async-1",
+    risk: Risk = Risk.medium,
+    reasons: tuple[ReasonCode, ...] = (ReasonCode.sensitive_path_access,),
+) -> Decision:
+    gr = GuardrailResult(
+        verdict=Verdict.AUTH,
+        risk=risk,
+        reason_codes=list(reasons),
+        explanation="test",
+    )
+    return Decision(
+        action_id=action_id,
+        final_verdict=Verdict.AUTH,
+        final_risk=risk,
+        objective=gr,
+        reason_codes=list(reasons),
+        explanation="test",
+        decided_at=_NOW,
+    )
+
+
+def _pass_decision(action_id: str = "act-pass") -> Decision:
+    gr = GuardrailResult(verdict=Verdict.PASS, risk=Risk.low, reason_codes=[], explanation="ok")
+    return Decision(
+        action_id=action_id,
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=gr,
+        reason_codes=[],
+        explanation="ok",
+        decided_at=_NOW,
+    )
+
+
+@pytest.fixture
+def backend() -> InMemoryAsyncBackend:
+    return InMemoryAsyncBackend()
+
+
+# ---------------------------------------------------------------------------
+# issue_challenge — basic contracts
+# ---------------------------------------------------------------------------
+
+
+def test_issue_returns_handle_without_blocking(backend):
+    """issue_challenge must return immediately — no waiting for human input."""
+    handle = issue_challenge(_auth_decision(), _action(), backend=backend)
+    assert isinstance(handle, ChallengeHandle)
+    assert handle.action_id == "act-async-1"
+    assert not handle.is_resolved
+    assert not handle.is_expired
+
+
+def test_issue_selects_tier_from_decision(backend):
+    """The tier must come from select_tier(), not be hardcoded."""
+    # sensitive_path_access floors at local_auth (medium risk)
+    h = issue_challenge(
+        _auth_decision(reasons=(ReasonCode.sensitive_path_access,), risk=Risk.medium),
+        _action(),
+        backend=backend,
+    )
+    assert h.tier is AuthTier.local_auth
+
+    # policy_source_sensitive floors at two_factor
+    h2 = issue_challenge(
+        _auth_decision(
+            action_id="act-2",
+            reasons=(ReasonCode.policy_source_sensitive,),
+            risk=Risk.medium,
+        ),
+        _action(action_id="act-2"),
+        backend=backend,
+    )
+    assert h2.tier is AuthTier.two_factor
+
+
+def test_issue_raises_for_non_auth_decision(backend):
+    """A PASS/BLOCK decision is not a challenge — fail loudly (matches select_tier)."""
+    with pytest.raises(ValueError):
+        issue_challenge(_pass_decision(), _action(action_id="act-pass"), backend=backend)
+
+
+def test_issue_sets_expiry_ttl(backend):
+    """expires_at should be approximately issued_at + ttl_s."""
+    ttl = 300.0
+    handle = issue_challenge(_auth_decision(), _action(), ttl_s=ttl, at=_NOW, backend=backend)
+    expected_expiry = _NOW + timedelta(seconds=ttl)
+    assert handle.expires_at == expected_expiry
+
+
+def test_handle_id_is_unique_per_call(backend):
+    """Two calls on the same action must yield distinct handle IDs."""
+    h1 = issue_challenge(_auth_decision(), _action(), backend=backend)
+    h2 = issue_challenge(_auth_decision(), _action(), backend=backend)
+    assert h1.handle_id != h2.handle_id
+
+
+# ---------------------------------------------------------------------------
+# resolve_challenge — approval path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_approves_soft_confirm_tier(backend):
+    # Risk.low with a reason that carries no tier floor → soft_confirm
+    handle = issue_challenge(
+        _auth_decision(reasons=(ReasonCode.unknown_tool,), risk=Risk.low),
+        _action(),
+        backend=backend,
+    )
+    assert handle.tier is AuthTier.soft_confirm
+    result = resolve_challenge(handle, approved=True, backend=backend)
+    assert result.approved is True
+    assert result.action_id == "act-async-1"
+    assert result.method == AuthTier.soft_confirm.value
+
+
+def test_resolve_denies_when_approved_false(backend):
+    handle = issue_challenge(_auth_decision(), _action(), backend=backend)
+    result = resolve_challenge(handle, approved=False, backend=backend)
+    assert result.approved is False
+    assert result.method == ASYNC_DENIED_METHOD
+
+
+def test_resolve_is_single_use(backend):
+    """A second resolve must return the FIRST result unchanged."""
+    handle = issue_challenge(
+        _auth_decision(reasons=(ReasonCode.sensitive_path_access,), risk=Risk.low),
+        _action(),
+        backend=backend,
+    )
+    first = resolve_challenge(handle, approved=True, backend=backend)
+    second = resolve_challenge(handle, approved=False, backend=backend)  # tries to deny
+    assert second.approved is True  # first answer wins
+    assert second.method == first.method
+
+
+def test_resolve_marks_handle_as_resolved(backend):
+    handle = issue_challenge(_auth_decision(), _action(), backend=backend)
+    assert not handle.is_resolved
+    resolve_challenge(handle, approved=False, backend=backend)
+    assert handle.is_resolved
+
+
+def test_resolve_unknown_handle_raises(backend):
+    """A handle that was never issued must never approve (fail closed)."""
+    orphan = ChallengeHandle(
+        handle_id="not-a-real-id",
+        action_id="act-async-1",
+        tier=AuthTier.local_auth,
+        issued_at=_NOW,
+        expires_at=_NOW + timedelta(hours=1),
+    )
+    with pytest.raises(KeyError):
+        backend.resolve(orphan, approved=True)
+
+
+def test_resolve_wrong_action_id_raises(backend):
+    """Tamper protection: a mismatched action_id must raise (fail closed)."""
+    handle = issue_challenge(_auth_decision(), _action(), backend=backend)
+    tampered = ChallengeHandle(
+        handle_id=handle.handle_id,
+        action_id="totally-different-action",  # ← mismatch
+        tier=handle.tier,
+        issued_at=handle.issued_at,
+        expires_at=handle.expires_at,
+    )
+    with pytest.raises(ValueError, match="act-async-1"):
+        backend.resolve(tampered, approved=True)
+
+
+# ---------------------------------------------------------------------------
+# Expiry
+# ---------------------------------------------------------------------------
+
+
+def test_expired_handle_denies_on_resolve(backend):
+    """Resolving a handle after its expiry yields a non-approved timeout result."""
+    handle = issue_challenge(_auth_decision(), _action(), ttl_s=0.0, at=_NOW, backend=backend)
+    # expires_at == issued_at, so it's already expired
+    result = backend.resolve(handle, approved=True, at=_NOW + timedelta(seconds=1))
+    assert result.approved is False
+    assert result.method == ASYNC_TIMEOUT_METHOD
+    assert result.action_id == "act-async-1"
+
+
+def test_is_expired_property(backend):
+    past = _NOW - timedelta(hours=1)
+    handle = issue_challenge(_auth_decision(), _action(), ttl_s=0.0, at=past, backend=backend)
+    assert handle.is_expired
+
+
+# ---------------------------------------------------------------------------
+# TOTP / two-factor tier
+# ---------------------------------------------------------------------------
+
+
+def test_two_factor_requires_code_approves_with_valid_code(backend):
+    totp_mod.enroll()
+    secret = totp_mod._read_secret()
+    valid_code = pyotp.TOTP(secret).now()
+
+    handle = issue_challenge(
+        _auth_decision(
+            reasons=(ReasonCode.policy_source_sensitive,),
+            risk=Risk.medium,
+        ),
+        _action(),
+        backend=backend,
+    )
+    assert handle.tier is AuthTier.two_factor
+
+    result = resolve_challenge(handle, approved=True, totp_code=valid_code, backend=backend)
+    assert result.approved is True
+    assert result.method == "totp"
+
+
+def test_two_factor_denies_with_invalid_code(backend):
+    totp_mod.enroll()
+    handle = issue_challenge(
+        _auth_decision(
+            reasons=(ReasonCode.policy_source_sensitive,),
+            risk=Risk.medium,
+        ),
+        _action(),
+        backend=backend,
+    )
+    result = resolve_challenge(handle, approved=True, totp_code="000000", backend=backend)
+    assert result.approved is False
+
+
+def test_two_factor_denies_when_no_code_supplied(backend):
+    """Missing TOTP code on a 2FA tier must deny (fail closed)."""
+    handle = issue_challenge(
+        _auth_decision(
+            reasons=(ReasonCode.policy_source_sensitive,),
+            risk=Risk.medium,
+        ),
+        _action(),
+        backend=backend,
+    )
+    result = resolve_challenge(handle, approved=True, totp_code=None, backend=backend)
+    assert result.approved is False
+    assert result.method == "denied_no_code"
+
+
+# ---------------------------------------------------------------------------
+# ChallengeHandle.wait()
+# ---------------------------------------------------------------------------
+
+
+def test_wait_blocks_until_resolved(backend):
+    """wait() must return the result once resolve_challenge() is called."""
+    handle = issue_challenge(_auth_decision(), _action(), backend=backend)
+
+    def _resolver():
+        time.sleep(0.05)
+        resolve_challenge(handle, approved=False, backend=backend)
+
+    t = threading.Thread(target=_resolver, daemon=True)
+    t.start()
+    result = handle.wait(timeout=5.0)
+    t.join(timeout=5.0)
+    assert result.approved is False
+
+
+def test_wait_short_timeout_returns_synthetic_timeout(backend):
+    """wait() with a very short timeout must return a non-approved result WITHOUT
+    marking the handle as resolved — a concurrent resolver can still settle it."""
+    handle = issue_challenge(_auth_decision(), _action(), backend=backend)
+    result = handle.wait(timeout=0.01)
+    assert result.approved is False
+    assert result.method == ASYNC_TIMEOUT_METHOD
+    # Handle is NOT marked resolved — a real human could still answer later.
+    assert not handle.is_resolved
+
+
+def test_wait_returns_immediately_if_already_resolved(backend):
+    handle = issue_challenge(_auth_decision(), _action(), backend=backend)
+    resolve_challenge(handle, approved=False, backend=backend)
+    result = handle.wait(timeout=0.0)
+    assert result.approved is False
+    assert result.method == ASYNC_DENIED_METHOD
+
+
+# ---------------------------------------------------------------------------
+# expire_stale
+# ---------------------------------------------------------------------------
+
+
+def test_expire_stale_settles_unresolved_expired_handles(backend):
+    past = _NOW - timedelta(hours=2)
+    h1 = issue_challenge(_auth_decision(), _action("a1"), ttl_s=0.0, at=past, backend=backend)
+    h2 = issue_challenge(
+        _auth_decision(action_id="a2"), _action("a2"), ttl_s=0.0, at=past, backend=backend
+    )
+    count = backend.expire_stale(now=_NOW)
+    assert count == 2
+    assert h1.is_resolved
+    assert h2.is_resolved
+    assert h1.result is not None and h1.result.method == ASYNC_TIMEOUT_METHOD
+    assert h2.result is not None and h2.result.method == ASYNC_TIMEOUT_METHOD
+
+
+def test_expire_stale_leaves_resolved_handles_untouched(backend):
+    # Issue a live handle with a generous TTL, resolve it (human denies),
+    # then confirm expire_stale does not touch it.
+    handle = issue_challenge(_auth_decision(), _action(), ttl_s=3600.0, backend=backend)
+    resolve_challenge(handle, approved=False, backend=backend)
+    assert handle.is_resolved
+    first_result = handle.result
+
+    count = backend.expire_stale()
+    assert count == 0  # already-resolved handles are never re-settled
+    assert handle.result is first_result  # original result object is unchanged
+    assert handle.result.method == ASYNC_DENIED_METHOD
+
+
+def test_expire_stale_ignores_unexpired_handles(backend):
+    handle = issue_challenge(_auth_decision(), _action(), ttl_s=3600.0, backend=backend)
+    count = backend.expire_stale()
+    assert count == 0
+    assert not handle.is_resolved
+
+
+# ---------------------------------------------------------------------------
+# Race-safety: concurrent resolvers
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_resolvers_only_one_wins(backend):
+    """Two threads simultaneously resolving the same handle: exactly one wins,
+    both receive the same (winning) result."""
+    handle = issue_challenge(
+        _auth_decision(reasons=(ReasonCode.sensitive_path_access,), risk=Risk.low),
+        _action(),
+        backend=backend,
+    )
+    results: list = []
+    barrier = threading.Barrier(2)
+
+    def _resolve(approved: bool) -> None:
+        barrier.wait()
+        results.append(resolve_challenge(handle, approved=approved, backend=backend))
+
+    t1 = threading.Thread(target=_resolve, args=(True,), daemon=True)
+    t2 = threading.Thread(target=_resolve, args=(False,), daemon=True)
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert len(results) == 2
+    # Both results must be identical (the first-writer-wins value).
+    assert results[0].approved == results[1].approved
+    assert results[0].method == results[1].method
+
+
+# ---------------------------------------------------------------------------
+# Registry / active_async_backend
+# ---------------------------------------------------------------------------
+
+
+def test_default_backend_is_in_memory():
+    """With no entry-points installed, the built-in in-memory backend is used."""
+    from doberman.auth.async_challenge import IN_MEMORY_BACKEND
+
+    assert active_async_backend() is IN_MEMORY_BACKEND
+
+
+def test_registered_backend_is_preferred(monkeypatch):
+    """A registered custom backend shadows the built-in."""
+
+    class StubBackend:
+        name = "stub"
+        sentinel = object()
+
+        def issue(self, decision, action, tier, *, ttl_s, at=None):
+            return self.sentinel
+
+        def resolve(self, handle, *, approved, totp_code=None, at=None):
+            return self.sentinel
+
+        def expire_stale(self, *, now=None):
+            return 0
+
+    stub = StubBackend()
+    monkeypatch.setattr(
+        "doberman.engine.registry._iter_entry_points",
+        lambda group: [_FakeEntryPoint(stub)],
+    )
+    from doberman.auth import async_challenge as ac
+
+    assert ac.active_async_backend() is stub
+
+
+def test_non_backend_shaped_registration_is_skipped(monkeypatch):
+    """An object missing 'issue'/'resolve' must be skipped; fallback to built-in."""
+    monkeypatch.setattr(
+        "doberman.engine.registry._iter_entry_points",
+        lambda group: [_FakeEntryPoint(object())],
+    )
+    from doberman.auth.async_challenge import IN_MEMORY_BACKEND
+
+    assert active_async_backend() is IN_MEMORY_BACKEND
+
+
+# ---------------------------------------------------------------------------
+# Helpers for registry tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeEntryPoint:
+    """A minimal importlib.metadata EntryPoint stand-in that returns a fixed object.
+
+    ``_load_and_construct`` calls ``entry_point.load()``.  If the result is a
+    class, it instantiates it.  If the result is already an instance, it uses it
+    directly.  We return the instance directly so we can pin the identity.
+    """
+
+    name = "fake"
+
+    def __init__(self, obj):
+        self._obj = obj
+
+    def load(self):
+        # Return the instance directly (not the class) so _load_and_construct
+        # uses it as-is without constructing a new one.
+        return self._obj


### PR DESCRIPTION
Closes #144

## What this adds

A non-blocking challenge path alongside the existing synchronous one. The caller
issues a challenge and immediately receives a `ChallengeHandle` token — no blocking,
no prompt shown. Later, when the human has decided via whatever out-of-band channel
the operator has wired, `resolve_challenge()` settles the handle and returns a normal
`AuthResult`.

## Files changed

- `src/doberman/auth/async_challenge.py` — new module: `ChallengeHandle`, `AsyncChallengeBackend`
  Protocol, `InMemoryAsyncBackend`, `issue_challenge()`, `resolve_challenge()`,
  `active_async_backend()` registry lookup
- `src/doberman/engine/registry.py` — added `ASYNC_CHALLENGE_BACKEND_GROUP` constant
- `tests/unit/test_async_challenge.py` — 26 tests

## Invariants preserved

- **Fail closed:** expired, unresolved, or error handles → non-approved `AuthResult`
- **Single-use, action-bound:** `_settle()` is write-once under lock; action-ID mismatch raises `ValueError`
- **No weakening:** tier selection, TOTP verification, and `AuthResult` structure unchanged
- **Import-linter:** `doberman.auth` never imports `doberman.proxy`/`hosthooks`/`dash`/`turngate`; both contracts KEPT
- **Delivery channels out of scope:** this module has no knowledge of Slack/email/push

## CI

ruff check ✓ · ruff format --check ✓ · lint-imports ✓ (2 contracts kept) · pytest tests/unit/ ✓ (26 new, full suite green)
