### PR TITLE
ci(imports): forbid the objective-rules hot path from the subjective ML chain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,3 +122,19 @@ name = "Public core must not depend on the private enterprise package"
 type = "forbidden"
 source_modules = ["doberman"]
 forbidden_modules = ["doberman_enterprise"]
+
+# Hot-path decoupling: the objective-rules package is built by the host hooks on
+# EVERY tool call, in a cold-start CLI process, so it must never drag in the
+# subjective layer's heavy ML import chain (river/numpy/scipy, pulled in via
+# doberman.subjective.{baseline,drift,martingale}). engine.trifecta was extracted
+# as a models-only leaf (see its module docstring) precisely so engine.rules could
+# share the lethal-trifecta predicate without importing engine.subjective; this
+# contract makes that convention a CI-enforced invariant instead of a review-only
+# one. forbidden_modules names numpy/scipy/river directly (not just
+# doberman.subjective) so a future rule that reaches the ML libraries through any
+# path — not only the current one — still fails the contract.
+[[tool.importlinter.contracts]]
+name = "Objective-rules hot path must not depend on the subjective ML import chain"
+type = "forbidden"
+source_modules = ["doberman.engine.rules", "doberman.engine.trifecta", "doberman.engine.objective"]
+forbidden_modules = ["doberman.engine.subjective", "doberman.engine.detectors", "numpy", "scipy", "river"]

