### PR TITLE
fix(engine): recognise control-plane paths spelled with Windows separators

### DIFF
--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -499,6 +499,37 @@ def _segment_targets_control_plane(tokens: list[str], root: str) -> bool:
     return False
 
 
+def _control_plane_in_windows_form(command: str, root: str) -> bool:
+    """True if the command names the control plane using ``\\`` separators.
+
+    :func:`shlex.split` in POSIX mode treats ``\\`` as an **escape character**, so
+    ``rm .doberman\\policies.yaml`` tokenizes to ``.dobermanpolicies.yaml`` — the
+    separators are consumed before any path check runs, and the token matches no
+    glob. Every control-plane guarantee in this module was therefore reachable on
+    Windows just by spelling the path the way Windows spells it.
+
+    Re-scan a separator-normalized copy of the raw command so the Windows form is
+    caught too. This is **scan-only**: these tokens never reach verb
+    classification, operand counting, or the bulk-delete threshold, so the pass
+    can only ever add a control-plane BLOCK — it can never change what a command
+    is understood to *do*, and never lowers a verdict.
+
+    Normalizing is safe for a genuine POSIX escape (``rm my\\ file.txt`` becomes
+    the harmless tokens ``my/`` and ``file.txt``) because only control-plane glob
+    matching consumes the result.
+    """
+    if "\\" not in command:
+        return False
+    normalized = command.replace("\\", "/")
+    try:
+        tokens = shlex.split(normalized, comments=True, posix=True)
+    except ValueError:
+        # Unbalanced quoting: fall back to a crude split rather than give up —
+        # the caller still treats an unparseable command as ambiguous.
+        tokens = [t for t in re.split(r"[\s'\"`(){}\[\],;]+", normalized) if t]
+    return _segment_targets_control_plane(tokens, root)
+
+
 def _interpreter_payload_verdict(tokens: list[str], root: str) -> GuardrailResult | None:
     """BLOCK obvious control-plane or destructive interpreter one-liners."""
     if not tokens or tokens[0] not in _INTERPRETERS:
@@ -750,6 +781,18 @@ class DestructiveCommandRule:
 
     def _classify_line(self, command: str, bulk_threshold: int, root: str) -> GuardrailResult:
         worst: GuardrailResult = GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
+
+        # Checked against the RAW command, before shlex: POSIX tokenization eats
+        # the `\` separators, so a Windows-spelled control-plane path never
+        # survives to the per-segment scan below. _normalize_windows_backslashes
+        # only fires on Windows-verb trigger words, so a POSIX verb with a
+        # backslash-spelled path (`rm .doberman\policies.yaml`) needs this check.
+        if _control_plane_in_windows_form(command, root):
+            return _block_control_plane(
+                "Shell command targets Doberman's own control plane "
+                "(.doberman/ state or the .claude/ host-hook config)."
+            )
+
         pending, saw_unparseable, _ = walk_command(_normalize_windows_backslashes(command))
         processed = 0
         while pending and processed < _MAX_COMMAND_SEGMENTS:

