### PR TITLE
fix(auth): make challenge prompt pure ASCII for cp1252 compatibility

### DIFF
--- a/src/doberman/auth/provider.py
+++ b/src/doberman/auth/provider.py
@@ -78,8 +78,8 @@ def _challenge_message(decision: Decision, action: SecurityObject, tier: AuthTie
     return (
         f"[RISK: {decision.final_risk.upper()}]  Doberman authentication required [{tier.value}]\n"
         f"  role:   {action.agent_role}\n"
-        f"  action: {action.tool_name} → {target}\n"
-        f"  reason: {reasons} — {decision.explanation.strip() or 'no further detail'}\n"
+        f"  action: {action.tool_name} -> {target}\n"
+        f"  reason: {reasons} - {decision.explanation.strip() or 'no further detail'}\n"
         f"Approve THIS exact action?"
     )
 

--- a/tests/unit/test_auth_provider.py
+++ b/tests/unit/test_auth_provider.py
@@ -167,6 +167,15 @@ def test_challenge_message_low_risk_renders_cleanly():
     assert "role_out_of_scope" in message  # the reason
 
 
+def test_challenge_message_is_ascii_and_cp1252_safe():
+    """_challenge_message output must be ASCII and cp1252-safe for legacy Windows consoles."""
+    from doberman.auth.provider import _challenge_message
+
+    msg = _challenge_message(_auth_decision(), _action(), AuthTier.soft_confirm)
+    assert msg.isascii(), f"non-ASCII in challenge prompt: {msg!r}"
+    msg.encode("ascii")  # raises UnicodeEncodeError if non-ASCII
+
+
 def test_registered_provider_is_preferred(monkeypatch):
     sentinel = object()
 


### PR DESCRIPTION
Replace non-ASCII arrow (→) with -> and em-dash (—) with - in _challenge_message to prevent UnicodeEncodeError on legacy Windows consoles.

# Pull Request

## Slice
- Repo: doberman-core | doberman-enterprise
- Feature / Slice: <id> — <title>
- Plan reference: doberman_implementation_plan.md

## What this PR does

## Tests added (run in CI)
-

## Public-release safety (doberman-core only)
- [ ] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [ ] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [ ] Fails closed on error / uncertainty
- [ ] No secret, full file, or unredacted prompt logged or committed
- [ ] Any guardrail/learning change is raise-only (no silent loosening)
- [ ] Every BLOCK/AUTH carries reason codes + a human explanation
- [ ] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
-
fix(auth): make challenge prompt pure ASCII for cp1252 compatibility

Fixes #341

## Summary
- Replaced non-ASCII arrow (`→` -> `->`) and em-dash (`—` -> `-`) in `_challenge_message` inside `src/doberman/auth/provider.py`.
- Added unit test `test_challenge_message_is_ascii_and_cp1252_safe` in `tests/unit/test_auth_provider.py` asserting `.isascii()` and `.encode("ascii")`.
- Prevents `UnicodeEncodeError` crashes on legacy Windows consoles (cp1252).
- Added DCO `Signed-off-by` header to commit.

thank you. 