### PR TITLE
fix(dash): auto-scroll recent-decisions feed to newest entry

### DIFF
--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -511,11 +511,21 @@ _HTML_SHELL = """<!doctype html>
             " @ " + (String(row.ts || "").slice(11, 19) || "-");
           li.appendChild(detail);
 
+          // Rows are appended oldest-first, so the newest decision is always
+          // the last child - keep the scrollable list pinned to that end
+          // (unless the user has scrolled up to read older rows) so a
+          // freshly loaded dashboard shows the latest activity, not the
+          // oldest backfilled row.
+          var nearBottom = feedEl.scrollHeight - feedEl.scrollTop - feedEl.clientHeight < 4;
+
           // The empty state is CSS-only (`#feed:not(:empty) ~ #feed-empty`) -
           // appending the first row is enough to reveal the real list.
           feedEl.appendChild(li);
           while (feedEl.children.length > MAX_FEED_ROWS) {
             feedEl.removeChild(feedEl.firstChild);
+          }
+          if (nearBottom) {
+            feedEl.scrollTop = feedEl.scrollHeight;
           }
         });
       } catch (e) {


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: bugfix — dashboard feed default scroll position
- Plan reference: n/a (small client-side bugfix, no plan slice)

## What this PR does
The `#feed` list in the dashboard (`src/doberman/dash/app.py`) appends
decisions oldest-first, so the newest row is always the last DOM child. The
scrollable container (`max-height: 60vh; overflow-y: auto`) defaults to a
scroll position at the top, so on load (and as new decisions stream in via
SSE) the dashboard showed the oldest backfilled decision instead of the
latest one — the opposite of what a user watching live activity wants.

This pins the feed's scroll position to the bottom on initial backfill and
on each new SSE row, unless the user has manually scrolled up to read older
entries (checked via a "near bottom" threshold before appending), so it
doesn't yank their view away mid-read.

## Tests added (run in CI)
- None — this is a pure client-side rendering fix (scroll position) inside
  the inline dashboard JS; existing `tests/unit/test_dash_feed_stats.py`,
  `test_dash_serve.py`, and `test_dash_polish.py` already cover the feed's
  data/ordering contract and continue to pass unchanged.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- If the user has scrolled up to review older decisions, new rows no longer
  yank the view back down (matches standard chat/log-viewer behavior).
- No behavior change to `MAX_FEED_ROWS` trimming or the SSE payload/ordering
  contract — purely a scroll-position fix.