### PR TITLE
fix(dash): disable uvicorn access log so the URL token never lands in logs

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -912,7 +912,10 @@ def dash(
 
     token = secrets.token_urlsafe(32)
     typer.echo(f"Dashboard: http://{_DASH_HOST}:{port}/?token={token}")
-    uvicorn.run(create_app(token, path), host=_DASH_HOST, port=port)
+    # access_log=False: the single-use token rides in the URL query string, so
+    # uvicorn's request access log would write it verbatim into a log line.
+    # Disable it so the bearer token never lands in a log.
+    uvicorn.run(create_app(token, path), host=_DASH_HOST, port=port, access_log=False)
 
 
 @app.command()

--- a/tests/unit/test_dash_serve.py
+++ b/tests/unit/test_dash_serve.py
@@ -105,6 +105,26 @@ def test_dash_binds_localhost_only():
     assert cli_main._DASH_HOST == "127.0.0.1"
 
 
+def test_dash_disables_uvicorn_access_log(monkeypatch, tmp_path):
+    # The single-use bearer token rides in the URL query string, so uvicorn's
+    # default request access log would write it into a log line
+    # (`GET /?token=<secret> ...`). The `dash` command must disable the access
+    # log so the token never lands in a log. Never bind a real socket: capture
+    # the uvicorn.run call and stub the heartbeat side effect.
+    import uvicorn
+
+    from doberman.cli.main import app as cli_app
+
+    captured: dict = {}
+    monkeypatch.setattr(uvicorn, "run", lambda _app, **kwargs: captured.update(kwargs))
+    monkeypatch.setattr("doberman.storage.heartbeat.touch_heartbeat", lambda _path: None)
+
+    result = runner.invoke(cli_app, ["dash", "--port", "0", "--path", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert captured.get("access_log") is False
+
+
 def test_shell_pending_list_is_polite_live_region():
     assert 'id="pending-list" aria-live="polite"' in app_module._HTML_SHELL
 


### PR DESCRIPTION
## What this PR does

`doberman dash` prints the dashboard URL with its single-use bearer token in the query string, then starts uvicorn with the **default request access log**. That log writes the request line verbatim — `GET /?token=<token> HTTP/1.1` — into stdout/logging, so the token outlives its one-time terminal print and can be captured or persisted.

Pass `access_log=False` so uvicorn never logs the request line. The token is still shown once, on the operator's own terminal; error logging is untouched.

## Tests added (run in CI)

- `tests/unit/test_dash_serve.py::test_dash_disables_uvicorn_access_log` — monkeypatches `uvicorn.run` and the heartbeat so no socket binds, then asserts `access_log=False` reaches uvicorn.

## Security checklist

- [x] Fails closed on error / uncertainty — N/A (removes a log sink; the decision path is untouched)
- [x] No secret, full file, or unredacted prompt logged or committed — this **is** the fix: the token no longer reaches a log
- [x] Any guardrail/learning change is raise-only — N/A (no verdict or guardrail change)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — N/A

## Edge cases / Risks

Localhost-bound, single-use token; small blast radius. No behavior change beyond suppressing the request access log.
