### PR TITLE
fix(proxy): scan error results and structured/embedded channels for secrets

### DIFF
--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -18,12 +18,13 @@ exactly one action id (no replay onto a different call).
 """
 
 import asyncio
+import json
 import logging
 import uuid
 from datetime import datetime, timezone
 
 from mcp.client.session import ClientSession
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, EmbeddedResource, TextContent, TextResourceContents
 
 from doberman.auth.challenge import (
     TIMEOUT_METHOD,
@@ -416,6 +417,39 @@ def _result_text(result: CallToolResult) -> str:
     return "".join(block.text for block in result.content if isinstance(block, TextContent))
 
 
+def _scannable_text(result: CallToolResult) -> str:
+    """Every text-bearing channel of a tool result, for the secret scan + taint.
+
+    A tool result can carry plaintext in more than bare ``TextContent`` blocks:
+    ``structuredContent`` (a JSON object) and an ``EmbeddedResource``'s text
+    (e.g. a returned file resource). A secret in either of those must not bypass
+    the output scan just because it isn't a plain text block (CRIT-3), so this
+    folds all three channels — separated by newlines so an adjacent boundary can
+    neither hide nor fabricate a match — into the string the scan/taint see.
+
+    Binary blobs (``BlobResourceContents``) and image/audio blocks are skipped:
+    they carry no plaintext to leak here, and a full base64 blob is scan noise.
+    Never raises — a malformed block must not break the forward/return path.
+
+    ponytail: text channels only; if binary/blob exfil ever needs scanning,
+    decode the blob here behind a size cap.
+    """
+    parts: list[str] = []
+    for block in result.content:
+        if isinstance(block, TextContent):
+            parts.append(block.text)
+        elif isinstance(block, EmbeddedResource) and isinstance(
+            block.resource, TextResourceContents
+        ):
+            parts.append(block.resource.text)
+    if result.structuredContent:
+        try:
+            parts.append(json.dumps(result.structuredContent, default=str, sort_keys=True))
+        except (TypeError, ValueError):
+            parts.append(str(result.structuredContent))
+    return "\n".join(part for part in parts if part)
+
+
 async def _record_result_taint(result: CallToolResult) -> None:
     """Best-effort: feed a successful tool result's text to the taint floor.
 
@@ -426,7 +460,7 @@ async def _record_result_taint(result: CallToolResult) -> None:
     result (e.g. a non-string ``.text``) must not break the forward/return path.
     """
     try:
-        output_text = _result_text(result)
+        output_text = _scannable_text(result)
         if output_text:
             await record_output_taint(output_text, REPO_ROOT, None)
     except Exception:  # noqa: BLE001 — recording must never break the execution path
@@ -457,7 +491,7 @@ async def _scan_output_for_secrets(
     rather than silently letting it through.
     """
     try:
-        output_text = _result_text(result)
+        output_text = _scannable_text(result)
         if not output_text:
             return None
         scan_args = dict(arguments or {})
