### PR TITLE
feat(tokens): add calibrate_perplexity_threshold for the OT.4 perplexity seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
   import of the subjective layer (and therefore the whole test suite) died on
   3.11 with `TypeError: type 'DictReader' is not subscriptable`. 3.12+ keeps
   the unpinned floor.
+- **`calibrate_perplexity_threshold`, the model-agnostic half of the OT.4 perplexity seam:**
+  `doberman.tokens.calibrate_perplexity_threshold(benign_scores, target_fpr)` returns the
+  nearest-rank empirical `(1 - target_fpr)` quantile of a benign score corpus, for the
+  `TokenChannelDetector` `perplexity_fn`/`perplexity_threshold` seam. Fails closed (raises
+  `ValueError`) on an out-of-range `target_fpr` or fewer than 20 benign scores. No model, no
+  new dependency; the reference scorer that calls it lands separately as an optional extra.
 - **Auth dialog: the highlighted button takes the click again.** The Canvas focus ring was
   drawn on top of the keyboard-highlighted button, and Tk hit-tests a polygon's whole interior
   even when unfilled — so clicking Deny (or Approve, after Tab) did nothing and the hover

--- a/src/doberman/tokens.py
+++ b/src/doberman/tokens.py
@@ -59,8 +59,9 @@ subjective detector). It is not marketed as airtight.
 
 from __future__ import annotations
 
+import math
 import unicodedata
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import parse_qsl, urlsplit
@@ -507,6 +508,30 @@ def scan_text(text: str, glitch_store: GlitchFragmentStore | None = None) -> OOD
         )
 
     return report
+
+
+# --- Perplexity threshold calibration -----------------------------------------
+# The pure-stats half of the opt-in perplexity_fn seam (TokenChannelDetector):
+# calibrates a threshold against a benign corpus, no model, no dependency.
+
+
+def calibrate_perplexity_threshold(benign_scores: Sequence[float], target_fpr: float) -> float:
+    """Nearest-rank empirical ``(1 - target_fpr)`` quantile of ``benign_scores``,
+    for the ``perplexity_fn``/``perplexity_threshold`` seam on
+    :class:`~doberman.engine.detectors.token_channels.TokenChannelDetector`.
+    Fails closed: raises ``ValueError`` if ``target_fpr`` is not in ``(0, 1)``
+    or fewer than 20 benign scores are given.
+    """
+    if not 0 < target_fpr < 1:
+        raise ValueError(f"target_fpr must be in (0, 1), got {target_fpr!r}")
+    samples = sorted(benign_scores)
+    if len(samples) < 20:
+        raise ValueError(
+            "need at least 20 benign samples to calibrate a false-positive "
+            f"rate, got {len(samples)}"
+        )
+    rank = math.ceil((1 - target_fpr) * len(samples))
+    return samples[rank - 1]
 
 
 # --- Action surface collection -----------------------------------------------

--- a/src/doberman/tokens.py
+++ b/src/doberman/tokens.py
@@ -519,12 +519,14 @@ def calibrate_perplexity_threshold(benign_scores: Sequence[float], target_fpr: f
     """Nearest-rank empirical ``(1 - target_fpr)`` quantile of ``benign_scores``,
     for the ``perplexity_fn``/``perplexity_threshold`` seam on
     :class:`~doberman.engine.detectors.token_channels.TokenChannelDetector`.
-    Fails closed: raises ``ValueError`` if ``target_fpr`` is not in ``(0, 1)``
-    or fewer than 20 benign scores are given.
+    Fails closed: raises ``ValueError`` if ``target_fpr`` is not in ``(0, 1)``,
+    fewer than 20 benign scores are given, or any score is not finite.
     """
     if not 0 < target_fpr < 1:
         raise ValueError(f"target_fpr must be in (0, 1), got {target_fpr!r}")
     samples = sorted(benign_scores)
+    if not all(math.isfinite(s) for s in samples):
+        raise ValueError("benign_scores must all be finite, got a NaN or infinite value")
     if len(samples) < 20:
         raise ValueError(
             "need at least 20 benign samples to calibrate a false-positive "

--- a/tests/unit/test_detector_token_channels.py
+++ b/tests/unit/test_detector_token_channels.py
@@ -7,6 +7,7 @@ raising scorer is isolated; a per-model glitch list is honored; and the detector
 is wired into SubjectiveGuardrail as a built-in (escalates a soft-signal action).
 """
 
+import pathlib
 from datetime import datetime, timezone
 
 from doberman.engine.detectors.token_channels import TokenChannelDetector
@@ -18,7 +19,9 @@ from doberman.models import (
     SecurityObject,
     Verdict,
 )
-from doberman.tokens import GlitchFragmentStore
+from doberman.tokens import GlitchFragmentStore, calibrate_perplexity_threshold
+
+_GCG_FIXTURE = pathlib.Path(__file__).parents[1] / "redteam" / "fixtures" / "gcg_suffixes.txt"
 
 CYRILLIC_A = chr(0x0430)
 
@@ -97,6 +100,34 @@ def test_per_model_glitch_list_is_honored():
     det = TokenChannelDetector(glitch_store=store)
     result = det.evaluate(_action(target="x.ts"), _ctx(content="here is zzGlitchToken"))
     assert result.verdict is Verdict.AUTH
+
+
+def test_calibrated_threshold_escalates_gcg_suffix_and_passes_benign():
+    """calibrate_perplexity_threshold, wired through a stub scorer: a real
+    GCG adversarial suffix escalates to AUTH; ordinary benign text passes."""
+    if not _GCG_FIXTURE.exists():
+        import pytest
+
+        pytest.skip("No GCG suffix fixtures found")
+    suffix = next(
+        line.strip()
+        for line in _GCG_FIXTURE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    )
+    benign_scores = [0.30 + 0.001 * i for i in range(200)]  # deterministic, no RNG
+    threshold = calibrate_perplexity_threshold(benign_scores, target_fpr=0.05)
+
+    def stub_perplexity_fn(text: str) -> float:
+        return 0.99 if text == suffix else 0.10
+
+    det = TokenChannelDetector(perplexity_fn=stub_perplexity_fn, perplexity_threshold=threshold)
+
+    adversarial = det.evaluate(_action(target="x.ts"), _ctx(content=suffix))
+    assert adversarial.verdict is Verdict.AUTH
+    assert ReasonCode.anomalous_token_pattern in adversarial.reason_codes
+
+    benign = det.evaluate(_action(target="x.ts"), _ctx(content="please summarize this document"))
+    assert benign.verdict is Verdict.PASS
 
 
 def test_builtin_detector_is_wired_into_subjective_guardrail():

--- a/tests/unit/test_tokens_scanner.py
+++ b/tests/unit/test_tokens_scanner.py
@@ -7,6 +7,8 @@ NEVER appears in any report field. Every non-ASCII channel character is built
 with ``chr()`` so the test source stays pure ASCII and encoding-robust.
 """
 
+import math
+
 import pytest
 
 from doberman.tokens import (
@@ -214,3 +216,12 @@ def test_calibrate_perplexity_threshold_rejects_too_few_samples():
 def test_calibrate_perplexity_threshold_handles_saturated_scores():
     threshold = calibrate_perplexity_threshold([1.0] * 25, target_fpr=0.1)
     assert threshold == 1.0
+
+
+def test_calibrate_perplexity_threshold_rejects_non_finite_scores():
+    scores = [i / 20 for i in range(19)] + [math.nan]
+    with pytest.raises(ValueError):
+        calibrate_perplexity_threshold(scores, 0.1)
+    scores[-1] = math.inf
+    with pytest.raises(ValueError):
+        calibrate_perplexity_threshold(scores, 0.1)

--- a/tests/unit/test_tokens_scanner.py
+++ b/tests/unit/test_tokens_scanner.py
@@ -7,10 +7,13 @@ NEVER appears in any report field. Every non-ASCII channel character is built
 with ``chr()`` so the test source stays pure ASCII and encoding-robust.
 """
 
+import pytest
+
 from doberman.tokens import (
     HARD_CHANNELS,
     SOFT_CHANNELS,
     GlitchFragmentStore,
+    calibrate_perplexity_threshold,
     decode_tag_block,
     scan_text,
 )
@@ -172,3 +175,42 @@ def test_glitch_store_accepts_extra_fragments():
     assert store.count("nothing here") == 0
     # An empty fragment must not match everything.
     assert GlitchFragmentStore(extra=[""]).count("anything") == 0
+
+
+# --- perplexity threshold calibration -----------------------------------------
+
+
+def test_calibrate_perplexity_threshold_meets_target_fpr():
+    # 1000 distinct benign scores, evenly spaced across [0, 1).
+    scores = [i / 1000 for i in range(1000)]
+    target_fpr = 0.05
+    threshold = calibrate_perplexity_threshold(scores, target_fpr)
+    measured_fpr = sum(1 for s in scores if s >= threshold) / len(scores)
+    assert abs(measured_fpr - target_fpr) <= 2 / len(scores)
+
+
+def test_calibrate_perplexity_threshold_ignores_input_order():
+    ascending = [i / 100 for i in range(100)]
+    descending = list(reversed(ascending))
+    assert calibrate_perplexity_threshold(ascending, 0.1) == calibrate_perplexity_threshold(
+        descending, 0.1
+    )
+
+
+def test_calibrate_perplexity_threshold_rejects_bad_target_fpr():
+    scores = [i / 20 for i in range(20)]
+    for bad_fpr in (0.0, 1.0, -0.1, 1.5):
+        with pytest.raises(ValueError):
+            calibrate_perplexity_threshold(scores, bad_fpr)
+
+
+def test_calibrate_perplexity_threshold_rejects_too_few_samples():
+    with pytest.raises(ValueError):
+        calibrate_perplexity_threshold([0.1] * 19, 0.1)
+    # 20 is the floor, not itself rejected.
+    calibrate_perplexity_threshold([0.1] * 20, 0.1)
+
+
+def test_calibrate_perplexity_threshold_handles_saturated_scores():
+    threshold = calibrate_perplexity_threshold([1.0] * 25, target_fpr=0.1)
+    assert threshold == 1.0


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: #234 (calibrate_perplexity_threshold, the model-agnostic half of the OT.4 perplexity seam)
- Plan reference: n/a (self-contained level-4 issue)

## What this PR does

`TokenChannelDetector` (`src/doberman/engine/detectors/token_channels.py`) accepts an opt-in
`perplexity_fn` seam for the statistical OOD token channel, but nothing in the tree could pick a
`perplexity_threshold` from real data. Issue #235 (the reference windowed scorer) names this as
its blocker: "Blocked by #234 (the calibration helper lands first)".

Adds `doberman.tokens.calibrate_perplexity_threshold(benign_scores, target_fpr)`, returning the
nearest-rank empirical `(1 - target_fpr)` quantile of a benign score corpus: the smallest scored
sample at or above that rank. Nearest-rank rather than interpolated, so the returned threshold is
a value that actually occurred in the corpus, at the cost of granularity no finer than
`1 / len(benign_scores)`: the measured false-positive rate can exceed `target_fpr` by up to one
sample (n=20, target 0.10 measures 0.15 in the worst case). Fails closed: raises `ValueError` on a
`target_fpr` outside `(0, 1)`, fewer than 20 benign scores, or any non-finite score, since none of
those can honestly promise the requested false-positive rate.

## Tests added (run in CI)
- `test_calibrate_perplexity_threshold_meets_target_fpr`, `..._ignores_input_order`,
  `..._rejects_bad_target_fpr`, `..._rejects_too_few_samples`, `..._handles_saturated_scores`,
  `..._rejects_non_finite_scores`
  (`tests/unit/test_tokens_scanner.py`), all with fixed, seed-free score arrays per your note on
  the issue.
- `test_calibrated_threshold_escalates_gcg_suffix_and_passes_benign`
  (`tests/unit/test_detector_token_channels.py`): wires a calibrated threshold through
  `TokenChannelDetector` with a stub scorer against a real GCG-style adversarial suffix from
  `tests/redteam/fixtures/gcg_suffixes.txt` (AUTH) and an ordinary benign string (PASS).
- `pytest -n auto --cov=doberman --cov-report=term-missing --cov-fail-under=80`: 90.7% total,
  `tokens.py` 96%, no line this PR adds is in the missing set.
- `ruff check .`, `ruff format --check .`, `lint-imports`,
  `python -m tools.parity.generate_parity --check`: all clean.

Not checked: the four real-Tk tests in `test_gui_prompter.py` fail in my Docker verification
image (`libtk8.6.so` missing from `python:3.13-slim`), identically on a clean `main` checkout in
the same image; unrelated to this change and not introduced by it.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty: bad `target_fpr` or too little data raises rather than returning a threshold that looks calibrated but is not
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening): this is a pure stats helper with no side effects; it does not wire into any detector or change default behavior on its own
- [x] Every BLOCK/AUTH carries reason codes + a human explanation: unchanged, this PR adds no new call site into the detector
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Nearest-rank was chosen over interpolation per your comment on the issue: the returned
  threshold is always a value that actually occurred, at the cost of granularity no finer than
  `1 / len(benign_scores)`.
- No wiring into `TokenChannelDetector` or a default scorer here; #235 (the reference windowed
  scorer) is the natural next step and stays a separate PR.

---
Written with AI assistance (Claude Code); every command in the verification section above was
run this session before pushing.

Fixes #234

