### PR TITLE
test: extend ASCII-only guarantee to 2fa remove and setup mode errors (#254)

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -761,7 +761,7 @@ def twofa_remove() -> None:
     if not password.is_enrolled():
         typer.echo(
             "warning: no possession factor is enrolled now, so every policy weakening "
-            "will be denied — run `doberman password set` (or `doberman 2fa setup`) to "
+            "will be denied - run `doberman password set` (or `doberman 2fa setup`) to "
             "restore one.",
             err=True,
         )

--- a/tests/unit/test_cli_encode_safe.py
+++ b/tests/unit/test_cli_encode_safe.py
@@ -12,11 +12,20 @@ a box-drawing rule, an emoji) there raised ``UnicodeEncodeError`` and crashed
 import io
 import sys
 
+import pyotp
 from typer.testing import CliRunner
 
+from doberman.auth import totp
 from doberman.cli.main import _ensure_encode_safe_stdio, app
 
 runner = CliRunner()
+
+
+def _current_code() -> str:
+    """A code for the live enrollment on the real clock (same as test_2fa_remove)."""
+    secret = totp._read_secret()
+    assert secret is not None
+    return pyotp.TOTP(secret).now()
 
 
 def test_encode_safe_stdio_prevents_cp1252_crash(monkeypatch):
@@ -51,3 +60,35 @@ def test_setup_yes_output_is_ascii_and_cp1252_safe(tmp_path):
     assert result.exit_code == 0, result.output
     assert result.output.isascii(), f"non-ASCII in setup output: {result.output!r}"
     result.output.encode("cp1252")
+
+
+def test_2fa_remove_warning_is_ascii_and_cp1252_safe():
+    # The 2fa remove path warns when no possession factor remains; that warning
+    # used an em-dash and must stay ASCII like the rest of onboarding.
+    totp.enroll()
+
+    result = runner.invoke(app, ["2fa", "remove"], input=f"y\n{_current_code()}\n")
+
+    assert result.exit_code == 0, result.output
+    assert "will be denied" in result.stderr
+    output = result.output + result.stderr
+    assert output.isascii(), f"non-ASCII in 2fa remove output: {output!r}"
+    output.encode("cp1252")  # raises if any char is not cp1252-encodable
+
+
+def test_setup_bad_mode_choice_error_is_ascii_and_cp1252_safe(tmp_path):
+    # An out-of-range numeric mode choice surfaces parse_mode_choice's error
+    # message (which used an en-dash); it must be ASCII too. Since #266 the
+    # wizard re-prompts instead of dying, so feed a valid choice after the
+    # invalid one and let the run complete.
+    result = runner.invoke(
+        app,
+        ["setup", "--path", str(tmp_path)],
+        input="9\nbalanced\nn\nn\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "choose 1-4 or type a mode name" in result.output
+    output = result.output + result.stderr
+    assert output.isascii(), f"non-ASCII in setup error output: {output!r}"
+    output.encode("cp1252")  # raises if any char is not cp1252-encodable


### PR DESCRIPTION
Rebased on current main and ready for review.

Fixes issue #254: two user-facing CLI messages slipped non-ASCII dashes past the cp1252-safe onboarding guarantee.

- \src/doberman/cli/main.py\: the \2fa remove\ warning used an em-dash (U+2014) - still live on main, replaced with a plain hyphen
- The \parse_mode_choice\ en-dash was already fixed by #266; this PR's \	est_setup_bad_mode_choice_error_is_ascii_and_cp1252_safe\ now guards that message against regression (the wizard re-prompts since #266, so the test feeds a valid choice after the invalid one)

## Tests added (run in CI)

Extended \	ests/unit/test_cli_encode_safe.py\ so the ASCII guarantee covers the two paths that slipped through:

- \	est_2fa_remove_warning_is_ascii_and_cp1252_safe\ - drives \2fa remove\ to the no-possession-factor warning and asserts ASCII + cp1252 safety
- \	est_setup_bad_mode_choice_error_is_ascii_and_cp1252_safe\ - drives a bad numeric mode choice through the wizard and asserts the re-prompt message is ASCII + cp1252-safe

Verified both new tests go RED when the character fixes are reverted. \uff check\, \uff format --check\ and the touched unit tests pass on Python 3.11 and 3.13.