### PR TITLE
feat(engine): gate deletes of unrecoverable gitignored data files (AN-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
 
 ## Unreleased (merged since v0.17.1)
 
+- **Security fix:** deleting an unrecoverable, gitignored data file (local DB `*.db`/`*.sqlite*`, `.env`, `*.key`) now requires authentication instead of silently passing (AN-1) — narrow lexical gate on `rm` operands; directory deletes remain out of scope
+
 ## 0.17.1 — 2026-08-06
 
 - **New:** `doberman 2fa reset-lockout` clears the TOTP rate-limit lockout early, gated on your local password (never on the locked-out 2FA factor, which cannot verify itself). With no password enrolled it refuses and points to the self-recovering cooldown (UX-B).

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -29,6 +29,7 @@ SECURITY: the explanation names the *category* of danger, never echoes the
 command string or its arguments.
 """
 
+import fnmatch
 import posixpath
 import re
 import shlex
@@ -249,6 +250,25 @@ def _count_delete_operands(tokens: list[str]) -> int:
     return len([t for t in tokens[1:] if not t.startswith("-")])
 
 
+# Gitignored, unrecoverable-by-git data whose deletion git cannot undo: local
+# databases and secret/key material. Matched lexically on the operand basename.
+_UNRECOVERABLE_DELETE_GLOBS = ("*.db", "*.sqlite", "*.sqlite3", "*.key", ".env", ".env.*")
+
+
+def _rm_targets_unrecoverable_data(tokens: list[str]) -> bool:
+    """``rm`` whose operand basename matches an unrecoverable, gitignored data
+    file (local DB / secret / key)."""
+    # ponytail: lexical glob on operands only — no filesystem or git access in the
+    # decision path. Catches file targets; a directory operand (rm -rf data/) cannot
+    # be classified lexically and is deliberately out of scope (deferred — see ADR).
+    operands = [t for t in tokens[1:] if not t.startswith("-")]
+    return any(
+        fnmatch.fnmatch(posixpath.basename(op.strip().strip("'\"")), pattern)
+        for op in operands
+        for pattern in _UNRECOVERABLE_DELETE_GLOBS
+    )
+
+
 def _git_force_push_to_protected(tokens: list[str], protected: Iterable[str]) -> bool:
     """``git push`` with a force flag targeting a protected branch."""
     if len(tokens) < 2 or tokens[0] != "git" or "push" not in tokens:
@@ -413,6 +433,12 @@ def _segment_verdict(
         return _auth(
             ReasonCode.bulk_operation,
             "Bulk delete at or above the configured threshold; authentication required.",
+        )
+    if cmd == "rm" and _rm_targets_unrecoverable_data(tokens):
+        return _auth(
+            ReasonCode.destructive_command,
+            "Deleting an unrecoverable, gitignored data file (local database, "
+            "secret, or key); authentication required.",
         )
     if cmd == "git" and _git_is_history_rewrite(tokens):
         return _auth(

--- a/tests/unit/test_rule_commands.py
+++ b/tests/unit/test_rule_commands.py
@@ -141,6 +141,43 @@ def test_bulk_delete_at_threshold_requires_auth():
     assert ReasonCode.bulk_operation in result.reason_codes
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm data/app.db",
+        "rm ./prod.sqlite3",
+        "rm cache.sqlite",
+        "rm config/server.key",
+        "rm .env",
+        "rm .env.local",
+        "rm -f secrets.db",
+        "rm -rf data/app.db",
+    ],
+)
+def test_unrecoverable_gitignored_data_delete_requires_auth(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.destructive_command in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "command", ["rm src/main.py", "rm README.md", "rm notes.txt", "rm build.log"]
+)
+def test_recoverable_file_delete_passes(command):
+    assert _cmd(command).verdict is Verdict.PASS
+
+
+def test_unrecoverable_data_gate_never_lowers_block():
+    assert _cmd("rm -rf /").verdict is Verdict.BLOCK
+    assert _cmd("rm .doberman/agent.key").verdict is Verdict.BLOCK
+
+
+def test_unrecoverable_data_auth_explanation_does_not_echo_operand():
+    result = _cmd("rm data/app.db")
+    assert "app.db" not in result.explanation.lower()
+    assert "data/" not in result.explanation.lower()
+
+
 def test_small_delete_passes():
     assert _cmd("rm a.txt").verdict is Verdict.PASS
     assert _cmd("rm -f one.log two.log").verdict is Verdict.PASS


### PR DESCRIPTION
## What

Closes finding **AN-1**: a single-operand `rm` of an unrecoverable, gitignored data file — a local database (`*.db` / `*.sqlite*`), a secret (`.env` / `.env.*`), or key material (`*.key`) — used to **PASS** the destructive-command rule.

`_segment_verdict` escalated a delete only when it was *catastrophic* (recursive + force at root/home/whole-tree) or *bulk* (operand count over the threshold). `rm data/app.db` is neither, so it passed silently. Git cannot restore a gitignored file, so that deletion is permanent data loss — the rule treated it the same as deleting a git-tracked source file.

## Fix

A narrow, **lexical** escalation in the AUTH tier: an `rm` whose operand *basename* matches `("*.db", "*.sqlite", "*.sqlite3", "*.key", ".env", ".env.*")` returns **AUTH** with the existing `ReasonCode.destructive_command`. Matching is pure `fnmatch` on parsed operands — no filesystem access, no `git check-ignore`, no subprocess in the decision path. The explanation names the category, never the operand.

- **AUTH, not BLOCK** — deleting a local DB or `.env` is a legitimate developer action (rebuild fixtures, rotate a key); AUTH puts a human in the loop without dead-ending them. PASS → AUTH is **raise-only**.
- **Reuses `destructive_command`** — the sibling unrecoverable commands already in this tier (`git reset --hard`, `git clean -f`, `curl | sh`) use the same code; `models.py` is untouched.
- **Precedence preserved** — every BLOCK branch (control-plane, catastrophic `rm`, disk-wipe, `dd`, force-push, fork-bomb) precedes the new AUTH and returns first. `rm -rf /` still BLOCKs; `rm .doberman/agent.key` still BLOCKs (control-plane). Nothing is lowered.

## Scope / residual

Catches **file** targets. A directory operand (`rm -rf data/`) can't be classified lexically — the operand is `data/`, matching no data-file glob — and is deliberately out of scope, since catching it would need git/FS introspection in the fail-closed decision path. A `ponytail:` comment marks the ceiling; the design question (bounded git-tracked-status consult vs. the new failure surface it adds) is written up in the accompanying ADR for review.

## Verification

- `ruff check` / `ruff format --check` clean; `lint-imports` **2 kept, 0 broken**.
- `python -m pytest tests/unit/test_rule_commands.py -q` — all pass, including 8 new AUTH cases, 4 preserved-PASS cases (recoverable/git-tracked files stay PASS), the raise-only guard (`rm -rf /` and `rm .doberman/agent.key` still BLOCK), and a redaction assertion (the explanation never echoes the operand).
- Mutation-checked: emptying `_UNRECOVERABLE_DELETE_GLOBS` flips exactly the 8 new AUTH cases red (they fall back to PASS); restoring the tuple returns green.
