### PR TITLE
chore(release): 0.18.1 — README images on PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 Shipped history for Doberman. Planned work lives on the [roadmap](README.md#roadmap) and the
 [project board](https://github.com/users/fu351/projects/5); exact per-commit detail is in the
 [git log](https://github.com/fu351/Doberman-Core/commits/main) and
-[releases](https://github.com/fu351/Doberman-Core/releases) (latest: **v0.18.0**, the security-audit wave — the proxy output-secret gate closed over error and structured/embedded channels, per-user auth state and Windows-separator paths brought under control-plane protection — plus the RAND-aligned guardrail rehaul and the UX/contributor work since 0.17.1).
+[releases](https://github.com/fu351/Doberman-Core/releases) (latest: **v0.18.1**, a docs patch fixing the README images on PyPI, atop **v0.18.0**'s security-audit wave — the proxy output-secret gate closed over error and structured/embedded channels, per-user auth state and Windows-separator paths brought under control-plane protection — plus the RAND-aligned guardrail rehaul and the UX/contributor work since 0.17.1).
+
+## 0.18.1 — 2026-08-15
+
+- **Docs:** the README's logo and demo GIF now use absolute `raw.githubusercontent.com` URLs so they render on the PyPI project page. They used repo-relative paths, which GitHub resolves but PyPI (which renders the README standalone) cannot, so both showed as broken images on the 0.18.0 page. Docs-only; no code change.
 
 ## 0.18.0 — 2026-08-15
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doberman-core"
-version = "0.18.0"
+version = "0.18.1"
 description = "Adaptive authorization layer for coding agents (open core)"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Docs-only patch on top of 0.18.0. Bumps `pyproject.toml` 0.18.0 → 0.18.1 and adds the 0.18.1 CHANGELOG entry for the README image fix (#382).

Why a patch: PyPI descriptions are immutable per release, so the corrected README (absolute image URLs) only surfaces on a new version. This republishes the description so the logo and demo GIF render on the project page.

Release path: GitHub Release tag `v0.18.1` → publish.yml OIDC → PyPI.

## Security checklist
- [x] Fails closed on error / uncertainty (N/A — release chore)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (N/A)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (N/A)