### PR TITLE
docs(hosthooks): warn about pip uninstall order for Claude Code hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ pip install doberman-core
 After installing, run `doberman --install-completion` to enable shell tab
 completion.
 
+> **Uninstalling?** Run `doberman uninstall-hooks` *before* `pip uninstall doberman-core` -
+> otherwise the hook entries left in `settings.json` will keep invoking a binary that's gone,
+> and every tool call fails with `doberman: command not found`. Already hit this? Just
+> `pip install doberman-core` again - the existing entries are still correct and start working
+> immediately, no repair needed.
+
 | Your agent | How Doberman plugs in | Get started |
 |---|---|---|
 | **Claude Code** | Hooks - gate every built-in *and* MCP tool call *(recommended)* | `doberman setup` -> [guide](docs/SETUP.md#claude-code-hooks) |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -97,6 +97,14 @@ doberman uninstall-hooks             # remove only Doberman's entries (leaves yo
 `install-hooks` is idempotent (safe to re-run), backs up an existing `settings.json` before
 writing, and never touches your other settings or hooks. `doberman setup` above runs it for you.
 
+> **Order matters when removing Doberman.** `pip uninstall doberman-core` has no way to also
+> clean up the hook entries it wrote - pip doesn't support that. Always run
+> `doberman uninstall-hooks` *first*. If you already uninstalled the package and every tool call
+> now fails with `doberman: command not found`, don't edit `settings.json` by hand - just
+> `pip install doberman-core` again. The hook entries were never touched, so they start working
+> the moment the binary is back; run `doberman uninstall-hooks` afterward if you still want it
+> gone.
+
 On Claude Code it writes this snippet - or add it by hand:
 
 ```jsonc


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: docs — warn about pip uninstall order for Claude Code hooks
- Plan reference: n/a (ad hoc doc fix, see #372)

## What this PR does
`pip uninstall doberman-core` has no way to also clean up the `PreToolUse`/`PostToolUse`/
`SessionStart` hook entries `doberman install-hooks` wrote into `settings.json` — pip doesn't
support a post-uninstall hook for this. If a user uninstalls without first running
`doberman uninstall-hooks`, every subsequent tool call in Claude Code fails with
`doberman: command not found`, indefinitely, since the stale entries still reference the binary.

This is a docs-only fix: it adds a clear warning + recovery instructions in the two places users
would look (`README.md` Quick Start, `docs/SETUP.md` hooks section). The recovery path itself
needs no new code — the existing hook entries are still correct, so simply reinstalling
(`pip install doberman-core`) makes them work again immediately.

Closes #372.

## Tests added (run in CI)
- None — docs-only change, no code paths touched.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (unchanged — no code touched)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — n/a, no guardrail change
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — n/a, no decision-path change
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- None. This is a documentation-only change with zero behavioral risk.
