### PR TITLE
feat(cli): status --json and sectioned text output

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -472,68 +472,22 @@ def _hook_install_states(path: str) -> list[tuple[str, str, bool]]:
     return hook_install_states(path)
 
 
-@app.command(rich_help_panel="Daily")
-def status(
-    path: str = typer.Option(".", "--path", "-p", help="Repository root."),
-) -> None:
-    """Show the active role, security mode, policy summary, hook install state,
-    taint state, and the most recent decisions."""
+def _status_payload(path: str) -> dict:
+    """Collect the same redacted data the text and JSON status views share.
+
+    Nothing secret-shaped is included: enrollment is a boolean, elevations carry
+    ids/scopes/expiry only, decisions carry ts/verdict/reason codes only.
+    """
     role = load_active_role(path)
     doc = load_policy(path)
-    typer.echo("Doberman status")
-    typer.echo("=" * 32)
-    typer.echo(f"Version: {__version__}")
-    typer.echo(f"Role:   {role.name if role else '(none - role enforcement off)'}")
-    typer.echo(f"Mode:   {load_mode(path)}  (of: {', '.join(m.value for m in SecurityMode)})")
     vector = load_preferences(path)
-    typer.echo(
-        "Prefs:  "
-        + "  ".join(f"{name}={getattr(vector, name):.2f}" for name in DIMENSIONS)
-        + f"  (preset: {preset_name(vector) or 'custom'})"
-    )
-    if doc is None:
-        typer.echo("Policy: (none saved - run `doberman review --yes`)")
-    else:
-        enabled = sum(1 for it in doc.items if it.enabled)
-        typer.echo(f"Policy: {enabled}/{len(doc.items)} items enabled")
-
-    twofa_status = "yes" if totp.is_enrolled() else "no"
-    typer.echo(f"2FA:    {twofa_status} (optional; run `doberman 2fa setup`)")
-    password_status = "yes" if password.is_enrolled() else "no (run `doberman password set`)"
-    typer.echo(f"Password: {password_status}")
-
+    mode = load_mode(path)
+    twofa = totp.is_enrolled()
+    password_enrolled = password.is_enrolled()
     grants = asyncio.run(active_elevations(path, datetime.now(timezone.utc)))
-    if not grants:
-        typer.echo("Elevations: (none active)")
-    else:
-        typer.echo(f"Elevations: {len(grants)} active")
-        for grant in grants:
-            kind = "single-use" if grant.single_use else "reusable"
-            typer.echo(
-                f"  {grant.id}  {grant.scope_glob}  "
-                f"(expires {grant.expires_at.isoformat()}; {kind})"
-            )
-
     taints = asyncio.run(read_taint(path, entity_scope(path)))
-    if not taints:
-        typer.echo("Taint: (none)")
-    else:
-        typer.echo(f"Taint: {', '.join(f'{kind}={count}' for kind, count in taints.items())}")
-
-    typer.echo("Hooks:")
-    for scope, settings_path, installed in _hook_install_states(path):
-        state = "installed" if installed else "not installed"
-        typer.echo(f"  {scope:<8} {settings_path}  [{state}]")
-
-    typer.echo("Recent decisions:")
-    rows = asyncio.run(read_decisions(path, limit=5))
-    if not rows:
-        typer.echo("  (no decisions recorded yet)")
-    else:
-        for row in rows:
-            reasons = ", ".join(json.loads(row["reason_codes_json"] or "[]")) or "-"
-            typer.echo(f"  {row['ts']}  {verdict_label_str(row['final_verdict'])}  {reasons}")
-
+    hook_states = _hook_install_states(path)
+    recent_rows = asyncio.run(read_decisions(path, limit=5))
     cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
     missed_challenges = 0
     for row in asyncio.run(read_decisions(path, limit=200)):
