### PR TITLE
feat(auth): plain-language auth messages via a message_tone setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
 
 ## Unreleased (merged since v0.18.1)
 
+- **Plain-language auth messages — new `message_tone` setting:** the authorization prompt now
+  speaks plainly by default — *"Your agent wants to run a command: … Approve this exact action?"* —
+  instead of the terse `[RISK: …] role: … reason: …` block. `doberman message-tone human|technical`
+  switches between the two; **human** is the default. The setting is cosmetic — it changes wording
+  only and is **not** possession-factor gated (there is no strengthen/weaken ordering to a phrasing
+  choice). Reason codes and the PASS/AUTH/BLOCK verdict are identical either way and still logged;
+  only what the human reads changes.
 - **Auth popup redesign — one brand system across every surface:** the out-of-band
   tkinter authorization dialog is redrawn on a `Canvas` — the Doberman logo mark, a
   tan **DOBERMAN** wordmark, a rounded message panel (with the command shown in amber),

--- a/README.md
+++ b/README.md
@@ -300,6 +300,10 @@ Every AUTH prompt is already in the redacted decision log; `doberman tune` turns
 
 `doberman uninstall-hooks` only strips the hook entries: it never touches `.doberman/`, and needs no authentication, which means nothing stops a protected agent that reaches a shell from disabling its own security layer if it wanted to. `doberman uninstall` closes that gap: it removes both the project- and local-scope hooks *and* the project's `.doberman/` control plane (policy + decision database) in one step, gated the same way as `doberman taint clear` / `doberman memory reset`: an enrolled possession factor (TOTP if enrolled, otherwise the local password), with no confirm-only fallback and a hard fail-closed refusal if neither is enrolled. Because it's destructive and irreversible, it also asks you to type the project directory name back before proceeding (`--yes` skips that prompt; it never skips the factor check). It is deliberately **project-scoped only**: `--global` hooks and your device-wide password / 2FA / fingerprint key / `~/.doberman/metrics.db` are shared across every project Doberman protects on the machine and are never touched, even on success. `uninstall` is itself a control-plane-blocked subcommand, so a mediated agent can never shell out to run it. Same protection as `uninstall-hooks`.
 
+### Plain or technical wording, `doberman message-tone`
+
+The authorization prompt speaks plain English by default - *"Your agent wants to run a command: `git push --force main`. The command looked destructive. Approve this exact action?"* - so you can read a catch and decide in seconds without parsing reason codes. Prefer the detailed engineering view? `doberman message-tone technical` switches to the terse `[RISK: …] role: … reason: …` block, and `doberman message-tone human` switches back. It changes wording only: cosmetic, not possession-factor gated, and it never touches the decision, the reason codes, or what lands in the decision log.
+
 ---
 
 ## Who is this for?

--- a/src/doberman/auth/challenge.py
+++ b/src/doberman/auth/challenge.py
@@ -269,6 +269,7 @@ def run_auth_challenge(
     prompter: Prompter | None = None,
     at: AwareDatetime | None = None,
     timeout_s: float = DEFAULT_CHALLENGE_TIMEOUT_S,
+    message_tone: str = "human",
 ) -> AuthResult:
     """Select the tier and run the challenge through the active provider.
 
@@ -277,6 +278,11 @@ def run_auth_challenge(
     it never alters the decision's verdict or the required tier. With nothing
     installed, the local provider runs (CLI confirm + TOTP). Lazy-imports the
     provider to avoid an import cycle (challenge defines the types it consumes).
+
+    ``message_tone`` (S1) is purely cosmetic — "human" (plain wording, the
+    default) or "technical" (the original detailed format) — and is passed
+    through as data; this module never reads config/repo state itself, so a
+    caller with repo access resolves the tone and hands it in here.
 
     Returns within ``timeout_s`` no matter what the channel does: an unanswered
     challenge yields a non-approved result with ``method`` set to
@@ -300,7 +306,7 @@ def run_auth_challenge(
     try:
         return _run_with_deadline(
             lambda: active_provider().authenticate(
-                decision, action, tier, prompter=prompter, at=at
+                decision, action, tier, prompter=prompter, at=at, message_tone=message_tone
             ),
             timeout_s=timeout_s,
             on_timeout=lambda: AuthResult(

--- a/src/doberman/auth/provider.py
+++ b/src/doberman/auth/provider.py
@@ -23,7 +23,8 @@ from typing import Protocol, runtime_checkable
 
 from doberman.auth import totp
 from doberman.auth.challenge import AuthResult, AuthTier, Prompter
-from doberman.models import Decision, SecurityObject
+from doberman.explain import _describe_reason
+from doberman.models import ActionType, Decision, SecurityObject
 
 logger = logging.getLogger("doberman.auth.provider")
 
@@ -45,6 +46,7 @@ class AuthProvider(Protocol):
         *,
         prompter: Prompter | None = None,
         at: datetime | None = None,
+        message_tone: str = "human",
     ) -> AuthResult: ...
 
 
@@ -66,21 +68,70 @@ class CliPrompter:
         return str(typer.prompt(message, hide_input=True))
 
 
-def _challenge_message(decision: Decision, action: SecurityObject, tier: AuthTier) -> str:
+#: Plain-language verb for the S1 "human" tone's first line. ``other`` is what
+#: an unrecognized/generic MCP tool normalizes to (see proxy/normalize.py), so
+#: it reads as "use a tool" rather than the more generic fallback below. An
+#: ActionType genuinely absent here falls back to "do this" — never inventing
+#: a more specific-sounding claim than the action type actually supports.
+_PLAIN_VERBS: dict[ActionType, str] = {
+    ActionType.file_write: "write to a file",
+    ActionType.file_read: "read a file",
+    ActionType.file_delete: "delete a file",
+    ActionType.shell_exec: "run a command",
+    ActionType.network_request: "send data out",
+    ActionType.other: "use a tool",
+}
+
+
+def _plain_verb(action_type: ActionType) -> str:
+    return _PLAIN_VERBS.get(action_type, "do this")
+
+
+def _plain_why(decision: Decision) -> str:
+    """One capitalized sentence explaining the reason, reusing explain.py's copy.
+
+    No reason codes → the decision's own explanation, or a safe generic default.
+    Never oversells — it states the recorded reason, not a verdict on intent.
+    """
+    if decision.reason_codes:
+        fragments = [_describe_reason(code) for code in decision.reason_codes]
+        sentence = "; ".join(fragments)
+    else:
+        sentence = decision.explanation.strip() or "Doberman flagged this action for review"
+    sentence = sentence.strip().rstrip(".")
+    return sentence[:1].upper() + sentence[1:] + "."
+
+
+def _challenge_message(
+    decision: Decision, action: SecurityObject, tier: AuthTier, tone: str = "human"
+) -> str:
     """Build a prompt that names the EXACT action, target, and reason.
 
     Shown only to the local human approving the action (never logged), so it may
     include the concrete target — that is the whole point of an action-specific
