### PR TITLE
fix(subjective): fingerprint destination baseline keys, purge legacy raw hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
   promote, so a schema-changed tool scores as brand-new after re-approval instead of inheriting
   pre-change trust. (The reset helper existed but nothing called it; found by the subjective-layer
   hardening audit.)
+- **Destination baseline keys are now keyed fingerprints:** the per-entity baseline stored
+  `destination:<host>` verbatim — the one feature key that was neither a coarse class nor a
+  fingerprint, so a secret encoded into a hostname would persist after any allowed egress.
+  Hosts are now HMAC-fingerprinted (familiarity math unchanged), a fingerprint failure drops
+  the key rather than storing the raw host, and the v12 schema migration purges legacy raw
+  rows (raise-safe: colder scores as more novel). Found by the hardening audit's redaction probe.
 - **Plain-language auth messages — new `message_tone` setting:** the authorization prompt now
   speaks plainly by default — *"Your agent wants to run a command: … Approve this exact action?"* —
   instead of the terse `[RISK: …] role: … reason: …` block. `doberman message-tone human|technical`

--- a/src/doberman/storage/db.py
+++ b/src/doberman/storage/db.py
@@ -59,7 +59,9 @@ DB_FILE = "doberman.db"
 #: gate, never the raw prompt text).
 #: Version 11 adds issue #246's tool-schema TOFU pins (additive CREATE TABLE;
 #: keyed HMAC fingerprints only, never raw tool descriptions/input schemas).
-SCHEMA_VERSION = 11
+#: Version 12 fingerprints the baseline's destination feature keys and purges
+#: legacy raw-host rows (H4 — a hostname can embed secret material).
+SCHEMA_VERSION = 12
 
 # Every table uses CREATE TABLE IF NOT EXISTS so opening an older DB transparently
 # adds the new tables (a forward-only, additive migration; the one re-shape —
@@ -344,6 +346,16 @@ async def _migrate_legacy(conn: aiosqlite.Connection) -> None:
             await conn.execute(f"ALTER TABLE {table} ADD COLUMN last_touched TEXT")  # noqa: S608 — table is a fixed literal above
             if backfill_from:
                 await conn.execute(f"UPDATE {table} SET last_touched = {backfill_from}")  # noqa: S608 — fixed literals above
+    # v11 -> v12: destination feature keys become keyed fingerprints — the raw
+    # host must leave the store (a hostname can embed secret material). Legacy
+    # raw rows are DROPPED, not re-keyed; losing that familiarity is raise-safe
+    # (colder = more novel = more step-ups). Idempotent: fingerprinted
+    # ``destination:hmac:*`` rows are untouched.
+    if await _table_columns(conn, "baseline_counts"):
+        await conn.execute(
+            "DELETE FROM baseline_counts WHERE feature_key LIKE 'destination:%' "
+            "AND feature_key NOT LIKE 'destination:hmac:%'"
+        )
 
 
 async def _ensure_schema(conn: aiosqlite.Connection) -> None:

--- a/src/doberman/subjective/baseline.py
+++ b/src/doberman/subjective/baseline.py
@@ -13,8 +13,9 @@ Invariants (same as the legacy F9 baseline, now per entity):
 * **Update on ALLOW only.** :func:`observe` is called by the proxy after a
   successful forward — a blocked/denied attempt never teaches "normal".
 * **Classes, never payloads.** Feature keys are coarse classes (algebra
-  members, path classes, command verbs, destination hosts); the ``entity_id``
-  itself is a keyed HMAC fingerprint, never a raw role/path string.
+  members, path classes, command verbs) or keyed fingerprints (destination
+  hosts); the ``entity_id`` itself is a keyed HMAC fingerprint. A raw host,
+  role, or path string never lands in the store.
 * **Bounded cardinality.** Past :data:`MAX_FEATURE_KEYS` distinct keys per
   entity, new keys aggregate into an overflow bucket — no attacker-driven
   table blow-up.
@@ -139,7 +140,15 @@ def scoring_keys(action: SecurityObject) -> list[str]:
     # evidence that the tenant/host is normal. Keep it out of the learned
     # destination-host baseline so approval cannot poison future scoring.
     if action.external_destination and action.action_type not in _COMMAND_EGRESS_ACTIONS:
-        keys.append(f"destination:{action.external_destination}")
+        # Keyed fingerprint, never the raw host: a hostname can carry secret
+        # material (token-in-subdomain exfil), and this store holds classes and
+        # fingerprints only. Same equality class, so familiarity math is
+        # unchanged. On fingerprint failure the destination simply is not
+        # learned — no key beats a raw host (unlearned = more novel, raise-safe).
+        try:
+            keys.append(f"destination:{fingerprint(action.external_destination)}")
+        except Exception:  # noqa: BLE001 — raw host must never be the fallback
+            logger.warning("destination fingerprint unavailable; destination not learned")
     if action.action_type is ActionType.shell_exec and action.target:
         verb = str(action.target).strip().split()[0] if str(action.target).strip() else ""
         if verb:

--- a/tests/unit/test_destination_key_redaction.py
+++ b/tests/unit/test_destination_key_redaction.py
@@ -1,0 +1,100 @@
+"""H4 — destination feature keys are keyed fingerprints, never raw hosts.
+
+Found by flipping on H3's redaction probe: ``scoring_keys()`` appended
+``destination:<host>`` verbatim — the one feature key that was neither a
+coarse class nor a fingerprint, so a secret encoded into a hostname
+(token-in-subdomain exfil) would persist raw in ``baseline_counts`` after any
+*allowed* egress. Now the host is HMAC-fingerprinted (same equality class, so
+familiarity math is unchanged), a fingerprint failure drops the key instead of
+falling back to the raw host, and the v12 migration purges legacy raw rows
+(raise-safe: colder = more novel).
+"""
+
+from datetime import datetime, timezone
+
+from doberman.models import ActionType, Algebra, Capability, SecurityObject, TargetClass
+from doberman.storage.db import open_db
+from doberman.storage.fingerprint import fingerprint
+from doberman.subjective import baseline
+from doberman.subjective.baseline import frequency, observe, scoring_keys
+
+_NOW = datetime(2026, 6, 9, tzinfo=timezone.utc)
+_HOST = "attacker.example"
+
+
+def _egress(host: str = _HOST) -> SecurityObject:
+    return SecurityObject(
+        id="dk-1",
+        ts=_NOW,
+        agent_role="frontend",
+        action_type=ActionType.network_request,
+        tool_name="net_post",
+        target="https://x.test",
+        external_destination=host,
+        algebra=Algebra(
+            capability=Capability.send,
+            target_class=TargetClass.internal,
+            classification_confidence=0.8,
+        ),
+    )
+
+
+def test_destination_key_is_a_keyed_fingerprint_not_the_raw_host():
+    keys = scoring_keys(_egress())
+    destination_keys = [k for k in keys if k.startswith("destination:")]
+    assert destination_keys == [f"destination:{fingerprint(_HOST)}"]
+    assert destination_keys[0].startswith("destination:hmac:")
+    assert all(_HOST not in k for k in keys)
+
+
+async def test_familiarity_still_accrues_per_host(tmp_path):
+    # Same host → same fingerprint → the familiarity count works exactly as the
+    # raw key did; a different host maps to a different key.
+    root = str(tmp_path)
+    await observe(_egress(), entity_id="hmac:aaa", repo_root=root, now=_NOW)
+    await observe(_egress(), entity_id="hmac:aaa", repo_root=root, now=_NOW)
+    key = f"destination:{fingerprint(_HOST)}"
+    assert await frequency(key, entity_id="hmac:aaa", repo_root=root) == 2
+    other = f"destination:{fingerprint('other.example')}"
+    assert await frequency(other, entity_id="hmac:aaa", repo_root=root) == 0
+
+
+def test_fingerprint_failure_drops_the_key_never_the_raw_host(monkeypatch):
+    def _boom(_value: str) -> str:
+        raise RuntimeError("no key")
+
+    monkeypatch.setattr(baseline, "fingerprint", _boom)
+    keys = scoring_keys(_egress())
+    # Removing the try/except (or falling back to the raw host) flips this red.
+    assert not any(k.startswith("destination:") for k in keys)
+    assert all(_HOST not in k for k in keys)
+
+
+async def test_v12_migration_purges_legacy_raw_destination_rows(tmp_path):
+    root = str(tmp_path)
+    stamp = _NOW.isoformat()
+    rows = [
+        ("hmac:aaa", f"destination:{_HOST}"),  # legacy raw — must be purged
+        ("hmac:aaa", f"destination:{fingerprint(_HOST)}"),  # already fingerprinted
+        ("hmac:aaa", "capability:send"),  # untouched bystander
+    ]
+    async with open_db(root) as conn:
+        for eid, key in rows:
+            await conn.execute(
+                "INSERT INTO baseline_counts "
+                "(entity_id, feature_key, role, count, first_seen, last_seen, last_touched) "
+                "VALUES (?, ?, 'frontend', 3, ?, ?, ?)",
+                (eid, key, stamp, stamp, stamp),
+            )
+        await conn.commit()
+
+    # Reopening runs _ensure_schema → the idempotent v12 purge.
+    async with open_db(root) as conn:
+        async with conn.execute(
+            "SELECT feature_key FROM baseline_counts ORDER BY feature_key"
+        ) as cur:
+            kept = [row[0] for row in await cur.fetchall()]
+
+    assert f"destination:{_HOST}" not in kept
+    assert f"destination:{fingerprint(_HOST)}" in kept
+    assert "capability:send" in kept

