### PR TITLE
docs(cli): define shared JSON-output contract in CLI.md and conftest.py (Issue #192)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,9 +1,6 @@
 # Doberman CLI reference
-
 Entry point: `doberman` (Typer). All commands accept `--help`.
-
 ## Core commands
-
 | Command | Purpose |
 |---------|---------|
 | `doberman scan` | Read-only capability risk map of the repo |
@@ -30,57 +27,41 @@ Entry point: `doberman` (Typer). All commands accept `--help`.
 | `doberman serve` | MCP stdio proxy in front of a downstream tool server |
 | `doberman version` | Print the installed Doberman version |
 | `doberman session-summary` | Print the device-global session-guard summary and exit |
-
 Global option: `doberman --version` / `-V` also prints the version and exits.
-
 ## Output conventions
-
 Human-readable diagnostics use one severity vocabulary: `error:` means the command failed and
 returned a non-zero exit code, `warning:` means the command succeeded but skipped or degraded
 something, and `note:` marks a purely informational aside. Machine-readable flags keep their
 documented schemas and do not add these prefixes.
-
 ## Auth enrollment
-
 Security-posture commands used by [SETUP.md](SETUP.md). Group entry points also appear in `doberman --help`.
-
 | Command | Purpose |
 |---------|---------|
 | `doberman 2fa setup` | Enroll TOTP two-factor; print provisioning URI |
 | `doberman 2fa remove` | Remove TOTP enrollment (proves possession of the factor) |
 | `doberman 2fa reset-lockout` | Clear TOTP lockout early (proves password possession) |
 | `doberman password set` | Set or rotate the local password possession factor |
-
 ## Session taint recovery
-
 | Command | Purpose |
 |---------|---------|
 | `doberman taint clear` | Clear this repo's sticky session taint (gated; needs a possession factor) |
-
 ## Host hooks
-
 Low-level harness integration (also installed via `install-hooks` / `setup`).
-
 | Command | Purpose |
 |---------|---------|
 | `doberman hook pre` | Claude Code PreToolUse — gate one tool call |
 | `doberman hook codex-pre` | Codex CLI PreToolUse — gate one tool call (same decision spine as `hook pre`) |
 | `doberman hook post` | Claude Code PostToolUse — scan output for secrets; record history |
 | `doberman hook openclaw` | OpenClaw `before_tool_call` plugin hook — gate one tool call |
-
 ## Machine-readable flags
-
 | Flag | Commands | Notes |
 |------|----------|-------|
 | `--json` | `scan`, `doctor`, `policy-history` | One JSON document on stdout |
 | `--jsonl` | `log` | One redacted decision object per line (empty if none) |
 | `--quiet` / `-q` | `scan` | No human map; exit code preserved |
 | `--path` / `-p` | most commands | Repository root (default `.`) |
-
 When both are passed, `--json` wins over `--quiet`: machine-readable JSON is still emitted.
-
 ### `doberman scan --json` schema
-
 ```json
 {
   "version": 1,
@@ -96,21 +77,63 @@ When both are passed, `--json` wins over `--quiet`: machine-readable JSON is sti
   ]
 }
 ```
-
 Capabilities are sorted by `(category, name)` for deterministic output.
-
 Each capability's `evidence` list is capped at **10** entries in discovery. The human-readable risk map shows only the first **3** of those entries per capability — so `doberman scan` and `doberman scan --json` can legitimately differ in how much evidence they display for the same capability.
-
 ### `doberman doctor --json`
-
 Emits `{version, path, ok, checks[], critical_failures[]}`. Exit code is still non-zero when critical checks fail.
-
 ### `doberman log --jsonl`
-
 Emits one redacted JSON object per decision line (newest first). Columns are an allowlist of already-redacted fields (`ts`, `final_verdict`, `action_type`, `target_path_class`, `reason_codes`, `auth_result`, plus `id` / `agent_role` / `risk` when present). Empty output when there are no rows.
 
-## Examples
+## JSON output conventions
 
+All four machine-readable modes share one contract. Understanding it once covers every command.
+
+### Flag naming
+
+- **`--json`** (`scan`, `doctor`, `policy-history`) — emits **one JSON document** on stdout: a single
+  JSON object or array that can be piped directly into `jq`, `python -m json.tool`, or any
+  JSON-aware tool.
+- **`--jsonl`** (`log`) — emits **one JSON object per line** (JSON Lines / NDJSON). Each line is
+  independently parseable; an empty result set produces empty stdout, not `[]`. This shape suits
+  streaming consumers and `while read line` shell loops.
+
+The two shapes are genuinely different and the flag names make the difference explicit:
+`--json` → one document, `--jsonl` → one object per line.
+
+### Stdout purity
+
+When a machine-readable flag is active, **stdout contains JSON and nothing else**. Rich tables,
+headings, progress spinners, and `note:` / `warning:` lines are suppressed or redirected to
+stderr. Scripts must read only stdout; humans can read stderr.
+
+### Redaction guarantee
+
+JSON output never contains raw file paths, file contents, argument values, environment variables,
+secrets, or prompt text. It contains only what the human view already shows — path *classes*
+(`*.env`, `backend/auth/*.ts`), reason-code enumerations, risk levels, and verdicts — because
+both modes draw from the same already-redacted data source.
+
+### Determinism guarantee
+
+All `--json` documents have **deterministic key ordering** (`sort_keys=True`) and **compact
+separators** (`","` / `":"`). Two invocations on identical state produce byte-for-byte identical
+output. `--jsonl` produces deterministic per-line objects with the same key ordering; line order
+follows the command's documented row order (newest-first for `log`).
+
+### Exit codes
+
+Machine-readable flags do not change exit semantics. `doctor --json` still exits non-zero when
+critical checks fail. `scan --json` still exits zero even when high-risk capabilities are present
+(the human `--quiet` behavior). Scripts must check the exit code independently of parsing the
+JSON payload.
+
+### `doberman policy-history --json` schema
+
+Emits a JSON array of policy-change rows in newest-first order, using the same redacted fields
+`read_policy_changes()` returns. Each element contains the change timestamp, the changed key,
+the previous and new values, and the actor. No raw policy contents, secrets, or file paths appear.
+
+## Examples
 ```bash
 doberman scan --path . | less
 doberman scan --json | jq '.capabilities[] | select(.present)'
@@ -122,5 +145,4 @@ doberman 2fa setup
 doberman password set
 doberman setup
 ```
-
 See also [SETUP.md](SETUP.md) and the root README.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,6 +1,9 @@
 # Doberman CLI reference
+
 Entry point: `doberman` (Typer). All commands accept `--help`.
+
 ## Core commands
+
 | Command | Purpose |
 |---------|---------|
 | `doberman scan` | Read-only capability risk map of the repo |
@@ -27,41 +30,57 @@ Entry point: `doberman` (Typer). All commands accept `--help`.
 | `doberman serve` | MCP stdio proxy in front of a downstream tool server |
 | `doberman version` | Print the installed Doberman version |
 | `doberman session-summary` | Print the device-global session-guard summary and exit |
+
 Global option: `doberman --version` / `-V` also prints the version and exits.
+
 ## Output conventions
+
 Human-readable diagnostics use one severity vocabulary: `error:` means the command failed and
 returned a non-zero exit code, `warning:` means the command succeeded but skipped or degraded
 something, and `note:` marks a purely informational aside. Machine-readable flags keep their
 documented schemas and do not add these prefixes.
+
 ## Auth enrollment
+
 Security-posture commands used by [SETUP.md](SETUP.md). Group entry points also appear in `doberman --help`.
+
 | Command | Purpose |
 |---------|---------|
 | `doberman 2fa setup` | Enroll TOTP two-factor; print provisioning URI |
 | `doberman 2fa remove` | Remove TOTP enrollment (proves possession of the factor) |
 | `doberman 2fa reset-lockout` | Clear TOTP lockout early (proves password possession) |
 | `doberman password set` | Set or rotate the local password possession factor |
+
 ## Session taint recovery
+
 | Command | Purpose |
 |---------|---------|
 | `doberman taint clear` | Clear this repo's sticky session taint (gated; needs a possession factor) |
+
 ## Host hooks
+
 Low-level harness integration (also installed via `install-hooks` / `setup`).
+
 | Command | Purpose |
 |---------|---------|
 | `doberman hook pre` | Claude Code PreToolUse — gate one tool call |
 | `doberman hook codex-pre` | Codex CLI PreToolUse — gate one tool call (same decision spine as `hook pre`) |
 | `doberman hook post` | Claude Code PostToolUse — scan output for secrets; record history |
 | `doberman hook openclaw` | OpenClaw `before_tool_call` plugin hook — gate one tool call |
+
 ## Machine-readable flags
+
 | Flag | Commands | Notes |
 |------|----------|-------|
-| `--json` | `scan`, `doctor`, `policy-history` | One JSON document on stdout |
+| `--json` | `status`, `scan`, `doctor`, `policy-history` | One JSON document on stdout |
 | `--jsonl` | `log` | One redacted decision object per line (empty if none) |
 | `--quiet` / `-q` | `scan` | No human map; exit code preserved |
 | `--path` / `-p` | most commands | Repository root (default `.`) |
+
 When both are passed, `--json` wins over `--quiet`: machine-readable JSON is still emitted.
+
 ### `doberman scan --json` schema
+
 ```json
 {
   "version": 1,
@@ -77,22 +96,30 @@ When both are passed, `--json` wins over `--quiet`: machine-readable JSON is sti
   ]
 }
 ```
+
 Capabilities are sorted by `(category, name)` for deterministic output.
+
 Each capability's `evidence` list is capped at **10** entries in discovery. The human-readable risk map shows only the first **3** of those entries per capability — so `doberman scan` and `doberman scan --json` can legitimately differ in how much evidence they display for the same capability.
+
 ### `doberman doctor --json`
+
 Emits `{version, path, ok, checks[], critical_failures[]}`. Exit code is still non-zero when critical checks fail.
+
 ### `doberman log --jsonl`
+
 Emits one redacted JSON object per decision line (newest first). Columns are an allowlist of already-redacted fields (`ts`, `final_verdict`, `action_type`, `target_path_class`, `reason_codes`, `auth_result`, plus `id` / `agent_role` / `risk` when present). Empty output when there are no rows.
 
 ## JSON output conventions
 
-All four machine-readable modes share one contract. Understanding it once covers every command.
+All five machine-readable modes (`status --json`, `scan --json`, `doctor --json`,
+`policy-history --json`, `log --jsonl`) share one contract. Understanding it once covers every
+command.
 
 ### Flag naming
 
-- **`--json`** (`scan`, `doctor`, `policy-history`) — emits **one JSON document** on stdout: a single
-  JSON object or array that can be piped directly into `jq`, `python -m json.tool`, or any
-  JSON-aware tool.
+- **`--json`** (`status`, `scan`, `doctor`, `policy-history`) — emits **one JSON document** on
+  stdout: a single JSON object or array that can be piped directly into `jq`,
+  `python -m json.tool`, or any JSON-aware tool.
 - **`--jsonl`** (`log`) — emits **one JSON object per line** (JSON Lines / NDJSON). Each line is
   independently parseable; an empty result set produces empty stdout, not `[]`. This shape suits
   streaming consumers and `while read line` shell loops.
@@ -129,11 +156,14 @@ JSON payload.
 
 ### `doberman policy-history --json` schema
 
-Emits a JSON array of policy-change rows in newest-first order, using the same redacted fields
-`read_policy_changes()` returns. Each element contains the change timestamp, the changed key,
-the previous and new values, and the actor. No raw policy contents, secrets, or file paths appear.
+Emits a JSON array of ledger rows, newest first — the same redacted dicts the human view reads:
+`ts`, `rule_id`, `from_state`, `to_state`, `classification` (strengthen / weaken / neutral),
+`reason` (redacted at write time), `approval_method`, `approved` (denied weakening attempts are
+recorded too — the poisoning signal), and `approved_by`. No raw policy contents, secrets, or file
+paths appear.
 
 ## Examples
+
 ```bash
 doberman scan --path . | less
 doberman scan --json | jq '.capabilities[] | select(.present)'
@@ -145,4 +175,5 @@ doberman 2fa setup
 doberman password set
 doberman setup
 ```
+
 See also [SETUP.md](SETUP.md) and the root README.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Shared test fixtures.
+
 Feature 3 introduces keyed HMAC fingerprinting, which reads/creates a local key
 file. Tests must NEVER touch the real per-user key (deterministic, isolated
 runs only), so we point ``DOBERMAN_KEY_FILE`` at a throwaway path inside a
@@ -23,6 +24,7 @@ from doberman.storage.fingerprint import KEY_FILE_ENV
 def isolated_fingerprint_key(tmp_path, monkeypatch):
     """Point the HMAC key at a per-test temp file so tests never use the real
     user key and never share key state across tests.
+
     Returns the key path so tests that exercise key generation/rotation can use
     it directly (there is exactly ONE setter of the env var — this fixture — so
     the key path is deterministic and free of fixture-ordering races).
@@ -35,6 +37,7 @@ def isolated_fingerprint_key(tmp_path, monkeypatch):
 @pytest.fixture(autouse=True)
 def isolated_totp_secret(tmp_path, monkeypatch):
     """Point the TOTP secret at a per-test temp file (Feature 7).
+
     Tests must never touch the real per-user 2FA secret, and the
     consecutive-failure rate-limit state is keyed by this path, so a fresh path
     per test isolates rate-limit state too. Returns the path for tests that
@@ -48,6 +51,7 @@ def isolated_totp_secret(tmp_path, monkeypatch):
 @pytest.fixture(autouse=True)
 def isolated_password_hash(tmp_path, monkeypatch):
     """Point the local password hash at a per-test temp file (C1 slice 2).
+
     Tests must never touch a real per-user possession factor. The failure
     counter is keyed by this path, so a fresh path also isolates lockout state.
     """
@@ -59,6 +63,7 @@ def isolated_password_hash(tmp_path, monkeypatch):
 @pytest.fixture(autouse=True)
 def isolated_device_metrics_home(tmp_path, monkeypatch):
     """Point the device-global metrics rollup (dashboard) at a per-test temp dir.
+
     ``storage.device_metrics`` writes a lifetime rollup to
     ``~/.doberman/metrics.db`` on every decision (:mod:`doberman.storage.log`);
     tests must never touch the real per-user rollup, so point ``DOBERMAN_HOME``
@@ -74,6 +79,7 @@ def isolated_device_metrics_home(tmp_path, monkeypatch):
 @pytest.fixture(autouse=True)
 def isolated_executor_repo_root(tmp_path, monkeypatch):
     """Point the proxy's repo root (config + elevation DB) at a temp dir.
+
     Feature 7 persists elevations to ``<repo_root>/.doberman/doberman.db``; this
     keeps every test's DB/config inside its own tmp dir so nothing is ever
     written into the working tree, and elevation state never leaks across tests.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 """Shared test fixtures.
-
 Feature 3 introduces keyed HMAC fingerprinting, which reads/creates a local key
 file. Tests must NEVER touch the real per-user key (deterministic, isolated
 runs only), so we point ``DOBERMAN_KEY_FILE`` at a throwaway path inside a
@@ -8,7 +7,11 @@ need to exercise key generation/rotation override this with their own
 ``tmp_path`` injection.
 """
 
+import json as _json
+from typing import Any
+
 import pytest
+from typer.testing import Result
 
 from doberman.auth.password import PASSWORD_FILE_ENV
 from doberman.auth.totp import TOTP_FILE_ENV
@@ -20,7 +23,6 @@ from doberman.storage.fingerprint import KEY_FILE_ENV
 def isolated_fingerprint_key(tmp_path, monkeypatch):
     """Point the HMAC key at a per-test temp file so tests never use the real
     user key and never share key state across tests.
-
     Returns the key path so tests that exercise key generation/rotation can use
     it directly (there is exactly ONE setter of the env var — this fixture — so
     the key path is deterministic and free of fixture-ordering races).
@@ -33,7 +35,6 @@ def isolated_fingerprint_key(tmp_path, monkeypatch):
 @pytest.fixture(autouse=True)
 def isolated_totp_secret(tmp_path, monkeypatch):
     """Point the TOTP secret at a per-test temp file (Feature 7).
-
     Tests must never touch the real per-user 2FA secret, and the
     consecutive-failure rate-limit state is keyed by this path, so a fresh path
     per test isolates rate-limit state too. Returns the path for tests that
@@ -47,7 +48,6 @@ def isolated_totp_secret(tmp_path, monkeypatch):
 @pytest.fixture(autouse=True)
 def isolated_password_hash(tmp_path, monkeypatch):
     """Point the local password hash at a per-test temp file (C1 slice 2).
-
     Tests must never touch a real per-user possession factor. The failure
     counter is keyed by this path, so a fresh path also isolates lockout state.
     """
@@ -59,7 +59,6 @@ def isolated_password_hash(tmp_path, monkeypatch):
 @pytest.fixture(autouse=True)
 def isolated_device_metrics_home(tmp_path, monkeypatch):
     """Point the device-global metrics rollup (dashboard) at a per-test temp dir.
-
     ``storage.device_metrics`` writes a lifetime rollup to
     ``~/.doberman/metrics.db`` on every decision (:mod:`doberman.storage.log`);
     tests must never touch the real per-user rollup, so point ``DOBERMAN_HOME``
@@ -75,7 +74,6 @@ def isolated_device_metrics_home(tmp_path, monkeypatch):
 @pytest.fixture(autouse=True)
 def isolated_executor_repo_root(tmp_path, monkeypatch):
     """Point the proxy's repo root (config + elevation DB) at a temp dir.
-
     Feature 7 persists elevations to ``<repo_root>/.doberman/doberman.db``; this
     keeps every test's DB/config inside its own tmp dir so nothing is ever
     written into the working tree, and elevation state never leaks across tests.
@@ -107,3 +105,87 @@ def _neutralize_hosthook_auth_prompter(monkeypatch):
             raise PrompterUnavailableError("headless test: no auth channel")
 
     monkeypatch.setattr(claude_code, "AUTH_PROMPTER", _NoChannel())
+
+
+# ── JSON output assertion helper (Issue #192) ─────────────────────────────────
+
+
+def assert_json_stdout(result: Result, *, jsonl: bool = False) -> Any:
+    """Assert that *result.stdout* contains valid JSON and nothing else.
+
+    Parameters
+    ----------
+    result:
+        The ``CliRunner`` result whose ``stdout`` attribute is inspected.
+    jsonl:
+        ``False`` (default) — assert stdout is exactly **one** valid JSON
+        value (object or array) and return it.  This is the ``--json`` contract
+        shared by ``scan``, ``doctor``, and ``policy-history``.
+
+        ``True`` — assert stdout is zero or more **newline-separated** JSON
+        objects, one per non-empty line, and return them as a list.  This is
+        the ``--jsonl`` contract used by ``log``.  An empty result set must
+        produce empty stdout, not ``[]``; this helper returns ``[]`` in that
+        case.
+
+    Returns
+    -------
+    Any
+        The parsed Python value(s):
+        - ``jsonl=False``: the single parsed document (dict, list, …).
+        - ``jsonl=True``: a list of parsed dicts (may be empty).
+
+    Raises
+    ------
+    AssertionError
+        If stdout is not valid JSON, if it mixes JSON with non-JSON text,
+        or (for ``jsonl=True``) if any non-empty line is not a JSON object.
+
+    Safety contract
+    ---------------
+    This helper asserts *shape only* — valid JSON, nothing extraneous on stdout.
+    It deliberately does **not** assert redaction, field presence, or content
+    values.  Each command's own test keeps its redaction assertions so they
+    cannot be accidentally weakened by sharing this helper.
+    """
+    stdout = result.stdout
+
+    if not jsonl:
+        # ── Single-document mode (--json) ────────────────────────────────────
+        # stdout must be exactly one JSON value — nothing before, nothing after
+        # (allow a single trailing newline as typer.echo adds one).
+        text = stdout.strip()
+        assert text, (  # noqa: S101
+            "Expected one JSON document on stdout but stdout was empty.\n"
+            f"stderr: {getattr(result, 'stderr', '(unavailable)')}"
+        )
+        try:
+            doc = _json.loads(text)
+        except _json.JSONDecodeError as exc:
+            raise AssertionError(f"stdout is not valid JSON: {exc}\nstdout was: {text!r}") from exc
+        # Guard against mixed output: extra bytes surrounding the JSON value
+        # (e.g. a Rich heading on the same stream) are caught here.
+        extra = stdout.replace(text, "", 1).strip()
+        assert not extra, (  # noqa: S101
+            f"Non-JSON text found on stdout alongside the JSON document: {extra!r}"
+        )
+        return doc
+
+    else:
+        # ── JSON Lines mode (--jsonl) ─────────────────────────────────────────
+        # Empty stdout is valid (no rows → no output).
+        lines = [line for line in stdout.splitlines() if line.strip()]
+        records: list[Any] = []
+        for i, line in enumerate(lines):
+            try:
+                obj = _json.loads(line)
+            except _json.JSONDecodeError as exc:
+                raise AssertionError(
+                    f"Line {i + 1} of --jsonl output is not valid JSON: {exc}\nLine was: {line!r}"
+                ) from exc
+            assert isinstance(obj, dict), (  # noqa: S101
+                f"Line {i + 1} of --jsonl output is not a JSON object "
+                f"(got {type(obj).__name__})\nLine was: {line!r}"
+            )
+            records.append(obj)
+        return records


### PR DESCRIPTION
## What

Issue #192.

Two files changed, no behaviour changed:

- `docs/CLI.md` — added a "JSON output conventions" section that states the shared contract once:
  flag naming (`--json` = one document, `--jsonl` = one object per line and why they differ),
  stdout purity, redaction guarantee, determinism guarantee (`sort_keys=True`, compact separators),
  exit-code semantics, and the `policy-history --json` schema.

- `tests/conftest.py` — added `assert_json_stdout(result, *, jsonl=False)`, a shared helper that
  asserts stdout is valid JSON and nothing else. `jsonl=False` covers `scan`, `doctor`,
  `policy-history`; `jsonl=True` covers `log`. The helper asserts shape only — each command's
  own redaction assertions are untouched.

## Validation

`pytest tests/ -k "json" -v` → 51 passed  
`ruff check .` → all checks passed  
No existing test modified, no command output changed.