### PR TITLE
refactor(hosthooks): share Claude-style hook output + action-bound AUTH challenge (W1.0b)

### DIFF
--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -46,8 +46,8 @@ from doberman.branding import DOG
 from doberman.config import load_active_role
 from doberman.engine.decision_engine import PASS_STUB, decide, max_risk
 from doberman.engine.objective import ObjectiveGuardrail
-from doberman.hosthooks import spine
-from doberman.models import Decision, EvalContext, ReasonCode, Risk, SecurityObject, Verdict
+from doberman.hosthooks import hookio, spine
+from doberman.models import Decision, EvalContext, Risk, SecurityObject, Verdict
 from doberman.proxy.normalize import normalize
 
 if TYPE_CHECKING:  # annotations only — keeps the hot path free of the auth stack
@@ -99,31 +99,10 @@ _REQUIRED_FIELD: dict[str, str] = {
 }
 
 _HOOK_EVENT = "PreToolUse"
-_REASON = DOG + " Doberman [{verdict}]: {explanation} (reasons: {reasons}; action {action_id})"
-_FAILSAFE_REASON = DOG + " Doberman: failing closed — could not evaluate this action safely."
-#: Default next step on a BLOCK (leemeo3's #70 wording, kept verbatim). Reused as the
-#: fallback for any reason without a more specific hint below.
-_BLOCK_NEXT_STEP = (
-    "Next step: this BLOCK has no in-session override. If this is trusted "
-    "administrative recovery work, run it outside the hooked Claude Code session."
-)
-#: Reason-specific BLOCK next steps (issues #65/#67: adapt the guidance to the actual
-#: block). An exfiltration block is not "recovery work to run elsewhere" — it stays
-#: blocked in every channel — so it says so. Reasons not listed here use the default.
-_BLOCK_NEXT_STEP_BY_REASON: dict[str, str] = {
-    ReasonCode.secret_exfiltration.value: (
-        "Next step: blocked to stop a credential from leaving — there is no in-session "
-        "override; do not route this value to an external destination."
-    ),
-    ReasonCode.confirmed_exfil.value: (
-        "Next step: blocked — an outbound value matches a secret seen earlier this "
-        "session. There is no in-session override."
-    ),
-    ReasonCode.multi_step_exfil.value: (
-        "Next step: blocked — a secret entered this session and this call would send it "
-        "out. There is no in-session override."
-    ),
-}
+_FAILSAFE_REASON = hookio.FAILSAFE_REASON
+#: Back-compat re-export: the reason template moved to ``hookio`` with the rest of the
+#: hook-output shaping, but ``tests/unit/test_branding.py`` imports it from here.
+_REASON = hookio._REASON
 
 #: Prompter for the PreToolUse AUTH challenge. ``None`` ⇒ build the default GUI→TTY
 #: fallback lazily (keeps the hot path light; lets tests inject a headless fake, like
