### PR TITLE
feat(cli): Codex install-hooks --host codex + single-flight dedupe + doctor (W1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ completion.
 | Your agent | How Doberman plugs in | Get started |
 |---|---|---|
 | **Claude Code** | Hooks - gate every built-in *and* MCP tool call *(recommended)* | `doberman setup` -> [guide](docs/SETUP.md#claude-code-hooks) |
-| **Claude Desktop / Cursor / Codex** | MCP proxy - wrap your tool server | `doberman serve -- <your-server>` -> [guide](docs/SETUP.md#mcp-proxy) |
+| **Codex CLI** | Native PreToolUse hook *(experimental)* | `doberman install-hooks --host codex` |
+| **Claude Desktop / Cursor** | MCP proxy - wrap your tool server | `doberman serve -- <your-server>` -> [guide](docs/SETUP.md#mcp-proxy) |
 | **OpenClaw** | Native plugin adapter | [guide](docs/SETUP.md#openclaw) - [adapter](adapters/openclaw/README.md) |
 | **Any MCP-compatible agent** | MCP proxy | [guide](docs/SETUP.md#mcp-proxy) |
 

--- a/src/doberman/cli/doctor.py
+++ b/src/doberman/cli/doctor.py
@@ -65,16 +65,65 @@ def _safe_check(name: str, critical: bool, fn):
 
 def _check_hooks(path: str) -> CheckResult:
     from doberman.hosthooks.install import hook_install_states
+    from doberman.hosthooks.install_codex import codex_hook_install_states
 
     installed = [scope for scope, _p, ok in hook_install_states(path) if ok]
+    installed += [f"codex:{scope}" for scope, _p, ok in codex_hook_install_states(path) if ok]
     if installed:
         return CheckResult("Host hooks", CheckStatus.OK, f"installed ({', '.join(installed)})")
     return CheckResult(
         "Host hooks",
         CheckStatus.FAIL,
-        "not installed in any scope — run `doberman install-hooks`",
+        "not installed in any scope — run `doberman install-hooks` (add `--host codex` for Codex)",
         critical=True,
     )
+
+
+def _check_codex_version() -> CheckResult:
+    """Report the installed Codex CLI version against the adapter's supported
+    range. Always **non-critical** (WARN, never FAIL): a newer or absent Codex is
+    not "Doberman may not be protecting you" — Codex support is opt-in."""
+    import subprocess
+
+    from doberman.hosthooks.codex import SUPPORTED_CODEX_RANGE
+
+    try:
+        # noqa on the argv line: fixed argv, no shell; `codex` is intentionally a
+        # PATH lookup (the CLI is installed globally, not at a fixed path).
+        proc = subprocess.run(  # noqa: S603
+            ["codex", "--version"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except OSError:  # FileNotFoundError (codex not on PATH) is an OSError subclass
+        return CheckResult(
+            "Codex CLI", CheckStatus.WARN, "not found (only needed for `--host codex`)"
+        )
+    except subprocess.SubprocessError:
+        return CheckResult("Codex CLI", CheckStatus.WARN, "version could not be determined")
+
+    import re
+
+    match = re.search(r"(\d+\.\d+\.\d+)", proc.stdout or proc.stderr or "")
+    if not match:
+        return CheckResult("Codex CLI", CheckStatus.WARN, "version string not recognized")
+    version = match.group(1)
+    low, high = SUPPORTED_CODEX_RANGE
+    if _version_tuple(low) <= _version_tuple(version) < _version_tuple(high):
+        return CheckResult("Codex CLI", CheckStatus.OK, f"{version} (supported)")
+    return CheckResult(
+        "Codex CLI",
+        CheckStatus.WARN,
+        f"{version} outside tested range [{low}, {high}) — adapter may need an update",
+    )
+
+
+def _version_tuple(v: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(p) for p in v.split("."))
+    except ValueError:
+        return (0,)
 
 
 def _check_config(path: str) -> CheckResult:
@@ -189,6 +238,7 @@ def run_checks(path: str = ".") -> list[CheckResult]:
         _safe_check("Enforcement", False, lambda: _check_enforcement(path)),
         _safe_check("2FA", False, _check_2fa),
         _safe_check("Fingerprint key", False, _check_fingerprint_key),
+        _safe_check("Codex CLI", False, _check_codex_version),
     ]
 
 

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1133,22 +1133,35 @@ def policy_history(
 @app.command("install-hooks", rich_help_panel="Getting started")
 def install_hooks(
     global_: bool = typer.Option(
-        False, "--global", "-g", help="Install into ~/.claude/settings.json (user-wide)."
+        False,
+        "--global",
+        "-g",
+        help="Install into the user-wide file (Claude: ~/.claude; Codex: ~/.codex).",
     ),
     local: bool = typer.Option(
-        False, "--local", help="Install into .claude/settings.local.json (project-local)."
+        False, "--local", help="Install into .claude/settings.local.json (Claude only)."
     ),
+    host: str = typer.Option("claude", "--host", help="Which host to wire: claude | codex."),
     path: str = typer.Option(".", "--path", "-p", help="Project root (default: current dir)."),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print what would change; write nothing."
     ),
 ) -> None:
-    """Wire Doberman's PreToolUse and PostToolUse hooks into a Claude Code settings.json.
+    """Wire Doberman's hooks into a host so every tool call is gated before it runs.
 
-    Idempotent - safe to run more than once.  Default scope is the project-level
-    ``.claude/settings.json``; use ``--global`` for the user-wide file or
-    ``--local`` for ``.claude/settings.local.json``.
+    Idempotent - safe to run more than once. Claude Code (default): PreToolUse +
+    PostToolUse + SessionStart into a ``settings.json`` (``--global`` user-wide,
+    ``--local`` project-local, else project ``.claude/settings.json``). Codex CLI
+    (``--host codex``): a PreToolUse hook into a ``hooks.json`` (``--global`` ->
+    ``~/.codex/hooks.json``, else ``<repo>/.codex/hooks.json``).
     """
+    if host == "codex":
+        _install_codex(global_=global_, local=local, path=path, dry_run=dry_run)
+        return
+    if host != "claude":
+        typer.echo(f"error: unknown --host {host!r}; expected 'claude' or 'codex'.", err=True)
+        raise typer.Exit(2)
+
     from doberman.hosthooks.install import (
         load_settings,
         merge_doberman_hooks,
@@ -1181,24 +1194,119 @@ def install_hooks(
     typer.echo("The session dashboard will print at the start of every session.")
 
 
+def _install_codex(*, global_: bool, local: bool, path: str, dry_run: bool) -> None:
+    """`install-hooks --host codex`: wire ``doberman hook codex-pre`` into a
+    Codex hooks.json. ``--global`` -> ``~/.codex/hooks.json`` (user), else
+    ``<repo>/.codex/hooks.json`` (repo). ``--local`` has no Codex equivalent."""
+    if local:
+        typer.echo(
+            "error: --local has no Codex equivalent; use --global (user) or the default (repo).",
+            err=True,
+        )
+        raise typer.Exit(2)
+    from doberman.hosthooks.install import load_settings, write_settings
+    from doberman.hosthooks.install_codex import merge_codex_hooks, resolve_codex_hooks_path
+
+    scope = "user" if global_ else "repo"
+    hooks_path = resolve_codex_hooks_path(scope, path)
+
+    try:
+        current = load_settings(hooks_path)
+    except ValueError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+    merged = merge_codex_hooks(current)
+
+    if dry_run:
+        typer.echo(f"[dry-run] target: {hooks_path}")
+        typer.echo("[dry-run] would add:")
+        typer.echo("  PreToolUse -> doberman hook codex-pre")
+        return
+
+    write_settings(hooks_path, merged)
+    typer.echo(f"wrote {hooks_path}")
+    typer.echo("Doberman will now gate Codex's tool calls in this scope.")
+    typer.echo("")
+    typer.echo("Codex requires you to TRUST this hook before it runs:")
+    typer.echo("  run a Codex command and approve the hook when prompted, or launch with")
+    typer.echo("  --dangerously-bypass-hook-trust only if you already vet the hook source.")
+    typer.echo("Verify it's live: ask Codex to `cat .env` and confirm it is blocked.")
+
+
+def _uninstall_codex(*, global_: bool, local: bool, path: str, dry_run: bool) -> None:
+    """`uninstall-hooks --host codex`: remove Doberman's Codex hook group."""
+    if local:
+        typer.echo("error: --local has no Codex equivalent.", err=True)
+        raise typer.Exit(2)
+    from doberman.hosthooks.install import _is_doberman_group, load_settings, write_settings
+    from doberman.hosthooks.install_codex import remove_codex_hooks, resolve_codex_hooks_path
+
+    scope = "user" if global_ else "repo"
+    hooks_path = resolve_codex_hooks_path(scope, path)
+
+    try:
+        current = load_settings(hooks_path)
+    except ValueError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+    hooks_section = current.get("hooks") or {}
+    had_doberman = any(
+        _is_doberman_group(g)
+        for groups in hooks_section.values()
+        if isinstance(groups, list)
+        for g in groups
+    )
+    if not had_doberman:
+        typer.echo("No Doberman Codex hooks found - nothing to remove.")
+        return
+
+    cleaned = remove_codex_hooks(current)
+    if dry_run:
+        typer.echo(f"[dry-run] target: {hooks_path}")
+        typer.echo("[dry-run] would remove:  PreToolUse -> doberman hook codex-pre")
+        return
+
+    write_settings(hooks_path, cleaned)
+    typer.echo(f"wrote {hooks_path}")
+    typer.echo("Doberman Codex hooks removed.")
+    typer.echo(
+        "Note: a plugin-bundled hook (if installed) is removed by removing the plugin "
+        "(`codex plugin remove`), not by this command."
+    )
+
+
 @app.command("uninstall-hooks", rich_help_panel="Getting started")
 def uninstall_hooks(
     global_: bool = typer.Option(
-        False, "--global", "-g", help="Remove from ~/.claude/settings.json (user-wide)."
+        False,
+        "--global",
+        "-g",
+        help="Remove from the user-wide file (Claude: ~/.claude; Codex: ~/.codex).",
     ),
     local: bool = typer.Option(
-        False, "--local", help="Remove from .claude/settings.local.json (project-local)."
+        False, "--local", help="Remove from .claude/settings.local.json (Claude only)."
     ),
+    host: str = typer.Option("claude", "--host", help="Which host to unwire: claude | codex."),
     path: str = typer.Option(".", "--path", "-p", help="Project root (default: current dir)."),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print what would change; write nothing."
     ),
 ) -> None:
-    """Remove Doberman's PreToolUse and PostToolUse hooks from a Claude Code settings.json.
+    """Remove Doberman's hooks from a host.
 
     Idempotent - safe to run even when hooks are not present.  Non-Doberman hooks
-    and every other setting are left untouched.
+    and every other setting are left untouched. ``--host codex`` removes the Codex
+    hook group instead of the Claude Code hooks.
     """
+    if host == "codex":
+        _uninstall_codex(global_=global_, local=local, path=path, dry_run=dry_run)
+        return
+    if host != "claude":
+        typer.echo(f"error: unknown --host {host!r}; expected 'claude' or 'codex'.", err=True)
+        raise typer.Exit(2)
+
     from doberman.hosthooks.install import (
         _is_doberman_group,
         load_settings,

--- a/src/doberman/hosthooks/codex.py
+++ b/src/doberman/hosthooks/codex.py
@@ -187,6 +187,13 @@ def run_codex_pre(stdin_text: str) -> str | None:
 
     A payload that does not parse to a JSON object is denied: an unidentifiable
     call fails closed rather than slipping through.
+
+    **Single-flight (W1.2):** when both install channels are wired, Codex fires
+    this hook twice for one tool call. The first invocation records its answer
+    under a keyed marker; the second replays it byte-for-byte instead of
+    re-evaluating (avoiding a doubled AUTH prompt / history row / taint bump). A
+    missing/expired/unavailable marker just means a full evaluation — never a
+    skipped one.
     """
     try:
         payload = json.loads(stdin_text)
@@ -194,5 +201,15 @@ def run_codex_pre(stdin_text: str) -> str | None:
         return json.dumps(hookio.deny(_EVENT))
     if not isinstance(payload, dict):
         return json.dumps(hookio.deny(_EVENT))
+
+    from doberman.hosthooks import singleflight
+
+    key = singleflight.event_key(payload)
+    prior = singleflight.replay(key)
+    if prior is not None:
+        return prior or None  # "" -> abstain (print nothing); else replay the JSON
+
     out = evaluate_pre(payload)
-    return json.dumps(out) if out is not None else None
+    text = json.dumps(out) if out is not None else None
+    singleflight.record(key, text)
+    return text

--- a/src/doberman/hosthooks/install_codex.py
+++ b/src/doberman/hosthooks/install_codex.py
@@ -1,0 +1,161 @@
+"""Idempotent install/uninstall of Doberman's Codex CLI hook into a hooks.json.
+
+Codex's hooks.json is Claude-Code-shaped (a live capture confirmed the schema —
+see ``tests/fixtures/codex/README.md``): ``{"hooks": {"<Event>": [{"matcher":
+"<regex>", "hooks": [{"type": "command", "command": "..."}]}]}}``. Doberman
+registers a single ``PreToolUse`` group matching every tool (``matcher": ".*"``)
+that runs ``doberman hook codex-pre``.
+
+This mirrors :mod:`doberman.hosthooks.install` (Claude Code) and reuses its
+format-agnostic JSON I/O (:func:`~doberman.hosthooks.install.load_settings` /
+:func:`~doberman.hosthooks.install.write_settings`) and its Doberman-group
+sentinel (``doberman hook `` — matches ``codex-pre`` too). Pure merge/remove
+functions never mutate their inputs, so they are trivially unit-testable.
+
+Scopes: ``user`` -> ``~/.codex/hooks.json`` (auto-loaded by Codex; confirmed live),
+``repo`` -> ``<project_root>/.codex/hooks.json``. There is no Codex equivalent of
+Claude Code's ``settings.local.json`` "local" scope. A third **plugin** scope
+(a plugin-bundled hooks.json) is install/uninstalled by adding/removing the Codex
+plugin itself, not by this command — it is reported by
+:func:`codex_hook_install_states` but never written here.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+from doberman.hosthooks.install import _is_doberman_group, load_settings
+
+#: Codex PreToolUse group Doberman registers — matches every tool. The
+#: ``doberman hook `` marker (shared with the Claude Code installer) identifies it
+#: for idempotent replace + removal. Shape confirmed against a live codex CLI
+#: (see tests/fixtures/codex/README.md for version + date).
+CODEX_PRE_ENTRY: dict[str, Any] = {
+    "matcher": ".*",
+    "hooks": [{"type": "command", "command": "doberman hook codex-pre"}],
+}
+
+#: Where a Codex plugin's bundled hooks live once installed (cache probed
+#: read-only for the *reporting* path only; this module never writes here). Codex
+#: unpacks plugins under ``~/.codex/.tmp/plugins/plugins/<name>/`` (observed
+#: 2026-08-08); a Doberman plugin would ship its own ``hooks.json`` there.
+_PLUGIN_ROOT = Path.home() / ".codex" / ".tmp" / "plugins" / "plugins"
+
+
+def merge_codex_hooks(settings: dict[str, Any]) -> dict[str, Any]:
+    """Return a *new* hooks.json dict with Doberman's PreToolUse group added.
+
+    Existing non-Doberman groups and every other key are preserved. **Idempotent:**
+    a pre-existing Doberman group is replaced in place, never duplicated.
+    """
+    result: dict[str, Any] = copy.deepcopy(settings)
+    hooks: dict[str, Any] = copy.deepcopy(result.get("hooks") or {})
+
+    existing: list[dict[str, Any]] = list(hooks.get("PreToolUse") or [])
+    non_doberman = [g for g in existing if not _is_doberman_group(g)]
+    hooks["PreToolUse"] = [*non_doberman, copy.deepcopy(CODEX_PRE_ENTRY)]
+
+    result["hooks"] = hooks
+    return result
+
+
+def remove_codex_hooks(settings: dict[str, Any]) -> dict[str, Any]:
+    """Return a *new* hooks.json dict with Doberman's hook groups removed.
+
+    Non-Doberman groups and every other key are preserved. Empty event lists are
+    dropped; if ``hooks`` becomes empty it is removed too. A no-op when absent.
+    """
+    result: dict[str, Any] = copy.deepcopy(settings)
+    if "hooks" not in result:
+        return result
+
+    hooks: dict[str, Any] = copy.deepcopy(result["hooks"])
+    cleaned: dict[str, Any] = {}
+    for event_key, groups in hooks.items():
+        if not isinstance(groups, list):
+            cleaned[event_key] = groups
+            continue
+        kept = [g for g in groups if not _is_doberman_group(g)]
+        if kept:
+            cleaned[event_key] = kept
+
+    if cleaned:
+        result["hooks"] = cleaned
+    else:
+        del result["hooks"]
+    return result
+
+
+def resolve_codex_hooks_path(scope: str, project_root: str) -> Path:
+    """Resolve the target ``hooks.json`` path for *scope*.
+
+    ``user`` -> ``~/.codex/hooks.json`` · ``repo`` -> ``<project_root>/.codex/hooks.json``.
+
+    Raises:
+        ValueError: if *scope* is not ``"user"`` or ``"repo"`` (``"plugin"`` is not
+            writable here — the plugin owns its bundled hooks.json).
+    """
+    match scope:
+        case "user":
+            return Path.home() / ".codex" / "hooks.json"
+        case "repo":
+            return Path(project_root) / ".codex" / "hooks.json"
+        case _:
+            raise ValueError(f"Unknown Codex scope {scope!r}; expected 'user' or 'repo'.")
+
+
+def codex_hook_install_states(project_root: str) -> list[tuple[str, str, bool]]:
+    """Report, per Codex scope, whether Doberman's hook is wired in.
+
+    Returns ``(scope, path, installed)`` for ``user`` / ``repo`` / ``plugin``.
+    **Never raises:** an unreadable or unparseable hooks.json is reported as
+    *not installed* rather than crashing ``status`` / ``doctor``.
+    """
+    states: list[tuple[str, str, bool]] = []
+    for scope in ("user", "repo"):
+        path = resolve_codex_hooks_path(scope, project_root)
+        installed = False
+        try:
+            settings = load_settings(path)
+            hooks_section = settings.get("hooks") or {}
+            installed = any(
+                _is_doberman_group(group)
+                for groups in hooks_section.values()
+                if isinstance(groups, list)
+                for group in groups
+            )
+        except Exception:  # noqa: BLE001,S110 — a bad hooks.json must not crash the caller
+            pass
+        states.append((scope, str(path), installed))
+    states.append(("plugin", str(_PLUGIN_ROOT), _plugin_installed()))
+    return states
+
+
+def _plugin_installed() -> bool:
+    """Best-effort read-only probe: is a Doberman plugin's bundled hooks.json
+    present in Codex's plugin cache? False (never a guess) when the cache is
+    absent or unreadable — the plugin is added/removed via ``codex plugin``, not
+    this command."""
+    try:
+        if not _PLUGIN_ROOT.is_dir():
+            return False
+        for plugin_dir in _PLUGIN_ROOT.iterdir():
+            if "doberman" not in plugin_dir.name.lower():
+                continue
+            hooks_json = plugin_dir / "hooks.json"
+            if not hooks_json.is_file():
+                continue
+            settings = load_settings(hooks_json)
+            hooks_section = settings.get("hooks") or {}
+            if any(
+                _is_doberman_group(group)
+                for groups in hooks_section.values()
+                if isinstance(groups, list)
+                for group in groups
+            ):
+                return True
+    except Exception:  # noqa: BLE001,S110 — probing the cache must never crash the caller
+        pass
+    return False

--- a/src/doberman/hosthooks/singleflight.py
+++ b/src/doberman/hosthooks/singleflight.py
@@ -1,0 +1,130 @@
+"""Cross-channel single-flight for Codex hooks (W1.2).
+
+Doberman's Codex hooks can be installed two ways at once — a config-layer
+``~/.codex/hooks.json`` (``doberman install-hooks --host codex``) and a
+plugin-bundled ``hooks.json`` (the awesome-codex-plugins package). With both
+wired, Codex fires the PreToolUse hook **twice per tool call**: two AUTH
+prompts, two history rows, and doubled taint counters (``storage/taint.py``
+increments unconditionally). The first invocation records its final answer
+under a per-call marker; the second replays it byte-for-byte instead of
+re-evaluating.
+
+The dedupe key is the tool call's ``tool_use_id`` (a live capture confirmed each
+Codex tool call carries a stable ``"tool_use_id": "exec-<uuid>"`` that is
+identical across both hook channels for the same call — see
+``tests/fixtures/codex/README.md``).
+
+SECURITY MODEL: dedupe is a UX / observability concern, **never a gate**. Two
+layers, both keyed by :func:`doberman.storage.fingerprint.fingerprint` (a ``0600``
+HMAC key, itself glob-blocked ``**/*.key``):
+
+* The marker **name** is a keyed HMAC of the ``tool_use_id`` — an agent cannot
+  precompute a marker path and pre-seed an answer without the key.
+* The marker **content** carries a keyed MAC verified on read — so even a blind
+  overwrite of every ``doberman-sf-*`` file in the shared tempdir (an attacker
+  who can't derive the name but can enumerate the prefix) cannot spoof a replayed
+  verdict: a MAC mismatch is treated as no marker and the call is re-evaluated.
+
+Any marker read/write error, MAC mismatch, or expired marker falls through to a
+full duplicate evaluation (same verdict — safe), NEVER to a skipped one. The TTL
+is tight (older than 30s is dead) so a stale marker can never suppress a later
+genuine call.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+
+#: The payload key carrying Codex's per-tool-call identifier (live-captured:
+#: ``"tool_use_id": "exec-<uuid>"``). If a payload carries none, dedupe is off
+#: and a doubled install double-fires (documented in adapters/codex/README).
+EVENT_ID_KEY = "tool_use_id"
+
+_TTL_SECONDS = 30.0
+_ABSTAIN = "__DOBERMAN_ABSTAIN__"  # noqa: S105 — a sentinel string, not a credential
+
+
+def event_key(payload: dict) -> str | None:
+    """A keyed, non-derivable marker key for this tool call — or ``None`` (no dedupe).
+
+    ``None`` whenever the payload carries no ``tool_use_id`` or the HMAC key is
+    unavailable: dedupe simply does not engage, and each channel evaluates
+    independently (safe — same verdict, just not de-duplicated).
+    """
+    raw = payload.get(EVENT_ID_KEY)
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        from doberman.storage.fingerprint import fingerprint  # keyed HMAC, lazy
+
+        sid = payload.get("session_id") or ""
+        return fingerprint(f"codex-event:{sid}:{raw}")[:32]
+    except Exception:  # noqa: BLE001 — no key material -> no dedupe (safe)
+        return None
+
+
+def _marker_path(key: str) -> str:
+    return os.path.join(tempfile.gettempdir(), f"doberman-sf-{key}")
+
+
+def _content_mac(content: str) -> str | None:
+    """Keyed MAC over a marker's content, or ``None`` if the key is unavailable."""
+    try:
+        from doberman.storage.fingerprint import fingerprint  # keyed HMAC, lazy
+
+        return fingerprint(f"codex-sf-content:{content}")[:32]
+    except Exception:  # noqa: BLE001 — no key -> cannot verify -> caller re-evaluates
+        return None
+
+
+def replay(key: str | None) -> str | None:
+    """The first invocation's recorded answer, or ``None`` to evaluate normally.
+
+    Returns ``""`` when the first invocation abstained (the caller maps that back
+    to "print nothing"), the recorded JSON string when it produced output, or
+    ``None`` when there is no *trustworthy* live marker — missing, expired, a read
+    error, or a **content-MAC mismatch** (a tampered / forged marker). In every
+    ``None`` case the caller evaluates from scratch (fail-safe).
+    """
+    if not key:
+        return None
+    path = _marker_path(key)
+    try:
+        if time.time() - os.path.getmtime(path) > _TTL_SECONDS:
+            return None
+        with open(path, encoding="utf-8") as f:
+            raw = f.read()
+    except OSError:
+        return None
+    stored_mac, sep, content = raw.partition("\n")
+    if not sep:
+        return None  # malformed marker (no MAC line) -> re-evaluate
+    expected = _content_mac(content)
+    if expected is None or stored_mac != expected:
+        return None  # tampered / unverifiable -> re-evaluate (never trust it)
+    return "" if content == _ABSTAIN else (content or None)
+
+
+def record(key: str | None, answer: str | None) -> None:
+    """Persist this call's final answer (``None`` -> the abstain sentinel) with a
+    keyed content MAC.
+
+    Best-effort and atomic (write-temp-then-rename); any failure (including an
+    unavailable MAC key) just means the other channel re-evaluates instead of
+    replaying — never a wrong verdict.
+    """
+    if not key:
+        return
+    content = _ABSTAIN if answer is None else answer
+    mac = _content_mac(content)
+    if mac is None:
+        return  # no key -> don't write an unverifiable marker (the peer re-evaluates)
+    try:
+        fd, tmp = tempfile.mkstemp(dir=tempfile.gettempdir(), prefix="doberman-sf-")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(f"{mac}\n{content}")
+        os.replace(tmp, _marker_path(key))
+    except OSError:
+        pass

--- a/tests/unit/test_codex_singleflight.py
+++ b/tests/unit/test_codex_singleflight.py
@@ -1,0 +1,139 @@
+"""Cross-channel single-flight for Codex hooks (W1.2).
+
+When both install channels are wired, Codex fires the PreToolUse hook twice per
+tool call; the second invocation must replay the first's answer instead of
+re-evaluating (no doubled AUTH prompt / history row / taint bump). Keyed on the
+captured ``tool_use_id``, with a keyed-MAC over the marker content so a tampered
+marker is re-evaluated rather than trusted.
+
+The marker name AND content MAC both use the keyed fingerprint, so every test
+that exercises ``event_key`` / ``record`` / ``replay`` requests the
+``isolated_fingerprint_key`` fixture (conftest) for a deterministic, xdist-safe
+key. The no-key / no-id fail-safe path is covered without it.
+"""
+
+import json
+import os
+import time
+import uuid
+
+from doberman.hosthooks import codex, singleflight
+
+
+def _payload(tmp_path, tool_use_id=None):
+    # Unique tool_use_id + session per test so a leftover marker from a prior run
+    # (TTL 30s) can't pre-satisfy replay.
+    return {
+        "tool_name": "Bash",
+        "tool_input": {"command": "rm -rf /"},
+        "cwd": str(tmp_path),
+        "session_id": "sess-" + uuid.uuid4().hex,
+        singleflight.EVENT_ID_KEY: tool_use_id or ("exec-" + uuid.uuid4().hex),
+    }
+
+
+def test_event_id_key_matches_capture():
+    # The dedupe key is the captured per-call id, not the plan's placeholder.
+    assert singleflight.EVENT_ID_KEY == "tool_use_id"
+
+
+def test_second_invocation_replays_first_answer(tmp_path, monkeypatch, isolated_fingerprint_key):
+    calls = {"n": 0}
+    real = codex.evaluate_pre
+
+    def counting(payload):
+        calls["n"] += 1
+        return real(payload)
+
+    monkeypatch.setattr(codex, "evaluate_pre", counting)
+    # Pin a deterministic marker key so this end-to-end replay test doesn't depend
+    # on event_key's fingerprint call being stable across xdist workers (that path
+    # is covered by test_event_key_is_keyed_not_raw). record/replay + the content
+    # MAC still run for real (isolated_fingerprint_key provides the MAC key).
+    fixed_key = "sf-e2e-" + uuid.uuid4().hex
+    monkeypatch.setattr(singleflight, "event_key", lambda _payload: fixed_key)
+    text = json.dumps(_payload(tmp_path))
+
+    first = codex.run_codex_pre(text)
+    second = codex.run_codex_pre(text)
+
+    assert calls["n"] == 1, "one evaluation per tool call, even with both channels installed"
+    assert first == second, "the second channel replays the first's answer byte-for-byte"
+    # rm -rf / is a hard BLOCK -> both channels deny.
+    assert json.loads(first)["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_no_event_id_means_no_dedupe_and_full_evaluation(tmp_path, monkeypatch):
+    calls = {"n": 0}
+    real = codex.evaluate_pre
+
+    def counting(payload):
+        calls["n"] += 1
+        return real(payload)
+
+    monkeypatch.setattr(codex, "evaluate_pre", counting)
+    p = _payload(tmp_path)
+    del p[singleflight.EVENT_ID_KEY]
+    text = json.dumps(p)
+
+    first = codex.run_codex_pre(text)
+    second = codex.run_codex_pre(text)
+
+    assert calls["n"] == 2, "no tool_use_id -> no dedupe -> each channel evaluates"
+    assert first is not None and second is not None  # still denied, never skipped
+
+
+def test_event_key_is_none_without_id(tmp_path):
+    p = _payload(tmp_path)
+    del p[singleflight.EVENT_ID_KEY]
+    assert singleflight.event_key(p) is None
+
+
+def test_event_key_is_keyed_not_raw(tmp_path, isolated_fingerprint_key):
+    tuid = "exec-marker-visible-123"
+    key = singleflight.event_key(_payload(tmp_path, tool_use_id=tuid))
+    assert key is not None
+    assert tuid not in key  # keyed HMAC digest, never the raw id
+
+
+def test_replay_none_without_key():
+    assert singleflight.replay(None) is None
+
+
+def test_record_then_replay_roundtrip(isolated_fingerprint_key):
+    key = "unit-sf-" + uuid.uuid4().hex
+    assert singleflight.replay(key) is None  # nothing recorded yet
+    singleflight.record(key, '{"x": 1}')
+    assert singleflight.replay(key) == '{"x": 1}'
+    # An abstain (None) round-trips to "" (the caller maps that to "print nothing").
+    key2 = "unit-sf-" + uuid.uuid4().hex
+    singleflight.record(key2, None)
+    assert singleflight.replay(key2) == ""
+
+
+def test_expired_marker_is_ignored(isolated_fingerprint_key):
+    key = "unit-sf-" + uuid.uuid4().hex
+    singleflight.record(key, '{"x": 1}')
+    path = singleflight._marker_path(key)
+    old = time.time() - (singleflight._TTL_SECONDS + 5)
+    os.utime(path, (old, old))  # backdate past the TTL
+    assert singleflight.replay(key) is None  # stale marker -> re-evaluate
+
+
+def test_tampered_marker_content_is_rejected(isolated_fingerprint_key):
+    # A blind overwrite of the marker (attacker who can't forge the keyed MAC)
+    # must not be trusted — replay returns None so the call is re-evaluated.
+    key = "unit-sf-" + uuid.uuid4().hex
+    singleflight.record(key, '{"hookSpecificOutput": {"permissionDecision": "deny"}}')
+    path = singleflight._marker_path(key)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write('deadbeef\n{"hookSpecificOutput": {"permissionDecision": "allow"}}')
+    assert singleflight.replay(key) is None  # forged content rejected, never replayed
+
+
+def test_missing_key_writes_no_marker(monkeypatch):
+    # With no MAC key available, record must not write an unverifiable marker.
+    monkeypatch.setattr(singleflight, "_content_mac", lambda _c: None)
+    key = "unit-sf-" + uuid.uuid4().hex
+    singleflight.record(key, '{"x": 1}')
+    assert not os.path.exists(singleflight._marker_path(key))

--- a/tests/unit/test_install_hooks_codex.py
+++ b/tests/unit/test_install_hooks_codex.py
@@ -1,0 +1,138 @@
+"""Install/uninstall Doberman's Codex hook into a hooks.json (W1.2).
+
+Mirrors ``test_install_hooks.py`` (Claude Code) for the Codex-shaped hooks.json:
+idempotent merge, foreign-entry preservation, no-op remove, scope path
+resolution, ``.bak`` backup on overwrite, unparseable-file error, and a
+never-raising install-state report.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from doberman.hosthooks.install import load_settings, write_settings
+from doberman.hosthooks.install_codex import (
+    CODEX_PRE_ENTRY,
+    codex_hook_install_states,
+    merge_codex_hooks,
+    remove_codex_hooks,
+    resolve_codex_hooks_path,
+)
+
+
+def test_merge_adds_pretooluse_group():
+    merged = merge_codex_hooks({})
+    groups = merged["hooks"]["PreToolUse"]
+    assert CODEX_PRE_ENTRY in groups
+    assert groups[-1]["hooks"][0]["command"] == "doberman hook codex-pre"
+
+
+def test_merge_is_idempotent():
+    once = merge_codex_hooks({})
+    twice = merge_codex_hooks(once)
+    doberman_groups = [
+        g
+        for g in twice["hooks"]["PreToolUse"]
+        if g.get("hooks", [{}])[0].get("command") == "doberman hook codex-pre"
+    ]
+    assert len(doberman_groups) == 1  # replaced, never duplicated
+
+
+def test_merge_preserves_foreign_entries():
+    existing = {
+        "hooks": {
+            "PreToolUse": [
+                {"matcher": "Bash", "hooks": [{"type": "command", "command": "some-other-tool"}]}
+            ],
+            "Stop": [{"hooks": [{"type": "command", "command": "upload.sh"}]}],
+        },
+        "other_key": 42,
+    }
+    merged = merge_codex_hooks(existing)
+    commands = [h["command"] for g in merged["hooks"]["PreToolUse"] for h in g["hooks"]]
+    assert "some-other-tool" in commands  # foreign PreToolUse group kept
+    assert "doberman hook codex-pre" in commands
+    assert merged["hooks"]["Stop"][0]["hooks"][0]["command"] == "upload.sh"  # foreign event kept
+    assert merged["other_key"] == 42
+
+
+def test_merge_does_not_mutate_input():
+    original = {"hooks": {"PreToolUse": []}}
+    merge_codex_hooks(original)
+    assert original == {"hooks": {"PreToolUse": []}}
+
+
+def test_remove_is_noop_when_absent():
+    settings = {"hooks": {"PreToolUse": [{"hooks": [{"command": "not-doberman"}]}]}}
+    assert remove_codex_hooks(settings) == settings
+
+
+def test_remove_strips_doberman_and_keeps_the_rest():
+    merged = merge_codex_hooks({"hooks": {"PreToolUse": [{"hooks": [{"command": "keep-me"}]}]}})
+    cleaned = remove_codex_hooks(merged)
+    commands = [h["command"] for g in cleaned["hooks"]["PreToolUse"] for h in g["hooks"]]
+    assert commands == ["keep-me"]
+
+
+def test_remove_drops_empty_hooks_key():
+    merged = merge_codex_hooks({})
+    cleaned = remove_codex_hooks(merged)
+    assert "hooks" not in cleaned  # only Doberman was present -> hooks removed entirely
+
+
+def test_resolve_paths():
+    user = resolve_codex_hooks_path("user", "/repo")
+    assert user == Path.home() / ".codex" / "hooks.json"
+    repo = resolve_codex_hooks_path("repo", "/repo")
+    assert repo == Path("/repo") / ".codex" / "hooks.json"
+
+
+def test_resolve_rejects_unknown_scope():
+    with pytest.raises(ValueError):
+        resolve_codex_hooks_path("local", "/repo")
+
+
+def test_write_backs_up_existing(tmp_path):
+    target = tmp_path / ".codex" / "hooks.json"
+    target.parent.mkdir(parents=True)
+    target.write_text('{"hooks": {}}', encoding="utf-8")
+    write_settings(target, merge_codex_hooks({}))
+    assert (target.with_suffix(".json.bak")).exists()  # prior content backed up
+    assert "doberman hook codex-pre" in target.read_text(encoding="utf-8")
+
+
+def test_unparseable_file_raises_clear_error(tmp_path):
+    bad = tmp_path / "hooks.json"
+    bad.write_text("NOT JSON", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_settings(bad)
+
+
+def test_codex_hook_install_states_reports_all_scopes(tmp_path):
+    (tmp_path / ".codex").mkdir()
+    write_settings(tmp_path / ".codex" / "hooks.json", merge_codex_hooks({}))
+    states = codex_hook_install_states(str(tmp_path))
+    assert [s for s, _, _ in states] == ["user", "repo", "plugin"]
+    repo = next(s for s in states if s[0] == "repo")
+    assert repo[2] is True  # the repo hooks.json we just wrote is detected
+
+
+def test_codex_hook_install_states_never_raises(tmp_path):
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".codex" / "hooks.json").write_text("NOT JSON", encoding="utf-8")
+    states = codex_hook_install_states(str(tmp_path))
+    assert [s for s, _, _ in states] == ["user", "repo", "plugin"]
+    repo = next(s for s in states if s[0] == "repo")
+    assert repo[2] is False  # unreadable reports not-installed, never crashes
+
+
+def test_round_trip_install_then_uninstall(tmp_path):
+    target = tmp_path / ".codex" / "hooks.json"
+    target.parent.mkdir(parents=True)
+    write_settings(target, merge_codex_hooks({}))
+    assert "doberman hook codex-pre" in target.read_text(encoding="utf-8")
+    write_settings(target, remove_codex_hooks(load_settings(target)))
+    assert "doberman hook codex-pre" not in target.read_text(encoding="utf-8")
+    # File stays valid JSON after removal.
+    json.loads(target.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Slice
Feature / Slice: two-hosts-one-spine — W1.2 (Codex install + single-flight dedupe + doctor) / Task 5

## What this PR does

Makes the Codex adapter installable and de-duplicated:

- **`doberman install-hooks --host codex`** (and `uninstall-hooks --host codex`) wires `doberman hook codex-pre` into a Codex hooks.json — `--global` → `~/.codex/hooks.json` (user), else `<repo>/.codex/hooks.json`. `--local` has no Codex equivalent and is rejected with a clear error; unknown `--host` errors. The Claude Code path is unchanged. The installer documents Codex's own hook-**trust** step (and the "verify it's live: ask Codex to `cat .env`" canary) rather than auto-trusting — trust is Codex's security gate, not ours to bypass.
- **Single-flight dedupe** (`hosthooks/singleflight.py`): with both install channels wired (config hooks.json + a plugin bundle), Codex fires the hook twice per tool call. The first invocation records its answer under a marker keyed to the captured `tool_use_id`; the second replays it byte-for-byte — no doubled AUTH prompt, history row, or taint bump. It is a UX/observability concern, **never a gate**: any missing/expired/tampered/keyless marker falls through to a full re-evaluation (fail-safe). The marker name is a keyed HMAC (an agent can't derive the path) **and** the content carries a keyed MAC verified on read (a blind tempdir overwrite can't spoof a replayed verdict).
- **doctor**: `_check_hooks` now counts Codex scopes (`codex:user`/`codex:repo`); a new non-critical `_check_codex_version` reports the installed Codex CLI against the adapter's supported range (absent/newer → WARN, never a critical failure — Codex support is opt-in).

## Tests added (run in CI)
- `tests/unit/test_install_hooks_codex.py` — idempotent/foreign-preserving/non-mutating merge; no-op/strip/drop-empty remove; scope path resolution + ValueError; `.bak` on overwrite; unparseable → error; install-state reports all scopes + never raises; round-trip stays valid JSON.
- `tests/unit/test_codex_singleflight.py` — dedupe replays once (both channels), no-id → no dedupe, keyed-not-raw marker, record/replay roundtrip incl. abstain sentinel, **expired marker ignored**, **tampered content rejected**, keyless → no marker written.
- Full suite green (`-n auto`).

## Security checklist
- [x] Fails closed on error / uncertainty (dedupe never skips evaluation; a bad/forged/expired marker → re-evaluate)
- [x] No secret, full file, or unredacted prompt logged or committed (marker holds the hook's own JSON verdict + a keyed MAC; no arguments)
- [x] Any guardrail/learning change is raise-only (install/dedupe/doctor only; no verdict logic changed)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged; dedupe replays the same payload)

## Edge cases covered / Deviations from plan / Risks introduced
- **Captured-fact correction:** the dedupe key is `tool_use_id` (the plan guessed `event_id`) — the real per-call id, identical across both channels. `~/.codex/hooks.json` is auto-loaded (proven in the Task 4 capture), so user-scope install needs no config.toml edit.
- Dedupe is best-effort by design: a same-user attacker cannot forge a replay (keyed name + keyed content MAC), and any doubt fails safe to re-evaluation.
- Operational note (fixtures README): a user-scope `~/.codex/hooks.json` intercepts every running Codex session — the canary lane (Task 9) accounts for this.
