### PR TITLE
test(proxy): mark output secret scan parity

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -13,7 +13,7 @@ Each row is a security guarantee; each column a host Doberman can front.
 | Deleting unrecoverable gitignored data is gated (AN-1) | ◻ | ◻ | ◻ | ◻ |
 | A session that read a secret gets a raised floor on egress | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_taint_floor.py) | ◻ | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_proxy_taint_floor.py) | ◻ |
 | An outbound value matching a read secret is blocked | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_exfil_fingerprint.py) | ◻ | ◻ | ◻ |
-| Tool output carrying credentials is blocked from the model | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_claude_post.py) | ◻ | ◻ | — |
+| Tool output carrying credentials is blocked from the model | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_claude_post.py) | ◻ | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_proxy_secret_output_gating.py) | — |
 | The agent cannot edit Doberman's own config or hooks | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_control_plane.py) | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_rule_paths_codex_control_plane.py) | ◻ | ◻ |
 | Approvals are single-use and bound to one action id | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_auth_challenge.py) | ◻ | ◻ | ◻ |
 | AUTH challenges auto-deny at the wall-clock deadline | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_auth_challenge_timeout.py) | ◻ | ◻ | ◻ |

--- a/tests/unit/test_proxy_secret_output_gating.py
+++ b/tests/unit/test_proxy_secret_output_gating.py
@@ -60,6 +60,7 @@ async def _rows() -> list[dict]:
     return await read_decisions(executor.REPO_ROOT)
 
 
+@pytest.mark.guarantee("output-secret-scan", host="mcp-proxy")
 async def test_secret_output_triggers_block_gate_without_leaking_secret():
     # The request itself is unremarkable (a plain local read) — only the
     # downstream RESULT carries the secret, so the pre-execution decision is a


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: #332
- Plan reference: Issue #332

## What this PR does

Marks the existing MCP proxy test as the parity proof for blocking credential-bearing tool output and regenerates the parity matrix.

Closes #332.

## Tests added (run in CI)

- Parity test, full suite, lint, formatting, and import checks pass.

## Public-release safety (doberman-core only)

- [x] Contains no enterprise/hosted code, proprietary detection, customer data, secrets, or commercial-license code
- [x] Core builds/tests/runs without the enterprise package

## Security checklist

- [x] Fails closed on error / uncertainty
- [x] No secrets, full files, or unredacted prompts logged or committed
- [x] No guardrail/learning loosening; test-only change
- [x] Existing BLOCK/AUTH decisions retain reason codes and explanations
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced

- Credential-bearing output is blocked and not exposed.
- No production behavior changed.