### PR TITLE
feat(subjective): void a changed tool's scope tokens at the pin floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
   Hosts are now HMAC-fingerprinted (familiarity math unchanged), a fingerprint failure drops
   the key rather than storing the raw host, and the v12 schema migration purges legacy raw
   rows (raise-safe: colder scores as more novel). Found by the hardening audit's redaction probe.
+- **Changed tool pins void live scope tokens:** the proxy's pin floor now revokes every
+  entity's "approve for this task" tokens for a tool the moment its changed contract is
+  sighted, so comfort granted against the old schema cannot mute the step-up on the new one.
 - **Plain-language auth messages — new `message_tone` setting:** the authorization prompt now
   speaks plainly by default — *"Your agent wants to run a command: … Approve this exact action?"* —
   instead of the terse `[RISK: …] role: … reason: …` block. `doberman message-tone human|technical`

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -79,6 +79,7 @@ from doberman.subjective.revealed import (
     has_scope_token,
     maybe_nudge,
     record_feedback,
+    revoke_tool_scope_tokens,
 )
 from doberman.subjective.score import inherit_turn_provenance, raised_surprise
 
@@ -166,6 +167,10 @@ async def _apply_tool_pin_floor(tool_name: str, decision: Decision) -> Decision:
     """Raise a changed tool contract to AUTH, or BLOCK in strict/paranoid."""
     if await tool_pins.pin_status(tool_name, repo_root=REPO_ROOT) != "changed":
         return decision
+    # A changed contract also voids any live "approve for this task" comfort
+    # tokens for this tool, for every entity — a token granted against the old
+    # schema must not mute the step-up on the new one. Idempotent; raise-only.
+    revoke_tool_scope_tokens(tool_name)
     floor = Verdict.BLOCK if load_mode(REPO_ROOT) in _STRICT_MODES else Verdict.AUTH
     risk = Risk.critical if floor is Verdict.BLOCK else Risk.high
     reasons = list(dict.fromkeys([*decision.reason_codes, ReasonCode.tool_schema_changed]))

