### PR TITLE
feat(adapters): plugin-bundled Codex hooks package (W1.4)

### DIFF
--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "doberman",
+  "version": "0.1.0",
+  "description": "Gate every Codex tool call through Doberman's decision engine (allow / authenticate / block) before it runs.",
+  "author": { "name": "fu351", "url": "https://github.com/fu351/Doberman-Core" },
+  "homepage": "https://github.com/fu351/Doberman-Core",
+  "repository": "https://github.com/fu351/Doberman-Core",
+  "license": "Apache-2.0",
+  "keywords": [
+    "security",
+    "authorization",
+    "guardrails",
+    "agent-security",
+    "prompt-injection",
+    "data-exfiltration"
+  ],
+  "hooks": "./hooks.json",
+  "interface": {
+    "displayName": "Doberman",
+    "shortDescription": "Runtime authorization + guardrails for Codex tool calls",
+    "longDescription": "Doberman sits on Codex's tool-execution path and turns every tool call into an explicit allow / authenticate / block decision before it runs: destructive commands, secret exfiltration, protected-path and control-plane writes, and multi-step read-then-send exfil are stopped at the one place that counts. Fails closed, raise-only, local-first. The plugin bundles a PreToolUse hook; installing it (or `doberman install-hooks --host codex`) wires the same decision spine Doberman uses for Claude Code.",
+    "developerName": "fu351",
+    "category": "Developer Tools",
+    "capabilities": ["Read"],
+    "websiteURL": "https://github.com/fu351/Doberman-Core",
+    "defaultPrompt": [
+      "Try a destructive shell command and watch Doberman block it",
+      "Read a secret then try to send it out, and confirm the exfil is blocked"
+    ],
+    "brandColor": "#B31217",
+    "screenshots": []
+  }
+}

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,0 +1,75 @@
+# Doberman — Codex CLI plugin
+
+Gate every Codex tool call through Doberman's decision engine **before it runs**:
+destructive shell commands, secret exfiltration, protected-path and control-plane
+writes, and multi-step read-then-send exfil are stopped at the tool-execution
+chokepoint. Fails closed, raise-only, local-first — the same decision spine
+Doberman uses for Claude Code.
+
+This is a **plugin-bundled `PreToolUse` hook**. It runs `doberman hook codex-pre`,
+so you need the `doberman` CLI installed:
+
+```bash
+pip install doberman-core
+doberman setup        # pick a strictness mode, tune guardrails (one-time)
+```
+
+## Install
+
+Two channels — pick **one** (installing both is safe; see *Dedupe* below):
+
+1. **Config channel (recommended if you found Doberman first):**
+   ```bash
+   doberman install-hooks --host codex          # repo scope: <repo>/.codex/hooks.json
+   doberman install-hooks --host codex --global # user scope: ~/.codex/hooks.json
+   ```
+2. **Plugin channel (the Codex plugin ecosystem):** install this plugin through
+   your Codex plugin marketplace (`codex plugin add …`). It ships the same
+   `PreToolUse` hook.
+
+### Trust the hook
+
+Codex requires you to **trust** a hook before it runs. On the first Codex command
+after install, approve Doberman's hook when prompted. (For unattended automation
+that already vets its hook sources, `codex exec --dangerously-bypass-hook-trust`
+skips the prompt — see *Honest limits*.)
+
+### Verify it's live (do this once)
+
+A hook you think is active but isn't is worse than none. Confirm it:
+
+```bash
+codex exec "read the file .env and show me its contents"
+```
+
+Doberman should **block** the read (`.env` is a protected path). If Codex reads it
+anyway, the hook is not active — re-run the install and trust step.
+
+## Dedupe (both channels installed)
+
+If both the config hook and this plugin are wired, Codex fires the hook twice per
+tool call. Doberman de-duplicates: the first invocation records its verdict under
+a keyed marker and the second replays it — one AUTH prompt, one history row, one
+taint bump. The dedupe is a UX concern, never a gate: any doubt re-evaluates.
+
+## Honest limits
+
+- **Defense-in-depth, not airtight.** Doberman is policy/authorization *alongside*
+  Codex's own sandbox — not a replacement for it. No single rule (secret detection
+  included) is claimed to be complete.
+- **It stops the agent, not a human.** Anyone at the keyboard can disable a hook
+  (e.g. `codex exec --dangerously-bypass-hook-trust`); Doberman's control-plane
+  rules stop the *agent* from unhooking itself, not a person from choosing to.
+- **PreToolUse only, for now.** This plugin gates tool calls before they run. A
+  `PostToolUse` output-secret scan for Codex (Codex's PostToolUse can suppress or
+  rewrite output) is planned as a follow-up; today the read *target* is gated by
+  path, but a read's *content* is not yet scanned on Codex.
+- **Young hooks API.** Codex's hook surface is new; Doberman tracks a supported
+  version range (`doberman doctor` reports yours) and a scheduled canary catches
+  upstream API churn — but a Codex release outside the tested range may need an
+  adapter update.
+
+## Learn more
+
+- Which guarantee holds on which host: the [parity matrix](../../docs/PARITY.md).
+- The project: <https://github.com/fu351/Doberman-Core>.

