### PR TITLE
fix(cli): standardize diagnostic severity prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
 - **New:** shell tab completion is enabled — `doberman --install-completion` (thanks @slegarraga, #280, closes #255)
 - **UX:** `--help` groups commands into panels — Getting started / Daily use / Policy & control / Auth & recovery / Advanced (thanks @slegarraga, #279, closes #259)
 - **UX:** `uninstall-hooks` now states what it leaves behind (`.doberman/`, `~/.doberman/metrics.db`, password/2FA enrollment), and `setup`'s next steps name the exit (thanks @slegarraga, #276, closes #256)
+- **UX:** CLI diagnostics now use one severity vocabulary: `error:` for non-zero failures, `warning:` for successful but skipped or degraded work, and `note:` for informational asides (#344)
 - **Docs:** docs/CLI.md documents `log --jsonl` (field allowlist, newest-first, empty-if-none) and the scan evidence 3-vs-10 display cap (thanks @AshSgDe29071999, #295, closes #223)
 - **New:** `WebhookAuditSink` — the first built-in concrete audit sink (F8.5). Drop a `.doberman/audit_webhook.yaml` (`url`, `auth_env`, `timeout_s`) and every redacted decision record is also POSTed to your own log pipeline. `emit()` never blocks the decision path (bounded queue, drop-oldest with a counted drop), HTTPS is required off-loopback, and the auth token is read from the named env var at POST time — never stored, never logged (thanks @Maqbool61, #317, closes #233)
 - **CI:** Python 3.13 joins the test matrix, and the package classifiers say so (thanks @jasperdingg, #328, closes #211)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Verdicts are colour-coded everywhere they're shown (`BLOCK` red, `AUTH` amber, `
 width. Colour is dropped automatically when output is piped or redirected, and honours
 [`NO_COLOR`](https://no-color.org) when that variable is set to a non-empty value.
 
+CLI diagnostics use one severity vocabulary: fatal failures start with `error:`, successful but
+degraded or skipped work starts with `warning:`, and informational asides start with `note:`.
+
 ---
 
 ## Verify it end-to-end

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -29,6 +29,13 @@ Entry point: `doberman` (Typer). All commands accept `--help`.
 
 Global option: `doberman --version` / `-V` also prints the version and exits.
 
+## Output conventions
+
+Human-readable diagnostics use one severity vocabulary: `error:` means the command failed and
+returned a non-zero exit code, `warning:` means the command succeeded but skipped or degraded
+something, and `note:` marks a purely informational aside. Machine-readable flags keep their
+documented schemas and do not add these prefixes.
+
 ## Auth enrollment
 
 Security-posture commands used by [SETUP.md](SETUP.md). Group entry points also appear in `doberman --help`.

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -700,7 +700,8 @@ def doctor(
     typer.echo("")
     if failures:
         typer.echo(
-            f"{len(failures)} critical check(s) not healthy - Doberman may not be protecting you."
+            f"error: {len(failures)} critical check(s) not healthy - "
+            "Doberman may not be protecting you."
         )
         raise typer.Exit(code=1)
     typer.echo("All critical checks passed.")

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -344,7 +344,7 @@ def mode(
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2) from exc
     if saved is None:
-        typer.echo("mode change denied; unchanged", err=True)
+        typer.echo("error: mode change denied; unchanged", err=True)
         raise typer.Exit(code=1)
     typer.echo(f"mode set to {saved}")
 
@@ -403,7 +403,7 @@ def enforcement(
         )
     )
     if not outcome.approved:
-        typer.echo("enforcement change denied; unchanged", err=True)
+        typer.echo("error: enforcement change denied; unchanged", err=True)
         raise typer.Exit(code=1)
     save_policy((load_policy(path) or recommend_policy()).with_enforcement(new), path)
     typer.echo(f"enforcement set to {new}")
@@ -454,7 +454,7 @@ def prefs(
         )
     )
     if not outcome.approved:
-        typer.echo("preference change denied; unchanged", err=True)
+        typer.echo("error: preference change denied; unchanged", err=True)
         raise typer.Exit(code=1)
     save_preferences(updated, path)
     typer.echo(f"{dimension} set to {value:.2f}")
@@ -874,7 +874,7 @@ def twofa_remove() -> None:
     if not prompter.confirm(
         "Remove 2FA? Policy weakenings will then be gated by your local password instead"
     ):
-        typer.echo("aborted; 2FA is unchanged", err=True)
+        typer.echo("error: aborted; 2FA is unchanged", err=True)
         raise typer.Exit(code=1)
     current_code = prompter.read_code("Current 2FA code")
     try:
@@ -953,7 +953,7 @@ def taint_clear(
         # raise here would be a traceback, not a denial.
         approved, method = False, "denied"
     if not approved:
-        typer.echo(f"taint clear denied ({method}); unchanged", err=True)
+        typer.echo(f"error: taint clear denied ({method}); unchanged", err=True)
         raise typer.Exit(code=1)
 
     try:
@@ -979,7 +979,7 @@ def revoke(
     if revoked:
         typer.echo(f"revoked elevation {elevation_id}")
     else:
-        typer.echo(f"no elevation with id {elevation_id}", err=True)
+        typer.echo(f"error: no elevation with id {elevation_id}", err=True)
         raise typer.Exit(code=1)
 
 
@@ -1056,7 +1056,8 @@ def tui(
     """
     if importlib.util.find_spec("textual") is None:
         typer.echo(
-            "The TUI requires the optional 'textual' extra: pip install \"doberman-core[tui]\"",
+            "error: The TUI requires the optional 'textual' extra: "
+            'pip install "doberman-core[tui]"',
             err=True,
         )
         raise typer.Exit(code=1)
@@ -1091,7 +1092,8 @@ def dash(
         from doberman.dash import create_app
     except ImportError as exc:
         typer.echo(
-            'The dashboard requires the optional "dash" extra: pip install "doberman-core[dash]"',
+            'error: The dashboard requires the optional "dash" extra: '
+            'pip install "doberman-core[dash]"',
             err=True,
         )
         raise typer.Exit(code=1) from exc

--- a/tests/integration/test_cli_auth.py
+++ b/tests/integration/test_cli_auth.py
@@ -78,3 +78,4 @@ def test_status_lists_then_revoke_removes_an_elevation(tmp_path):
 def test_revoke_unknown_id_errors(tmp_path):
     result = runner.invoke(app, ["revoke", "no-such-id", "--path", str(tmp_path)])
     assert result.exit_code == 1
+    assert result.stderr == "error: no elevation with id no-such-id\n"

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -122,7 +122,7 @@ def test_doctor_hooks_missing_fails(tmp_path):
     result = runner.invoke(app, ["doctor", "--path", root])
     assert result.exit_code == 1
     assert "[FAIL] Host hooks: not installed" in result.stdout
-    assert "critical check(s) not healthy" in result.stdout
+    assert "error: 1 critical check(s) not healthy" in result.stdout
 
 
 def test_doctor_config_missing_fails(tmp_path):

--- a/tests/unit/test_cli_lowering_gate.py
+++ b/tests/unit/test_cli_lowering_gate.py
@@ -134,6 +134,7 @@ def test_lowering_with_enrolled_2fa_decline_or_non_totp_factor_is_denied(
     result = _invoke_lowering(kind, root)
 
     assert result.exit_code == 1
+    assert result.stderr.startswith("error: ")
     _assert_lowering_state(kind, root, applied=False)
     _assert_single_ledger_method(root, "denied", approved=0)
 

--- a/tests/unit/test_dash_serve.py
+++ b/tests/unit/test_dash_serve.py
@@ -94,6 +94,7 @@ def test_cli_dash_missing_extra_exits_nonzero_with_install_hint(monkeypatch):
     result = runner.invoke(cli_app, ["dash"])
 
     assert result.exit_code != 0
+    assert result.stderr.startswith("error: ")
     assert 'pip install "doberman-core[dash]"' in result.stderr
 
 

--- a/tests/unit/test_explain.py
+++ b/tests/unit/test_explain.py
@@ -329,6 +329,7 @@ def test_tui_command_without_textual_prints_install_hint_and_exits_1(monkeypatch
     monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
     result = runner.invoke(app, ["tui"])
     assert result.exit_code == 1
+    assert result.stderr.startswith("error: ")
     assert "doberman-core[tui]" in result.output
 
 


### PR DESCRIPTION
# Pull Request

## Slice

- Repo: doberman-core
- Feature / Slice: #344 — one CLI message-severity vocabulary
- Plan reference: issue #344

## What this PR does

- Prefixes all eight audited fatal CLI diagnostics with `error:` while preserving their existing exit codes and stdout/stderr channels.
- Extends focused coverage for denial, unknown elevation, and missing optional-dependency paths.
- Documents the `error:` / `warning:` / `note:` vocabulary in the README, CLI reference, and changelog.

Fixes #344.

## Tests added (run in CI)

- Focused changed-path suite: 25 passed.
- Full suite: 2,571 passed, 5 skipped, 1 failed locally; the sole failure is the unchanged real-plugin discovery harness, which reproduces on current `main` with the same `ModuleNotFoundError: No module named doberman`.
- Ruff check and format check.
- Markdown link check: 25 files.
- Import contracts: 2 kept, 0 broken.
- Parity generator check and `git diff --check`.
- Built sdist and wheel; verified the clean wheel environment reports version 0.17.1 and includes bundled roles without the enterprise package.

## Public-release safety (doberman-core only)

- [x] Contains nothing from the not-allowed list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist

- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (N/A: message prefixes only)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (N/A: no decision-path change)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced

- Missing `textual` and dashboard dependencies retain their original install hints and exit 1, now with the same fatal prefix.
- No machine-readable output, command behavior, or exit code changes.

## AI assistance

This contribution was prepared with Codex assistance.
