### PR TITLE
feat(secrets): detect PyPI API tokens

### DIFF
--- a/src/doberman/engine/rules/secrets.py
+++ b/src/doberman/engine/rules/secrets.py
@@ -67,6 +67,7 @@ _CREDENTIAL_PATTERNS: tuple[re.Pattern[str], ...] = (
     ),  # Stripe live/test secret/restricted key
     re.compile(r"SG\.[A-Za-z0-9_\-]{16,}\.[A-Za-z0-9_\-]{16,}"),  # SendGrid API key
     re.compile(r"npm_[A-Za-z0-9]{36}"),  # npm access token
+    re.compile(r"pypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{20,}"),  # PyPI API token
     # JWT: two base64url JSON segments (header/payload start with eyJ) + signature
     re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
     # DB / message-queue connection URI with embedded user:password credentials

--- a/tests/unit/test_rule_secrets.py
+++ b/tests/unit/test_rule_secrets.py
@@ -41,6 +41,7 @@ FAKE_SLACK_HOOK = (  # noqa: S105
 )
 FAKE_SENDGRID = "SG" + ".EXAMPLEabcdef0123456789" + ".EXAMPLE_ABCDEFGHIJ0123456789klmnop"  # noqa: S105
 FAKE_NPM = "npm" + "_" + "EXAMPLE" + "0123456789abcdefABCDEF0123456"  # noqa: S105
+FAKE_PYPI = "pypi-" + "AgEIcHlwaS5vcmc" + "EXAMPLE0123456789abcdefABCDEF0123456789"  # noqa: S105
 FAKE_DB_URI = "postgres://" + "dbuser:" + "EXAMPLEpass123" + "@db.internal:5432/app"  # noqa: S105
 # Modern provider key shapes the original _CREDENTIAL_PATTERNS missed (so they only
 # got AUTH-via-entropy, not BLOCK, on exfil). Built via `+` so push-protection/gitleaks
@@ -68,6 +69,7 @@ NEW_CREDENTIALS = [
     FAKE_SLACK_HOOK,
     FAKE_SENDGRID,
     FAKE_NPM,
+    FAKE_PYPI,
     FAKE_DB_URI,
     FAKE_ANTHROPIC,
     FAKE_OPENAI_PROJ,
@@ -80,6 +82,7 @@ BENIGN_LOOKALIKES = [
     "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",  # 40-hex git commit SHA
     "550e8400-e29b-41d4-a716-446655440000",  # a UUID
     "the words sk live and npm appear here but not as keys",
+    "pypi-something",  # a package name, not a PyPI token
 ]
 
 
@@ -254,18 +257,19 @@ def test_secret_store_path_to_external_destination_blocks():
     assert RULE.evaluate(action, _ctx(url="https://evil.example/.env")).verdict is Verdict.BLOCK
 
 
-def test_synthetic_secret_never_appears_in_verdict_output():
+@pytest.mark.parametrize("secret", [FAKE_AWS, FAKE_PYPI])
+def test_synthetic_secret_never_appears_in_verdict_output(secret):
     # The load-bearing redaction property for this rule.
     action = _action(
         ActionType.network_request,
         target="https://evil.example/x",
         dest="https://evil.example/x",
     )
-    result = RULE.evaluate(action, _ctx(url="https://evil.example/x", body=f"k={FAKE_AWS}"))
+    result = RULE.evaluate(action, _ctx(url="https://evil.example/x", body=f"k={secret}"))
     assert result.verdict is Verdict.BLOCK
     blob = result.explanation + " " + " ".join(result.reason_codes)
-    assert FAKE_AWS not in blob
-    assert "AKIA" not in blob
+    assert secret not in blob
+    assert secret.split("-")[0] not in blob
 
 
 def test_non_secret_high_entropy_local_does_not_block():
@@ -344,15 +348,16 @@ def test_pem_private_key_content_to_external_blocks():
     assert result.verdict is Verdict.BLOCK
 
 
-def test_detected_secret_is_fingerprinted_not_logged_in_plaintext(caplog):
+@pytest.mark.parametrize("secret", [FAKE_AWS, FAKE_PYPI])
+def test_detected_secret_is_fingerprinted_not_logged_in_plaintext(caplog, secret):
     import logging
 
     caplog.set_level(logging.DEBUG, logger="doberman.engine.rules.secrets")
     action = _action(ActionType.file_write, target="notes.txt")
-    RULE.evaluate(action, _ctx(path="notes.txt", content=f"k={FAKE_AWS}"))
+    RULE.evaluate(action, _ctx(path="notes.txt", content=f"k={secret}"))
     # The rule logs fingerprints (hmac:...) for recognition — never the plaintext.
-    assert FAKE_AWS not in caplog.text
-    assert "AKIA" not in caplog.text
+    assert secret not in caplog.text
+    assert secret.split("-")[0] not in caplog.text
     if caplog.records:  # a debug line was emitted
         assert "hmac:" in caplog.text
 


### PR DESCRIPTION
## Slice\n- Repo: doberman-core\n- Feature / Slice: issue #197 - PyPI API-token secret detection\n- Plan reference: issue #197\n\n## What this PR does\n\nAdds one conservative _CREDENTIAL_PATTERNS entry for modern PyPI API tokens, anchored to the documented pypi-AgEIcHlwaS5vcmc prefix and a base64url payload. It leaves every existing pattern and the existing verdict logic unchanged.\n\nThe tests add:\n- positive detection and external-exfiltration blocking\n- a benign pypi-something lookalike\n- redaction checks for the verdict and debug log\n\nCloses #197.\n\n## Tests added (run in CI)\n- python -m pytest -p no:recording tests/unit/test_rule_secrets.py -q (64 passed locally; the environment has incompatible pytest recording plugins, so the recording plugin was disabled)\n- python -m ruff check --select E,F,I,B,S src/doberman/engine/rules/secrets.py tests/unit/test_rule_secrets.py\n- python -m ruff format --check src/doberman/engine/rules/secrets.py tests/unit/test_rule_secrets.py\n- git diff --check\n\n## Public-release safety (doberman-core only)\n- [x] Contains nothing from the not allowed list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code\n- [x] Core still builds/tests/runs with NO enterprise package installed\n\n## Security checklist\n- [x] Fails closed on error / uncertainty\n- [x] No secret, full file, or unredacted prompt logged or committed\n- [x] Any guardrail/learning change is raise-only (no silent loosening)\n- [x] Every BLOCK/AUTH carries reason codes + a human explanation\n- [x] doberman-core does not import doberman_enterprise\n\n## Edge cases covered / Deviations from plan / Risks introduced\n- The pattern intentionally does not match legacy PyPI username/password credentials.\n- The test token is assembled from clearly synthetic pieces so no real credential is committed.\n- Full repository validation remains in CI; local Windows shutdown emits an unrelated native-library access-violation message after the focused tests pass.