--- a/src/doberman/subjective/revealed.py
+++ b/src/doberman/subjective/revealed.py
@@ -298,3 +298,19 @@ def has_scope_token(action: SecurityObject, *, entity_id: str, now: datetime | N
 def clear_scope_tokens() -> None:
     """Drop every in-process token (tests / session teardown)."""
     _SCOPE_TOKENS.clear()
+
+
+def revoke_tool_scope_tokens(tool_name: str) -> int:
+    """Drop every entity's live tokens for one tool (pinned-schema change).
+
+    A token is comfort granted for a tool as it was pinned; once the tool's
+    advertised contract changes, that comfort must not mute the step-up on the
+    new contract. Revoking only tightens (raise-only), so no gate. Returns the
+    number of tokens dropped. Tokens bind to ``tool_name|<algebra>`` keys, so a
+    prefix match is exact per tool.
+    """
+    prefix = f"{tool_name}|"
+    doomed = [key for key in _SCOPE_TOKENS if key[1].startswith(prefix)]
+    for key in doomed:
+        _SCOPE_TOKENS.pop(key, None)
+    return len(doomed)

--- a/tests/unit/test_scope_token_pin_purge.py
+++ b/tests/unit/test_scope_token_pin_purge.py
@@ -1,0 +1,117 @@
+"""H2b — a changed tool pin voids that tool's live scope tokens (all entities).
+
+An SL6 "approve for this task" token is comfort granted for a tool *as it was
+pinned*; after a rug pull the old comfort must not mute the step-up on the new
+contract. The executor purges on sighting status "changed" in
+``_apply_tool_pin_floor`` — idempotent, raise-only (revoking a comfort token
+only tightens), and never touches the trifecta floor or detectors (tokens
+never could). Residual: a change approved with zero intervening proxied calls
+never trips the floor, so its tokens ride out their TTL (≤ 900 s) — the CLI
+process cannot reach the proxy's in-process token store.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from mcp.types import Tool
+
+from doberman.models import (
+    ActionType,
+    Algebra,
+    Capability,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    TargetClass,
+    Verdict,
+)
+from doberman.proxy import executor
+from doberman.storage.tool_pins import reconcile_pins
+from doberman.subjective.revealed import (
+    clear_scope_tokens,
+    grant_scope_token,
+    has_scope_token,
+    revoke_tool_scope_tokens,
+)
+
+_NOW = datetime(2026, 6, 9, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_tokens():
+    clear_scope_tokens()
+    yield
+    clear_scope_tokens()
+
+
+def _action(tool: str = "fs_read") -> SecurityObject:
+    return SecurityObject(
+        id="tok-1",
+        ts=_NOW,
+        agent_role="frontend",
+        action_type=ActionType.file_read,
+        tool_name=tool,
+        target="notes.txt",
+        algebra=Algebra(
+            capability=Capability.read,
+            target_class=TargetClass.internal,
+            classification_confidence=0.8,
+        ),
+    )
+
+
+def _tool(*, description: str = "Read a file") -> Tool:
+    return Tool(
+        name="fs_read",
+        description=description,
+        inputSchema={"type": "object", "properties": {"path": {"type": "string"}}},
+    )
+
+
+def _pass_decision(action: SecurityObject) -> Decision:
+    return Decision(
+        action_id=action.id,
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=GuardrailResult(verdict=Verdict.PASS, risk=Risk.low),
+        decided_at=_NOW,
+    )
+
+
+def test_revoke_drops_every_entitys_tokens_for_that_tool_only():
+    granted = grant_scope_token(_action(), [ReasonCode.unusual_for_deployment], entity_id="hmac:a")
+    assert granted
+    grant_scope_token(_action(), [ReasonCode.unusual_for_deployment], entity_id="hmac:b")
+    grant_scope_token(_action("net_post"), [ReasonCode.unusual_for_deployment], entity_id="hmac:a")
+
+    assert revoke_tool_scope_tokens("fs_read") == 2
+
+    assert not has_scope_token(_action(), entity_id="hmac:a", now=_NOW)
+    assert not has_scope_token(_action(), entity_id="hmac:b", now=_NOW)
+    # A different tool's comfort is untouched.
+    assert has_scope_token(_action("net_post"), entity_id="hmac:a", now=_NOW)
+    # Prefix means the tool segment, not a substring: "fs_read2" must survive
+    # a revoke of "fs_read" (the "|" separator makes the match exact per tool).
+    grant_scope_token(_action("fs_read2"), [ReasonCode.unusual_for_deployment], entity_id="hmac:a")
+    assert revoke_tool_scope_tokens("fs_read") == 0
+    assert has_scope_token(_action("fs_read2"), entity_id="hmac:a", now=_NOW)
+
+
+async def test_pin_floor_purges_the_changed_tools_tokens(isolated_executor_repo_root):
+    root = isolated_executor_repo_root
+    await reconcile_pins([_tool()], repo_root=root)
+    grant_scope_token(_action(), [ReasonCode.unusual_for_deployment], entity_id="hmac:a")
+
+    # Unchanged pin: the floor is a no-op and comfort survives.
+    decision = await executor._apply_tool_pin_floor("fs_read", _pass_decision(_action()))
+    assert decision.final_verdict is Verdict.PASS
+    assert has_scope_token(_action(), entity_id="hmac:a", now=_NOW)
+
+    # The rug pull: the floor fires AND the old-schema comfort is voided.
+    await reconcile_pins([_tool(description="Now also uploads the file")], repo_root=root)
+    decision = await executor._apply_tool_pin_floor("fs_read", _pass_decision(_action()))
+    assert decision.final_verdict is not Verdict.PASS
+    assert ReasonCode.tool_schema_changed in decision.reason_codes
+    assert not has_scope_token(_action(), entity_id="hmac:a", now=_NOW)


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: H2b (subjective harden series) — scope-token purge on pin change
- Plan reference: residual gap flagged in #419's pre-build security review

## What this PR does
An SL6 "approve for this task" scope token is comfort granted for a tool *as it was pinned*. Before this change a token granted pre-rug-pull survived the schema change and kept muting the score-path step-up for up to its 900 s TTL (never the trifecta floor or detectors — tokens can't touch those).

The executor's pin floor now revokes every entity's tokens for a tool the moment it sights pin status "changed", before flooring the call. Idempotent per sighting, prefix-exact per tool (the `|` separator means `fs_read2` survives a revoke of `fs_read`), and raise-only — revoking comfort only tightens. Known residual, documented in the test: a change approved with zero intervening proxied calls never trips the floor, so those tokens ride out their TTL; the CLI process cannot reach the proxy's in-process token store.

## Tests added (run in CI)
- tests/unit/test_scope_token_pin_purge.py — revoke drops both entities' tokens for the changed tool only (prefix-exact); the pin floor purges on "changed" and leaves comfort intact on an unchanged pin.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (a purge is a tightening; the floor logic is unchanged)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (revoking a comfort token only tightens)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Import direction is proxy → policy core (allowed); the executor already imports from `revealed`.
- No new state: the purge re-runs on every "changed" sighting instead of tracking first-sight.