### PR TITLE
test(parity): prove auth-action-bound gate on codex

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -15,7 +15,7 @@ Each row is a security guarantee; each column a host Doberman can front.
 | An outbound value matching a read secret is blocked | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_exfil_fingerprint.py) | ◻ | ◻ | ◻ |
 | Tool output carrying credentials is blocked from the model | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_claude_post.py) | ◻ | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_proxy_secret_output_gating.py) | — |
 | The agent cannot edit Doberman's own config or hooks | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_control_plane.py) | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_rule_paths_codex_control_plane.py) | ◻ | ◻ |
-| Approvals are single-use and bound to one action id | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_auth_challenge.py) | ◻ | ◻ | ◻ |
+| Approvals are single-use and bound to one action id | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_auth_challenge.py) | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_hosthook_codex.py) | ◻ | ◻ |
 | AUTH challenges auto-deny at the wall-clock deadline | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_auth_challenge_timeout.py) | ◻ | ◻ | ◻ |
 | A timeout is logged distinctly from a refusal | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/unit/test_auth_challenge_timeout.py) | ◻ | ◻ | ◻ |
 | Policy weakening requires the human-approved path | ◻ | ◻ | [✅](https://github.com/fu351/Doberman-Core/blob/main/tests/integration/test_drift_gate.py) | ◻ |

--- a/tests/unit/test_hosthook_codex.py
+++ b/tests/unit/test_hosthook_codex.py
@@ -8,10 +8,12 @@ present). Deterministic and hermetic — no live ``codex`` process.
 """
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
+from doberman.auth.challenge import AuthResult, AuthTier
 from doberman.hosthooks import codex
 from doberman.hosthooks import spine as spine_module
 
@@ -188,6 +190,44 @@ def test_auth_runs_dobermans_own_challenge(tmp_path, monkeypatch):
     # A Write to a CI/CD config is DEFAULT_SENSITIVE -> AUTH tier (the path rule
     # runs on the file_write target; a shell redirect to the same path is not
     # AUTH'd by the command rule, so use a real file-write action here).
+    payload["tool_name"] = "Write"
+    payload["tool_input"] = {"file_path": ".github/workflows/ci.yml", "content": "x"}
+    out = codex.evaluate_pre(payload)
+    assert out is not None, "an AUTH-tier action must not abstain"
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+class _Approve:
+    """A local human who is present and says yes (confirm-only tiers)."""
+
+    def confirm(self, message):
+        return True
+
+    def read_code(self, message):
+        return "000000"
+
+
+@pytest.mark.guarantee("auth-action-bound", host="codex")
+def test_approval_is_bound_to_the_action_id(tmp_path, monkeypatch):
+    """#65/#67 parity: an approval for one action id must never authorize a
+    different action, even if a buggy or compromised auth provider returns
+    "approved" — mirrors test_hosthook_auth_challenge.py's own-host proof."""
+
+    def _fake_challenge(decision, action, *, prompter=None, at=None):
+        return AuthResult(
+            approved=True,
+            tier=AuthTier.local_auth,
+            method="local_auth",
+            at=datetime.now(timezone.utc),
+            action_id="some-other-action",  # approved, but for the WRONG action
+        )
+
+    monkeypatch.setattr(codex, "AUTH_PROMPTER", _Approve())
+    monkeypatch.setattr("doberman.auth.challenge.run_auth_challenge", _fake_challenge)
+    payload = _load("pre_bash.json")
+    payload["cwd"] = str(tmp_path)
+    # A Write to a CI/CD config is DEFAULT_SENSITIVE -> AUTH tier (same action
+    # used by test_auth_runs_dobermans_own_challenge above).
     payload["tool_name"] = "Write"
     payload["tool_input"] = {"file_path": ".github/workflows/ci.yml", "content": "x"}
     out = codex.evaluate_pre(payload)


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: parity — auth-action-bound gate on codex (closes #331)

## What this PR does
Adds the Codex sibling of `tests/unit/test_hosthook_auth_challenge.py::test_approval_is_bound_to_the_action_id`,
proving that an approved auth result is only honored when it's bound to the
same action id — through the Codex host-hook adapter, not just Claude Code.
No production code changes — `hookio.resolve_auth`'s binding check
(`result.approved and result.action_id == action.id`) is shared by both
adapters already; the gap was test coverage on the Codex host only.

`docs/PARITY.md` is regenerated (`python -m tools.parity.generate_parity`) so
the `Codex` cell for "Approvals are single-use and bound to one action id"
moves from `◻` to `✅`, linking to the new test. No other cell changes.

## Tests added (run in CI)
- `tests/unit/test_hosthook_codex.py::test_approval_is_bound_to_the_action_id`
  — marked `@pytest.mark.guarantee("auth-action-bound", host="codex")`.
  Monkeypatches `doberman.auth.challenge.run_auth_challenge` to return an
  `AuthResult(approved=True, action_id="some-other-action")` — approved, but
  for the wrong action — against an AUTH-tier `Write` to
  `.github/workflows/ci.yml`, and asserts `codex.evaluate_pre(...)` still
  denies.

**Mutation-checked:** temporarily dropped the `result.action_id == action.id`
comparison in `hookio.resolve_auth` and confirmed this new test goes red
(the mismatched-action approval wrongly resolves to `allow`); reverted before
committing.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (unchanged; this PR is test-only)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — N/A, no guardrail logic changed
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — unchanged, verified by the new test
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- None beyond the issue's scope. Locally, `pytest -n auto --cov=doberman --cov-fail-under=80`
  reports 2842 passed / 6 skipped / 1 failed at 91.78% coverage; the one
  failure (`test_real_plugin_install_discovery.py::test_installed_plugin_is_discovered_and_fires_despite_pip_target`)
  is the same pre-existing, environment-specific failure noted in #384 —
  reproduced identically on a clean `main` in this sandbox, unrelated to this
  change.

---
Written with AI assistance (Claude Code) as a guided contribution walkthrough;
all commands were run and verified locally before pushing.
