### PR TITLE
fix(cli): doctor treats a fresh install's absent decision DB as WARN, not FAIL

### DIFF
--- a/src/doberman/cli/doctor.py
+++ b/src/doberman/cli/doctor.py
@@ -172,17 +172,22 @@ def _check_db(path: str) -> CheckResult:
 
     p = db_path(path)
     if not p.exists():
+        # Absent is the normal state of a fresh install (the DB appears on the
+        # first gated decision), so it must not fail the run — a red "may not be
+        # protecting you" on a healthy first-run `doctor` teaches users to
+        # ignore the tool. Present-but-unreadable below stays a critical FAIL.
         return CheckResult(
             "Decision DB",
-            CheckStatus.FAIL,
-            "not found — created on first decision; run `doberman setup`",
-            critical=True,
+            CheckStatus.WARN,
+            "not created yet — appears on the first gated decision",
         )
     # Read-only probe: open in SQLite `mode=ro` so we never create or migrate.
     try:
         conn = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
         try:
-            conn.execute("SELECT 1").fetchone()
+            # Must touch the schema: a bare `SELECT 1` never reads the file, so
+            # a corrupt/non-SQLite file would probe as healthy.
+            conn.execute("SELECT 1 FROM sqlite_master LIMIT 1").fetchone()
         finally:
             conn.close()
     except sqlite3.Error as exc:

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -150,14 +150,32 @@ def test_doctor_config_corrupt_fails_closed(tmp_path):
     assert "failed to load" in result.stdout
 
 
-def test_doctor_db_missing_fails(tmp_path):
+def test_doctor_db_missing_warns_but_passes(tmp_path):
+    # A fresh install has no decision DB until the first gated decision — that
+    # is healthy, not a critical failure (P0-2, 2026-08-16 e2e review).
     root = str(tmp_path)
     _install_hooks(root)
-    _save_config(root)  # healthy EXCEPT the decision DB
+    _save_config(root)  # fresh install: no decision DB yet
+
+    result = runner.invoke(app, ["doctor", "--path", root])
+    assert result.exit_code == 0
+    assert "[warn] Decision DB: not created yet" in result.stdout
+    assert "may not be protecting you" not in result.stdout
+
+
+def test_doctor_db_unreadable_still_fails(tmp_path):
+    # The loosening is scoped to ABSENT only: a present-but-corrupt DB is a
+    # real health failure and must stay critical.
+    root = str(tmp_path)
+    _install_hooks(root)
+    _save_config(root)
+    db_file = tmp_path / ".doberman" / "doberman.db"
+    db_file.parent.mkdir(parents=True, exist_ok=True)
+    db_file.write_bytes(b"this is not a sqlite database")
 
     result = runner.invoke(app, ["doctor", "--path", root])
     assert result.exit_code == 1
-    assert "[FAIL] Decision DB: not found" in result.stdout
+    assert "[FAIL] Decision DB: present but unreadable" in result.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Slice
- P0 trust fix (2026-08-16 e2e review, P0-2): first-run doctor honesty

## What this PR does
Immediately after `doberman setup --yes`, `doctor` printed `[FAIL] Decision DB: not found`, exited 1, and warned 'Doberman may not be protecting you' — on a healthy install. The DB only appears on the first gated decision, and the check's own message said so. Absent is now a non-critical `[warn]`; a fresh install's doctor exits 0.

Scoped tightening in the same check: the read probe ran `SELECT 1`, which never touches the file, so a corrupt or non-SQLite DB probed as healthy. The probe now reads `sqlite_master`, making the present-but-unreadable FAIL branch real.

## Tests added (run in CI)
- `test_doctor_db_missing_warns_but_passes` — fresh install: exit 0, `[warn]`, no scare line.
- `test_doctor_db_unreadable_still_fails` — garbage bytes at the DB path: still a critical FAIL (the loosened path is absent-only).

## Security checklist
- [x] Fails closed on error / uncertainty — unreadable/corrupt stays critical FAIL, and now actually detects corruption
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only — health reporting only; no decision-path change
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (N/A)

## Edge cases covered / Deviations from plan / Risks introduced
- Absent-vs-corrupt distinction is the edge; both directions tested. Public-release safe.