### PR TITLE
docs: publish benchmark methodology + synthetic results + release checklist (W4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ It reports two plugin profiles — `builtins_only` and `with_plugins` (built-ins
 
 > Reports hold counts, verdicts, and reason codes only — never payload text. ASR is reported alongside a stricter `asr_strict` (where only a hard `BLOCK` counts as mitigation): honest measurement, not a single headline number.
 
+Published results, methodology, and the reproduce commands — **failure cases before wins** — live in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md); numbers refresh per release ([`docs/RELEASING.md`](docs/RELEASING.md)).
+
 ---
 
 ## Write a custom Guardrail (plugin)

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,105 @@
+# Benchmarks
+
+Doberman's protection claims should resolve to a number you can reproduce, not an
+adjective. This page documents how the numbers are produced, what they can and
+cannot show, and the results — **failure cases before wins**, on purpose.
+
+## Methodology & preconditions (read first)
+
+Doberman is evaluated as a **decision function over tool-call cases**, not by
+driving a live LLM agent. Each benchmark case is a tool call (or an ordered
+multi-step sequence) labelled `benign` or `attack`; the harness replays it through
+the real engine and records the verdict (PASS / AUTH / BLOCK). No model is called,
+so the numbers are deterministic and cost nothing to reproduce.
+
+The metrics:
+
+- **ASR (attack success rate)** — the fraction of attacks that reach the tool. A
+  hard `BLOCK` counts as stopped. `AUTH` counts as *not silently succeeded* in
+  `asr`, but `asr_strict` counts only hard blocks as stopped (an AUTH is not a
+  block — a human still has to say no).
+- **FPR (false-positive rate)** — the fraction of benign cases that get friction
+  (`AUTH`/`BLOCK`). `hard_fpr` counts only benign cases hard-blocked.
+- **Operator metrics** — the honest part. `effective_asr_deny` / `_approve` bound
+  the outcome if the human always denies vs. always approves an AUTH;
+  `asr_under_fatigue` and `auth_burden` model a human who rubber-stamps some
+  fraction. An AUTH-heavy defense is only as strong as the human answering it.
+
+Two profiles are compared: `no_guardrail` (the unmediated tool path — every attack
+executes) and `builtins_only` (Doberman's built-in rules). `before_after` reports
+both plus the delta.
+
+### What these numbers can and cannot show
+
+- They measure the **objective, deterministic floor** — path/command/secret/egress
+  rules — on documented attack shapes. They do **not** measure the adaptive
+  subjective layer (that needs the warm proxy path), nor do they prove any single
+  rule is complete. Doberman is defense-in-depth, not airtight.
+- An `AUTH` verdict is a *human-in-the-loop* outcome, not a block. Read
+  `asr_strict` and the operator metrics alongside `asr`, or you will overstate the
+  protection.
+
+## Reproduce
+
+Synthetic suite — **from a cold clone, no extra dependencies, deterministic:**
+
+```bash
+pip install -e ".[dev]"
+python -m tests.benchmarks.run --suite synthetic --profile before_after
+```
+
+AgentDojo (the larger external suite) — **reproducible with the documented
+preconditions**, not from a cold clone (the harness keeps `agentdojo` a lazy,
+operator-supplied dependency so CI never depends on it, and vendors no suite data):
+
+```bash
+pip install agentdojo            # pin the commit you ran; record it below
+python -m tests.benchmarks.run --suite agentdojo --profile before_after
+```
+
+Numbers refresh **per release** as a documented release step (see
+[`RELEASING.md`](RELEASING.md)), not as a per-commit CI artifact.
+
+## What Doberman missed (failure cases)
+
+| Case class | On the synthetic suite | Why |
+|---|---|---|
+| Every synthetic attack | Stopped at **AUTH, not BLOCK** (`asr` 0.0 but `asr_strict` 1.0) | These attack shapes route to a human decision, not a hard block; a human who **approves** is not protected (`effective_asr_approve` = 1.0). |
+| Rubber-stamped AUTH | `asr_under_fatigue` = 0.8 | If the operator approves most prompts, most attacks still land. AUTH is a leash, not a wall. |
+| Scale | n = 3 attacks / 3 benign | The synthetic suite is a deterministic **CI smoke gate**, not a scale benchmark. Real coverage numbers come from the AgentDojo run below. |
+
+## Results
+
+### Synthetic suite (deterministic CI gate, n = 3 attack / 3 benign)
+
+Run: `python -m tests.benchmarks.run --suite synthetic --profile before_after` (2026-08-08, doberman-core 0.17.1).
+
+| Metric | Before (no guardrail) | After (Doberman built-ins) |
+|---|---|---|
+| ASR (silent success) | 1.00 (3/3 bypass) | **0.00** (0/3 bypass) |
+| ASR strict (hard block only) | 1.00 | 1.00 (all 3 → AUTH, not BLOCK) |
+| FPR (benign friction) | 0.00 | **0.00** (3/3 benign pass) |
+| Operator: deny-all / approve-all | 1.00 / 1.00 | **0.00** / 1.00 |
+
+Read honestly: on this tiny suite Doberman converts **every silent bypass into a
+human-gated AUTH with zero benign friction** — but it hard-blocks none of them, so
+the protection is exactly as strong as the human answering the prompt (`deny-all`
+stops everything; `approve-all` stops nothing). This is a smoke gate, not a
+coverage claim.
+
+### AgentDojo suite (extended, operator-supplied)
+
+_Pending an operator run — populated at release time per [`RELEASING.md`](RELEASING.md).
+Record the pinned `agentdojo` commit and the `before_after` table here._
+
+## Fixed bypasses
+
+Disclosed-and-fixed only (date · bypass class · fix PR). A privately-reported
+bypass stays held until it is fixed and shipped, then it is listed here.
+
+_None disclosed yet._
+
+## Non-goals
+
+No leaderboard infrastructure, no competitor comparisons. Reproducibility — and
+listing the failure cases before the wins — is the point.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,40 @@
+# Releasing Doberman-Core
+
+The checklist for cutting a release. The goal is that every published claim
+resolves to something in the repo — a test, a parity cell, or a reproducible
+number — at the moment of release.
+
+## Before tagging
+
+1. **Green `main`.** CI green on `main`: `ruff check .`, `ruff format --check .`,
+   `lint-imports`, `pytest -n auto --cov-fail-under=…`, the parity `--check` step,
+   and the secret scan.
+2. **Parity matrix current.** `python -m tools.parity.generate_parity --check`
+   passes (CI enforces it). Every ✅ in [`PARITY.md`](PARITY.md) still resolves to
+   a collected test.
+3. **Refresh the benchmark numbers.** Re-run the suites per
+   [`BENCHMARKS.md`](BENCHMARKS.md) and update its Results tables **in the release
+   PR**:
+   - Synthetic (deterministic, from a cold clone):
+     `python -m tests.benchmarks.run --suite synthetic --profile before_after`.
+   - AgentDojo (operator-supplied): `pip install agentdojo` at a pinned commit,
+     then `python -m tests.benchmarks.run --suite agentdojo --profile before_after`.
+     Record the pinned commit and the run date. Keep the raw run out of git
+     (`test-logs/`); transcribe only the aggregate numbers.
+   - Update the "Fixed bypasses" wall with anything disclosed-and-fixed since the
+     last release.
+4. **Version + changelog.** Bump `version` in `pyproject.toml`; move shipped items
+   into `CHANGELOG.md`; confirm the README roadmap/versioning reflects reality.
+5. **Docs sweep.** Every protection claim in the README resolves to a parity cell
+   or a benchmark number (no orphan adjectives).
+
+## Tag & publish
+
+6. Tag the release and let CI build/publish the artifact. The public core must
+   build, test, and run with **zero enterprise code installed** (the standalone
+   guarantee) — CI's standalone step enforces this.
+
+## After release
+
+7. Confirm the published artifact installs clean (`pip install doberman-core==<v>`
+   in a fresh venv) and `doberman doctor` runs.


### PR DESCRIPTION
## Slice
Feature / Slice: two-hosts-one-spine — W4 (published benchmarks) / Task 12

## What this PR does

Turns Doberman's protection numbers into something reproducible and honestly framed, per the design's rule: methodology and preconditions first, failure cases before wins.

- `docs/BENCHMARKS.md` — how the numbers are produced (Doberman scored as a deterministic decision function over labelled tool-call cases; no live model, so it's free and reproducible), what they can and cannot show (objective floor only, AUTH ≠ BLOCK, operator-fatigue caveat), the exact reproduce commands, a **failure-cases** table, results, a fixed-bypasses wall, and non-goals.
- `docs/RELEASING.md` — the release checklist, including the mandatory benchmark-refresh step (numbers refresh per release, not per commit).
- README links both from the Benchmark section.

## Real numbers included (synthetic suite)
Ran `python -m tests.benchmarks.run --suite synthetic --profile before_after` (2026-08-08, 0.17.1) and published the actual result, honestly caveated: Doberman converts all 3 silent bypasses into human-gated **AUTH** (asr 1.00 → 0.00) with **zero** benign friction (fpr 0.00) — but hard-blocks none of them (`asr_strict` stays 1.00), so protection equals the human answering the prompt (`deny-all` 0.00 / `approve-all` 1.00). It's a deterministic CI smoke gate (n=3), presented as such, not a coverage claim.

## Deferred for you (needs a decision / operator run)
The **AgentDojo** extended numbers are left as a documented operator run (`pip install agentdojo` at a pinned commit → `python -m tests.benchmarks.run --suite agentdojo`). The adapter never calls a live model, so there's **no API spend** — but the install is heavy and publishing extended benchmark numbers publicly is your call, so BENCHMARKS.md marks that section "pending an operator run" with the exact command, and RELEASING.md makes refreshing it a release step.

## Tests added (run in CI)
- None — docs-only change (no executable code touched). The benchmark harness and its synthetic-gate test already exist and are unchanged.

## Security checklist
- [x] Fails closed on error / uncertainty (N/A — docs)
- [x] No secret, full file, or unredacted prompt logged or committed (reports hold counts/verdicts/reason codes only; no payload text, per the harness design)
- [x] Any guardrail/learning change is raise-only (docs only)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged)

## Edge cases covered / Deviations from plan / Risks introduced
- Honest framing throughout: the synthetic result leads with the AUTH-not-BLOCK caveat and the operator-fatigue metric rather than a flattering headline.
- No competitor comparisons, no leaderboard (design non-goals).
