### PR TITLE
ci: add Python 3.13 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         # Doberman is a local-first tool that runs on developer machines of every
         # OS, and it carries OS-specific code (e.g. the Windows O_BINARY key-write
         # path in storage/fingerprint.py). Guard that surface with one Windows leg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Security",
     "Topic :: Software Development :: Quality Assurance",
 ]


### PR DESCRIPTION
# Pull Request

Closes #211

## Slice
- Repo: doberman-core
- Feature / Slice: #211
- Plan reference: Issue #211

## What this PR does
- Adds Python 3.13 to the Ubuntu CI matrix
- Adds the Python 3.13 package classifier
- Keeps Python 3.11/3.12 support and the Windows 3.12 job unchanged

## Tests added (run in CI)
- No new tests, the existing suite now runs on Python 3.13
- Local suite: 2530 passed, 6 skipped, 91.63% coverage

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core builds, tests, and runs without the enterprise package

## Security checklist
- [x] No runtime or guardrail behavior changed
- [x] No secrets or sensitive data committed
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- No Python 3.13 compatibility fixes were required
- AI used to help testing / planning