@@ -664,21 +698,24 @@ async def _handle_auth(
         return _verdict_result(redecision)
 
     result = await _forward(downstream, tool_name, arguments, action)
+    # The output-secret gate runs on EVERY result — success OR error (CRIT-2): a
+    # secret rides an error payload to the model just as easily as a clean one.
+    # Record output taint and spend a single-use grant BEFORE the gate, on error
+    # results too: (a) a gated secret still taints the session for the next call's
+    # cross-call exfil check, and (b) spending tracks EXECUTION, not a clean
+    # result — a secret-bearing OR errored output can't leave the grant unspent
+    # to release a second execution.
+    await _record_result_taint(result)
+    await _consume_single_use(action, grants, now)
+    gate = await _scan_output_for_secrets(tool_name, arguments, action, result)
+    if gate is not None:
+        # Output-scan parity (parity-1): a secret in the RESULT must not reach
+        # the model even though the call itself was approved. Log only the block
+        # — skip the baseline "allowed" observation, since the outcome is not
+        # confirmed safe (mirrors the host-hook: one log row, the block).
+        await _persist(gate, action, auth_result="blocked", elevation_id=elevation_id, eid=eid)
+        return _verdict_result(gate)
     if not result.isError:
-        await _record_result_taint(result)
-        # Spending != learning: a single-use grant is spent by EXECUTION, not by
-        # a clean result — consume it here, before the gate, so a secret-bearing
-        # output can't leave the grant unspent to release a second execution.
-        await _consume_single_use(action, grants, now)
-        gate = await _scan_output_for_secrets(tool_name, arguments, action, result)
-        if gate is not None:
-            # Output-scan parity (parity-1): a secret in the RESULT must not
-            # reach the model even though the call itself was approved. Log
-            # only the block — skip the baseline "allowed" observation, since
-            # the outcome is not confirmed safe (mirrors the host-hook: one log
-            # row, the block, not a clean one).
-            await _persist(gate, action, auth_result="blocked", elevation_id=elevation_id, eid=eid)
-            return _verdict_result(gate)
         artifact_gate = await _verify_artifact_digest(action, result)
         if artifact_gate is not None:
             # RB.7: a pinned artifact's fetched content disagreed with its
@@ -778,21 +815,24 @@ async def decide_and_execute(
     # then consume any single-use elevation that released it.
     softened = decision.final_verdict is not Verdict.PASS
     result = await _forward(downstream, tool_name, arguments, action)
+    # The output-secret gate runs on EVERY result — success OR error (CRIT-2): a
+    # secret rides an error payload to the model just as easily as a clean one.
+    # Record output taint and spend a single-use grant BEFORE the gate, on error
+    # results too: (a) a gated secret still taints the session for the next call's
+    # cross-call exfil check, and (b) spending tracks EXECUTION, not a clean
+    # result — a secret-bearing OR errored output can't leave the grant unspent
+    # to release a second execution.
+    await _record_result_taint(result)
+    await _consume_single_use(action, grants, now)
+    gate = await _scan_output_for_secrets(tool_name, arguments, action, result)
+    if gate is not None:
+        # Output-scan parity (parity-1): a secret in the RESULT must not reach
+        # the model even though the call itself was PASS. Log only the block —
+        # skip the baseline "allowed" observation below, since the outcome is
+        # not confirmed safe (mirrors the host-hook: one log row, the block).
+        await _persist(gate, action, auth_result="blocked", eid=eid)
+        return _verdict_result(gate)
     if not result.isError:
-        await _record_result_taint(result)
-        # Spending != learning: a single-use grant is spent by EXECUTION, not by
-        # a clean result — consume it here, before the gate, so a secret-bearing
-        # output can't leave the grant unspent to release a second execution.
-        await _consume_single_use(action, grants, now)
-        gate = await _scan_output_for_secrets(tool_name, arguments, action, result)
-        if gate is not None:
-            # Output-scan parity (parity-1): a secret in the RESULT must not
-            # reach the model even though the call itself was PASS. Log only
-            # the block — skip the baseline "allowed" observation below, since
-            # the outcome is not confirmed safe (mirrors the host-hook: one log
-            # row, the block, not a clean one).
-            await _persist(gate, action, auth_result="blocked", eid=eid)
-            return _verdict_result(gate)
         artifact_gate = await _verify_artifact_digest(action, result)
         if artifact_gate is not None:
             # RB.7: a pinned artifact's fetched content disagreed with its

--- a/tests/unit/test_proxy_secret_output_gating.py
+++ b/tests/unit/test_proxy_secret_output_gating.py
@@ -25,6 +25,7 @@ import json
 from datetime import datetime, timezone
 
 import pytest
+from mcp.types import CallToolResult, EmbeddedResource, TextContent, TextResourceContents
 
 from doberman.auth.challenge import AuthResult, AuthTier
 from doberman.models import ReasonCode
@@ -175,3 +176,114 @@ async def test_gated_output_still_consumes_a_single_use_elevation(
         ("fs_delete", {"path": "backend/api.ts"}),
         ("fs_delete", {"path": "backend/api.ts"}),
     ]
+
+
+# ---------------------------------------------------------------------------
+# CRIT-2 / CRIT-3: the output scan must cover every channel a secret can ride —
+# an *error* result's payload (CRIT-2) and the non-``TextContent`` channels
+# ``structuredContent`` / ``EmbeddedResource`` (CRIT-3), not just plain text
+# blocks on a success result. Each of these would sail past the gate before the
+# fix, delivering the secret to the model.
+# ---------------------------------------------------------------------------
+
+
+def _error_result(text: str) -> CallToolResult:
+    """A downstream *error* result carrying ``text`` — the channel CRIT-2 covers."""
+    return CallToolResult(content=[TextContent(type="text", text=text)], isError=True)
+
+
+def _structured_result(payload: dict, *, text: str = "ok") -> CallToolResult:
+    """A success result whose secret (if any) lives ONLY in ``structuredContent``."""
+    return CallToolResult(
+        content=[TextContent(type="text", text=text)],
+        structuredContent=payload,
+        isError=False,
+    )
+
+
+def _embedded_resource_result(text: str) -> CallToolResult:
+    """A success result whose secret lives ONLY inside an ``EmbeddedResource``."""
+    return CallToolResult(
+        content=[
+            EmbeddedResource(
+                type="resource",
+                resource=TextResourceContents(uri="file:///cfg.txt", text=text),
+            )
+        ],
+        isError=False,
+    )
+
+
+def _dump(result: CallToolResult) -> str:
+    """The whole returned result serialized — a leak in ANY field trips this."""
+    return json.dumps(result.model_dump(mode="json"), default=str)
+
+
+async def test_secret_in_error_result_is_still_gated():
+    # CRIT-2: a downstream ERROR can still carry a secret in its payload. If the
+    # scan only ran on clean results, the secret would ride the error straight to
+    # the model. The gate must replace the whole error with the synthetic BLOCK.
+    session = _FakeSession({"fs_read": _error_result(_SYNTHETIC_AWS_KEY)})
+
+    result = await executor.decide_and_execute(session, "fs_read", {"path": "cfg.txt"})
+
+    assert result.isError
+    assert "blocked by policy" in result.content[0].text
+    assert ReasonCode.sensitive_secret_access.value in result.content[0].text
+    assert _SYNTHETIC_AWS_KEY not in _dump(result)
+    assert session.calls == [("fs_read", {"path": "cfg.txt"})]
+    rows = await _rows()
+    assert len(rows) == 1
+    assert rows[0]["final_verdict"] == "BLOCK"
+    assert rows[0]["auth_result"] == "blocked"
+    assert _SYNTHETIC_AWS_KEY not in json.dumps(rows)
+    assert _SYNTHETIC_AWS_KEY.encode() not in db_path(executor.REPO_ROOT).read_bytes()
+
+
+async def test_secret_in_structured_content_is_gated():
+    # CRIT-3: a secret returned via structuredContent (no text block carries it)
+    # must be scanned — flattening only TextContent would miss it entirely.
+    session = _FakeSession({"fs_read": _structured_result({"api_key": _SYNTHETIC_AWS_KEY})})
+
+    result = await executor.decide_and_execute(session, "fs_read", {"path": "cfg.json"})
+
+    assert result.isError
+    assert "blocked by policy" in result.content[0].text
+    assert ReasonCode.sensitive_secret_access.value in result.content[0].text
+    assert _SYNTHETIC_AWS_KEY not in _dump(result)
+    rows = await _rows()
+    assert len(rows) == 1
+    assert rows[0]["final_verdict"] == "BLOCK"
+    assert _SYNTHETIC_AWS_KEY not in json.dumps(rows)
+
+
+async def test_secret_in_embedded_resource_is_gated():
+    # CRIT-3: a secret inside an EmbeddedResource's text (e.g. a returned file
+    # resource) must be scanned too, not just bare text blocks.
+    session = _FakeSession({"fs_read": _embedded_resource_result(_SYNTHETIC_AWS_KEY)})
+
+    result = await executor.decide_and_execute(session, "fs_read", {"path": "cfg.txt"})
+
+    assert result.isError
+    assert "blocked by policy" in result.content[0].text
+    assert ReasonCode.sensitive_secret_access.value in result.content[0].text
+    assert _SYNTHETIC_AWS_KEY not in _dump(result)
+    rows = await _rows()
+    assert len(rows) == 1
+    assert rows[0]["final_verdict"] == "BLOCK"
+
+
+async def test_benign_structured_content_flows_unchanged():
+    # The broader scan must not over-block ordinary structured output — a clean
+    # structuredContent payload passes through untouched, still attached.
+    payload = {"status": "ok", "count": 3}
+    session = _FakeSession({"fs_read": _structured_result(payload, text="done")})
+
+    result = await executor.decide_and_execute(session, "fs_read", {"path": "cfg.json"})
+
+    assert not result.isError
+    assert result.content[0].text == "done"
+    assert result.structuredContent == payload
+    rows = await _rows()
+    assert len(rows) == 1
+    assert rows[0]["final_verdict"] == "PASS"


### PR DESCRIPTION
Two gaps in the proxy's output secret gate (ADR 0062), held private until this release train:

- An `isError=True` downstream result skipped the output secret scan (and the RB.7 artifact check) at both call sites — an errored result carrying a credential reached the model unscanned.
- `_result_text` flattened only `TextContent`, so a secret inside `structuredContent` (JSON) or an `EmbeddedResource` was never scanned.

Fix: new `_scannable_text()` folds all three channels; taint-record, single-use consumption, and the scan are hoisted above the `isError` guard at both call sites (order preserved). Two deliberate raise-only tightenings: an error result now records output taint, and a single-use grant is spent by an errored execution too. `_verify_artifact_digest` and `_observe_allowed` stay inside the success guard.

Rebased today onto the correlator-era executor; ordering re-verified (taint → consume → scan above the guard, correlator untouched at the decision phase); targeted + proxy/correlator/taint integration tests green locally.

## Tests added (run in CI)
- tests/unit/test_proxy_secret_output_gating.py (+4: error-result gated, structuredContent gated, EmbeddedResource gated, benign structured passes)

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation