### PR TITLE
chore: add blackcoderx to CONTRIBUTORS

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@ In alphabetical order by handle (ordering is not a ranking):
 - [@AshSgDe29071999](https://github.com/AshSgDe29071999)
 - [@averyquinnhq](https://github.com/averyquinnhq)
 - [@Bestpart-Irene](https://github.com/Bestpart-Irene)
+- [@blackcoderx](https://github.com/blackcoderx)
 - [@harshitagrawal2O](https://github.com/harshitagrawal2O)
 - [@jasperdingg](https://github.com/jasperdingg)
 - **Lee Sang Hoon** — [@leemeo3](https://github.com/leemeo3)


### PR DESCRIPTION
## Slice
- §8b step 6: contributor credit for PR #384 (parity test proving the gitignored-delete gate on the MCP proxy, closes #330).

## What this PR does
Adds @blackcoderx to CONTRIBUTORS.md, alphabetical by handle.

## Tests added (run in CI)
- None — docs-only.

## Security checklist
- [x] N/A — contributor list only.