### PR TITLE
feat(dash): per-project tab title and topbar label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
 
 ## Unreleased (merged since v0.18.1)
 
+- **Dashboard: per-project tab title.** `doberman dash` is already scoped to one repo per run
+  (`--path`, default the current directory), but every browser tab read the same "Doberman
+  Dashboard" title, so running several dashboards side by side (one per project) gave no way to
+  tell the tabs apart. The tab title and the topbar now carry the repo folder's name (e.g.
+  `widget-service — Doberman Dashboard`), safely escaped for both the HTML shell and the inline
+  JS unread-count title update.
 - **Plain-language auth messages — new `message_tone` setting:** the authorization prompt now
   speaks plainly by default — *"Your agent wants to run a command: … Approve this exact action?"* —
   instead of the terse `[RISK: …] role: … reason: …` block. `doberman message-tone human|technical`

--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -54,8 +54,10 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import html
 import json
 from collections.abc import AsyncIterator
+from pathlib import Path
 
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -82,7 +84,7 @@ _HTML_SHELL = """<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Doberman Dashboard</title>
+<title>%%DASH_PAGE_TITLE%%</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
   :root {
@@ -151,6 +153,11 @@ _HTML_SHELL = """<!doctype html>
   .brand .word {
     font-family: var(--mono); font-weight: 700; font-size: .95rem;
     letter-spacing: .06em; color: var(--tan);
+  }
+  .brand .project {
+    font-family: var(--mono); font-weight: 600; font-size: .95rem;
+    color: var(--fg-2); padding-left: .6rem; margin-left: .6rem;
+    border-left: 1px solid var(--rule);
   }
   .topbar-right { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap; }
   .chip {
@@ -257,6 +264,7 @@ _HTML_SHELL = """<!doctype html>
         <text x="16" y="21.5" text-anchor="middle" font-family="ui-monospace, Consolas, monospace" font-weight="700" font-size="15" style="fill:var(--tan)">D</text>
       </svg>
       <span class="word">DOBERMAN</span>
+      <span class="project">%%DASH_PROJECT_NAME%%</span>
     </div>
     <div class="topbar-right">
       <span class="chip" id="status"><span class="dot" id="dot"></span><span id="label">connecting...</span></span>
@@ -274,6 +282,10 @@ _HTML_SHELL = """<!doctype html>
   <div id="feed-empty" class="empty-state">No decisions yet. Doberman's watching quietly.</div>
   <script>
     (function () {
+      // Rendered server-side per `create_app(repo_root=...)` call - this is
+      // why the tab title differs across dashboards opened for different
+      // projects instead of every tab reading the same "Doberman Dashboard".
+      var DASH_BASE_TITLE = %%DASH_JS_TITLE_JSON%%;
       // Verdict/risk/enforcement -> badge class lookups. Explicit,
       // exact-substring-matchable object literals (not an if/else chain) so
       // the served shell can be asserted against directly by a test.
@@ -537,7 +549,7 @@ _HTML_SHELL = """<!doctype html>
 
           pendingList.appendChild(li);
         });
-        document.title = (rows.length ? "(" + rows.length + ") " : "") + "Doberman Dashboard";
+        document.title = (rows.length ? "(" + rows.length + ") " : "") + DASH_BASE_TITLE;
         updateGuardStatus(rows.length);
       }
 
@@ -650,10 +662,55 @@ def _feed_token_matches(request: Request, token: str) -> bool:
     return hmac.compare_digest(supplied, token)
 
 
-async def _index(request: Request) -> Response:
-    # No auth: the shell carries no data, only the JS that reads the token
-    # back out of its own URL and calls the authenticated API routes.
-    return HTMLResponse(_HTML_SHELL)
+def _project_display_name(repo_root: str) -> str:
+    """The folder name of ``repo_root``, for telling dashboards apart.
+
+    Each ``doberman dash`` run is scoped to one repo (``--path``, default
+    cwd) - see :func:`create_app`. Resolving before taking ``.name`` handles
+    both a relative ``"."`` and a path with a trailing slash; falls back to
+    the resolved path itself for the rare case that has no name component
+    (e.g. ``repo_root="/"``).
+    """
+    resolved = Path(repo_root).resolve()
+    return resolved.name or str(resolved)
+
+
+def _js_string_literal(value: str) -> str:
+    """Encode ``value`` as a JS string literal, safe inside a ``<script>`` body.
+
+    ``json.dumps`` alone escapes quotes/backslashes but leaves ``<``, ``>``,
+    and ``&`` untouched - a value containing ``</script>`` would prematurely
+    close the enclosing script element, since the HTML tokenizer looks for
+    that literal byte sequence regardless of JS string context. Escaping
+    those three characters as unicode escapes closes that off entirely
+    (the same pattern used to embed untrusted JSON inside inline scripts
+    elsewhere), which matters here because the project name is a filesystem
+    folder name, not a value Doberman controls.
+    """
+    encoded = json.dumps(value)
+    return encoded.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
+
+
+def _render_shell(repo_root: str) -> str:
+    project = _project_display_name(repo_root)
+    page_title = f"{project} — Doberman Dashboard"
+    return (
+        _HTML_SHELL.replace("%%DASH_PAGE_TITLE%%", html.escape(page_title))
+        .replace("%%DASH_PROJECT_NAME%%", html.escape(project))
+        .replace("%%DASH_JS_TITLE_JSON%%", _js_string_literal(page_title))
+    )
+
+
+def _make_index_route(repo_root: str) -> Route:
+    shell = _render_shell(repo_root)
+
+    async def index(request: Request) -> Response:
+        # No auth: the shell carries no data, only the JS that reads the
+        # token back out of its own URL and calls the authenticated API
+        # routes.
+        return HTMLResponse(shell)
+
+    return Route("/", index)
 
 
 def _make_health_route(token: str) -> Route:
@@ -827,7 +884,7 @@ def create_app(
     their defaults (real interval, unbounded).
     """
     routes = [
-        Route("/", _index),
+        _make_index_route(repo_root),
         _make_health_route(token),
         _make_stats_route(token, repo_root),
         _make_feed_route(

--- a/tests/unit/test_dash_project_title.py
+++ b/tests/unit/test_dash_project_title.py
@@ -1,0 +1,116 @@
+"""Unit tests for per-project dashboard titles.
+
+``doberman dash`` is scoped to one repo per run (``--path``, default cwd -
+see ``create_app``'s ``repo_root`` param). Before this slice every dashboard
+shell hardcoded ``<title>Doberman Dashboard</title>`` and the JS title update
+re-hardcoded the same string, so a user running several dashboards for
+several projects (one per terminal/browser tab) had no way to tell the tabs
+apart. This derives the tab title, and a topbar label, from the repo folder
+name instead.
+
+Covers:
+
+* the served ``<title>`` and topbar both carry the repo folder's name;
+* the JS unread-count title update also uses the project-qualified title,
+  not the old hardcoded string;
+* a repo folder name containing HTML-special characters is escaped in the
+  markup (``<title>``/topbar) and safely JSON-encoded in the JS string -
+  never breaks out of either context;
+* the bearer token still never appears in the shell (unchanged invariant).
+"""
+
+from starlette.testclient import TestClient
+
+from doberman.dash.app import _js_string_literal, _project_display_name, create_app
+
+_TOKEN = "test-dash-token-0123456789"  # noqa: S105 - fixture value, not a real secret
+
+
+def _index_html(repo_root: str) -> str:
+    client = TestClient(create_app(_TOKEN, repo_root))
+    resp = client.get("/")
+    assert resp.status_code == 200
+    return resp.text
+
+
+def test_project_display_name_is_the_repo_folder_name(tmp_path):
+    project_dir = tmp_path / "widget-service"
+    project_dir.mkdir()
+    assert _project_display_name(str(project_dir)) == "widget-service"
+
+
+def test_page_title_carries_the_project_name(tmp_path):
+    project_dir = tmp_path / "widget-service"
+    project_dir.mkdir()
+    html = _index_html(str(project_dir))
+    assert "<title>widget-service — Doberman Dashboard</title>" in html
+
+
+def test_topbar_carries_the_project_name(tmp_path):
+    project_dir = tmp_path / "widget-service"
+    project_dir.mkdir()
+    html = _index_html(str(project_dir))
+    assert '<span class="project">widget-service</span>' in html
+
+
+def test_js_title_update_uses_the_project_qualified_title_not_the_old_hardcode(tmp_path):
+    project_dir = tmp_path / "widget-service"
+    project_dir.mkdir()
+    html = _index_html(str(project_dir))
+    # The em dash is outside ASCII, so json.dumps's default ensure_ascii
+    # renders it as — here, unlike the literal char used in <title>.
+    assert '"widget-service \\u2014 Doberman Dashboard"' in html
+    assert (
+        'document.title = (rows.length ? "(" + rows.length + ") " : "") + DASH_BASE_TITLE;' in html
+    )
+    # The old form re-hardcoded the base string inline instead of a variable.
+    assert '+ "Doberman Dashboard";' not in html
+
+
+def test_two_different_projects_render_different_titles(tmp_path):
+    a = tmp_path / "project-a"
+    b = tmp_path / "project-b"
+    a.mkdir()
+    b.mkdir()
+    html_a = _index_html(str(a))
+    html_b = _index_html(str(b))
+    assert "<title>project-a — Doberman Dashboard</title>" in html_a
+    assert "<title>project-b — Doberman Dashboard</title>" in html_b
+
+
+def test_project_name_with_html_special_characters_is_escaped(tmp_path):
+    project_dir = tmp_path / "my <cool> & co"
+    project_dir.mkdir()
+    html = _index_html(str(project_dir))
+    # Never an unescaped "<cool>" landing anywhere in the page - neither the
+    # HTML-escaped markup nor the JS string (which unicode-escapes <, >, &
+    # so an embedded "</script>" can never close the enclosing script tag).
+    assert "<cool>" not in html
+    assert "my &lt;cool&gt; &amp; co — Doberman Dashboard" in html
+    assert '"my \\u003ccool\\u003e \\u0026 co \\u2014 Doberman Dashboard"' in html
+
+
+def test_project_name_with_quotes_is_safe_inside_the_js_string(tmp_path):
+    project_dir = tmp_path / 'weird"name'
+    project_dir.mkdir()
+    html = _index_html(str(project_dir))
+    # json.dumps escapes the embedded quote, so the JS string literal stays
+    # well-formed instead of terminating early.
+    assert '"weird\\"name \\u2014 Doberman Dashboard"' in html
+
+
+def test_js_string_literal_cannot_close_the_enclosing_script_tag():
+    """A folder named e.g. `</script><script>alert(1)</script>` must not be
+    able to break out of the inline <script> element - the browser's HTML
+    tokenizer looks for the literal "</script" byte sequence in the script's
+    text content, independent of JS string/quote context."""
+    hostile = "</script><script>alert(1)</script>"
+    literal = _js_string_literal(hostile)
+    assert "</script" not in literal
+    assert "<script" not in literal
+
+
+def test_shell_still_never_leaks_the_token(tmp_path):
+    project_dir = tmp_path / "widget-service"
+    project_dir.mkdir()
+    assert _TOKEN not in _index_html(str(project_dir))

--- a/tests/unit/test_dash_project_title.py
+++ b/tests/unit/test_dash_project_title.py
@@ -79,8 +79,10 @@ def test_two_different_projects_render_different_titles(tmp_path):
 
 
 def test_project_name_with_html_special_characters_is_escaped(tmp_path):
+    # Deliberately not .mkdir()'d: `<`/`>` are illegal in a real directory name on
+    # Windows (WinError 123). _render_shell only needs the string - Path.resolve()
+    # works fine on a path that was never created on disk.
     project_dir = tmp_path / "my <cool> & co"
-    project_dir.mkdir()
     html = _index_html(str(project_dir))
     # Never an unescaped "<cool>" landing anywhere in the page - neither the
     # HTML-escaped markup nor the JS string (which unicode-escapes <, >, &
@@ -91,8 +93,10 @@ def test_project_name_with_html_special_characters_is_escaped(tmp_path):
 
 
 def test_project_name_with_quotes_is_safe_inside_the_js_string(tmp_path):
+    # Deliberately not .mkdir()'d: `"` is illegal in a real directory name on
+    # Windows (WinError 123). _render_shell only needs the string - Path.resolve()
+    # works fine on a path that was never created on disk.
     project_dir = tmp_path / 'weird"name'
-    project_dir.mkdir()
     html = _index_html(str(project_dir))
     # json.dumps escapes the embedded quote, so the JS string literal stays
     # well-formed instead of terminating early.


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: dash / per-project-title — Per-project dashboard tab title
- Plan reference: n/a (small UX fix, not tied to a plan slice)

## What this PR does

`doberman dash` is already scoped to one repo per run (`--path`, default the current
directory — see `create_app(repo_root=...)`), but every browser tab rendered the identical
`<title>Doberman Dashboard</title>`, so running several dashboards side by side (one per
project) gave no way to tell the tabs apart. The tab title and the topbar wordmark now carry
the repo folder's name, e.g. `widget-service — Doberman Dashboard`.

- `_project_display_name(repo_root)` derives the label from the resolved folder name.
- `_render_shell(repo_root)` renders the HTML shell per `create_app` call instead of serving
  one static string, substituting the project name into `<title>`, the topbar, and the JS
  unread-count title update (`document.title = "(N) " + DASH_BASE_TITLE`).
- The project name is HTML-escaped in markup and separately encoded via `_js_string_literal`
  (JSON-encode + unicode-escape `<`, `>`, `&`) before landing inside the inline `<script>`, so
  a folder literally named `</script><script>...` can't break out of the script element.
- Appearance/labeling only — no new endpoints, no change to auth, redaction, or the decision
  path.

## Tests added (run in CI)
- `tests/unit/test_dash_project_title.py` — project name derived from the repo folder;
  `<title>`/topbar carry it; two different projects render different titles; the JS title
  update uses the project-qualified base title instead of the old hardcoded string; HTML
  special characters are escaped in markup; quotes are safely embedded in the JS string;
  `_js_string_literal` cannot be used to close the enclosing `<script>` tag; the bearer token
  still never appears in the shell.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (n/a — no new decision logic; this is a display-only change)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) (n/a — no guardrail/learning change)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (n/a — no verdict logic touched)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Edge cases: HTML-special characters in the project folder name; embedded quotes; a
  `</script>`-style script-breakout attempt via the folder name; two dashboards for different
  projects open at once.
- Deviations: none.
- Risks: none — purely cosmetic labeling of an already per-project-scoped server.