### PR TITLE
feat(cli): state what uninstall-hooks leaves behind

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1133,6 +1133,14 @@ def uninstall_hooks(
     write_settings(settings_path, cleaned)
     typer.echo(f"wrote {settings_path}")
     typer.echo("Doberman hooks removed.")
+    typer.echo("")
+    typer.echo("What remains (manual, optional cleanup):")
+    typer.echo("  .doberman/              policy, decision log, taint state")
+    typer.echo("  ~/.doberman/metrics.db  device metrics")
+    typer.echo("  password / 2FA enrollment")
+    typer.echo(
+        "These are not removed automatically; delete them only if you no longer use Doberman."
+    )
 
 
 @app.command()
@@ -1299,7 +1307,7 @@ def setup(
     typer.echo("Restart your Claude Code session to pick up the hooks.")
     typer.echo(
         "Next steps: `doberman password set`  |  `doberman 2fa setup` (optional)  |  "
-        "`doberman status`"
+        "`doberman status`  |  `doberman uninstall-hooks` (exit)"
     )
 
 


### PR DESCRIPTION
Closes #256.

- After a successful `uninstall-hooks`, prints a short note listing what remains: `.doberman/`, `~/.doberman/metrics.db`, and password / 2FA enrollment, with cleanup being manual and optional.
- Adds `doberman uninstall-hooks` to setup's closing Next steps so the exit is discoverable from onboarding.

Verified with the hooks unit tests and the ASCII-only guarantee tests; `ruff check` passes.