### PR TITLE
docs: document every CLI command in docs/CLI.md

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -8,14 +8,53 @@ Entry point: `doberman` (Typer). All commands accept `--help`.
 |---------|---------|
 | `doberman scan` | Read-only capability risk map of the repo |
 | `doberman review` | Policy checklist (optional `--yes` to save) |
-| `doberman mode` | Strictness dial |
-| `doberman status` | Current posture + elevations |
+| `doberman mode` | Show or set the security strength mode |
+| `doberman enforcement` | Show or set the enforcement dial (`enforce` / `monitor` / `off`) |
+| `doberman prefs` | Show or set the subjective preference vector (SL5) |
+| `doberman status` | Current posture, hooks, taint, elevations, recent decisions |
 | `doberman doctor` | Health self-check (script-friendly exit codes) |
 | `doberman policy-history` | Append-only policy change ledger |
 | `doberman log` | Decision log (redacted) |
 | `doberman memory` | Aggregated class counts (no secrets) |
+| `doberman tui` | Interactive decision log with plain-language "why" panel |
+| `doberman dash` | Localhost-only dashboard (preview) |
+| `doberman demo` | Scripted attack reel through the real decision engine |
+| `doberman revoke` | Revoke an active role elevation by id |
+| `doberman setup` | First-run wizard (posture + Claude Code hooks) |
 | `doberman install-hooks` | Wire Claude Code host hooks |
-| `doberman serve` | MCP stdio proxy |
+| `doberman uninstall-hooks` | Remove Claude Code host hooks |
+| `doberman serve` | MCP stdio proxy in front of a downstream tool server |
+| `doberman version` | Print the installed Doberman version |
+| `doberman session-summary` | Print the device-global session-guard summary and exit |
+
+Global option: `doberman --version` / `-V` also prints the version and exits.
+
+## Auth enrollment
+
+Security-posture commands used by [SETUP.md](SETUP.md). Group entry points also appear in `doberman --help`.
+
+| Command | Purpose |
+|---------|---------|
+| `doberman 2fa setup` | Enroll TOTP two-factor; print provisioning URI |
+| `doberman 2fa remove` | Remove TOTP enrollment (proves possession of the factor) |
+| `doberman 2fa reset-lockout` | Clear TOTP lockout early (proves password possession) |
+| `doberman password set` | Set or rotate the local password possession factor |
+
+## Session taint recovery
+
+| Command | Purpose |
+|---------|---------|
+| `doberman taint clear` | Clear this repo's sticky session taint (gated; needs a possession factor) |
+
+## Host hooks
+
+Low-level harness integration (also installed via `install-hooks` / `setup`).
+
+| Command | Purpose |
+|---------|---------|
+| `doberman hook pre` | Claude Code PreToolUse — gate one tool call |
+| `doberman hook post` | Claude Code PostToolUse — scan output for secrets; record history |
+| `doberman hook openclaw` | OpenClaw `before_tool_call` plugin hook — gate one tool call |
 
 ## Machine-readable flags
 
@@ -67,6 +106,9 @@ doberman scan --quiet; echo $?
 doberman doctor --json | jq .ok
 doberman policy-history --json | jq 'length'
 doberman log --jsonl | jq -c 'select(.final_verdict=="block")'
+doberman 2fa setup
+doberman password set
+doberman setup
 ```
 
 See also [SETUP.md](SETUP.md) and the root README.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -16,13 +16,13 @@ Entry point: `doberman` (Typer). All commands accept `--help`.
 | `doberman policy-history` | Append-only policy change ledger |
 | `doberman log` | Decision log (redacted) |
 | `doberman memory` | Aggregated class counts (no secrets) |
-| `doberman tui` | Interactive decision log with plain-language "why" panel |
+| `doberman tui` | Interactive decision log with plain-language "why" panel (needs the `[tui]` extra) |
 | `doberman dash` | Localhost-only dashboard (preview) |
 | `doberman demo` | Scripted attack reel through the real decision engine |
 | `doberman revoke` | Revoke an active role elevation by id |
 | `doberman setup` | First-run wizard (posture + Claude Code hooks) |
-| `doberman install-hooks` | Wire Claude Code host hooks |
-| `doberman uninstall-hooks` | Remove Claude Code host hooks |
+| `doberman install-hooks` | Wire host hooks (Claude Code by default; `--host codex` for Codex CLI) |
+| `doberman uninstall-hooks` | Remove host hooks (Claude Code by default; `--host codex` for Codex CLI) |
 | `doberman serve` | MCP stdio proxy in front of a downstream tool server |
 | `doberman version` | Print the installed Doberman version |
 | `doberman session-summary` | Print the device-global session-guard summary and exit |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -53,6 +53,7 @@ Low-level harness integration (also installed via `install-hooks` / `setup`).
 | Command | Purpose |
 |---------|---------|
 | `doberman hook pre` | Claude Code PreToolUse — gate one tool call |
+| `doberman hook codex-pre` | Codex CLI PreToolUse — gate one tool call (same decision spine as `hook pre`) |
 | `doberman hook post` | Claude Code PostToolUse — scan output for secrets; record history |
 | `doberman hook openclaw` | OpenClaw `before_tool_call` plugin hook — gate one tool call |
 


### PR DESCRIPTION
## Summary

- Expand `docs/CLI.md` so every command printed by `doberman --help` is listed, including sub-group commands.
- Add tables for auth enrollment (`2fa`, `password`), session taint recovery, and host hooks.
- Keep the existing machine-readable flags section and examples; add a few enrollment/setup examples.

## Why

Issue #185 required the reference page to cover every help command. The page drifted to 10 of ~26 entry points and omitted the security-posture surface that SETUP walks users through.

## Test plan

- [x] Cross-checked command names against `doberman --help` and `doberman {2fa,password,taint,hook} --help`.
- [x] Docs-only change; no code changes.

Fixes #222