### PR TITLE
docs(readme): claim only the hosts that ship adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ AI agent ──▶ Doberman ──▶ real tools (files, shell, MCP servers, API
                  └─ normalize → risk engine → PASS / AUTH / BLOCK
 ```
 
-Works with **Claude Code, Cursor, Codex, Copilot, and any MCP-compatible agent.** Open-source, local-first, and bound by two rules it will never break: it **fails closed** (uncertainty denies) and is **raise-only** (it can tighten automatically, but never silently loosens).
+Works with **Claude Code, Codex, OpenClaw, and any MCP-compatible agent** — Cursor and other MCP clients connect through the [MCP proxy](#quick-start). Open-source, local-first, and bound by two rules it will never break: it **fails closed** (uncertainty denies) and is **raise-only** (it can tighten automatically, but never silently loosens).
 
 <div align="center">
 


### PR DESCRIPTION
## Slice
- P0 trust fix (2026-08-16 e2e review): honest host-support claim

## What this PR does
The opening line named Cursor and Copilot as supported hosts. Neither has an adapter, a quickstart row, or a parity-matrix column. The line now names the three adapter-backed hosts (Claude Code, Codex, OpenClaw) and routes Cursor and other MCP clients to the MCP proxy, which the quick-start table already documents.

## Tests added (run in CI)
- None — docs-only; no behavior changed.

## Security checklist
- [x] Fails closed on error / uncertainty (N/A — docs)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (N/A — docs)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (N/A — docs)

## Edge cases covered / Deviations from plan / Risks introduced
- Public-release safe: README wording only.