### PR TITLE
feat(engine): treat the per-user auth state as control plane

### DIFF
--- a/src/doberman/engine/rules/paths.py
+++ b/src/doberman/engine/rules/paths.py
@@ -40,7 +40,8 @@ from doberman.models import (
 #: active role, and the DB holding the append-only policy_changes ledger /
 #: decision log / baselines / elevations; ADR 0011) and the Claude Code
 #: host-hook install config (``.claude/settings*.json`` + the ``.claude`` dir
-#: itself; ADR 0022 host-hook architecture / ADR 0024 this block). Editing or
+#: itself; ADR 0022 host-hook architecture / ADR 0024 this block), plus the
+#: per-user auth state that backs every possession-factor gate (ADR 0065). Editing or
 #: deleting either disables Doberman at the engine or harness level ("fire the
 #: cop") and bypasses the Feature 10 apply_change gate; Doberman writes these via
 #: direct I/O, never through the proxy, so any agent-proxied write/delete/read is
@@ -75,6 +76,28 @@ CONTROL_PLANE_GLOBS: tuple[str, ...] = (
     "**/.codex/config.toml",
     "**/.codex/plugins",
     "**/.codex/plugins/**",
+    # The per-user auth state (``doberman.auth.totp`` / ``doberman.auth.password``):
+    # the TOTP seed, its lockout counter, and the password hash. These live OUTSIDE
+    # any repo (``%LOCALAPPDATA%``/``$XDG_CONFIG_HOME``/``~/.config`` + ``doberman/``)
+    # precisely so they are never committed — which also puts them past
+    # :func:`canonicalize`'s repo-root confinement, so the repo-relative globs above
+    # can never reach them. Matched here against the RAW token instead (see
+    # :func:`names_control_plane`), which is why these patterns are shaped like the
+    # absolute path text rather than a relative one. Deleting the seed silently
+    # un-enrols 2FA (every "TOTP if enrolled" gate degrades to confirm-only);
+    # deleting the lockout file resets the brute-force counter; overwriting either
+    # secret hands an attacker the factor itself. ADR 0065.
+    "**/doberman/totp.secret",
+    "**/doberman/totp.secret.*",
+    "**/doberman/password.hash",
+    # ...and the containing state dir, so a recursive delete of the whole directory
+    # is caught too. Deliberately NOT a bare ``**/doberman`` — that would match any
+    # checkout of this project (the repo itself is named ``doberman``) and block
+    # ordinary work on it.
+    "**/appdata/local/doberman",
+    "**/appdata/local/doberman/**",
+    "**/.config/doberman",
+    "**/.config/doberman/**",
 )
 
 #: Paths that are NEVER allowed without going through the human-approved path.

--- a/tests/unit/test_control_plane_auth_state.py
+++ b/tests/unit/test_control_plane_auth_state.py
@@ -1,0 +1,163 @@
+"""The per-user auth state is control plane: shell commands naming it are blocked.
+
+``doberman.auth.totp`` and ``doberman.auth.password`` keep the TOTP seed, its
+lockout counter, and the password hash in a per-user config dir
+(``%LOCALAPPDATA%`` / ``$XDG_CONFIG_HOME`` / ``~/.config``, then ``doberman/``) —
+deliberately **outside** any repository so they are never committed. That same
+property put them past :func:`doberman.canonical.canonicalize`'s repo-root
+confinement, so the repo-relative ``CONTROL_PLANE_GLOBS`` could never reach them
+and every one of these commands PASSed with no reason code at all.
+
+What that bought an agent:
+
+* ``rm .../doberman/totp.secret`` — un-enrols 2FA, so every "TOTP if enrolled"
+  gate silently degrades to confirm-only.
+* ``rm .../doberman/totp.secret.lockout`` — resets the consecutive-failure
+  counter, removing the brake on TOTP guessing.
+* overwriting either secret — hands the attacker the possession factor itself.
+
+ADR 0065.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from doberman.engine.rules.commands import DestructiveCommandRule
+from doberman.engine.rules.paths import names_control_plane
+from doberman.models import ActionType, EvalContext, ReasonCode, SecurityObject, Verdict
+
+RULE = DestructiveCommandRule()
+
+
+def _cmd(command, *, root="."):
+    action = SecurityObject(
+        id="cp-auth-1",
+        ts=datetime(2026, 8, 6, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.shell_exec,
+        tool_name="Bash",
+        target=command,
+        metadata={},
+    )
+    ctx = EvalContext(metadata={"raw_arguments": {"command": command}, "repo_root": root})
+    return RULE.evaluate(action, ctx)
+
+
+# --- the auth-state files, named in a shell command → BLOCK ---
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # POSIX default location ($XDG_CONFIG_HOME unset → ~/.config)
+        "rm ~/.config/doberman/totp.secret",
+        "rm ~/.config/doberman/totp.secret.lockout",
+        "rm ~/.config/doberman/password.hash",
+        # Windows default location (%LOCALAPPDATA%)
+        "rm ~/AppData/Local/doberman/totp.secret",
+        "rm ~/AppData/Local/doberman/password.hash",
+        "rm %LOCALAPPDATA%/doberman/totp.secret",
+        # absolute, fully spelled out
+        "rm /home/dev/.config/doberman/totp.secret",
+        "rm C:/Users/dev/AppData/Local/doberman/totp.secret",
+    ],
+)
+def test_deleting_an_auth_state_file_is_blocked(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo AAAAAAAAAAAAAAAA > ~/.config/doberman/totp.secret",
+        "echo x >> ~/AppData/Local/doberman/password.hash",
+        "cp /tmp/mine.secret ~/.config/doberman/totp.secret",
+    ],
+)
+def test_overwriting_an_auth_state_file_is_blocked(command):
+    """Replacing the seed is worse than deleting it — the attacker then knows the
+    factor. Redirect targets and copy destinations both have to be caught."""
+    assert _cmd(command).verdict is Verdict.BLOCK
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm -rf ~/.config/doberman",
+        "rm -rf ~/AppData/Local/doberman",
+        "rm -rf /home/dev/.config/doberman",
+    ],
+)
+def test_deleting_the_whole_auth_state_dir_is_blocked(command):
+    """The per-file globs alone would miss a recursive delete of the directory."""
+    assert _cmd(command).verdict is Verdict.BLOCK
+
+
+def test_reading_the_totp_seed_is_blocked():
+    """Reading the seed is enough to generate valid codes forever."""
+    assert _cmd("cat ~/.config/doberman/totp.secret").verdict is Verdict.BLOCK
+
+
+# --- the regression that pins the narrow glob choice ---
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A checkout of this very project is a directory named `doberman`. A bare
+        # `**/doberman` glob would have blocked ordinary work on it.
+        "rm ~/src/doberman/README.md",
+        "rm -rf ~/Documents/GitHub/Doberman/build",
+        "cat ~/code/doberman/pyproject.toml",
+        # ...and an unrelated file that merely lives under a config dir.
+        "rm ~/.config/someapp/settings.json",
+        "rm ~/notes.txt",
+    ],
+)
+def test_ordinary_work_on_a_doberman_checkout_is_not_blocked(command):
+    """The auth-state globs are deliberately narrow: they name the state dir's
+    real parents (`appdata/local`, `.config`) and the three real filenames, never
+    a bare `**/doberman`. Widening them would make this project unworkable."""
+    assert _cmd(command).verdict is not Verdict.BLOCK
+
+
+def test_explanation_does_not_echo_the_auth_state_path():
+    """Prime Directive 3: the reason names the category, never the path."""
+    result = _cmd("rm /home/dev/.config/doberman/totp.secret")
+    blob = f"{result.explanation} {' '.join(str(c) for c in result.reason_codes)}"
+    assert "/home/dev" not in blob
+    assert "totp.secret" not in blob
+
+
+# --- the glob predicate itself, independent of the command rule ---
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "~/.config/doberman/totp.secret",
+        "~/.config/doberman/totp.secret.lockout",
+        "~/.config/doberman/password.hash",
+        "C:/Users/dev/AppData/Local/doberman/totp.secret",
+        "C:\\Users\\dev\\AppData\\Local\\doberman\\totp.secret",
+        "%LOCALAPPDATA%\\doberman\\password.hash",
+    ],
+)
+def test_names_control_plane_recognises_the_auth_state(path):
+    assert names_control_plane(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "~/src/doberman/README.md",
+        "~/Documents/GitHub/Doberman/pyproject.toml",
+        "~/.config/someapp/settings.json",
+        "totp.secret",  # a bare filename in the repo is not the per-user state
+    ],
+)
+def test_names_control_plane_leaves_ordinary_paths_alone(path):
+    assert names_control_plane(path) is False


### PR DESCRIPTION
The TOTP seed, its lockout counter, and the password hash live outside any repo (`%LOCALAPPDATA%\doberman` / `~/.config/doberman`), past the repo-relative control-plane globs — probing showed every auth-state tamper command returned PASS with no reason codes. Deleting the seed silently un-enrolls 2FA; overwriting it hands an attacker the factor (ADR 0065).

Fix: 7 new `CONTROL_PLANE_GLOBS` entries matched against the raw token (`totp.secret`, `totp.secret.*`, `password.hash`, and the containing state dirs). Deliberately NOT a bare `**/doberman` — that would match this project's own checkout.

## Tests added (run in CI)
- tests/unit/test_control_plane_auth_state.py (new)

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation