### PR TITLE
fix(auth): keep the dialog focus ring beneath the buttons so clicks reach them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
 
 ## Unreleased (merged since v0.18.1)
 
+- **Auth dialog: the highlighted button takes the click again.** The Canvas focus ring was
+  drawn on top of the keyboard-highlighted button, and Tk hit-tests a polygon's whole interior
+  even when unfilled — so clicking Deny (or Approve, after Tab) did nothing and the hover
+  shade never showed. The ring now sits beneath the buttons; a real-Tk test pins the click
+  target and a faked-canvas test pins the stacking on headless CI.
 - **Rug-pull follow-through — approving a changed tool pin now resets learned familiarity:**
   `approve_pin` deletes every entity's `tool:<name>` baseline rows in the same transaction as the
   promote, so a schema-changed tool scores as brand-new after re-approval instead of inheriting

--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -398,6 +398,9 @@ def _add_button_row(
             outline=_BRAND,
             width=2,
         )
+        # Tk hit-tests a polygon's whole interior even with fill="" — left on top, the ring
+        # would swallow clicks (and hover) on the highlighted button. Keep it beneath them.
+        canvas.tag_lower(state["ring"], "_dobermanbtn0")
 
     def _move_highlight(_event: Any = None) -> str:
         state["index"] = (state["index"] + 1) % len(specs)

