### PR TITLE
feat(auth): DOBERMAN_AUTODENY_AUTH — deny-only headless switch for unattended runs

### DIFF
--- a/src/doberman/auth/challenge.py
+++ b/src/doberman/auth/challenge.py
@@ -31,6 +31,7 @@ wall-clock deadline on every challenge and denies when it expires.
 import asyncio
 import contextvars
 import logging
+import os
 import threading
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -63,6 +64,22 @@ DEFAULT_CHALLENGE_TIMEOUT_S = 1200.0
 #: and ``"error"`` (a channel failed): an audit must be able to tell silence
 #: apart from refusal, because they call for different operator responses.
 TIMEOUT_METHOD = "timeout"
+
+#: Dev/test escape hatch (ADR 0074): when this env var is truthy every AUTH
+#: challenge denies immediately, before any approval channel (dashboard, GUI
+#: dialog, TTY) opens. Deny-only by construction — there is no approve path —
+#: so setting it can only make Doberman stricter; it cannot bypass auth. Meant
+#: for unattended dev/test/CI runs; deliberately absent from user-facing docs.
+AUTODENY_ENV = "DOBERMAN_AUTODENY_AUTH"
+
+#: :attr:`AuthResult.method` when :data:`AUTODENY_ENV` resolved the challenge.
+#: Distinct from ``"denied"``/``"timeout"``/``"error"`` so the audit log never
+#: mistakes a dev-switch denial for a human decision or a channel failure.
+AUTODENY_METHOD = "autodeny"
+
+
+def _autodeny_enabled() -> bool:
+    return os.environ.get(AUTODENY_ENV, "").strip().lower() in {"1", "true", "yes"}
 
 
 class AuthTier(StrEnum):
