### PR TITLE
fix(tests): neutralize codex.AUTH_PROMPTER in the headless test fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,9 +99,18 @@ def _neutralize_hosthook_auth_prompter(monkeypatch):
     AUTH verdict. Force the injected prompter to an unavailable channel so no test ever
     pops a real GUI dialog or blocks on a terminal — an AUTH then fails closed to deny
     unless a test injects its own approving/declining fake.
+
+    Every hosthook module with its own ``AUTH_PROMPTER`` injection seam must be patched
+    here — ``claude_code`` and ``codex`` today (see each module's ``AUTH_PROMPTER``
+    docstring; ``codex.py``'s explicitly says it "mirrors" ``claude_code``'s). Missing one
+    isn't just a coverage gap: any of that module's tests that reach an AUTH-tier decision
+    without injecting their own fake prompter falls through to
+    ``hookio._default_auth_prompter()``, which opens a REAL GUI dialog (blocking up to
+    ``DEFAULT_CHALLENGE_TIMEOUT_S`` = 20 minutes) on any machine with an active desktop
+    session — this previously happened to ``codex.AUTH_PROMPTER`` before it was added below.
     """
     from doberman.auth.gui_prompter import PrompterUnavailableError
-    from doberman.hosthooks import claude_code
+    from doberman.hosthooks import claude_code, codex
 
     class _NoChannel:
         def confirm(self, message):
@@ -111,6 +120,7 @@ def _neutralize_hosthook_auth_prompter(monkeypatch):
             raise PrompterUnavailableError("headless test: no auth channel")
 
     monkeypatch.setattr(claude_code, "AUTH_PROMPTER", _NoChannel())
+    monkeypatch.setattr(codex, "AUTH_PROMPTER", _NoChannel())
 
 
 # ── JSON output assertion helper (Issue #192) ─────────────────────────────────

--- a/tests/unit/test_hosthook_auth_prompter_isolation.py
+++ b/tests/unit/test_hosthook_auth_prompter_isolation.py
@@ -1,0 +1,60 @@
+"""Regression test for the autouse hosthook auth-prompter neutralizer.
+
+``tests/conftest.py``'s ``_neutralize_hosthook_auth_prompter`` autouse fixture used to
+patch only ``claude_code.AUTH_PROMPTER``. ``codex.AUTH_PROMPTER`` is a separate
+module-level seam (mirrors ``claude_code``'s — see ``codex.py``'s docstring on it) that
+the fixture never touched, so any test driving ``codex.evaluate_pre`` into an AUTH-tier
+decision without injecting its own fake prompter fell through to
+``hookio._default_auth_prompter()`` — which opens a REAL GUI dialog and blocks up to
+``DEFAULT_CHALLENGE_TIMEOUT_S`` (20 minutes) on any machine with an active desktop
+session. This hit several existing tests (``test_hosthook_codex.py``'s
+``test_windows_powershell_delete_is_gated`` and ``test_reason_never_echoes_raw_command``,
+``test_hosthook_taint_floor.py``'s ``test_codex_taint_floor_multistep_exfil_denied``) that
+were written assuming a fast headless deny, per their own "headless test = fail-closed
+deny" comments.
+
+This proves the fixture now covers ``codex`` too — with NO test-local monkeypatch of its
+own. If this regresses, this test would hang and pop a real window instead of failing
+fast, exactly like the tests above did before this fix.
+"""
+
+import json
+from pathlib import Path
+
+from doberman.hosthooks import claude_code, codex
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "codex"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def test_codex_auth_prompter_is_neutralized_without_a_test_local_monkeypatch(tmp_path):
+    # A Write to a CI/CD config is DEFAULT_SENSITIVE -> AUTH tier (same trigger used by
+    # test_hosthook_codex.py::test_auth_runs_dobermans_own_challenge, which explicitly
+    # monkeypatches codex.AUTH_PROMPTER itself; this test deliberately does not, to prove
+    # the autouse fixture alone is enough).
+    payload = _load("pre_bash.json")
+    payload["cwd"] = str(tmp_path)
+    payload["tool_name"] = "Write"
+    payload["tool_input"] = {"file_path": ".github/workflows/ci.yml", "content": "x"}
+
+    out = codex.evaluate_pre(payload)
+
+    assert out is not None, "an AUTH-tier action must not abstain"
+    hso = out["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "deny"
+    # This specific "channel could not be shown" wording only comes from the
+    # PrompterUnavailableError path (see hookio._auth_denied_reason's channel_error
+    # branch) - proof this went through the neutralized _NoChannel stub, a fast and
+    # deterministic fail-closed path, rather than a real GUI/TTY channel actually
+    # being tried and eventually timing out.
+    assert "could not be shown" in hso["permissionDecisionReason"]
+
+
+def test_codex_and_claude_code_get_the_same_kind_of_neutralized_prompter():
+    # Both hosthook modules' AUTH_PROMPTER seams must be patched to the same no-channel
+    # behavior by the one autouse fixture - not just "codex has *a* patch" but "the
+    # same protection claude_code already had".
+    assert type(codex.AUTH_PROMPTER) is type(claude_code.AUTH_PROMPTER)


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: tests / codex-hosthook-gui-prompter-isolation — Close a test-isolation gap for the Codex hosthook's AUTH prompter
- Plan reference: n/a (test-infrastructure fix, discovered while verifying an unrelated PR locally)

## What this PR does

`tests/conftest.py`'s autouse `_neutralize_hosthook_auth_prompter` fixture (added for
issues #65/#67) patches the injected auth-prompter to a no-op stub so no test ever pops a
real GUI dialog or blocks on a terminal. It only patched `doberman.hosthooks.claude_code
.AUTH_PROMPTER`. `doberman.hosthooks.codex.py` keeps its own separate `AUTH_PROMPTER`
module variable — its own docstring says it "mirrors" claude_code's — that the fixture
never touched.

Any test that drives `codex.evaluate_pre` into an AUTH-tier decision **without** injecting
its own fake prompter therefore fell through to `hookio._default_auth_prompter()` =
`FallbackPrompter([GuiPrompter(), TtyPrompter()])`. On a headless CI runner both channels
fail instantly and the code fails closed to `deny` in milliseconds (matching what the
affected tests assert) — so **CI was never affected**. On any machine with an active
desktop session, `GuiPrompter()` successfully opens a real Tk window and blocks waiting for
a human click, up to `DEFAULT_CHALLENGE_TIMEOUT_S` = 1200s (20 minutes) per call. That's a
real popup, on the developer's own screen, every time they run the full local suite.

Confirmed affected before this fix: `test_hosthook_codex.py::test_windows_powershell_delete_is_gated`,
`::test_reason_never_echoes_raw_command`, and
`test_hosthook_taint_floor.py::test_codex_taint_floor_multistep_exfil_denied` — all three
were written assuming a fast headless deny (see their own "headless test = fail-closed
deny" comments), they just weren't actually getting one.

The fix: extend the fixture to also `monkeypatch.setattr(codex, "AUTH_PROMPTER", _NoChannel())`,
mirroring what it already does for `claude_code`.

Verified: the full unrestricted `pytest --cov=doberman` suite now completes in one clean
run with no exclusions needed and no popup — previously it would hang for many minutes and
eventually abort on the first unmocked codex AUTH test it hit.

## Tests added (run in CI)
- `tests/unit/test_hosthook_auth_prompter_isolation.py`:
  - `test_codex_auth_prompter_is_neutralized_without_a_test_local_monkeypatch` — drives
    `codex.evaluate_pre` into the same AUTH-tier trigger used by
    `test_hosthook_codex.py::test_auth_runs_dobermans_own_challenge`, but with **no**
    test-local monkeypatch, and asserts the specific "could not be shown" channel-error
    wording that only comes from the neutralized `_NoChannel` path (proof it's the fast
    fail-closed path, not a real channel that happened to also deny).
  - `test_codex_and_claude_code_get_the_same_kind_of_neutralized_prompter` — both hosthook
    modules' `AUTH_PROMPTER` seams get patched to the same no-channel type by the one
    fixture.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (n/a — test-only change; the product's own fail-closed behavior on a channel error is unchanged and is exactly what these tests now exercise deterministically)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) (n/a — no guardrail/learning code touched, `tests/` only)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (n/a — no verdict logic touched)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Edge cases: an AUTH-tier codex decision with no test-local prompter override now
  deterministically fails closed instead of depending on GUI/terminal availability.
- Deviations: none.
- Risks: none — this only tightens test isolation (a real channel is used even less often
  now than before); no production code path changes. `doberman.hosthooks.openclaw` has no
  `AUTH_PROMPTER` seam of its own (doesn't call `hookio.resolve_auth`), so there was nothing
  else to cover.