--- a/tests/unit/test_subjective_hardening_pins.py
+++ b/tests/unit/test_subjective_hardening_pins.py
@@ -170,21 +170,6 @@ def test_proposed_changes_clamps_at_the_weight_boundaries():
 # --- 4. baseline store never holds a raw secret-shaped value ---------------------
 
 
-@pytest.mark.skip(
-    reason=(
-        "KNOWN LEAK, 2026-08-19 hardening audit (not softened per H3 "
-        "instructions): scoring_keys() in src/doberman/subjective/baseline.py "
-        "(~L119-146) appends f'destination:{action.external_destination}' "
-        "VERBATIM into the feature key — unlike the path-class bucket (drops "
-        "the filename) and the command key (keeps only the verb), the "
-        "destination host is never coarsened or redacted. A marker embedded in "
-        "external_destination (e.g. a secret encoded into a destination "
-        "hostname) lands raw in baseline_counts.feature_key via observe(). "
-        "Needs a source fix (hash/coarsen the host, or exclude it the way "
-        "command-egress destinations already are) before this assert can go "
-        "green — do not remove this skip without one."
-    )
-)
 async def test_baseline_never_stores_a_raw_secret_shaped_value(tmp_path):
     """Feeds a marker through the file_write path (filename), the shell_exec
     path (command line, after the verb), and the external_destination path (a


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: H4 (subjective harden series) — destination-key redaction
- Plan reference: found by #420's redaction probe (shipped there skipped)

## What this PR does
`scoring_keys()` stored `destination:<host>` verbatim — the one feature key that was neither a coarse class nor a keyed fingerprint. A secret encoded into a hostname (token-in-subdomain exfil) would persist raw in `baseline_counts` after any *allowed* egress, against the module's own "classes, never payloads" rule.

Destination hosts are now HMAC-fingerprinted with the same per-install key as `entity_id`. Same equality class, so familiarity math is unchanged; `_familiar_at` keys off the `destination:` prefix, which survives. A fingerprint failure drops the key instead of falling back to the raw host (unlearned = more novel, raise-safe). The v12 schema migration purges legacy raw rows idempotently — losing that familiarity is raise-safe by construction. Un-skips #420's redaction probe, which now passes.

## Tests added (run in CI)
- tests/unit/test_destination_key_redaction.py — key is `destination:hmac:<hex>` and the raw host appears in no key; familiarity still accrues per host; fingerprint failure drops the key, never the raw host; the v12 migration purges raw rows and keeps fingerprinted and bystander rows.
- tests/unit/test_subjective_hardening_pins.py — the redaction probe un-skipped (file/shell/destination paths all scanned for a synthetic marker).

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (fingerprint failure → destination not learned)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (colder destination baseline = more step-ups)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Benchmarks (before/after, corpus, subjective separation, poisoning) are byte-identical to main — the equality-class swap changes no scoring behavior.
- Legacy raw rows are dropped, not re-keyed: the raw value must leave the DB, and the migration cannot recompute a keyed fingerprint it never stored inputs for.