--- a/tests/unit/test_import_boundaries.py
+++ b/tests/unit/test_import_boundaries.py
@@ -1,0 +1,141 @@
+"""Issue #324 — the objective-rules hot path must stay free of the subjective
+layer's ML import chain (numpy/scipy/river).
+
+Host hooks rebuild ``ObjectiveGuardrail`` (``doberman.engine.rules`` /
+``doberman.engine.objective`` / ``doberman.engine.trifecta``) on *every* tool
+call, in a cold-start CLI process. Before this slice, staying clear of
+numpy/scipy/river was a convention (see the ``doberman.engine.trifecta``
+module docstring) that only code review enforced. This file turns the
+``import-linter`` "forbidden" contract declared in ``pyproject.toml`` into a
+test-suite-visible, CI-enforced invariant, covering three things ``lint-imports``
+alone wouldn't make obvious from a red/green CI badge:
+
+* the contract in ``pyproject.toml`` hasn't been silently narrowed (raise-only
+  applies to CI guards too);
+* the "forbidden" mechanism itself actually catches both a direct import and an
+  indirect/transitive chain (a plugin's own dependency reaching numpy/river),
+  matching the exact regression this issue is guarding against;
+* the mechanism does NOT over-constrain ``doberman.engine.registry`` — the
+  legitimate, ML-free discovery seam that ``engine.objective`` shares with the
+  subjective side (see the issue's "check before finalizing the source list").
+"""
+
+import grimp
+import importlinter.api  # noqa: F401 -- import configures importlinter's app settings
+from importlinter.api import read_configuration
+from importlinter.contracts.forbidden import ForbiddenContract
+
+CONTRACT_NAME = "Objective-rules hot path must not depend on the subjective ML import chain"
+
+
+def _contract_options() -> dict:
+    cfg = read_configuration()
+    for options in cfg["contracts_options"]:
+        if options["name"] == CONTRACT_NAME:
+            return options
+    raise AssertionError(f"contract {CONTRACT_NAME!r} is missing from pyproject.toml")
+
+
+def test_contract_is_declared_with_the_exact_source_and_forbidden_sets():
+    options = _contract_options()
+    assert options["type"] == "forbidden"
+    assert set(options["source_modules"]) == {
+        "doberman.engine.rules",
+        "doberman.engine.trifecta",
+        "doberman.engine.objective",
+    }
+    assert set(options["forbidden_modules"]) == {
+        "doberman.engine.subjective",
+        "doberman.engine.detectors",
+        "numpy",
+        "scipy",
+        "river",
+    }
+
+
+def test_contract_is_kept_against_the_real_codebase():
+    cfg = read_configuration()
+    session_options = cfg["session_options"]
+    graph = grimp.build_graph(*session_options["root_packages"], include_external_packages=True)
+    contract = ForbiddenContract(
+        name=CONTRACT_NAME, session_options=session_options, contract_options=_contract_options()
+    )
+    check = contract.check(graph, verbose=False)
+    assert check.kept, "the real codebase must not violate the objective-rules ML boundary"
+
+
+def _synthetic_graph(*modules: str) -> grimp.ImportGraph:
+    graph = grimp.ImportGraph()
+    for module in modules:
+        graph.add_module(module)
+    return graph
+
+
+def test_contract_catches_a_direct_forbidden_import():
+    # Models the exact regression this issue guards against: a new rule module
+    # reaches straight for numpy instead of staying a pure/models-only leaf.
+    graph = _synthetic_graph(
+        "doberman",
+        "doberman.engine",
+        "doberman.engine.rules",
+        "doberman.engine.rules.leaky",
+        "doberman.engine.trifecta",
+        "doberman.engine.objective",
+        "numpy",
+    )
+    graph.add_import(importer="doberman.engine.rules.leaky", imported="numpy")
+    contract = ForbiddenContract(
+        name=CONTRACT_NAME,
+        session_options={"root_packages": ["doberman"], "include_external_packages": True},
+        contract_options=_contract_options(),
+    )
+    assert contract.check(graph, verbose=False).kept is False
+
+
+def test_contract_catches_an_indirect_forbidden_import_chain():
+    # The riskier case: a rule doesn't import river directly, it imports some
+    # OTHER module that does. The "forbidden" contract must still catch this
+    # (allow_indirect_imports defaults to False, i.e. indirect chains count).
+    graph = _synthetic_graph(
+        "doberman",
+        "doberman.engine",
+        "doberman.engine.rules",
+        "doberman.engine.rules.helper",
+        "doberman.engine.trifecta",
+        "doberman.engine.objective",
+        "doberman.some_other_helper",
+        "river",
+    )
+    graph.add_import(importer="doberman.engine.rules.helper", imported="doberman.some_other_helper")
+    graph.add_import(importer="doberman.some_other_helper", imported="river")
+    contract = ForbiddenContract(
+        name=CONTRACT_NAME,
+        session_options={"root_packages": ["doberman"], "include_external_packages": True},
+        contract_options=_contract_options(),
+    )
+    assert contract.check(graph, verbose=False).kept is False
+
+
+def test_contract_permits_the_shared_registry_dependency():
+    # engine.objective legitimately imports engine.registry (discover_rules) to
+    # run plugin rules alongside the built-ins. registry.py itself is a thin,
+    # ML-free entry-point loader (its ML-adjacent discovery functions, e.g. for
+    # algebra adapters, import their targets lazily and are never reached from
+    # the objective path) so it is deliberately NOT in forbidden_modules. A
+    # contract that (wrongly) treated registry as tainted would break this
+    # legitimate, everyday import.
+    graph = _synthetic_graph(
+        "doberman",
+        "doberman.engine",
+        "doberman.engine.rules",
+        "doberman.engine.trifecta",
+        "doberman.engine.objective",
+        "doberman.engine.registry",
+    )
+    graph.add_import(importer="doberman.engine.objective", imported="doberman.engine.registry")
+    contract = ForbiddenContract(
+        name=CONTRACT_NAME,
+        session_options={"root_packages": ["doberman"], "include_external_packages": True},
+        contract_options=_contract_options(),
+    )
+    assert contract.check(graph, verbose=False).kept is True


### PR DESCRIPTION
## Slice
- Feature / Slice: CI enhancement — import-linter contract for issue #324

## What this PR does

Adds an `import-linter` **forbidden** contract that keeps the objective-rules hot path (`doberman.engine.rules`, `doberman.engine.objective`, `doberman.engine.trifecta`) rebuilt by the host hooks on **every tool call**, in a cold-start CLI process from ever importing the subjective layer's heavy ML import chain (`numpy`/`scipy`/`river`).

Prior to this change, that boundary holds only by convention: PR #323 deliberately extracted `trifecta_fires` into `doberman.engine.trifecta`, a models-only leaf, specifically so `engine.rules.trifecta_floor` could share the lethal-trifecta predicate without pulling in `engine.subjective` (-> `engine.detectors` / `engine.registry` -> river/numpy/scipy). Nothing enforced that convention in CI, so a future rule that did `from doberman.engine.subjective import ...` would silently add ~2s of import cost to every tool call, and only review would catch it (assuming the reviewer notices). This PR makes it a CI-checked invariant, enforcing the rule.

