### PR TITLE
test: enforce ASCII output for 2fa remove and mode choice

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -761,7 +761,7 @@ def twofa_remove() -> None:
     if not password.is_enrolled():
         typer.echo(
             "warning: no possession factor is enrolled now, so every policy weakening "
-            "will be denied — run `doberman password set` (or `doberman 2fa setup`) to "
+            "will be denied - run `doberman password set` (or `doberman 2fa setup`) to "
             "restore one.",
             err=True,
         )

--- a/tests/unit/test_cli_encode_safe.py
+++ b/tests/unit/test_cli_encode_safe.py
@@ -12,9 +12,11 @@ a box-drawing rule, an emoji) there raised ``UnicodeEncodeError`` and crashed
 import io
 import sys
 
+import pytest
 from typer.testing import CliRunner
 
 from doberman.cli.main import _ensure_encode_safe_stdio, app
+from doberman.hosthooks.setup import parse_mode_choice
 
 runner = CliRunner()
 
@@ -51,3 +53,33 @@ def test_setup_yes_output_is_ascii_and_cp1252_safe(tmp_path):
     assert result.exit_code == 0, result.output
     assert result.output.isascii(), f"non-ASCII in setup output: {result.output!r}"
     result.output.encode("cp1252")
+
+
+def test_2fa_remove_warning_output_is_ascii(monkeypatch):
+    """The post-removal warning must stay pure ASCII (cp1252 consoles)."""
+    from doberman.cli import main as main_mod
+
+    class FakePrompter:
+        def confirm(self, message: str) -> bool:
+            return True
+
+        def read_code(self, label: str) -> str:
+            return "123456"
+
+    monkeypatch.setattr(main_mod.totp, "is_enrolled", lambda: True)
+    monkeypatch.setattr(main_mod.totp, "unenroll", lambda current_code: None)
+    monkeypatch.setattr(main_mod.password, "is_enrolled", lambda: False)
+    monkeypatch.setattr(main_mod, "CliPrompter", lambda: FakePrompter())
+
+    result = runner.invoke(app, ["2fa", "remove"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.isascii(), f"non-ASCII in 2fa remove output: {result.output!r}"
+
+
+def test_bad_mode_choice_error_is_ascii():
+    """The setup mode prompt error must remain pure ASCII."""
+    with pytest.raises(ValueError) as excinfo:
+        parse_mode_choice("99")
+
+    assert str(excinfo.value).isascii()


### PR DESCRIPTION
Closes #254.

Replaces the em dash in the `2fa remove` warning with a plain hyphen and extends `test_cli_encode_safe.py` so the ASCII guarantee covers both the `2fa remove` warning path and a bad `parse_mode_choice` error.

The bad-mode-choice message in current `main` already uses an ASCII hyphen, but the new test locks that contract in. Verified with the encode-safe test file.