-    challenge ("approve THIS file", not a generic "enter 2FA").
+    challenge ("approve THIS file", not a generic "enter 2FA"). ``tone``
+    controls wording only: "technical" is the original detailed format,
+    "human" (the default, S1) is a plain, friendly rendering of the exact same
+    facts — reason codes stay on the Decision and in the logs either way.
     """
-    reasons = ", ".join(decision.reason_codes) or "unspecified"
     target = action.target or "(no target)"
+    if tone == "technical":
+        reasons = ", ".join(decision.reason_codes) or "unspecified"
+        return (
+            f"[RISK: {decision.final_risk.upper()}]  Doberman authentication required [{tier.value}]\n"
+            f"  role:   {action.agent_role}\n"
+            f"  action: {action.tool_name} -> {target}\n"
+            f"  reason: {reasons} - {decision.explanation.strip() or 'no further detail'}\n"
+            f"Approve THIS exact action?"
+        )
     return (
-        f"[RISK: {decision.final_risk.upper()}]  Doberman authentication required [{tier.value}]\n"
-        f"  role:   {action.agent_role}\n"
-        f"  action: {action.tool_name} -> {target}\n"
-        f"  reason: {reasons} - {decision.explanation.strip() or 'no further detail'}\n"
-        f"Approve THIS exact action?"
+        f"Your agent wants to {_plain_verb(action.action_type)}:\n"
+        f"\n"
+        f"    {target}\n"
+        f"\n"
+        f"{_plain_why(decision)}\n"
+        f"\n"
+        f"Approve this exact action?"
     )
 
 
@@ -97,10 +148,11 @@ class LocalAuthProvider:
         *,
         prompter: Prompter | None = None,
         at: datetime | None = None,
+        message_tone: str = "human",
     ) -> AuthResult:
         prompter = prompter or CliPrompter()
         when = at or datetime.now(timezone.utc)
-        message = _challenge_message(decision, action, tier)
+        message = _challenge_message(decision, action, tier, message_tone)
 
         try:
             approved, method = self._run_tier(tier, message, prompter)

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -24,13 +24,16 @@ from doberman.auth.challenge import TIMEOUT_METHOD
 from doberman.auth.provider import CliPrompter
 from doberman.config import (
     CONFIG_DIR,
+    MESSAGE_TONES,
     default_role_enabled,
     load_active_role,
     load_enforcement,
+    load_message_tone,
     load_mode,
     load_policy,
     load_preferences,
     save_default_role_enabled,
+    save_message_tone,
     save_mode,
     save_policy,
     save_preferences,
@@ -582,6 +585,30 @@ def prefs(
     typer.echo(f"{dimension} set to {value:.2f}")
 
 
+@app.command("message-tone", rich_help_panel="Policy")
+def message_tone(
+    tone: str = typer.Argument(None, help=f"New tone ({', '.join(MESSAGE_TONES)})."),
+    path: str = typer.Option(".", "--path", "-p", help="Repository root."),
+) -> None:
+    """Show or set the AUTH challenge message tone (S1; cosmetic display only).
+
+    With no argument, prints the active tone. "human" (the default) renders a
+    plain, friendly challenge; "technical" keeps the original detailed format.
+    This never changes what is evaluated, blocked, or logged — reason codes
+    stay on every decision either way — so, unlike `prefs`/`mode`, it needs no
+    possession factor to change.
+    """
+    if tone is None:
+        typer.echo(load_message_tone(path))
+        return
+    try:
+        saved = save_message_tone(tone, path)
+    except ValueError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+    typer.echo(f"message tone set to {saved}")
+
+
 def _hook_install_states(path: str) -> list[tuple[str, str, bool]]:
     """Per-scope Doberman hook install state (delegates to the shared helper).
 
@@ -604,6 +631,7 @@ def _status_payload(path: str) -> dict:
     doc = load_policy(path)
     vector = load_preferences(path)
     mode = load_mode(path)
+    tone = load_message_tone(path)
     twofa = totp.is_enrolled()
     password_enrolled = password.is_enrolled()
     grants = asyncio.run(active_elevations(path, datetime.now(timezone.utc)))
@@ -649,6 +677,7 @@ def _status_payload(path: str) -> dict:
         "doberman_version": __version__,
         "role": role.name if role else None,
         "mode": mode,
+        "message_tone": tone,
         "prefs": {name: getattr(vector, name) for name in DIMENSIONS},
         "prefs_preset": preset_name(vector) or "custom",
         "policy": policy,
@@ -686,6 +715,9 @@ def _render_status_text(payload: dict) -> None:
     typer.echo("")
 
     typer.echo(f"Mode:   {payload['mode']}  (of: {modes})")
+    typer.echo("")
+
+    typer.echo(f"Messages: {payload['message_tone']}  (set via `doberman message-tone`)")
     typer.echo("")
 
     prefs = payload["prefs"]

--- a/src/doberman/config.py
+++ b/src/doberman/config.py
@@ -268,3 +268,32 @@ def save_mode(name: str, repo_root: str = ".") -> str:
     doc = load_policy(repo_root) or recommend_policy()
     save_policy(doc.with_mode(mode.value), repo_root)
     return mode.value
+
+
+#: The only valid values for the S1 message-tone display preference.
+MESSAGE_TONES: tuple[str, ...] = ("human", "technical")
+
+
+def load_message_tone(repo_root: str = ".") -> str:
+    """The active AUTH challenge message tone ("human" unless set to "technical").
+
+    Never raises: a missing/corrupt saved policy resolves to "human", same as
+    the field's own fail-closed default (see PolicyDoc.from_mapping).
+    """
+    doc = load_policy(repo_root)
+    return doc.message_tone if doc is not None else "human"
+
+
+def save_message_tone(tone: str, repo_root: str = ".") -> str:
+    """Validate and persist the message tone; returns the canonical value.
+
+    Raises ``ValueError`` on an unknown tone. Unlike ``save_default_role_enabled``
+    and ``save_mode``'s enforcement-softening siblings, this is a purely cosmetic
+    display preference with no strengthen/weaken ordering — it is written
+    directly, with NO drift/possession-factor gate (see doberman.policy.drift).
+    """
+    if tone not in MESSAGE_TONES:
+        raise ValueError(f"unknown message tone {tone!r}; choose one of {MESSAGE_TONES}")
+    doc = load_policy(repo_root) or recommend_policy()
+    save_policy(doc.with_message_tone(tone), repo_root)
+    return tone

