### PR TITLE
feat(cli): enable shell tab completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ dashboard, and health checks - lives in the **[Setup Guide](docs/SETUP.md)**.
 pip install doberman-core
 ```
 
+After installing, run `doberman --install-completion` to enable shell tab
+completion.
+
 | Your agent | How Doberman plugs in | Get started |
 |---|---|---|
 | **Claude Code** | Hooks - gate every built-in *and* MCP tool call *(recommended)* | `doberman setup` -> [guide](docs/SETUP.md#claude-code-hooks) |

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -72,7 +72,6 @@ _ensure_encode_safe_stdio()
 app = typer.Typer(
     help="Doberman - adaptive authorization layer for coding agents.",
     no_args_is_help=True,
-    add_completion=False,
 )
 
 twofa_app = typer.Typer(help="Two-factor (TOTP) enrollment.", no_args_is_help=True)


### PR DESCRIPTION
Closes #255.

Removes `add_completion=False` so `doberman --install-completion` and `--show-completion` are available, and adds a one-line mention to the README Quick Start.

Verified: help output includes both flags, ruff passes, and CLI tests pass (79).