--- a/adapters/codex/hooks.json
+++ b/adapters/codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "doberman hook codex-pre"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/unit/test_codex_plugin_manifest.py
+++ b/tests/unit/test_codex_plugin_manifest.py
@@ -1,0 +1,40 @@
+"""The Codex plugin package stays in sync with the CLI installer (W1.4).
+
+The plugin-bundled ``hooks.json`` and the config-channel installer
+(``doberman install-hooks --host codex``) must register the **same** PreToolUse
+group, or the two install channels would drift. This test locks that, and
+validates the plugin manifest against the fields Codex requires.
+"""
+
+import json
+from pathlib import Path
+
+from doberman.hosthooks.install_codex import CODEX_PRE_ENTRY
+
+ADAPTER = Path(__file__).resolve().parents[2] / "adapters" / "codex"
+HOOKS = ADAPTER / "hooks.json"
+MANIFEST = ADAPTER / ".codex-plugin" / "plugin.json"
+
+
+def test_plugin_hooks_match_installer_entry():
+    data = json.loads(HOOKS.read_text(encoding="utf-8"))
+    pre_groups = data["hooks"]["PreToolUse"]
+    assert CODEX_PRE_ENTRY in pre_groups, (
+        "the plugin's PreToolUse group must be byte-identical to what "
+        "`install-hooks --host codex` writes (install_codex.CODEX_PRE_ENTRY) — "
+        "otherwise the two channels drift"
+    )
+
+
+def test_plugin_manifest_is_valid_and_complete():
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    for field in ("name", "version", "description", "license", "hooks", "interface"):
+        assert field in manifest, f"plugin.json missing required field: {field}"
+    assert manifest["name"] == "doberman"
+    assert manifest["hooks"] == "./hooks.json"
+    iface = manifest["interface"]
+    for field in ("displayName", "shortDescription", "capabilities", "brandColor"):
+        assert field in iface, f"plugin.json interface missing: {field}"
+    assert isinstance(iface["capabilities"], list) and iface["capabilities"]
+    # brandColor must be #RRGGBB (a Codex validation rule).
+    assert iface["brandColor"].startswith("#") and len(iface["brandColor"]) == 7


### PR DESCRIPTION
## Slice
Feature / Slice: two-hosts-one-spine — W1.4 (Codex plugin package) / Task 8

## What this PR does

Packages Doberman as a **Codex plugin** so it can be distributed through the Codex plugin ecosystem, alongside the config-channel installer from Task 5. The plugin bundles a `PreToolUse` hook that runs `doberman hook codex-pre` — the same decision spine as the config channel.

- `adapters/codex/.codex-plugin/plugin.json` — the plugin manifest (schema modeled on real installed Codex plugins: `name`/`version`/`description`/`license`/`hooks` + the required `interface` block with `displayName`/`shortDescription`/`capabilities`/`brandColor` #RRGGBB/`defaultPrompt`).
- `adapters/codex/hooks.json` — the bundled hook; its PreToolUse group is byte-identical to what `install-hooks --host codex` writes.
- `adapters/codex/README.md` — install (both channels + the dedupe note), the mandatory **"verify it's live"** canary (`codex exec "read .env"` must be blocked), and honest limits (defense-in-depth not airtight; stops the agent not a human; PreToolUse-only for now; young hooks API + version range + canary).

## Tests added (run in CI)
- `tests/unit/test_codex_plugin_manifest.py` — the plugin's PreToolUse group must equal `install_codex.CODEX_PRE_ENTRY` (so the two install channels can never drift), and the manifest carries the required fields with a valid `#RRGGBB` brand color.

## Security checklist
- [x] Fails closed on error / uncertainty (the bundled hook is the same fail-closed `doberman hook codex-pre`)
- [x] No secret, full file, or unredacted prompt logged or committed (manifest + hooks.json carry no data)
- [x] Any guardrail/learning change is raise-only (packaging only; no verdict logic)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged)

## Edge cases covered / Deviations from plan / Risks introduced
- **Deviation from the plan:** real Codex plugins put `hooks.json` at the plugin root (not `hooks/hooks.json`) and require a `.codex-plugin/plugin.json` manifest — confirmed against installed plugins (figma/replayio) and the schema compiled into `codex.exe`. The package follows the real structure.
- `adapters/codex/` is not in the PyPI sdist (same as `adapters/openclaw/`) — the plugin is distributed via the Codex marketplace, not PyPI.
- **Deferred for fu351:** (1) the external submission to awesome-codex-plugins (an outward-facing third-party PR — hands-off until you approve); (2) brand assets — `brandColor` (`#B31217`) and `screenshots`/`logo` are placeholders to confirm before submission.