--- a/tests/unit/test_gui_prompter.py
+++ b/tests/unit/test_gui_prompter.py
@@ -19,6 +19,8 @@ The tkinter machinery is monkeypatched at module seams (mirroring how the TTY te
 fake ``_open_tty``) so everything here runs headless and deterministically.
 """
 
+import types
+
 import pytest
 
 from doberman.auth import gui_prompter
@@ -295,6 +297,96 @@ def test_real_dialog_widgets_dark_theme_and_masked_entry(monkeypatch):
         assert entries, "code dialog must contain an entry field"
         assert entries[0].cget("show") == "*"  # the code must be masked on screen
         assert root.cget("bg") == gui_prompter._BG
+    finally:
+        root.destroy()
+
+
+class _FakeCanvas:
+    """Records the Canvas display list (bottom → top) and mirrors Tk's ``tag_lower``."""
+
+    def __init__(self):
+        self.items: list[int] = []  # display list: creation order = stacking order
+        self.tags: dict[int, tuple] = {}
+
+    def _create(self, tags):
+        item = len(self.tags) + 1
+        self.items.append(item)
+        self.tags[item] = tuple(tags)
+        return item
+
+    def create_polygon(self, _points, **kw):
+        return self._create(kw.get("tags", ()))
+
+    def create_text(self, _x, _y, **kw):
+        return self._create(kw.get("tags", ()))
+
+    def tag_lower(self, item, below):
+        # Tk: move `item` to just before the LOWEST item carrying tag `below`.
+        self.items.remove(item)
+        self.items.insert(
+            next(i for i, it in enumerate(self.items) if below in self.tags[it]), item
+        )
+
+    def delete(self, item):
+        self.items.remove(item)
+
+    def tag_bind(self, *_a, **_kw):
+        pass
+
+    def itemconfig(self, *_a, **_kw):
+        pass
+
+    def focus_set(self):
+        pass
+
+    def ring_is_beneath_every_button(self) -> bool:
+        [ring] = [i for i in self.items if not self.tags[i]]  # the ring is the only untagged item
+        return all(self.items.index(ring) < self.items.index(i) for i in self.items if self.tags[i])
+
+
+def test_focus_ring_is_stacked_beneath_the_buttons(monkeypatch):
+    """Tk hit-tests a polygon's WHOLE interior even when it is unfilled, so a focus ring
+    drawn on top of the highlighted button receives that button's clicks (and hover)
+    instead of the button — clicking Deny did nothing. The ring must sit beneath every
+    button item, both at the start and after each highlight move (it is redrawn each
+    time). Faked canvas, so this runs on headless CI; the real-Tk check is below.
+    """
+    tkfont = pytest.importorskip("tkinter.font")
+    monkeypatch.setattr(tkfont, "Font", lambda **_kw: types.SimpleNamespace(measure=len))
+    canvas, root = _FakeCanvas(), _FakeRoot()
+    specs = [("Deny", lambda: None, False), ("Approve", lambda: None, True)]
+
+    gui_prompter._add_button_row(root, canvas, y=100, specs=specs)
+    assert canvas.ring_is_beneath_every_button()
+
+    root.bindings["<Tab>"]()  # highlight → Approve; ring deleted and redrawn
+    assert canvas.ring_is_beneath_every_button()
+
+
+def test_real_canvas_click_target_is_the_highlighted_button_not_the_ring():
+    """With a real display: the item Tk would hand a click to — the topmost item under the
+    button's centre, which is exactly ``find_closest``'s tie-break — must be the button
+    itself (tagged), never the untagged focus ring, for Deny (highlighted at open) and
+    Approve alike. Skipped where Tk cannot open (headless CI); the faked-canvas test above
+    still covers the stacking contract there.
+    """
+    tkinter = pytest.importorskip("tkinter")
+    try:
+        root = tkinter.Tk()
+    except tkinter.TclError:
+        pytest.skip("no display available")
+    try:
+        root.withdraw()
+        canvas = tkinter.Canvas(root, width=gui_prompter._DIALOG_W, height=200)
+        canvas.pack()
+        specs = gui_prompter._confirm_specs(lambda _value: None)
+        gui_prompter._add_button_row(root, canvas, y=60, specs=specs)
+        root.update_idletasks()
+
+        for tag in ("_dobermanbtn0", "_dobermanbtn1"):
+            x1, y1, x2, y2 = canvas.bbox(tag)
+            topmost = canvas.find_closest((x1 + x2) / 2, (y1 + y2) / 2)[0]
+            assert tag in canvas.gettags(topmost), f"click on {tag} would land on item {topmost}"
     finally:
         root.destroy()
 


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: F7 auth dialog (popup redesign follow-up, #411) — focus ring swallows clicks
- Plan reference: n/a (bug fix)

## What this PR does

**Bug.** In the redesigned auth dialog, clicking the keyboard-highlighted button did nothing: Deny at open, Approve after Tab. The hover shade never showed on it either.

**Cause.** `_draw_ring` creates the focus ring after the buttons, so it sits on top of the highlighted one. Tk hit-tests a polygon's whole interior even with `fill=""`, so the click lands on the untagged ring instead of the button's `<Button-1>` tag binding. Reproduced on a real Tk canvas: `find_closest` at Deny's centre returned the ring.

**Fix.** One line in `_draw_ring`: `canvas.tag_lower(ring, "_dobermanbtn0")` each time the ring is drawn. Visually identical, since the ring is unfilled and sits 3px outside the button.

## Tests added (run in CI)
- `test_focus_ring_is_stacked_beneath_the_buttons`: a faked canvas mirrors Tk's `tag_lower`; asserts the ring is below every button item at open and after a Tab redraw. Runs on headless CI.
- `test_real_canvas_click_target_is_the_highlighted_button_not_the_ring`: real Tk; `find_closest` at each button's centre is the button, never the ring. Skips without a display.
- Mutation check: both fail with the fix reverted. A mapped-window `event_generate("<Button-1>")` on Deny now fires the deny command.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (unchanged: Escape/close/timeout still deny; Deny still starts highlighted)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — n/a, UI only
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — unchanged
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- The ring is redrawn on every highlight move; the lowering happens inside `_draw_ring`, so every redraw is covered (the fake-canvas test asserts after a Tab).
- The same `_add_button_row` serves the TOTP code dialog's Cancel/Submit row, so that dialog is fixed too.
- CHANGELOG bullet under Unreleased.