```toml
[[tool.importlinter.contracts]]
name = "Objective-rules hot path must not depend on the subjective ML import chain"
type = "forbidden"
source_modules = ["doberman.engine.rules", "doberman.engine.trifecta", "doberman.engine.objective"]
forbidden_modules = ["doberman.engine.subjective", "doberman.engine.detectors", "numpy", "scipy", "river"]
```

### Design choices

- **`numpy`/`scipy`/`river` are forbidden directly, not just `doberman.subjective`.**
  `import-linter`'s `forbidden` contract type checks indirect/transitive import   chains by default (`allow_indirect_imports` defaults to `False`). Naming the   actual ML libraries means the contract also catches a *future* path into them  (e.g. a rule importing some other helper module that happens to import `river`), not only today's `engine.subjective` route. 

- **`doberman.engine.registry` is deliberately *not* forbidden.** 
  The issue asked to "confirm the exact forbidden set doesn't over-constrain a legitimate import" i.e `engine.objective` legitimately imports `engine.registry.discover_rules()` to run plugin rules alongside the built-ins. I traced `registry.py`'s import  graph, including its several function-local/lazy imports (`discover_algebra_adapters`,  `discover_adjudicators`, `discover_egress_brokers`, `discover_policy_sources`, `discover_auth_providers`, `discover_audit_sinks`, `discover_drift_observers`,  `discover_cost_observers`) and none of them reach `numpy`/`scipy`/`river`, even indirectly. `registry.py` stays a thin, ML-free entry-point loader, so it's
  safe to leave out of `forbidden_modules`.

- **`doberman.engine.detectors` is forbidden even though it currently contains no ML imports.** 
 (just TokenChannelDetector, which only touches doberman.models/doberman.tokens). This is a forward-looking guard, and not a fix for a present violation. The package's own docstring designates it as where advanced/behavioral detectors are meant to land (built-in or plugin), so keeping it forbidden now means a future ML-heavy detector added there is automatically blocked from the objective hot path, without anyone needing to remember to update the contract at that time.

## Tests added (run in CI)

`tests/unit/test_import_boundaries.py`:

- `test_contract_is_declared_with_the_exact_source_and_forbidden_sets` parses the contract out of `pyproject.toml` via `importlinter.api.read_configuration()` and asserts the exact `source_modules`/`forbidden_modules` sets, so the
  contract can't be silently narrowed later (raise-only applies to CI guards too).
- `test_contract_is_kept_against_the_real_codebase` builds the real import graph with `grimp.build_graph("doberman", include_external_packages=True)` and asserts the contract is `kept`, i.e. this is a pytest-visible regression test of the same property `lint-imports` checks in CI, not just a manual
  one-off confirmation.
- `test_contract_catches_a_direct_forbidden_import` synthetic graph where a hypothetical `doberman.engine.rules.leaky` module imports `numpy` directly; asserts the contract reports `kept is False`.
- `test_contract_catches_an_indirect_forbidden_import_chain` synthetic graph where a rule module imports an unrelated helper module that itself imports `river`; asserts the contract still catches this transitive chain (proving
  the contract isn't only a direct-import check).
- `test_contract_permits_the_shared_registry_dependency` synthetic graph mirroring `engine.objective` -> `engine.registry`; asserts the contract stays `kept`, documenting why `engine.registry` is intentionally absent from
  `forbidden_modules`.

## Security checklist
- [x] Fails closed on error / uncertainty - N/A, no runtime decision path changed
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) - this
      PR only *adds* a CI check; it cannot loosen anything
- [x] Every BLOCK/AUTH carries reason codes + a human explanation - N/A, no
      runtime behavior changed

## Edge cases covered / Minor Notes

- Verified locally (fresh `.venv`, `pip install -e ".[dev]"`) that `lint-imports`
  reports all 3 contracts `KEPT`, `ruff check .` / `ruff format --check .` pass,
  and the new test file passes.
- CI-guard only, as scoped in the issue - no runtime behavior change, so
  README/CONTRIBUTING weren't touched (neither of the two pre-existing
  import-linter contracts is documented there either; this follows the same
  convention).