@@ -545,11 +499,153 @@ def status(
                 missed_challenges += 1
         except (TypeError, ValueError):
             continue
-    if missed_challenges:
-        typer.echo(
-            f"warning: {missed_challenges} challenge(s) auto-denied in the last 24h - "
-            "see doberman log"
+
+    policy: dict | None
+    if doc is None:
+        policy = None
+    else:
+        enabled = sum(1 for it in doc.items if it.enabled)
+        policy = {"enabled": enabled, "total": len(doc.items)}
+
+    recent_decisions: list[dict] = []
+    for row in recent_rows:
+        try:
+            reasons = json.loads(row["reason_codes_json"] or "[]")
+        except json.JSONDecodeError:
+            reasons = []
+        recent_decisions.append(
+            {
+                "ts": row["ts"],
+                "final_verdict": row["final_verdict"],
+                "reason_codes": reasons,
+            }
         )
+
+    return {
+        "version": 1,
+        "path": path,
+        "doberman_version": __version__,
+        "role": role.name if role else None,
+        "mode": mode,
+        "prefs": {name: getattr(vector, name) for name in DIMENSIONS},
+        "prefs_preset": preset_name(vector) or "custom",
+        "policy": policy,
+        "twofa": twofa,
+        "password": password_enrolled,
+        "elevations": [
+            {
+                "id": grant.id,
+                "scope_glob": grant.scope_glob,
+                "expires_at": grant.expires_at.isoformat(),
+                "single_use": grant.single_use,
+            }
+            for grant in grants
+        ],
+        "taint": dict(taints) if taints else {},
+        "hooks": [
+            {"scope": scope, "path": settings_path, "installed": installed}
+            for scope, settings_path, installed in hook_states
+        ],
+        "recent_decisions": recent_decisions,
+        "missed_challenges_24h": missed_challenges,
+    }
+
+
+def _render_status_text(payload: dict) -> None:
+    """Human view: one blank line between each status block."""
+    modes = ", ".join(m.value for m in SecurityMode)
+    typer.echo("Doberman status")
+    typer.echo("=" * 32)
+    typer.echo(f"Version: {payload['doberman_version']}")
+    typer.echo("")
+
+    role = payload["role"]
+    typer.echo(f"Role:   {role if role else '(none - role enforcement off)'}")
+    typer.echo("")
+
+    typer.echo(f"Mode:   {payload['mode']}  (of: {modes})")
+    typer.echo("")
+
+    prefs = payload["prefs"]
+    typer.echo(
+        "Prefs:  "
+        + "  ".join(f"{name}={prefs[name]:.2f}" for name in DIMENSIONS)
+        + f"  (preset: {payload['prefs_preset']})"
+    )
+    typer.echo("")
+
+    policy = payload["policy"]
+    if policy is None:
+        typer.echo("Policy: (none saved - run `doberman review --yes`)")
+    else:
+        typer.echo(f"Policy: {policy['enabled']}/{policy['total']} items enabled")
+    typer.echo("")
+
+    twofa_status = "yes" if payload["twofa"] else "no"
+    typer.echo(f"2FA:    {twofa_status} (optional; run `doberman 2fa setup`)")
+    typer.echo("")
+
+    enrolled = "yes" if payload["password"] else "no (run `doberman password set`)"
+    typer.echo(f"Password: {enrolled}")
+    typer.echo("")
+
+    elevations = payload["elevations"]
+    if not elevations:
+        typer.echo("Elevations: (none active)")
+    else:
+        typer.echo(f"Elevations: {len(elevations)} active")
+        for grant in elevations:
+            kind = "single-use" if grant["single_use"] else "reusable"
+            typer.echo(
+                f"  {grant['id']}  {grant['scope_glob']}  (expires {grant['expires_at']}; {kind})"
+            )
+    typer.echo("")
+
+    taint = payload["taint"]
+    if not taint:
+        typer.echo("Taint: (none)")
+    else:
+        typer.echo(f"Taint: {', '.join(f'{kind}={count}' for kind, count in taint.items())}")
+    typer.echo("")
+
+    typer.echo("Hooks:")
+    for hook in payload["hooks"]:
+        state = "installed" if hook["installed"] else "not installed"
+        typer.echo(f"  {hook['scope']:<8} {hook['path']}  [{state}]")
+    typer.echo("")
+
+    typer.echo("Recent decisions:")
+    recent = payload["recent_decisions"]
+    if not recent:
+        typer.echo("  (no decisions recorded yet)")
+    else:
+        for row in recent:
+            reasons = ", ".join(row["reason_codes"]) or "-"
+            typer.echo(f"  {row['ts']}  {verdict_label_str(row['final_verdict'])}  {reasons}")
+
+    missed = payload["missed_challenges_24h"]
+    if missed:
+        typer.echo("")
+        typer.echo(f"warning: {missed} challenge(s) auto-denied in the last 24h - see doberman log")
+
+
+@app.command(rich_help_panel="Daily")
+def status(
+    path: str = typer.Option(".", "--path", "-p", help="Repository root."),
+    as_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit one deterministic JSON document on stdout instead of the sectioned text view.",
+    ),
+) -> None:
+    """Show the active role, security mode, policy summary, hook install state,
+    taint state, and the most recent decisions."""
+    payload = _status_payload(path)
+    if as_json:
+        # Same style as ``scan --json`` / ``doctor --json`` (#178 / #179).
+        typer.echo(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+        return
+    _render_status_text(payload)
 
 
 @app.command(rich_help_panel="Getting started")

--- a/tests/unit/test_cli_status.py
+++ b/tests/unit/test_cli_status.py
@@ -7,11 +7,13 @@ placeholder lines.
 """
 
 import asyncio
+import json
 from datetime import datetime, timezone
 
 from typer.testing import CliRunner
 
 from doberman import __version__
+from doberman.auth import totp
 from doberman.cli.main import app
 from doberman.hosthooks.install import (
     merge_doberman_hooks,
@@ -159,3 +161,83 @@ def test_status_shows_no_taint_by_default(tmp_path):
     result = runner.invoke(app, ["status", "--path", str(tmp_path)])
     assert result.exit_code == 0
     assert "Taint: (none)" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# #258 — status --json + sectioned text; secret never leaks
+# ---------------------------------------------------------------------------
+
+_EXPECTED_STATUS_KEYS = {
+    "version",
+    "path",
+    "doberman_version",
+    "role",
+    "mode",
+    "prefs",
+    "prefs_preset",
+    "policy",
+    "twofa",
+    "password",
+    "elevations",
+    "taint",
+    "hooks",
+    "recent_decisions",
+    "missed_challenges_24h",
+}
+
+
+def test_status_json_parses_with_expected_keys(tmp_path):
+    result = runner.invoke(app, ["status", "--path", str(tmp_path), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["version"] == 1
+    assert payload["path"] == str(tmp_path)
+    assert set(payload) == _EXPECTED_STATUS_KEYS
+    assert isinstance(payload["prefs"], dict)
+    assert isinstance(payload["elevations"], list)
+    assert isinstance(payload["hooks"], list)
+    assert isinstance(payload["recent_decisions"], list)
+    assert isinstance(payload["taint"], dict)
+    assert isinstance(payload["twofa"], bool)
+    assert isinstance(payload["password"], bool)
+    assert isinstance(payload["missed_challenges_24h"], int)
+    # deterministic separators / keys (mirror scan --json)
+    again = runner.invoke(app, ["status", "--path", str(tmp_path), "--json"])
+    assert again.stdout == result.stdout
+
+
+def test_status_text_has_blank_line_section_breaks(tmp_path):
+    result = runner.invoke(app, ["status", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    # Each major block is separated by a blank line so the dump scans as sections.
+    assert "\n\nRole:" in result.stdout
+    assert "\n\nMode:" in result.stdout
+    assert "\n\nPrefs:" in result.stdout
+    assert "\n\nPolicy:" in result.stdout
+    assert "\n\n2FA:" in result.stdout
+    assert "\n\nPassword:" in result.stdout
+    assert "\n\nElevations:" in result.stdout
+    assert "\n\nTaint:" in result.stdout
+    assert "\n\nHooks:" in result.stdout
+    assert "\n\nRecent decisions:" in result.stdout
+
+
+def test_status_never_leaks_enrolled_secret_in_either_view(tmp_path):
+    """A synthetic TOTP secret seeded into state must never appear in text or JSON."""
+    totp.enroll()
+    secret = totp._read_secret()
+    assert secret is not None and len(secret) >= 8
+
+    text = runner.invoke(app, ["status", "--path", str(tmp_path)])
+    assert text.exit_code == 0, text.output
+    assert secret not in text.stdout
+    assert secret not in text.output
+
+    js = runner.invoke(app, ["status", "--path", str(tmp_path), "--json"])
+    assert js.exit_code == 0, js.output
+    assert secret not in js.stdout
+    payload = json.loads(js.stdout)
+    # Enrollment is reported as a boolean, never the secret material.
+    assert payload["twofa"] is True
+    dumped = json.dumps(payload)
+    assert secret not in dumped


### PR DESCRIPTION
## Summary

Implements `doberman status --json` and blank-line sectioned text so status matches the machine-readable surface of `scan` / `doctor` / `log` / `policy-history`.

### `--json`
- One deterministic JSON document on stdout (`sort_keys=True`, compact separators), same style as `scan --json`.
- Shared `_status_payload()` so text and JSON cannot diverge on redaction.
- Top-level keys: `version`, `path`, `doberman_version`, `role`, `mode`, `prefs`, `prefs_preset`, `policy`, `twofa`, `password`, `elevations`, `taint`, `hooks`, `recent_decisions`, `missed_challenges_24h`.
- Enrollment is boolean only; elevations are id/scope/expiry; decisions are ts/verdict/reason codes.

### Text view
- Same content as before, with a blank line between each block (role, mode, prefs, policy, 2FA, password, elevations, taint, hooks, recent decisions) so the dump scans as sections.

## Tests
- `test_status_json_parses_with_expected_keys` — parses and has the full key set; deterministic across two runs.
- `test_status_text_has_blank_line_section_breaks` — section separators present.
- `test_status_never_leaks_enrolled_secret_in_either_view` — seeds a TOTP secret; asserts it never appears in text or JSON.

```bash
pytest tests/unit/test_cli_status.py -q
# 10 passed
ruff check src/doberman/cli/main.py tests/unit/test_cli_status.py
ruff format --check src/doberman/cli/main.py tests/unit/test_cli_status.py
```

Fixes #258