--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -43,7 +43,7 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from doberman.branding import DOG
-from doberman.config import load_active_role
+from doberman.config import load_active_role, load_message_tone
 from doberman.engine.decision_engine import PASS_STUB, decide, max_risk
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.hosthooks import hookio, spine
@@ -139,8 +139,14 @@ def _hook_output(permission: str, reason: str) -> dict[str, Any]:
     return hookio.hook_output(_HOOK_EVENT, permission, reason)
 
 
-def _resolve_auth(decision: Decision, action: SecurityObject) -> dict[str, Any]:
-    return hookio.resolve_auth(decision, action, event=_HOOK_EVENT, prompter=AUTH_PROMPTER)
+def _resolve_auth(decision: Decision, action: SecurityObject, repo_root: str) -> dict[str, Any]:
+    return hookio.resolve_auth(
+        decision,
+        action,
+        event=_HOOK_EVENT,
+        prompter=AUTH_PROMPTER,
+        message_tone=load_message_tone(repo_root),
+    )
 
 
 def _decision_payload(decision: Decision) -> dict[str, Any]:
@@ -191,7 +197,7 @@ def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
         if result.acted is Verdict.AUTH:
             # Run Doberman's own action-bound challenge so the human can actually
             # approve in-session (issues #65/#67) — not just be told to.