@@ -268,6 +285,17 @@ def run_auth_challenge(
     from doberman.auth.provider import active_provider
 
     tier = select_tier(decision)
+    if _autodeny_enabled():
+        # ADR 0074: dev-only fail-closed shortcut — deny before any channel
+        # opens. Cannot approve, so it is never an auth bypass.
+        logger.info("auth challenge auto-denied by %s (action %s)", AUTODENY_ENV, action.id)
+        return AuthResult(
+            approved=False,
+            tier=tier,
+            method=AUTODENY_METHOD,
+            at=at or datetime.now(timezone.utc),
+            action_id=action.id,
+        )
     token = _current_challenge.set((decision, action, tier))
     try:
         return _run_with_deadline(

--- a/tests/unit/test_auth_autodeny.py
+++ b/tests/unit/test_auth_autodeny.py
@@ -1,0 +1,121 @@
+"""DOBERMAN_AUTODENY_AUTH — the dev-only, deny-only headless switch (ADR 0074).
+
+The env var must deny every AUTH challenge *before any approval channel opens*
+and must never be able to approve — it is a fail-closed escape hatch for
+unattended dev/test runs, not an auth bypass.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from doberman.auth.challenge import AUTODENY_ENV, AUTODENY_METHOD, run_auth_challenge
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    SourceContext,
+    Verdict,
+)
+
+
+class _MustNotBeConsulted:
+    """A prompter that fails the test if any channel is opened."""
+
+    def confirm(self, message: str) -> bool:
+        raise AssertionError("prompter consulted despite autodeny")
+
+    def read_code(self, message: str) -> str:
+        raise AssertionError("prompter consulted despite autodeny")
+
+
+class _AlwaysYes:
+    def confirm(self, message: str) -> bool:
+        return True
+
+    def read_code(self, message: str) -> str:
+        return "000000"
+
+
+def _auth_decision_and_action() -> tuple[Decision, SecurityObject]:
+    action = SecurityObject(
+        id="autodeny-test-action",
+        ts=datetime.now(timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.shell_exec,
+        tool_name="shell_exec",
+        target=None,
+        external_destination=None,
+        source_context=SourceContext.unknown,
+        raw_args_redacted={},
+        metadata={},
+    )
+    objective = GuardrailResult(
+        verdict=Verdict.AUTH,
+        risk=Risk.medium,
+        reason_codes=[ReasonCode.egress_requires_auth],
+        explanation="test challenge",
+    )
+    decision = Decision(
+        action_id=action.id,
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.medium,
+        objective=objective,
+        reason_codes=[ReasonCode.egress_requires_auth],
+        explanation="test challenge",
+        decided_at=datetime.now(timezone.utc),
+    )
+    return decision, action
+
+
+def test_autodeny_denies_without_opening_any_channel(monkeypatch):
+    monkeypatch.setenv(AUTODENY_ENV, "1")
+    decision, action = _auth_decision_and_action()
+
+    result = run_auth_challenge(decision, action, prompter=_MustNotBeConsulted())
+
+    assert result.approved is False
+    assert result.method == AUTODENY_METHOD
+    assert result.action_id == action.id
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "yes", " 1 "])
+def test_autodeny_accepts_common_truthy_spellings(monkeypatch, value):
+    monkeypatch.setenv(AUTODENY_ENV, value)
+    decision, action = _auth_decision_and_action()
+
+    result = run_auth_challenge(decision, action, prompter=_MustNotBeConsulted())
+
+    assert result.approved is False
+    assert result.method == AUTODENY_METHOD
+
+
+@pytest.mark.parametrize("value", ["0", "false", "", "no"])
+def test_non_truthy_values_leave_the_challenge_live(monkeypatch, value):
+    # With the switch off (or nonsense), the normal challenge path runs — the
+    # prompter IS consulted. An _AlwaysYes prompter approving proves we took
+    # the real path, not the autodeny shortcut.
+    monkeypatch.setenv(AUTODENY_ENV, value)
+    decision, action = _auth_decision_and_action()
+
+    result = run_auth_challenge(decision, action, prompter=_AlwaysYes())
+
+    assert result.method != AUTODENY_METHOD
+
+
+def test_autodeny_can_never_approve(monkeypatch):
+    # The whole point: even a prompter that says yes to everything cannot
+    # produce an approval while the switch is set, because no channel is ever
+    # consulted. Deny-only by construction — not an auth bypass.
+    monkeypatch.setenv(AUTODENY_ENV, "1")
+    decision, action = _auth_decision_and_action()
+
+    result = run_auth_challenge(decision, action, prompter=_AlwaysYes())
+
+    assert result.approved is False
+    assert result.method == AUTODENY_METHOD


### PR DESCRIPTION
## Slice
- P0-5 (2026-08-16 e2e review): headless dev runs had no way to avoid the GUI auth dialog. ADR 0074.

## What this PR does
`hook pre` on piped stdin — exactly how a harness invokes it — pops a tkinter dialog on every AUTH and stalls up to 120 s before auto-denying. With `DOBERMAN_AUTODENY_AUTH` set (`1`/`true`/`yes`), `run_auth_challenge` denies immediately, before any approval channel opens, with the distinct method `autodeny` so the audit log never reads a dev-switch denial as a human decision or a timeout.

Scope guard, by design: **deny-only**. There is no approve path under the switch, so it cannot be used to bypass authentication — setting it only makes Doberman stricter. It lives at the one challenge seam, so host hooks, the MCP proxy, and the turn gate inherit it uniformly. Deliberately absent from README and user docs: it is a dev/CI escape hatch, not a product feature.

## Tests added (run in CI)
`tests/unit/test_auth_autodeny.py` — denies without consulting any prompter (a prompter that raises on contact proves no channel opened); common truthy spellings; non-truthy values leave the real challenge live; and the core property: even an always-approve prompter cannot produce an approval while the switch is set.

## Security checklist
- [x] Fails closed on error / uncertainty — the switch IS a fail-closed shortcut
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only — deny-only; strictly tighter
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — decision content unchanged; only the challenge outcome method differs

## Edge cases covered / Deviations from plan / Risks introduced
- Distinct `autodeny` method string keeps audit rows honest vs `denied`/`timeout`/`error`.
- Residual: a forgotten exported var denies every AUTH — the method string in `doberman log` is the breadcrumb. Public-release safe.