--- a/tests/unit/test_control_plane_windows_separators.py
+++ b/tests/unit/test_control_plane_windows_separators.py
@@ -1,0 +1,124 @@
+"""A control-plane path spelled with Windows separators is still control plane.
+
+The command rule scans each segment's argv tokens for control-plane paths, and
+those tokens come from ``shlex.split(..., posix=True)``. In POSIX mode ``\\`` is
+an **escape character**, so ``rm .doberman\\policies.yaml`` tokenizes to the
+single token ``.dobermanpolicies.yaml``: the separators are consumed before any
+path check runs, and the result matches no glob.
+
+Every control-plane guarantee in the command rule was therefore reachable on
+Windows just by spelling the path the way Windows spells it — deleting the policy
+document, or rewriting the ``.claude`` host-hook config to unhook Doberman
+entirely. `names_control_plane` itself was never the problem; it normalizes
+separators correctly. The path simply never reached it.
+
+The fix re-scans a separator-normalized copy of the raw command, scan-only, so it
+can only ever add a control-plane BLOCK.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from doberman.engine.rules.commands import DestructiveCommandRule
+from doberman.models import ActionType, EvalContext, ReasonCode, SecurityObject, Verdict
+
+RULE = DestructiveCommandRule()
+
+
+def _cmd(command, *, root="."):
+    action = SecurityObject(
+        id="cp-winsep-1",
+        ts=datetime(2026, 8, 6, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.shell_exec,
+        tool_name="Bash",
+        target=command,
+        metadata={},
+    )
+    ctx = EvalContext(metadata={"raw_arguments": {"command": command}, "repo_root": root})
+    return RULE.evaluate(action, ctx)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        r"rm .doberman\policies.yaml",
+        r"del .doberman\policies.yaml",
+        r"rm -rf .doberman\baselines",
+        r"rm .claude\settings.json",
+        r"rm .claude\settings.local.json",
+        # nested, and absolute
+        r"rm sub\.doberman\policies.yaml",
+        r"rm C:\repo\.doberman\policies.yaml",
+        # mixed separators — the realistic copy-paste shape
+        r"rm ./sub\.doberman\policies.yaml",
+    ],
+)
+def test_windows_spelled_control_plane_delete_is_blocked(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.protected_path_blocked in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        r"echo {} > .claude\settings.json",
+        r"echo x >> .claude\settings.local.json",
+        r"cp evil.json .claude\settings.json",
+        r"sed -i s/a/b/ .doberman\policies.yaml",
+    ],
+)
+def test_windows_spelled_control_plane_write_is_blocked(command):
+    """Rewriting the hook config unhooks Doberman without deleting anything."""
+    assert _cmd(command).verdict is Verdict.BLOCK
+
+
+def test_the_forward_slash_form_still_blocks():
+    """Regression: the fix must not disturb the path that already worked."""
+    assert _cmd("rm -rf .doberman").verdict is Verdict.BLOCK
+    assert _cmd("echo '{}' > .claude/settings.json").verdict is Verdict.BLOCK
+
+
+# --- the normalization must not invent blocks ---
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A genuine POSIX escape. Normalizing gives the harmless tokens
+        # `my/` and `file.txt`; neither is control plane.
+        r"rm my\ file.txt",
+        r"echo hello\ world",
+        # Backslashes that have nothing to do with a path.
+        r"grep -r 'a\\b' src",
+        r"printf 'a\tb\n'",
+        # An ordinary Windows path that is not control plane.
+        r"rm C:\repo\build\out.txt",
+        r"type src\doberman\models.py",
+    ],
+)
+def test_ordinary_backslash_commands_are_not_blocked(command):
+    assert _cmd(command).verdict is not Verdict.BLOCK
+
+
+def test_a_command_with_no_backslash_is_untouched():
+    """The scan short-circuits on commands with no `\\`, so the common path pays
+    nothing and cannot change behavior."""
+    assert _cmd("ls -la").verdict is not Verdict.BLOCK
+    assert _cmd("git status").verdict is not Verdict.BLOCK
+
+
+def test_explanation_does_not_echo_the_command():
+    """Prime Directive 3: name the category, never the path."""
+    result = _cmd(r"rm C:\repo\.doberman\policies.yaml")
+    blob = f"{result.explanation} {' '.join(str(c) for c in result.reason_codes)}"
+    assert "C:" not in blob
+    assert "policies.yaml" not in blob
+
+
+def test_unbalanced_quoting_still_catches_the_control_plane():
+    """A command whose normalized form will not tokenize must not become a free
+    bypass — the crude fallback split still sees the path."""
+    assert _cmd(r"rm '.doberman\policies.yaml").verdict is Verdict.BLOCK


### PR DESCRIPTION
`commands.py` tokenizes with POSIX shlex, where `\` is an escape character — `rm .doberman\policies.yaml` tokenized to `.dobermanpolicies.yaml` and returned PASS. Main's word-triggered backslash normalization (#320) only fires on Windows verbs, so a POSIX verb with a backslash-spelled path still bypassed (ADR 0066).

Fix: `_control_plane_in_windows_form()` re-checks the raw, pre-shlex command for control-plane paths spelled with backslashes, before tokenization; composes with #320's normalization (which stays at the walk_command call site).

## Tests added (run in CI)
- tests/unit/test_control_plane_windows_separators.py (new)

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
