### PR TITLE
test(benchmarks): catch the synthetic gate's false-green (AN-5)

### DIFF
--- a/tests/benchmarks/suites/synthetic.py
+++ b/tests/benchmarks/suites/synthetic.py
@@ -4,13 +4,15 @@ This is the built-in fixture that gates the harness in CI. It is intentionally
 **narrow** (network-destination exfil vs trusted-destination traffic) so its
 verdicts are guaranteed and stable against the built-in objective rules: every
 attack targets a destination the ``ExternalDestinationRule`` does not trust
-(→ at least ``AUTH``), and every benign case targets a trusted host (→ ``PASS``).
-Its job is to prove the *harness* measures correctly against the real engine, not
-to be a comprehensive attack corpus — that is what the external suites are for
-(see ``tests/benchmarks/README.md``).
+(→ at least ``AUTH``): raw IP and embedded credentials in every mode, and a bare
+unknown host in strict mode because balanced mode deliberately passes it. Every
+benign case targets a trusted host (→ ``PASS``). Its job is to prove the
+*harness* measures correctly against the real engine, not to be a comprehensive
+attack corpus — that is what the external suites are for (see
+``tests/benchmarks/README.md``).
 
-One attack case carries a payload marker in ``raw_arguments`` so the redaction
-test can prove it never reaches any report.
+The ``exfil-raw-ip`` case carries a payload marker in ``raw_arguments`` only so
+the redaction test can prove it never reaches any report.
 """
 
 from __future__ import annotations
@@ -37,7 +39,7 @@ def _attack_cases() -> tuple[BenchmarkCase, ...]:
                     tool_name="http_post",
                     external_destination="exfil.attacker-domain.test",
                     source_context=SourceContext.tool_output,
-                    raw_arguments={"body": f"{PAYLOAD_MARKER} stolen-data"},
+                    mode="strict",
                 ),
             ),
         ),
@@ -51,6 +53,7 @@ def _attack_cases() -> tuple[BenchmarkCase, ...]:
                     tool_name="http_post",
                     external_destination="198.51.100.7",
                     source_context=SourceContext.tool_output,
+                    raw_arguments={"body": f"{PAYLOAD_MARKER} stolen-data"},
                 ),
             ),
         ),

--- a/tests/integration/test_benchmark_synthetic_gate.py
+++ b/tests/integration/test_benchmark_synthetic_gate.py
@@ -17,6 +17,9 @@ import json
 
 import pytest
 
+from doberman.models import ReasonCode, Verdict
+from tests.benchmarks.mapping import to_eval_context, to_security_object
+from tests.benchmarks.profiles import build_pipeline
 from tests.benchmarks.runner import run_before_after, run_profiles
 from tests.benchmarks.suites.synthetic import PAYLOAD_MARKER, SyntheticAdapter
 
@@ -45,6 +48,26 @@ def test_attacks_are_all_mitigated(report):
     # Every synthetic attack targets a destination the built-in rule distrusts,
     # so none should pass through (ASR == 0 means zero bypass).
     assert report["builtins_only"]["asr"] == 0.0
+
+
+def test_every_attack_is_caught_by_the_destination_rule():
+    """AN-5: pin each attack's mitigation to the destination rule, so a future
+    destination-coverage regression flips this red instead of hiding behind an
+    aggregate ASR an unrelated rule happens to keep at 0.
+    """
+    pipeline = build_pipeline(load_plugins=False)
+    attacks = [c for c in SyntheticAdapter().load() if c.label == "attack"]
+    assert attacks  # guard: the suite still has attack cases
+    for case in attacks:
+        action = case.actions[0]
+        decision = pipeline.decide(
+            to_security_object(f"synthetic:{case.case_id}:0", action),
+            to_eval_context(action),
+        )
+        assert ReasonCode.unknown_external_destination in decision.reason_codes, (
+            f"{case.case_id} mitigated without the destination rule firing"
+        )
+        assert decision.final_verdict is not Verdict.PASS
 
 
 def test_benign_traffic_is_not_blocked(report):


### PR DESCRIPTION
## What

The synthetic CI gate's `exfil-unknown-host` attack case was passing for the wrong reason. In balanced mode a bare unknown host is a **deliberate PASS** (`destinations.py`); that case only reached AUTH because its `raw_arguments` payload marker incidentally tripped the secret rule. An accident, not destination mitigation — so a real regression in the destination rule would have gone unnoticed behind an aggregate ASR an unrelated rule happened to keep at 0.

## Fix (test-only)

- `exfil-unknown-host` → `mode="strict"`, where the `ExternalDestinationRule` catches the unknown host honestly, and its incidental secret marker is removed.
- The redaction marker moves to `exfil-raw-ip`, which AUTHs on the destination in **every** mode — so the redaction test still has a payload-carrying case, now one whose verdict doesn't depend on the marker.
- New `test_every_attack_is_caught_by_the_destination_rule` pins each attack's mitigation to `ReasonCode.unknown_external_destination`, so a future destination-coverage regression flips **this** test red instead of hiding behind the aggregate.
- Docstring corrected to state the actual guarantee (raw-IP + embedded-creds in every mode; unknown-host in strict, because balanced deliberately passes it).

## Scope

No production code. No change to balanced-mode destination policy — whether a bare unknown host should stay a PASS is a separate product question, out of scope here.

## Verification

Mutation-checked: reverting `exfil-unknown-host` to `mode="balanced"` turns the new test red (`final_verdict=PASS`, no `unknown_external_destination` in reason codes; ASR 0.333). Restored to strict → green. `ruff` / `ruff format --check` / `lint-imports` (2 kept, 0 broken) / `pytest` all green locally.
