### PR TITLE
test(claude): prove unrecoverable delete parity

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -10,7 +10,7 @@ Each row is a security guarantee; each column a host Doberman can front.
 | Guarantee | Claude Code | Codex | Mcp Proxy | Openclaw |
 |---|---|---|---|---|
 | Destructive shell commands are blocked or AUTH-gated | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_claude_pre.py) | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_codex.py) | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/integration/test_engine_blocks_reach_no_tool.py) | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_openclaw.py) |
-| Deleting unrecoverable gitignored data is gated (AN-1) | ◻ | ◻ | ◻ | ◻ |
+| Deleting unrecoverable gitignored data is gated (AN-1) | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_claude_pre.py) | ◻ | ◻ | ◻ |
 | A session that read a secret gets a raised floor on egress | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_taint_floor.py) | ◻ | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_proxy_taint_floor.py) | ◻ |
 | An outbound value matching a read secret is blocked | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_exfil_fingerprint.py) | ◻ | ◻ | ◻ |
 | Tool output carrying credentials is blocked from the model | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_claude_post.py) | ◻ | ◻ | — |

--- a/tests/unit/test_hosthook_claude_pre.py
+++ b/tests/unit/test_hosthook_claude_pre.py
@@ -118,6 +118,15 @@ def test_destructive_bash_is_denied(cwd):
     assert _permission(_pre("Bash", {"command": "rm -rf /"}, cwd)) == "deny"
 
 
+@pytest.mark.guarantee("gitignored-delete-gate", host="claude-code")
+def test_unrecoverable_gitignored_delete_requires_auth(cwd):
+    out = _pre("Bash", {"command": "rm data/app.db"}, cwd)
+    assert _permission(out) == "deny"
+    reason = _reason(out)
+    assert "[AUTH]" in reason
+    assert "data/app.db" not in reason
+
+
 def test_block_reason_tells_user_there_is_no_in_session_override(cwd):
     reason = _reason(_pre("Bash", {"command": "rm -rf /"}, cwd))
     assert "no in-session override" in reason


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: #329
- Plan reference: #329

## What this PR does
Marks the existing Claude Code test as proof that deleting unrecoverable gitignored data requires AUTH, and updates the parity matrix.

## Tests added (run in CI)
- Focused tests, full suite, parity, Ruff, formatting, and import checks pass.
- Mutation check confirms the test fails if the delete safeguard is removed.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- `rm data/app.db` requires AUTH.
- The operand is not exposed in the reason.
- No production behavior changed.
