### PR TITLE
docs: document log --jsonl and scan evidence cap difference

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -22,6 +22,7 @@ Entry point: `doberman` (Typer). All commands accept `--help`.
 | Flag | Commands | Notes |
 |------|----------|-------|
 | `--json` | `scan`, `doctor`, `policy-history` | One JSON document on stdout |
+| `--jsonl` | `log` | One JSON object per decision line on stdout |
 | `--quiet` / `-q` | `scan` | No human map; exit code preserved |
 | `--path` / `-p` | most commands | Repository root (default `.`) |
 
@@ -47,6 +48,11 @@ When both are passed, `--json` wins over `--quiet`: machine-readable JSON is sti
 
 Capabilities are sorted by `(category, name)` for deterministic output.
 
+JSON `evidence` arrays may include up to 10 path-class or tool-name entries per capability
+(`scan.py` caps at 10). The human-readable risk map shows at most 3 of those same entries,
+so `doberman scan` and `doberman scan --json` can legitimately differ in how many evidence
+items appear for a capability.
+
 ### `doberman doctor --json`
 
 Emits `{version, path, ok, checks[], critical_failures[]}`. Exit code is still non-zero when critical checks fail.
@@ -59,6 +65,7 @@ doberman scan --json | jq '.capabilities[] | select(.present)'
 doberman scan --quiet; echo $?
 doberman doctor --json | jq .ok
 doberman policy-history --json | jq 'length'
+doberman log --jsonl | head -n 5
 ```
 
 See also [SETUP.md](SETUP.md) and the root README.


### PR DESCRIPTION
## Summary
Fills two gaps in `docs/CLI.md`'s machine-readable section called out in #223.

## Changes
1. Add `--jsonl` to the flags table (command: `log`) and an example.
2. Document that `scan --json` may include up to 10 evidence entries per capability while the human risk map shows at most 3.

## Verification
- Numbers match `src/doberman/discovery/scan.py` (`[:10]` for collection; human map uses `[:3]`).
- `grep -c jsonl docs/CLI.md` is non-zero.

Fixes #223