@@ -151,148 +130,16 @@ def to_normalize_input(
     return canonical, args
 
 
-def _format_reason(decision: Decision, verdict_label: str) -> str:
-    """The redaction-safe reason line (verdict + explanation + reason codes + action
-    id). Built only from already-safe decision fields — never a raw argument value."""
-    return _REASON.format(
-        verdict=verdict_label,
-        explanation=(decision.explanation or "").strip() or "no further detail",
-        reasons=", ".join(str(rc) for rc in decision.reason_codes) or "unspecified",
-        action_id=decision.action_id,
-    )
-
-
-def _decision_payload(decision: Decision) -> dict[str, Any]:
-    """Build the PreToolUse hook output for a BLOCK (deny) verdict.
-
-    AUTH is handled by :func:`_resolve_auth` (it runs Doberman's own challenge);
-    only a hard BLOCK reaches here, and it always denies.
-    """
-    reason = _format_reason(decision, decision.final_verdict.name)
-    return _hook_output("deny", f"{reason} {_block_next_step(decision.reason_codes)}")
-
-
-def _block_next_step(reason_codes: list[ReasonCode]) -> str:
-    """The BLOCK next-step for the first reason code with a specific override, else default."""
-    for reason in reason_codes:
-        specific = _BLOCK_NEXT_STEP_BY_REASON.get(str(reason))
-        if specific is not None:
-            return specific
-    return _BLOCK_NEXT_STEP
+def _hook_output(permission: str, reason: str) -> dict[str, Any]:
+    return hookio.hook_output(_HOOK_EVENT, permission, reason)
 
 
 def _resolve_auth(decision: Decision, action: SecurityObject) -> dict[str, Any]:
-    """Run Doberman's tiered challenge for an AUTH and answer the host hook.
-
-    The proxy path (``proxy.executor._handle_auth``) already does this for MCP tools;
-    the host hook had no equivalent, so an AUTH here used to defer to the harness's own
-    yes/no prompt — which cannot satisfy a 2FA-tier action and left the user with no
-    real approve path (issues #65/#67). We now present the action-bound challenge over
-    a GUI→TTY fallback (the dialog is a channel the human can actually see even when the
-    agent's TUI owns the terminal).
-
-    Approved *and* bound to THIS action id → ``allow`` the one call. A denial, an
-    unavailable channel, or any error → ``deny`` (fail closed). The auth stack is
-    imported lazily so the common PASS/BLOCK hot path never pays for it.
-    """
-    # ponytail: no TOCTOU re-decide like the proxy — the hook grants no elevations and
-    # holds no state between calls, so there is nothing to re-check; each call is
-    # challenged independently.
-    try:
-        # Imported + built here (not at module scope) so the PASS/BLOCK hot path stays
-        # light, and inside the try so a construction failure (e.g. no tkinter) also
-        # fails closed with the actionable channel-error message.
-        from doberman.auth.challenge import TIMEOUT_METHOD, run_auth_challenge
-
-        prompter = AUTH_PROMPTER if AUTH_PROMPTER is not None else _default_auth_prompter()
-        result = run_auth_challenge(decision, action, prompter=prompter)
-    except Exception:  # noqa: BLE001 — any challenge/prompter error is a denial (fail closed)
-        return _hook_output("deny", _auth_denied_reason(decision, channel_error=True))
-
-    # Approval is bound to THIS action id — never honor a result meant for another call.
-    if result.approved and result.action_id == action.id:
-        reason = _format_reason(decision, "AUTH")
-        return _hook_output(
-            "allow",
-            f"{reason} Approved via Doberman's action-bound authentication ({result.method}).",
-        )
-    return _hook_output(
-        "deny",
-        _auth_denied_reason(
-            decision,
-            channel_error=result.method == "error",
-            timed_out=result.method == TIMEOUT_METHOD,
-        ),
-    )
+    return hookio.resolve_auth(decision, action, event=_HOOK_EVENT, prompter=AUTH_PROMPTER)
 
 
-def _default_auth_prompter() -> Prompter:
-    """The host-hook challenge channel: a topmost GUI dialog, then the controlling
-    terminal (no MCP elicitation — a hook has no agent session). Built lazily so the
-    common PASS/BLOCK hot path never imports the auth stack."""
-    from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
-    from doberman.auth.tty_prompter import TtyPrompter
-
-    return FallbackPrompter([GuiPrompter(), TtyPrompter()])
-
-
-def _auth_denied_reason(decision: Decision, *, channel_error: bool, timed_out: bool = False) -> str:
-    """A denied-AUTH message that names how to actually complete the approval
-    (issues #65/#67). Redaction-safe; adds the exact 2FA-enrollment command when an
-    un-enrolled 2FA tier is why the action can't be authenticated. A timeout gets its
-    own next-step wording so the log/message distinguishes silence from a refusal
-    (AN-4a, ADR 0046)."""
-    reason = _format_reason(decision, "AUTH")
-    if channel_error:
-        tail = (
-            "Next step: Doberman's approval dialog could not be shown (no GUI or "
-            "terminal channel). Approve from an interactive session, or run the action "
-            "yourself outside the hooked Claude Code session."
-        )
-    elif timed_out:
-        tail = (
-            "Next step: the approval request expired with no response (auto-denied "
-            "after the deadline) — retry the action to reopen Doberman's approval dialog."
-        )
-        if _needs_unenrolled_2fa(decision):
-            tail += (
-                " This action needs 2FA, which isn't set up yet — run "
-                "`doberman 2fa setup`, then retry."
-            )
-    else:
-        tail = (
-            "Next step: authentication was not completed — retry the action to reopen "
-            "Doberman's approval dialog."
-        )
-        if _needs_unenrolled_2fa(decision):
-            tail += (
-                " This action needs 2FA, which isn't set up yet — run "
-                "`doberman 2fa setup`, then retry."
-            )
-    return f"{reason} {tail}"
-
-
-def _needs_unenrolled_2fa(decision: Decision) -> bool:
-    """True when the challenge tier requires a TOTP code but none is enrolled — the
-    usual reason a high-risk AUTH dead-ends. Best-effort; never raises into the hook."""
-    try:
-        from doberman.auth import totp
-        from doberman.auth.challenge import AuthTier, select_tier
-
-        tier = select_tier(decision)
-        return tier in (AuthTier.two_factor, AuthTier.role_elevation) and not totp.is_enrolled()
-    except Exception:  # noqa: BLE001 — a messaging aid must never affect the decision
-        return False
-
-
-def _hook_output(permission: str, reason: str) -> dict[str, Any]:
-    return {
-        "hookSpecificOutput": {
-            "hookEventName": _HOOK_EVENT,
-            "permissionDecision": permission,
-            "permissionDecisionReason": reason,
-        }
-    }
+def _decision_payload(decision: Decision) -> dict[str, Any]:
+    return hookio.decision_payload(decision, event=_HOOK_EVENT)
 
 
 def _deny(reason: str = _FAILSAFE_REASON) -> dict[str, Any]:

--- a/src/doberman/hosthooks/hookio.py
+++ b/src/doberman/hosthooks/hookio.py
@@ -1,0 +1,212 @@
+"""Host-generic hook-output shaping + in-process action-bound AUTH challenge.
+
+Extracted from :mod:`doberman.hosthooks.claude_code` (W1.0b) so a second host
+adapter (Codex, whose hook protocol mirrors Claude Code's — same
+``hookSpecificOutput`` deny shape) can reuse this logic instead of copying it
+(issues #65/#67: a host's own yes/no prompt cannot satisfy a 2FA-tier action,
+so Doberman runs its own action-bound challenge over a GUI→TTY fallback).
+
+Every function takes the host's hook event name explicitly (``event: str``)
+instead of reading a module constant, and :func:`resolve_auth` takes its
+``Prompter`` explicitly — each adapter keeps its own module-level
+``AUTH_PROMPTER`` injection seam (so tests can still inject a headless fake
+there) and passes it in; ``None`` builds the default GUI→TTY fallback lazily.
+
+**Speed.** A host hook runs before or after *every* tool call, so this module
+must NEVER import :mod:`doberman.proxy.executor` or the subjective baseline —
+those pull ``numpy``/``scipy``/``river`` at module scope. The auth stack
+(:mod:`doberman.auth.challenge`, the GUI/TTY prompters, :mod:`doberman.auth.totp`)
+is imported lazily, only inside the AUTH branch that actually needs it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from doberman.branding import DOG
+from doberman.models import Decision, ReasonCode, SecurityObject
+
+if TYPE_CHECKING:  # annotations only — keeps the hot path free of the auth stack
+    from doberman.auth.challenge import Prompter
+
+_REASON = DOG + " Doberman [{verdict}]: {explanation} (reasons: {reasons}; action {action_id})"
+FAILSAFE_REASON = DOG + " Doberman: failing closed — could not evaluate this action safely."
+#: Default next step on a BLOCK (leemeo3's #70 wording, kept verbatim). Reused as the
+#: fallback for any reason without a more specific hint below.
+_BLOCK_NEXT_STEP = (
+    "Next step: this BLOCK has no in-session override. If this is trusted "
+    "administrative recovery work, run it outside the hooked Claude Code session."
+)
+#: Reason-specific BLOCK next steps (issues #65/#67: adapt the guidance to the actual
+#: block). An exfiltration block is not "recovery work to run elsewhere" — it stays
+#: blocked in every channel — so it says so. Reasons not listed here use the default.
+_BLOCK_NEXT_STEP_BY_REASON: dict[str, str] = {
+    ReasonCode.secret_exfiltration.value: (
+        "Next step: blocked to stop a credential from leaving — there is no in-session "
+        "override; do not route this value to an external destination."
+    ),
+    ReasonCode.confirmed_exfil.value: (
+        "Next step: blocked — an outbound value matches a secret seen earlier this "
+        "session. There is no in-session override."
+    ),
+    ReasonCode.multi_step_exfil.value: (
+        "Next step: blocked — a secret entered this session and this call would send it "
+        "out. There is no in-session override."
+    ),
+}
+
+
+def hook_output(event: str, permission: str, reason: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": event,
+            "permissionDecision": permission,
+            "permissionDecisionReason": reason,
+        }
+    }
+
+
+def deny(event: str, reason: str = FAILSAFE_REASON) -> dict[str, Any]:
+    return hook_output(event, "deny", reason)
+
+
+def format_reason(decision: Decision, verdict_label: str) -> str:
+    """The redaction-safe reason line (verdict + explanation + reason codes + action
+    id). Built only from already-safe decision fields — never a raw argument value."""
+    return _REASON.format(
+        verdict=verdict_label,
+        explanation=(decision.explanation or "").strip() or "no further detail",
+        reasons=", ".join(str(rc) for rc in decision.reason_codes) or "unspecified",
+        action_id=decision.action_id,
+    )
+
+
+def decision_payload(decision: Decision, *, event: str) -> dict[str, Any]:
+    """Build the PreToolUse-style hook output for a BLOCK (deny) verdict.
+
+    AUTH is handled by :func:`resolve_auth` (it runs Doberman's own challenge);
+    only a hard BLOCK reaches here, and it always denies.
+    """
+    reason = format_reason(decision, decision.final_verdict.name)
+    return hook_output(event, "deny", f"{reason} {_block_next_step(decision.reason_codes)}")
+
+
+def _block_next_step(reason_codes: list[ReasonCode]) -> str:
+    """The BLOCK next-step for the first reason code with a specific override, else default."""
+    for reason in reason_codes:
+        specific = _BLOCK_NEXT_STEP_BY_REASON.get(str(reason))
+        if specific is not None:
+            return specific
+    return _BLOCK_NEXT_STEP
+
+
+def resolve_auth(
+    decision: Decision,
+    action: SecurityObject,
+    *,
+    event: str,
+    prompter: "Prompter | None",
+) -> dict[str, Any]:
+    """Run Doberman's tiered challenge for an AUTH and answer the host hook.
+
+    The proxy path (``proxy.executor._handle_auth``) already does this for MCP tools;
+    a host hook has no equivalent, so an AUTH here used to defer to the harness's own
+    yes/no prompt — which cannot satisfy a 2FA-tier action and left the user with no
+    real approve path (issues #65/#67). We now present the action-bound challenge over
+    a GUI→TTY fallback (the dialog is a channel the human can actually see even when the
+    agent's TUI owns the terminal).
+
+    Approved *and* bound to THIS action id → ``allow`` the one call. A denial, an
+    unavailable channel, or any error → ``deny`` (fail closed). The auth stack is
+    imported lazily so the common PASS/BLOCK hot path never pays for it.
+    """
+    # ponytail: no TOCTOU re-decide like the proxy — the hook grants no elevations and
+    # holds no state between calls, so there is nothing to re-check; each call is
+    # challenged independently.
+    try:
+        # Imported + built here (not at module scope) so the PASS/BLOCK hot path stays
+        # light, and inside the try so a construction failure (e.g. no tkinter) also
+        # fails closed with the actionable channel-error message.
+        from doberman.auth.challenge import TIMEOUT_METHOD, run_auth_challenge
+
+        active_prompter = prompter if prompter is not None else _default_auth_prompter()
+        result = run_auth_challenge(decision, action, prompter=active_prompter)
+    except Exception:  # noqa: BLE001 — any challenge/prompter error is a denial (fail closed)
+        return hook_output(event, "deny", _auth_denied_reason(decision, channel_error=True))
+
+    # Approval is bound to THIS action id — never honor a result meant for another call.
+    if result.approved and result.action_id == action.id:
+        reason = format_reason(decision, "AUTH")
+        return hook_output(
+            event,
+            "allow",
+            f"{reason} Approved via Doberman's action-bound authentication ({result.method}).",
+        )
+    return hook_output(
+        event,
+        "deny",
+        _auth_denied_reason(
+            decision,
+            channel_error=result.method == "error",
+            timed_out=result.method == TIMEOUT_METHOD,
+        ),
+    )
+
+
+def _default_auth_prompter() -> "Prompter":
+    """The host-hook challenge channel: a topmost GUI dialog, then the controlling
+    terminal (no MCP elicitation — a hook has no agent session). Built lazily so the
+    common PASS/BLOCK hot path never imports the auth stack."""
+    from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
+    from doberman.auth.tty_prompter import TtyPrompter
+
+    return FallbackPrompter([GuiPrompter(), TtyPrompter()])
+
+
+def _auth_denied_reason(decision: Decision, *, channel_error: bool, timed_out: bool = False) -> str:
+    """A denied-AUTH message that names how to actually complete the approval
+    (issues #65/#67). Redaction-safe; adds the exact 2FA-enrollment command when an
+    un-enrolled 2FA tier is why the action can't be authenticated. A timeout gets its
+    own next-step wording so the log/message distinguishes silence from a refusal
+    (AN-4a, ADR 0046)."""
+    reason = format_reason(decision, "AUTH")
+    if channel_error:
+        tail = (
+            "Next step: Doberman's approval dialog could not be shown (no GUI or "
+            "terminal channel). Approve from an interactive session, or run the action "
+            "yourself outside the hooked Claude Code session."
+        )
+    elif timed_out:
+        tail = (
+            "Next step: the approval request expired with no response (auto-denied "
+            "after the deadline) — retry the action to reopen Doberman's approval dialog."
+        )
+        if _needs_unenrolled_2fa(decision):
+            tail += (
+                " This action needs 2FA, which isn't set up yet — run "
+                "`doberman 2fa setup`, then retry."
+            )
+    else:
+        tail = (
+            "Next step: authentication was not completed — retry the action to reopen "
+            "Doberman's approval dialog."
+        )
+        if _needs_unenrolled_2fa(decision):
+            tail += (
+                " This action needs 2FA, which isn't set up yet — run "
+                "`doberman 2fa setup`, then retry."
+            )
+    return f"{reason} {tail}"
+
+
+def _needs_unenrolled_2fa(decision: Decision) -> bool:
+    """True when the challenge tier requires a TOTP code but none is enrolled — the
+    usual reason a high-risk AUTH dead-ends. Best-effort; never raises into the hook."""
+    try:
+        from doberman.auth import totp
+        from doberman.auth.challenge import AuthTier, select_tier
+
+        tier = select_tier(decision)
+        return tier in (AuthTier.two_factor, AuthTier.role_elevation) and not totp.is_enrolled()
+    except Exception:  # noqa: BLE001 — a messaging aid must never affect the decision
+        return False

--- a/tests/unit/test_hosthook_hookio.py
+++ b/tests/unit/test_hosthook_hookio.py
@@ -1,0 +1,180 @@
+"""Tests for ``hosthooks.hookio`` — the host-generic hook-output shaping +
+in-process action-bound AUTH challenge (extracted from ``claude_code.py``,
+W1.0b) so a second host adapter (Codex) can reuse it instead of copying it.
+
+Ports the relevant cases from ``test_hosthook_auth_challenge.py`` onto the
+new, event-parametric seams. These tests inject a headless fake prompter so
+nothing pops a real dialog.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from doberman.auth.challenge import AuthResult, AuthTier
+from doberman.auth.gui_prompter import PrompterUnavailableError
+from doberman.hosthooks import hookio
+from doberman.models import Decision, GuardrailResult, ReasonCode, Risk, SecurityObject, Verdict
+
+
+class _Approve:
+    """A local human who is present and says yes (confirm-only tiers)."""
+
+    def confirm(self, message):
+        return True
+
+    def read_code(self, message):
+        return "000000"
+
+
+class _Decline:
+    def confirm(self, message):
+        return False
+
+    def read_code(self, message):
+        raise AssertionError("read_code must not be reached after a declined confirm")
+
+
+class _NoChannel:
+    def confirm(self, message):
+        raise PrompterUnavailableError("no channel in test")
+
+    def read_code(self, message):
+        raise PrompterUnavailableError("no channel in test")
+
+
+@pytest.fixture
+def sample_action():
+    # A WebFetch to a raw IP -> AUTH (unknown_external_destination) at the
+    # local_auth tier (confirm only, no TOTP) — mirrors test_hosthook_auth_challenge.py.
+    return SecurityObject(
+        id="action-1",
+        ts=datetime.now(timezone.utc),
+        agent_role="default",
+        action_type="network_request",
+        tool_name="WebFetch",
+        target="https://93.184.216.34/",
+        external_destination="93.184.216.34",
+    )
+
+
+@pytest.fixture
+def sample_auth_decision(sample_action):
+    objective = GuardrailResult(
+        verdict=Verdict.AUTH,
+        risk=Risk.medium,
+        reason_codes=[ReasonCode.unknown_external_destination],
+        explanation="destination is not a known/allowlisted host",
+    )
+    return Decision(
+        action_id=sample_action.id,
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.medium,
+        objective=objective,
+        reason_codes=[ReasonCode.unknown_external_destination],
+        explanation="destination is not a known/allowlisted host",
+        decided_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.fixture
+def approving_prompter_for_other_action(monkeypatch):
+    """An "approved" challenge result bound to a DIFFERENT action id —
+    resolve_auth must never honor it (single-use, action-bound approval)."""
+
+    def _fake_challenge(decision, action, *, prompter=None, at=None):
+        return AuthResult(
+            approved=True,
+            tier=AuthTier.local_auth,
+            method="local_auth",
+            at=datetime.now(timezone.utc),
+            action_id="some-other-action",
+        )
+
+    monkeypatch.setattr("doberman.auth.challenge.run_auth_challenge", _fake_challenge)
+    return _Approve()
+
+
+def test_hook_output_shape_is_event_parametric():
+    out = hookio.hook_output("PreToolUse", "deny", "why")
+    assert out["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert out["hookSpecificOutput"]["permissionDecisionReason"] == "why"
+
+    out2 = hookio.hook_output("SomeFutureEvent", "deny", "why")
+    assert out2["hookSpecificOutput"]["hookEventName"] == "SomeFutureEvent"
+
+
+def test_deny_uses_failsafe_reason_by_default():
+    out = hookio.deny("PreToolUse")
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert out["hookSpecificOutput"]["permissionDecisionReason"] == hookio.FAILSAFE_REASON
+
+
+def test_resolve_auth_approves_and_allows(sample_auth_decision, sample_action):
+    out = hookio.resolve_auth(
+        sample_auth_decision, sample_action, event="PreToolUse", prompter=_Approve()
+    )
+    assert out["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert "action-bound authentication" in out["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_resolve_auth_denies_on_decline(sample_auth_decision, sample_action):
+    out = hookio.resolve_auth(
+        sample_auth_decision, sample_action, event="PreToolUse", prompter=_Decline()
+    )
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_resolve_auth_denies_on_prompter_error(sample_auth_decision, sample_action):
+    out = hookio.resolve_auth(
+        sample_auth_decision, sample_action, event="PreToolUse", prompter=_NoChannel()
+    )
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"  # fail closed
+    assert "could not be shown" in out["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_resolve_auth_binds_to_action_id(
+    sample_auth_decision, sample_action, approving_prompter_for_other_action
+):
+    out = hookio.resolve_auth(
+        sample_auth_decision,
+        sample_action,
+        event="PreToolUse",
+        prompter=approving_prompter_for_other_action,
+    )
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_resolve_auth_is_event_parametric(sample_auth_decision, sample_action):
+    out = hookio.resolve_auth(
+        sample_auth_decision, sample_action, event="SomeFutureEvent", prompter=_Approve()
+    )
+    assert out["hookSpecificOutput"]["hookEventName"] == "SomeFutureEvent"
+
+
+def test_decision_payload_is_event_parametric(sample_action):
+    objective = GuardrailResult(
+        verdict=Verdict.BLOCK,
+        risk=Risk.high,
+        reason_codes=[ReasonCode.unknown_external_destination],
+        explanation="blocked for test",
+    )
+    decision = Decision(
+        action_id=sample_action.id,
+        final_verdict=Verdict.BLOCK,
+        final_risk=Risk.high,
+        objective=objective,
+        reason_codes=[ReasonCode.unknown_external_destination],
+        explanation="blocked for test",
+        decided_at=datetime.now(timezone.utc),
+    )
+    out = hookio.decision_payload(decision, event="SomeFutureEvent")
+    assert out["hookSpecificOutput"]["hookEventName"] == "SomeFutureEvent"
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_format_reason_includes_verdict_and_action_id(sample_auth_decision):
+    reason = hookio.format_reason(sample_auth_decision, "AUTH")
+    assert "AUTH" in reason
+    assert sample_auth_decision.action_id in reason


### PR DESCRIPTION
## Slice
Feature / Slice: two-hosts-one-spine — W1.0b (share Claude-style hook output + AUTH challenge) / Task 3

## What this PR does

Codex CLI's hook protocol is modeled on Claude Code's (same `hookSpecificOutput` deny shape). Before a Codex adapter can reuse that shaping — and Doberman's own in-process, action-bound AUTH challenge rather than a host's yes/no prompt (the #65/#67 lesson: a yes/no flow can't satisfy a 2FA-tier action) — the logic has to leave `claude_code.py`. This PR extracts it into a new `hosthooks/hookio.py`, event-parametric so any host passes its own event name.

Behavior is identical — pure refactor. `claude_code.py` keeps thin aliases (`_hook_output`, `_resolve_auth`, `_decision_payload`, `_FAILSAFE_REASON`, `_REASON`) so the PostToolUse path and existing tests are untouched, and keeps the `AUTH_PROMPTER` global as the test injection seam. The auth stack stays lazily imported inside `resolve_auth`/`_default_auth_prompter`, so the PASS/BLOCK hot path never pays for it.

## Tests added (run in CI)
- `tests/unit/test_hosthook_hookio.py` — the event-parametric output shape, and the fail-closed AUTH paths (declined, prompter error, action-id mismatch → deny). The action-id binding is verified directly: an approval for a different action id is refused.
- Existing `test_hosthook_auth_challenge.py` / `test_hosthook_claude_pre.py` / `test_hosthook_claude_post.py` / `test_branding.py` pass unchanged. Full suite green.

## Security checklist
- [x] Fails closed on error / uncertainty (approval honored only when `result.approved and result.action_id == action.id`; any prompter error/timeout/unavailable channel → deny)
- [x] No secret, full file, or unredacted prompt logged or committed (reason strings built from decision fields only)
- [x] Any guardrail/learning change is raise-only (pure refactor)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged)

## Edge cases covered / Deviations from plan / Risks introduced
- `_REASON` moved to hookio with the other reason templates; a back-compat alias `_REASON = hookio._REASON` in `claude_code.py` keeps `tests/unit/test_branding.py`'s import working (the one external importer).
- No behavior change; risk is subtle refactor drift, guarded by the retained auth/pre/post suites plus the new direct unit tests.
