### PR TITLE
test(engine): cover role boundary batch worst-wins

### DIFF
--- a/tests/unit/test_role_escalation.py
+++ b/tests/unit/test_role_escalation.py
@@ -9,6 +9,8 @@ cannot be learned away).
 
 from datetime import datetime, timezone
 
+import pytest
+
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.engine.rules.role_boundary import RoleBoundaryRule
 from doberman.models import (
@@ -25,7 +27,12 @@ FRONTEND = load_builtin_roles()["frontend"]
 RULE = RoleBoundaryRule()
 
 
-def _action(target, action_type=ActionType.file_write, source=SourceContext.unknown):
+def _action(
+    target,
+    action_type=ActionType.file_write,
+    source=SourceContext.unknown,
+    metadata=None,
+):
     return SecurityObject(
         id="ra-1",
         ts=datetime(2026, 6, 8, tzinfo=timezone.utc),
@@ -34,6 +41,7 @@ def _action(target, action_type=ActionType.file_write, source=SourceContext.unkn
         tool_name="fs_write",
         target=target,
         source_context=source,
+        metadata=metadata or {},
     )
 
 
@@ -74,6 +82,28 @@ def test_role_blocked_path_is_blocked(tmp_path):
     result = RULE.evaluate(
         _action("app/secret/key.txt", action_type=ActionType.file_delete), _ctx(role, tmp_path)
     )
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.role_blocked_target in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "raw_paths",
+    [
+        ["app/public.txt", "app/secret/key.txt"],
+        ["app/secret/key.txt", "app/public.txt"],
+    ],
+    ids=["blocked-last", "blocked-first"],
+)
+def test_batch_paths_use_worst_role_boundary_regardless_of_order(tmp_path, raw_paths):
+    role = RoleDefinition(name="scoped", allowed=["app/**"], blocked=["app/secret/**"])
+    action = _action(
+        "app/public.txt",
+        action_type=ActionType.file_delete,
+        metadata={"raw_paths": raw_paths},
+    )
+
+    result = RULE.evaluate(action, _ctx(role, tmp_path))
+
     assert result.verdict is Verdict.BLOCK
     assert ReasonCode.role_blocked_target in result.reason_codes
 


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: Issue #227
- Plan reference: Issue #227

## What this PR does

Adds a parameterized test confirming that a blocked path produces `BLOCK` regardless of whether it appears first or last in `raw_paths`. 

Closes #227.

## Tests added (run in CI)
- Tests allowed-first/blocked-last and blocked-first/allowed-last ordering.
- Verified by breaking the severity comparison and first-result behavior, both mutations made the test fail and were reverted.

## Public-release safety (doberman-core only)
- [x] Contains no enterprise code, proprietary detection, customer data, secrets, or commercial-license code
- [x] Core still builds/tests/runs without the enterprise package

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] The change protects a raise-only invariant
- [x] BLOCK assertions include the expected reason code
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Covers both path orderings.
- No deviations or runtime risks; test-only change.