### PR TITLE
fix(readme): absolute image URLs so the logo and demo GIF render on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="logo.png" alt="Doberman logo" width="200">
+<img src="https://raw.githubusercontent.com/fu351/Doberman-Core/main/logo.png" alt="Doberman logo" width="200">
 
 # Doberman
 
@@ -17,7 +17,7 @@ Your AI coding agent can `rm -rf` your repo, leak your API keys, or be prompt-in
 </div>
 
 <p align="center">
-  <img src="docs/assets/dash-demo.gif" alt="The doberman demo attack reel against the live dashboard: a secret exfiltration, a destructive rm -rf, a protected-branch force push, a smuggled-token egress and a .env read are blocked in the live feed, then a human denies a high-risk SSH-trust-file write from the pending-approvals queue" width="820">
+  <img src="https://raw.githubusercontent.com/fu351/Doberman-Core/main/docs/assets/dash-demo.gif" alt="The doberman demo attack reel against the live dashboard: a secret exfiltration, a destructive rm -rf, a protected-branch force push, a smuggled-token egress and a .env read are blocked in the live feed, then a human denies a high-risk SSH-trust-file write from the pending-approvals queue" width="820">
   <br>
   <em><code>doberman demo</code> against the live dashboard (<code>doberman dash</code>): five attacks blocked as they happen, then a human denies a high-risk approval.</em>
 </p>


### PR DESCRIPTION
The README is the PyPI long-description (`pyproject.toml` `readme = "README.md"`). Its logo (`<img src="logo.png">`) and demo GIF (`docs/assets/dash-demo.gif`) used **repo-relative** paths — GitHub resolves those, but PyPI renders the README standalone and can't, so both showed as broken images on the v0.18.0 project page. The badges were already absolute, which is why only these two broke.

Fix: point both `<img src>` at `https://raw.githubusercontent.com/fu351/Doberman-Core/main/...` (verified both return 200 with the right image content-type). No other change.

Note: PyPI descriptions are immutable per release, so this surfaces on the **next** published version, not retroactively on 0.18.0.

## Security checklist
- [x] Fails closed on error / uncertainty (N/A — docs only)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (N/A)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (N/A)