### PR TITLE
test(parity): prove gitignored-delete gate on mcp-proxy

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -10,7 +10,7 @@ Each row is a security guarantee; each column a host Doberman can front.
 | Guarantee | Claude Code | Codex | Mcp Proxy | Openclaw |
 |---|---|---|---|---|
 | Destructive shell commands are blocked or AUTH-gated | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_claude_pre.py) | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_codex.py) | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/integration/test_engine_blocks_reach_no_tool.py) | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_openclaw.py) |
-| Deleting unrecoverable gitignored data is gated (AN-1) | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_claude_pre.py) | ◻ | ◻ | ◻ |
+| Deleting unrecoverable gitignored data is gated (AN-1) | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_claude_pre.py) | ◻ | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/integration/test_engine_blocks_reach_no_tool.py) | ◻ |
 | A session that read a secret gets a raised floor on egress | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_taint_floor.py) | ◻ | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_proxy_taint_floor.py) | ◻ |
 | An outbound value matching a read secret is blocked | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_exfil_fingerprint.py) | ◻ | ◻ | ◻ |
 | Tool output carrying credentials is blocked from the model | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_claude_post.py) | ◻ | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_proxy_secret_output_gating.py) | — |

--- a/tests/integration/test_engine_blocks_reach_no_tool.py
+++ b/tests/integration/test_engine_blocks_reach_no_tool.py
@@ -90,6 +90,21 @@ async def test_auth_returns_error_and_nothing_recorded(monkeypatch):
         assert fake.calls == []
 
 
+@pytest.mark.guarantee("gitignored-delete-gate", host="mcp-proxy")
+async def test_unrecoverable_gitignored_delete_requires_auth(monkeypatch):
+    # Unlike the sibling above, DEFAULT_OBJECTIVE is left real: the actual
+    # DestructiveCommandRule decides AUTH here, proving the engine-level
+    # guarantee (tests/unit/test_rule_commands.py::
+    # test_unrecoverable_gitignored_data_delete_requires_auth) holds through
+    # the MCP proxy's wiring too.
+    monkeypatch.setattr(executor, "run_auth_challenge", _deny_challenge)
+    async with proxied_session() as (fake, agent):
+        result = await agent.call_tool("shell_exec", {"command": "rm data/app.db"})
+        assert result.isError
+        assert "authentication required" in result.content[0].text
+        assert fake.calls == []
+
+
 async def test_engine_exception_fails_closed(monkeypatch):
     def exploding_decide(*args, **kwargs):
         raise RuntimeError("engine exploded")


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: parity — gitignored-delete gate on mcp-proxy (closes #330)

## What this PR does
Adds the MCP-proxy sibling of `tests/unit/test_rule_commands.py::test_unrecoverable_gitignored_data_delete_requires_auth`,
proving the AN-1 guarantee ("deleting unrecoverable gitignored data is gated")
holds through the proxy's wiring, not just at the engine-rule level. No
production code changes — `DestructiveCommandRule` already enforces this; the
gap was test coverage on this host only.

`docs/PARITY.md` is regenerated (`python -m tools.parity.generate_parity`) so
the `Mcp Proxy` cell for that guarantee moves from `◻` to `✅`, linking to the
new test. No other cell changes.

## Tests added (run in CI)
- `tests/integration/test_engine_blocks_reach_no_tool.py::test_unrecoverable_gitignored_delete_requires_auth`
  — marked `@pytest.mark.guarantee("gitignored-delete-gate", host="mcp-proxy")`.
  Sends `rm data/app.db` as a `shell_exec` call through the real proxied
  session (`DEFAULT_OBJECTIVE` left un-stubbed, only `run_auth_challenge` is
  monkeypatched to a deterministic denial), and asserts the result is an
  AUTH-required error and that the fake downstream recorded **nothing**.

**Mutation-checked:** temporarily commented out the unrecoverable-data branch
in `_segment_verdict` (`src/doberman/engine/rules/commands.py`) and confirmed
this new test goes red (`assert result.isError` fails: the call passes
through unmediated instead); reverted before committing.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (unchanged; this PR is test-only)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — N/A, no guardrail logic changed
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — unchanged, verified by the new test
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- None beyond the issue's scope. Locally, `pytest -n auto --cov=doberman --cov-fail-under=80`
  reports 2841 passed / 6 skipped / 1 failed at 91.92% coverage; the one
  failure (`test_real_plugin_install_discovery.py::test_installed_plugin_is_discovered_and_fires_despite_pip_target`)
  is a pre-existing, environment-specific failure reproduced identically on
  a clean, unmodified `main` in this sandbox (an isolated venv it pip-installs
  into can't import `doberman` afterward) — unrelated to this change and not
  introduced by it.

---
Written with AI assistance (Claude Code) as a guided first-contribution
walkthrough; all commands were run and verified locally before pushing.