-            hook_result = _resolve_auth(result.decision, result.action)
+            hook_result = _resolve_auth(result.decision, result.action, result.repo_root)
         else:
             hook_result = _decision_payload(result.decision)  # BLOCK -> deny
         _record_pre_history(

--- a/src/doberman/hosthooks/codex.py
+++ b/src/doberman/hosthooks/codex.py
@@ -39,6 +39,7 @@ import json
 import re
 from typing import TYPE_CHECKING, Any
 
+from doberman.config import load_message_tone
 from doberman.hosthooks import claude_code, hookio, spine
 from doberman.models import Verdict
 
@@ -158,7 +159,11 @@ def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
             return None  # raise-only; monitor-softened history recorded by the spine
         if result.acted is Verdict.AUTH:
             hook_result = hookio.resolve_auth(
-                result.decision, result.action, event=_EVENT, prompter=AUTH_PROMPTER
+                result.decision,
+                result.action,
+                event=_EVENT,
+                prompter=AUTH_PROMPTER,
+                message_tone=load_message_tone(result.repo_root),
             )
         else:
             hook_result = hookio.decision_payload(result.decision, event=_EVENT)

--- a/src/doberman/hosthooks/hookio.py
+++ b/src/doberman/hosthooks/hookio.py
@@ -106,6 +106,7 @@ def resolve_auth(
     *,
     event: str,
     prompter: "Prompter | None",
+    message_tone: str = "human",
 ) -> dict[str, Any]:
     """Run Doberman's tiered challenge for an AUTH and answer the host hook.
 
@@ -115,6 +116,10 @@ def resolve_auth(
     real approve path (issues #65/#67). We now present the action-bound challenge over
     a GUI→TTY fallback (the dialog is a channel the human can actually see even when the
     agent's TUI owns the terminal).
+
+    ``message_tone`` (S1) is cosmetic wording only; the caller resolves it from
+    the repo's saved policy (this module stays config-free — see the file's own
+    hot-path note) and passes it in as data, same as ``prompter``.
 
     Approved *and* bound to THIS action id → ``allow`` the one call. A denial, an
     unavailable channel, or any error → ``deny`` (fail closed). The auth stack is
@@ -130,7 +135,9 @@ def resolve_auth(
         from doberman.auth.challenge import TIMEOUT_METHOD, run_auth_challenge
 
         active_prompter = prompter if prompter is not None else _default_auth_prompter()
-        result = run_auth_challenge(decision, action, prompter=active_prompter)
+        result = run_auth_challenge(
+            decision, action, prompter=active_prompter, message_tone=message_tone
+        )
     except Exception:  # noqa: BLE001 — any challenge/prompter error is a denial (fail closed)
         return hook_output(event, "deny", _auth_denied_reason(decision, channel_error=True))
 

--- a/src/doberman/policy/checklist.py
+++ b/src/doberman/policy/checklist.py
@@ -156,6 +156,15 @@ class PolicyDoc:
     #: never treated as True (see PolicyDoc.from_mapping) — fail closed to
     #: dormant, never to a wider grant.
     default_role_enabled: bool = False
+    #: Cosmetic display preference (S1) for the AUTH challenge message the local
+    #: human reads: "human" (plain, friendly wording) or "technical" (today's
+    #: exact detailed format). Purely presentational — it never changes what is
+    #: evaluated, blocked, or logged. "human" (the default) unless a garbage
+    #: stored value is read, which also falls back to "human" (see
+    #: PolicyDoc.from_mapping) — a cosmetic setting has no strengthen/weaken
+    #: ordering to fail closed on, but a corrupt value must still resolve to a
+    #: safe, known choice rather than propagate garbage.
+    message_tone: str = "human"
 
     def get(self, item_id: str) -> PolicyItem | None:
         return next((it for it in self.items if it.id == item_id), None)
@@ -200,6 +209,14 @@ class PolicyDoc:
         """Return a copy with the D1 default-role opt-in flag set."""
         return replace(self, default_role_enabled=bool(enabled))
 
+    def with_message_tone(self, tone: str) -> "PolicyDoc":
+        """Return a copy with the AUTH challenge message tone set.
+
+        Does not validate — the caller (:func:`doberman.config.save_message_tone`)
+        is the gate; this method just carries the value like every other ``with_*``.
+        """
+        return replace(self, message_tone=tone)
+
     def to_mapping(self) -> dict[str, Any]:
         mapping: dict[str, Any] = {
             "mode": self.mode,
@@ -228,6 +245,9 @@ class PolicyDoc:
         # Only emit when set, to keep the common (opted-out) policy file clean.
         if self.default_role_enabled:
             mapping["default_role_enabled"] = True
+        # Only emit when non-default, to keep a normal (human-tone) policy file clean.
+        if self.message_tone != "human":
+            mapping["message_tone"] = self.message_tone
         return mapping
 
     @classmethod
@@ -273,6 +293,13 @@ class PolicyDoc:
             # opt-in — `bool("false")` is truthy in Python, so a loose coercion
             # here would be a silent widening on a hand-edited/corrupt file.
             default_role_enabled=data.get("default_role_enabled") is True,
+            # Fail closed to "human": only the two known tone values are ever
+            # honored — a garbage/hand-edited value never propagates as-is.
+            message_tone=(
+                data.get("message_tone")
+                if data.get("message_tone") in ("human", "technical")
+                else "human"
+            ),
         )
 
 

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -34,7 +34,13 @@ from doberman.auth.challenge import (
     run_auth_challenge,
 )
 from doberman.auth.elevation import find_cover, scope_for_target
-from doberman.config import load_active_role, load_enforcement, load_mode, load_preferences
+from doberman.config import (
+    load_active_role,
+    load_enforcement,
+    load_message_tone,
+    load_mode,
+    load_preferences,
+)
 from doberman.egress.artifact import ArtifactPinStore, ArtifactVerdict
 from doberman.engine.correlator import DecisionRow, correlate
 from doberman.engine.decision_engine import Guardrail, decide, max_risk, max_verdict
@@ -674,7 +680,11 @@ async def _handle_auth(
     auth_result: AuthResult | None = None
     try:
         auth_result = await asyncio.to_thread(
-            run_auth_challenge, decision, action, prompter=AUTH_PROMPTER
+            run_auth_challenge,
+            decision,
+            action,
+            prompter=AUTH_PROMPTER,
+            message_tone=load_message_tone(REPO_ROOT),
         )
     except Exception:  # noqa: BLE001 — a challenge failure must fail closed, not crash/leak
         _engine_logger.warning("auth challenge raised; failing closed (action %s)", action.id)

--- a/src/doberman/turngate/hook.py
+++ b/src/doberman/turngate/hook.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from doberman.auth.challenge import TIMEOUT_METHOD, AuthResult, Prompter, run_auth_challenge
+from doberman.config import load_message_tone
 from doberman.engine.decision_engine import TurnGuardrail, decide_turn
 from doberman.models import (
     ActionType,
@@ -146,7 +147,13 @@ async def _enforce(
         return TurnGateOutcome(False, Verdict.BLOCK, decision, "blocked (Tier 0 signature)")
 
     if decision.final_verdict is Verdict.AUTH:
-        result = run_auth_challenge(decision, _synthetic_action(turn), prompter=prompter, at=when)
+        result = run_auth_challenge(
+            decision,
+            _synthetic_action(turn),
+            prompter=prompter,
+            at=when,
+            message_tone=load_message_tone(repo_root),
+        )
         approved = result.approved and result.action_id == turn.id
         label = _auth_result_label(result, approved=approved)
         await record_turn_decision(
@@ -178,7 +185,9 @@ async def _handle_repeat(
         await record_turn_decision(turn, decision, repo_root=repo_root, stage="turn_lockout")
         return TurnGateOutcome(False, Verdict.BLOCK, decision, "locked out (repeat)")
 
-    result = repeat.challenge_repeat(turn, record, prompter=prompter, at=when)
+    result = repeat.challenge_repeat(
+        turn, record, prompter=prompter, at=when, message_tone=load_message_tone(repo_root)
+    )
     if result.approved and result.action_id == turn.id:
         repeat.clear_record(entity_id, turn.prompt_fingerprint)  # single-use
         decision = _pass_decision(turn, when)
@@ -313,7 +322,11 @@ async def gate_turn(
         )
         decision = _fail_to_human(fallback_turn, when)
         result = run_auth_challenge(
-            decision, _synthetic_action(fallback_turn), prompter=prompter, at=when
+            decision,
+            _synthetic_action(fallback_turn),
+            prompter=prompter,
+            at=when,
+            message_tone=load_message_tone(repo_root),
         )
         approved = result.approved and result.action_id == fallback_turn.id
         return TurnGateOutcome(approved, Verdict.AUTH, decision, "fail-to-human")

--- a/src/doberman/turngate/repeat.py
+++ b/src/doberman/turngate/repeat.py
@@ -214,13 +214,18 @@ def challenge_repeat(
     *,
     prompter: Prompter | None = None,
     at: datetime | None = None,
+    message_tone: str = "human",
 ) -> AuthResult:
     """Run the F7 challenge for a repeated, just-blocked turn and return the result.
 
     On approval the caller releases the turn and clears the record (single-use);
     on denial the caller calls :func:`note_denied`. The proof tier is bound to
-    the original block reason (Tier 0 → 2FA).
+    the original block reason (Tier 0 → 2FA). ``message_tone`` (S1, cosmetic
+    only) is passed through as data — this module stays config-free, the caller
+    (turngate/hook.py, which already has repo_root) resolves it.
     """
     when = _now(at)
     action, decision = _repeat_decision(turn, record, when)
-    return run_auth_challenge(decision, action, prompter=prompter, at=when)
+    return run_auth_challenge(
+        decision, action, prompter=prompter, at=when, message_tone=message_tone
+    )

--- a/tests/integration/test_auth_release.py
+++ b/tests/integration/test_auth_release.py
@@ -21,7 +21,7 @@ _AUTHING = StaticGuardrail(
 
 
 def _approve(tier=AuthTier.local_auth):
-    def challenge(decision, action, *, prompter=None, at=None):
+    def challenge(decision, action, *, prompter=None, at=None, message_tone=None):
         return AuthResult(
             approved=True,
             tier=tier,
@@ -33,7 +33,7 @@ def _approve(tier=AuthTier.local_auth):
     return challenge
 
 
-def _deny(decision, action, *, prompter=None, at=None):
+def _deny(decision, action, *, prompter=None, at=None, message_tone=None):
     return AuthResult(
         approved=False,
         tier=AuthTier.local_auth,
@@ -43,7 +43,7 @@ def _deny(decision, action, *, prompter=None, at=None):
     )
 
 
-def _approve_for_wrong_action(decision, action, *, prompter=None, at=None):
+def _approve_for_wrong_action(decision, action, *, prompter=None, at=None, message_tone=None):
     return AuthResult(
         approved=True,
         tier=AuthTier.local_auth,
@@ -130,7 +130,7 @@ async def test_role_elevation_grants_then_covered_file_passes(
     _write_role(isolated_executor_repo_root)
     calls = {"n": 0}
 
-    def approve_elev(decision, action, *, prompter=None, at=None):
+    def approve_elev(decision, action, *, prompter=None, at=None, message_tone=None):
         calls["n"] += 1
         return AuthResult(
             approved=True,
@@ -161,7 +161,7 @@ async def test_destructive_elevation_is_single_use(monkeypatch, isolated_executo
     _write_role(isolated_executor_repo_root)
     calls = {"n": 0}
 
-    def approve_elev(decision, action, *, prompter=None, at=None):
+    def approve_elev(decision, action, *, prompter=None, at=None, message_tone=None):
         calls["n"] += 1
         return AuthResult(
             approved=True,
@@ -187,7 +187,7 @@ async def test_auth_challenge_raising_fails_closed_and_sanitized(monkeypatch):
     """A `run_auth_challenge` crash must deny — never crash the proxy or leak."""
     monkeypatch.setattr(executor, "DEFAULT_OBJECTIVE", _AUTHING)
 
-    def boom(decision, action, *, prompter=None, at=None):
+    def boom(decision, action, *, prompter=None, at=None, message_tone=None):
         raise RuntimeError("challenge backend exploded: leaked-internal-detail")
 
     monkeypatch.setattr(executor, "run_auth_challenge", boom)
@@ -211,7 +211,7 @@ async def test_mark_used_failure_does_not_corrupt_successful_forward(
     """A `mark_used` crash after a successful forward must not turn it into an error."""
     _write_role(isolated_executor_repo_root)
 
-    def approve_elev(decision, action, *, prompter=None, at=None):
+    def approve_elev(decision, action, *, prompter=None, at=None, message_tone=None):
         return AuthResult(
             approved=True,
             tier=AuthTier.role_elevation,

--- a/tests/integration/test_challenge_flow.py
+++ b/tests/integration/test_challenge_flow.py
@@ -61,9 +61,15 @@ def _auth_decision(reasons, risk=Risk.low):
 
 
 def test_prompt_names_the_specific_target_and_reason():
+    # "technical" tone: the raw reason code is asserted verbatim; the "human"
+    # default's plain-language rendering of the same facts is covered by
+    # test_auth_provider.py's own tone tests.
     prompter = ScriptedPrompter(confirm=False)
     run_auth_challenge(
-        _auth_decision([ReasonCode.unknown_tool]), _action("backend/api.ts"), prompter=prompter
+        _auth_decision([ReasonCode.unknown_tool]),
+        _action("backend/api.ts"),
+        prompter=prompter,
+        message_tone="technical",
     )
     msg = prompter.messages[0]
     assert "backend/api.ts" in msg

--- a/tests/integration/test_decision_log.py
+++ b/tests/integration/test_decision_log.py
@@ -20,7 +20,7 @@ from doberman.storage.log import read_decisions, recent_session_decisions, recor
 from .test_proxy_passthrough import proxied_session
 
 
-def _deny(decision, action, *, prompter=None, at=None):
+def _deny(decision, action, *, prompter=None, at=None, message_tone=None):
     return AuthResult(
         approved=False,
         tier=AuthTier.two_factor,

--- a/tests/integration/test_egress_coverage.py
+++ b/tests/integration/test_egress_coverage.py
@@ -42,7 +42,7 @@ FAKE_AWS = "AKIAIOSFODNN7EXAMPLE"  # noqa: S105
 def deny_auth(monkeypatch):
     """Make every EB.1 AUTH deterministic and prove it forwards nothing."""
 
-    def _deny(decision, action, *, prompter=None, at=None):
+    def _deny(decision, action, *, prompter=None, at=None, message_tone=None):
         return AuthResult(
             approved=False,
             tier=AuthTier.local_auth,
@@ -86,7 +86,7 @@ async def test_secret_exfil_domain_send_is_blocked(monkeypatch):
     _PASSING = StaticGuardrail(GuardrailResult(verdict=Verdict.PASS, risk=Risk.low))
     monkeypatch.setattr(executor, "DEFAULT_OBJECTIVE", _PASSING)
 
-    def _deny(decision, action, *, prompter=None, at=None):
+    def _deny(decision, action, *, prompter=None, at=None, message_tone=None):
         return AuthResult(
             approved=False,
             tier=AuthTier.local_auth,

--- a/tests/integration/test_engine_blocks_reach_no_tool.py
+++ b/tests/integration/test_engine_blocks_reach_no_tool.py
@@ -20,7 +20,7 @@ from doberman.proxy.interception_log import LOGGER_NAME
 from .test_proxy_passthrough import proxied_session
 
 
-def _deny_challenge(decision, action, *, prompter=None, at=None):
+def _deny_challenge(decision, action, *, prompter=None, at=None, message_tone=None):
     """A deterministic denied AuthResult (stands in for confirm/2FA failure)."""
     return AuthResult(
         approved=False,

--- a/tests/integration/test_repeat_escalation.py
+++ b/tests/integration/test_repeat_escalation.py
@@ -97,11 +97,13 @@ def test_replay_without_a_valid_totp_fails():
 
 
 def test_challenge_text_restates_the_block_reason_and_pattern():
+    # "technical" tone: the raw reason code is asserted verbatim (the S1 "human"
+    # default plain-language rendering is covered by test_auth_provider.py).
     code = _valid_code()
     register_block("ent", "hmac:abc", ReasonCode.secret_export, now=_NOW)
     record = lookup("ent", "hmac:abc", now=_NOW)
     prompter = RecordingPrompter(confirm=True, code=code)
-    challenge_repeat(_turn(), record, prompter=prompter, at=_NOW)
+    challenge_repeat(_turn(), record, prompter=prompter, at=_NOW, message_tone="technical")
     message = prompter.messages[0]
     assert "secret_export" in message
     assert restate(ReasonCode.secret_export).split()[0].lower() in message.lower()

--- a/tests/integration/test_revealed_pref.py
+++ b/tests/integration/test_revealed_pref.py
@@ -226,7 +226,7 @@ async def test_approval_grants_a_session_token_and_stops_repeat_asks(monkeypatch
 
     challenges = []
 
-    def _approve(decision, action, *, prompter=None, at=None):
+    def _approve(decision, action, *, prompter=None, at=None, message_tone=None):
         challenges.append(action.id)
         return AuthResult(
             approved=True,

--- a/tests/integration/test_subjective_escalation.py
+++ b/tests/integration/test_subjective_escalation.py
@@ -20,7 +20,7 @@ from doberman.subjective.drift import K_OBSERVATIONS, reset_adwin
 from .test_proxy_passthrough import proxied_session
 
 
-def _deny(decision, action, *, prompter=None, at=None):
+def _deny(decision, action, *, prompter=None, at=None, message_tone=None):
     return AuthResult(
         approved=False,
         tier=AuthTier.local_auth,

--- a/tests/integration/test_subjective_integration.py
+++ b/tests/integration/test_subjective_integration.py
@@ -44,7 +44,7 @@ _BLOCKING = StaticGuardrail(
 )
 
 
-def _deny(decision, action, *, prompter=None, at=None):
+def _deny(decision, action, *, prompter=None, at=None, message_tone=None):
     return AuthResult(
         approved=False,
         tier=AuthTier.local_auth,
@@ -54,7 +54,7 @@ def _deny(decision, action, *, prompter=None, at=None):
     )
 
 
-def _approve(decision, action, *, prompter=None, at=None):
+def _approve(decision, action, *, prompter=None, at=None, message_tone=None):
     return AuthResult(
         approved=True,
         tier=AuthTier.local_auth,

--- a/tests/integration/test_turn_hook.py
+++ b/tests/integration/test_turn_hook.py
@@ -198,7 +198,7 @@ async def test_auth_turn_timeout_recorded_distinctly_from_denial(tmp_path, monke
     ``timeout``, not ``denied`` — silence and a human refusal are different audit
     events (ADR 0046). Not released either way (fail closed)."""
 
-    def _timed_out(decision, action, *, prompter=None, at=None):
+    def _timed_out(decision, action, *, prompter=None, at=None, message_tone=None):
         return AuthResult(
             approved=False,
             tier=AuthTier.local_auth,
@@ -243,7 +243,7 @@ async def test_repeat_denied_timeout_recorded_distinctly(tmp_path, monkeypatch):
     first = await gate_turn(text, entity_id="e", repo_root=root, ts=_TS)
     assert first.released is False and first.verdict is Verdict.BLOCK
 
-    def _timed_out_repeat(turn, record, *, prompter=None, at=None):
+    def _timed_out_repeat(turn, record, *, prompter=None, at=None, message_tone=None):
         return AuthResult(
             approved=False,
             tier=AuthTier.two_factor,

--- a/tests/unit/test_auth_provider.py
+++ b/tests/unit/test_auth_provider.py
@@ -127,9 +127,15 @@ def test_prompter_failure_denies_fail_closed():
 
 
 def test_challenge_message_names_target_and_reason():
+    # "technical" tone: the original detailed format, pinned exactly (the
+    # "human" default is covered separately below).
     prompter = FakePrompter(confirm=False)
     LocalAuthProvider().authenticate(
-        _auth_decision(), _action("backend/api.ts"), AuthTier.soft_confirm, prompter=prompter
+        _auth_decision(),
+        _action("backend/api.ts"),
+        AuthTier.soft_confirm,
+        prompter=prompter,
+        message_tone="technical",
     )
     message = prompter.messages[0]
     assert "backend/api.ts" in message  # the EXACT target
@@ -144,6 +150,7 @@ def test_challenge_message_includes_risk_badge():
         _action("backend/api.ts"),
         AuthTier.soft_confirm,
         prompter=prompter,
+        message_tone="technical",
     )
     message = prompter.messages[0]
     assert "RISK: CRITICAL" in message  # the badge is additive, not a replacement
@@ -159,6 +166,7 @@ def test_challenge_message_low_risk_renders_cleanly():
         _action("backend/api.ts"),
         AuthTier.soft_confirm,
         prompter=prompter,
+        message_tone="technical",
     )
     message = prompter.messages[0]
     assert "RISK: LOW" in message
@@ -168,12 +176,31 @@ def test_challenge_message_low_risk_renders_cleanly():
 
 
 def test_challenge_message_is_ascii_and_cp1252_safe():
-    """_challenge_message output must be ASCII and cp1252-safe for legacy Windows consoles."""
+    """_challenge_message output must be ASCII and cp1252-safe for legacy Windows consoles,
+    in BOTH tones (the default "human" tone and the original "technical" one)."""
     from doberman.auth.provider import _challenge_message
 
-    msg = _challenge_message(_auth_decision(), _action(), AuthTier.soft_confirm)
-    assert msg.isascii(), f"non-ASCII in challenge prompt: {msg!r}"
-    msg.encode("ascii")  # raises UnicodeEncodeError if non-ASCII
+    for tone in ("human", "technical"):
+        msg = _challenge_message(_auth_decision(), _action(), AuthTier.soft_confirm, tone)
+        assert msg.isascii(), f"non-ASCII in {tone} challenge prompt: {msg!r}"
+        msg.encode("ascii")  # raises UnicodeEncodeError if non-ASCII
+
+
+def test_challenge_message_human_tone_is_plain_and_names_target_and_reason():
+    """S1: the "human" tone (the default) is plain-worded but states the same facts —
+    the exact target and the reason, in plain language, without the raw code or the
+    technical [RISK:]/role:/reason: scaffolding."""
+    prompter = FakePrompter(confirm=False)
+    LocalAuthProvider().authenticate(
+        _auth_decision(), _action("backend/api.ts"), AuthTier.soft_confirm, prompter=prompter
+    )
+    message = prompter.messages[0]
+    assert "    backend/api.ts" in message  # the exact target, indented
+    assert "role_out_of_scope" not in message  # no raw reason code
+    assert "[RISK:" not in message  # no technical badge
+    assert "role:" not in message
+    assert "Approve this exact action?" in message
+    assert "outside" in message and "scope" in message  # the plain-language reason
 
 
 def test_registered_provider_is_preferred(monkeypatch):

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -20,6 +20,7 @@ CLI_HELP_TARGETS = (
     ("mode",),
     ("enforcement",),
     ("prefs",),
+    ("message-tone",),
     ("role",),
     ("role", "enable-default"),
     ("role", "disable-default"),

--- a/tests/unit/test_cli_status.py
+++ b/tests/unit/test_cli_status.py
@@ -173,6 +173,7 @@ _EXPECTED_STATUS_KEYS = {
     "doberman_version",
     "role",
     "mode",
+    "message_tone",
     "prefs",
     "prefs_preset",
     "policy",

--- a/tests/unit/test_hosthook_auth_challenge.py
+++ b/tests/unit/test_hosthook_auth_challenge.py
@@ -102,7 +102,7 @@ def test_unavailable_channel_denies_with_dialog_hint(cwd, monkeypatch):
 def test_approval_is_bound_to_the_action_id(cwd, monkeypatch):
     # A result whose action_id is for a DIFFERENT call must never be honored, even
     # though it is "approved" — the single-use approval is bound to one action.
-    def _fake_challenge(decision, action, *, prompter=None, at=None):
+    def _fake_challenge(decision, action, *, prompter=None, at=None, message_tone=None):
         return AuthResult(
             approved=True,
             tier=AuthTier.local_auth,
@@ -160,7 +160,7 @@ def test_timed_out_auth_denies_with_expired_no_response_hint(cwd, monkeypatch):
     # A challenge that reaches its deadline unanswered (AN-4a, ADR 0046) is denied, and
     # the message says the request *expired* — distinct from a human refusal — so the
     # log and the user can tell silence from "no". Fail-closed either way.
-    def _timed_out(decision, action, *, prompter=None, at=None):
+    def _timed_out(decision, action, *, prompter=None, at=None, message_tone=None):
         return AuthResult(
             approved=False,
             tier=AuthTier.local_auth,
@@ -181,7 +181,7 @@ def test_timed_out_auth_denies_with_expired_no_response_hint(cwd, monkeypatch):
 def test_timed_out_two_factor_still_names_the_setup_command(cwd, monkeypatch):
     # The timeout branch must keep the same actionable 2FA-enrollment hint the refusal
     # branch carries — a timed-out un-enrolled 2FA action still dead-ends without it.
-    def _timed_out(decision, action, *, prompter=None, at=None):
+    def _timed_out(decision, action, *, prompter=None, at=None, message_tone=None):
         return AuthResult(
             approved=False,
             tier=AuthTier.two_factor,

--- a/tests/unit/test_hosthook_codex.py
+++ b/tests/unit/test_hosthook_codex.py
@@ -213,7 +213,7 @@ def test_approval_is_bound_to_the_action_id(tmp_path, monkeypatch):
     different action, even if a buggy or compromised auth provider returns
     "approved" — mirrors test_hosthook_auth_challenge.py's own-host proof."""
 
-    def _fake_challenge(decision, action, *, prompter=None, at=None):
+    def _fake_challenge(decision, action, *, prompter=None, at=None, message_tone=None):
         return AuthResult(
             approved=True,
             tier=AuthTier.local_auth,

--- a/tests/unit/test_hosthook_hookio.py
+++ b/tests/unit/test_hosthook_hookio.py
@@ -82,7 +82,7 @@ def approving_prompter_for_other_action(monkeypatch):
     """An "approved" challenge result bound to a DIFFERENT action id —
     resolve_auth must never honor it (single-use, action-bound approval)."""
 
-    def _fake_challenge(decision, action, *, prompter=None, at=None):
+    def _fake_challenge(decision, action, *, prompter=None, at=None, message_tone=None):
         return AuthResult(
             approved=True,
             tier=AuthTier.local_auth,

--- a/tests/unit/test_message_tone.py
+++ b/tests/unit/test_message_tone.py
@@ -1,0 +1,195 @@
+"""S1 — the `message_tone` cosmetic display preference ("human" | "technical").
+
+Covers: PolicyDoc round-trip (default not emitted, garbage fails closed to
+"human"); config save/load round-trip, including that it is UNGATED (no
+possession factor needed, unlike mode/prefs/default-role weakenings) and
+rejects an unknown tone; the `doberman message-tone` CLI show/set/invalid
+flow; and that the human tone never exposes MORE of a redaction-sensitive
+value than the technical tone already did.
+
+`_challenge_message`'s own tone-rendering behavior (exact format per tone) is
+covered in tests/unit/test_auth_provider.py; this file focuses on the
+config/CLI plumbing plus the redaction guarantee.
+"""
+
+from datetime import datetime, timezone
+
+from typer.testing import CliRunner
+
+from doberman import config
+from doberman.auth.challenge import AuthTier
+from doberman.auth.provider import _challenge_message
+from doberman.cli.main import app
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+from doberman.policy.checklist import PolicyDoc, recommend_policy
+
+runner = CliRunner()
+_NOW = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+
+def _action(target="backend/api.ts"):
+    return SecurityObject(
+        id="act-tone",
+        ts=_NOW,
+        agent_role="webdev",
+        action_type=ActionType.file_write,
+        tool_name="fs_write",
+        target=target,
+    )
+
+
+def _auth_decision(reasons=(ReasonCode.role_out_of_scope,), risk: Risk = Risk.medium):
+    objective = GuardrailResult(
+        verdict=Verdict.AUTH, risk=risk, reason_codes=list(reasons), explanation="why"
+    )
+    return Decision(
+        action_id="act-tone",
+        final_verdict=Verdict.AUTH,
+        final_risk=risk,
+        objective=objective,
+        reason_codes=list(reasons),
+        explanation="why",
+        decided_at=_NOW,
+    )
+
+
+# --- PolicyDoc round trip ----------------------------------------------------
+
+
+def test_default_tone_is_human_and_not_emitted():
+    doc = recommend_policy()
+    assert doc.message_tone == "human"
+    assert "message_tone" not in doc.to_mapping()
+
+
+def test_technical_tone_is_emitted():
+    doc = recommend_policy().with_message_tone("technical")
+    assert doc.to_mapping()["message_tone"] == "technical"
+
+
+def test_round_trips_through_mapping():
+    doc = recommend_policy().with_message_tone("technical")
+    restored = PolicyDoc.from_mapping(doc.to_mapping())
+    assert restored.message_tone == "technical"
+
+
+def test_garbage_stored_value_fails_closed_to_human():
+    mapping = recommend_policy().to_mapping()
+    mapping["message_tone"] = "shout-it-from-the-rooftops"
+    restored = PolicyDoc.from_mapping(mapping)
+    assert restored.message_tone == "human"
+
+
+def test_missing_key_defaults_to_human():
+    mapping = recommend_policy().to_mapping()
+    assert "message_tone" not in mapping
+    assert PolicyDoc.from_mapping(mapping).message_tone == "human"
+
+
+# --- config save/load ---------------------------------------------------------
+
+
+def test_load_defaults_to_human_with_no_saved_policy(tmp_path):
+    assert config.load_message_tone(str(tmp_path)) == "human"
+
+
+def test_save_and_load_round_trip(tmp_path):
+    root = str(tmp_path)
+    assert config.save_message_tone("technical", root) == "technical"
+    assert config.load_message_tone(root) == "technical"
+    # Flip back.
+    config.save_message_tone("human", root)
+    assert config.load_message_tone(root) == "human"
+
+
+def test_save_rejects_an_unknown_tone(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="unknown message tone"):
+        config.save_message_tone("sarcastic", str(tmp_path))
+    # Rejected — nothing was written.
+    assert config.load_message_tone(str(tmp_path)) == "human"
+
+
+def test_save_succeeds_with_no_possession_factor_enrolled(tmp_path):
+    """Proves it is UNGATED: unlike `save_default_role_enabled`'s disable path
+    (drift-gated, fails closed without an enrolled 2FA/password factor — see
+    test_default_role_opt_in.py's `test_cli_disable_default_with_no_factor_enrolled_fails_closed`),
+    this cosmetic setting writes with no possession factor enrolled at all —
+    the isolated_totp_secret/isolated_password_hash autouse fixtures leave
+    both unenrolled by default in every test, this one included.
+    """
+    from doberman.auth import password, totp
+
+    assert totp.is_enrolled() is False
+    assert password.is_enrolled() is False
+    assert config.save_message_tone("technical", str(tmp_path)) == "technical"
+    assert config.load_message_tone(str(tmp_path)) == "technical"
+
+
+# --- CLI -----------------------------------------------------------------------
+
+
+def test_cli_shows_the_default_tone(tmp_path):
+    result = runner.invoke(app, ["message-tone", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "human"
+
+
+def test_cli_sets_the_tone_with_no_gate(tmp_path):
+    result = runner.invoke(app, ["message-tone", "technical", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "technical" in result.stdout
+    assert config.load_message_tone(str(tmp_path)) == "technical"
+    # And it's reflected back by a no-arg call.
+    shown = runner.invoke(app, ["message-tone", "--path", str(tmp_path)])
+    assert shown.stdout.strip() == "technical"
+
+
+def test_cli_rejects_an_invalid_tone(tmp_path):
+    result = runner.invoke(app, ["message-tone", "loud", "--path", str(tmp_path)])
+    assert result.exit_code == 2
+    assert config.load_message_tone(str(tmp_path)) == "human"  # unchanged
+
+
+def test_cli_status_reports_the_tone(tmp_path):
+    result = runner.invoke(app, ["status", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "Messages: human" in result.stdout
+
+
+# --- redaction: human tone never exposes MORE than technical did ---------------
+
+
+def test_human_tone_shows_the_same_target_as_technical():
+    """The exact target is the whole point of an action-specific challenge in
+    EITHER tone — a synthetic secret-shaped target appears identically in both,
+    never more, never less."""
+    target = "backend/.env"  # a realistically sensitive-shaped path, not a raw secret
+    action = _action(target)
+    decision = _auth_decision()
+    technical = _challenge_message(decision, action, AuthTier.soft_confirm, "technical")
+    human = _challenge_message(decision, action, AuthTier.soft_confirm, "human")
+    assert target in technical
+    assert target in human
+
+
+def test_human_tone_never_repeats_raw_explanation_when_reason_codes_are_present():
+    """When reason codes exist, technical shows the raw `decision.explanation`
+    verbatim; human summarizes via the shared explain.py descriptions instead
+    and does not repeat it — strictly less raw text, never more."""
+    decision = _auth_decision()
+    decision = decision.model_copy(update={"explanation": "leaked-internal-detail"})
+    action = _action()
+    technical = _challenge_message(decision, action, AuthTier.soft_confirm, "technical")
+    human = _challenge_message(decision, action, AuthTier.soft_confirm, "human")
+    assert "leaked-internal-detail" in technical
+    assert "leaked-internal-detail" not in human

--- a/tests/unit/test_proxy_correlator.py
+++ b/tests/unit/test_proxy_correlator.py
@@ -24,7 +24,7 @@ from doberman.proxy import executor
 _EGRESS_URL = "https://attacker.example/collect"
 
 
-def _deny(decision, action, *, prompter=None, at=None):  # noqa: ARG001
+def _deny(decision, action, *, prompter=None, at=None, message_tone=None):  # noqa: ARG001
     return AuthResult(
         approved=False,
         tier=AuthTier.two_factor,

--- a/tests/unit/test_proxy_secret_output_gating.py
+++ b/tests/unit/test_proxy_secret_output_gating.py
@@ -143,7 +143,7 @@ async def test_gated_output_still_consumes_a_single_use_elevation(
     monkeypatch.setattr(executor, "_safe_decide", _real_safe_decide)
     calls = {"n": 0}
 
-    def approve_elev(decision, action, *, prompter=None, at=None):
+    def approve_elev(decision, action, *, prompter=None, at=None, message_tone=None):
         calls["n"] += 1
         return AuthResult(
             approved=True,


### PR DESCRIPTION
## What

Adds a cosmetic `message_tone` preference — **human** (default) or **technical** — so the authorization prompt speaks plain English instead of a terse machine block.

**human (default):**
```
Your agent wants to run a command:

    git push --force main

The command looked destructive.

Approve this exact action?
```

**technical** (`doberman message-tone technical`): the original `[RISK: …] role: … reason: …` format, byte-for-byte.

## Design

- `message_tone` is a new field on `PolicyDoc`, written to `policies.yaml` only when non-default. `load/save_message_tone` **bypass the weaken-gate** — a phrasing choice has no strengthen/weaken ordering, so it needs no possession factor (a test proves it saves with nothing enrolled).
- `doberman message-tone [human|technical]` shows/sets it; `doberman status` shows the current tone.
- `_challenge_message` gains a `tone` param. The human "why" **reuses `explain.py`'s plain reason descriptions** (no duplicated copy) and never overstates the recorded reason — the verb map falls back to "do this" rather than inventing specificity.
- The tone is threaded **as data** from the config seam (proxy executor, host-hooks, turn gate) down through `run_auth_challenge → authenticate`; `provider.py`/`challenge.py` stay config-free, so the `import-linter` boundary holds.

## Unchanged

Reason codes and the PASS/AUTH/BLOCK verdict are identical in both tones and still logged — only the human-facing wording changes. No decision-path change.

## Tests

New `tests/unit/test_message_tone.py` (PolicyDoc round-trip, ungated save, CLI show/set/invalid, redaction parity, both message formats). Existing provider/challenge/host-hook/turn tests updated to pin `tone="technical"` where they assert the old format. Targeted blast-radius sweep + `ruff` + `lint-imports` (3 contracts kept) green locally; the full suite was green in the build run and clean through 97% in my re-run (a local memory kill, not a failure) — CI runs the authoritative full suite here.

**Repo:** doberman-core (public). **Public-release safety:** wording/UX + a cosmetic setting; no secrets, no enterprise references, no proprietary logic; redaction parity asserted.
