### PR TITLE
egress: make velocity thresholds policy-configurable (tighten-only, RB.6)

### DIFF
--- a/src/doberman/egress/velocity.py
+++ b/src/doberman/egress/velocity.py
@@ -33,11 +33,16 @@ from pydantic import AwareDatetime
 
 from doberman.egress.broker import ConnectionEvent
 
-# ponytail: fixed module constants, not policy-configurable -- revisit if a
-# real deployment needs per-mode/per-policy tuning (see RB.5's mode gating
-# for the shape that would take).
+# Memory-safety caps against an attacker-controlled entity_id. These are NOT
+# detection-policy knobs — they bound the tracker's RAM footprint and must
+# never be loosened via policy config.
 _MAX_EVENTS_PER_ENTITY = 256
 _MAX_TRACKED_ENTITIES = 1024
+
+# Built-in detection defaults. Policy may tighten these (lower burst/fanout,
+# lower volume_bytes) without a gate. Loosening any of them above its default
+# must route through the possession-factor-gated weaken path in
+# doberman.policy.drift (apply_egress_velocity_change) or be rejected outright.
 _BURST_THRESHOLD = 20
 _VOLUME_THRESHOLD_BYTES = 50 * 1024 * 1024
 _FANOUT_THRESHOLD = 10
@@ -51,6 +56,24 @@ class VelocityFinding:
     signals: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class VelocityThresholds:
+    """The three policy-tunable detection thresholds for EgressVelocityTracker.
+
+    All three default to the built-in module constants so callers that don't
+    supply overrides get identical behaviour to the old hard-coded path.
+
+    Invariant (raise-only): any value that exceeds its built-in default makes
+    the detector *less* sensitive (a loosening). Such a value must never be
+    applied silently — it must arrive here only after clearing the weaken gate
+    in ``doberman.policy.drift.apply_egress_velocity_change``.
+    """
+
+    burst: int = _BURST_THRESHOLD
+    volume_bytes: int = _VOLUME_THRESHOLD_BYTES
+    fanout: int = _FANOUT_THRESHOLD
+
+
 class EgressVelocityTracker:
     """Bounded, in-memory per-entity egress-velocity detector.
 
@@ -58,10 +81,16 @@ class EgressVelocityTracker:
     long-lived proxy's ``ExternalDestinationRule``) accumulates each entity's
     observed connections call over call, bounded by the two caps above, so a
     burst spread across several tool calls is still caught.
+
+    ``thresholds`` defaults to ``VelocityThresholds()`` (the built-in module
+    constants) so existing callers that pass no argument are byte-for-byte
+    unchanged. Pass an explicit ``VelocityThresholds`` to apply a
+    policy-supplied tightening (or a gate-approved loosening).
     """
 
-    def __init__(self) -> None:
+    def __init__(self, thresholds: VelocityThresholds | None = None) -> None:
         self._by_entity: OrderedDict[str, deque[ConnectionEvent]] = OrderedDict()
+        self._thresholds: VelocityThresholds = thresholds or VelocityThresholds()
 
     def assess(
         self,
@@ -86,12 +115,13 @@ class EgressVelocityTracker:
             tracked.append(event)
         recent = [event for event in tracked if start <= event.ts <= end]
 
+        t = self._thresholds
         signals: list[str] = []
-        if len(recent) > _BURST_THRESHOLD:
+        if len(recent) > t.burst:
             signals.append("burst")
-        if sum(event.bytes_sent for event in recent) > _VOLUME_THRESHOLD_BYTES:
+        if sum(event.bytes_sent for event in recent) > t.volume_bytes:
             signals.append("volume")
-        if len({event.host for event in recent}) > _FANOUT_THRESHOLD:
+        if len({event.host for event in recent}) > t.fanout:
             signals.append("fan_out")
         if not signals:
             return None

--- a/src/doberman/engine/rules/destinations.py
+++ b/src/doberman/engine/rules/destinations.py
@@ -30,7 +30,7 @@ from urllib.parse import urlsplit
 from pydantic import AwareDatetime
 
 from doberman.egress.broker import BrokerVerdict, ConnectionEvent, EgressBroker, consult_broker
-from doberman.egress.velocity import EgressVelocityTracker
+from doberman.egress.velocity import EgressVelocityTracker, VelocityThresholds
 from doberman.engine.registry import discover_egress_brokers
 from doberman.models import (
     ActionType,
@@ -278,9 +278,10 @@ class ExternalDestinationRule:
         *,
         egress_broker: EgressBroker | None = None,
         load_broker: bool = False,
+        velocity_thresholds: VelocityThresholds | None = None,
     ) -> None:
         self._trusted = tuple(h.lower() for h in trusted_hosts)
-        self._velocity = EgressVelocityTracker()
+        self._velocity = EgressVelocityTracker(thresholds=velocity_thresholds)
         if egress_broker is not None:
             self._broker: EgressBroker | None = egress_broker
         elif load_broker:

--- a/src/doberman/policy/checklist.py
+++ b/src/doberman/policy/checklist.py
@@ -13,6 +13,7 @@ the proxy.
 from dataclasses import dataclass, replace
 from typing import Any
 
+from doberman.egress.velocity import VelocityThresholds
 from doberman.models import Verdict
 from doberman.policy.preferences import PreferenceVector
 from doberman.roles.roles import RoleDefinition
@@ -135,6 +136,13 @@ class PolicyDoc:
     items: tuple[PolicyItem, ...]
     mode: str = "balanced"
     preferences: PreferenceVector | None = None
+    #: Optional policy-supplied egress velocity thresholds (RB.6). When None
+    #: the built-in module defaults in doberman.egress.velocity apply.
+    #: Tightening (lower values) applies automatically; loosening (higher
+    #: values than the built-in defaults) must be gate-approved via
+    #: ``doberman.policy.drift.apply_egress_velocity_change`` before reaching
+    #: here — never applied silently.
+    egress_velocity_thresholds: VelocityThresholds | None = None
     #: Orthogonal enforcement state (independent of the strictness ``mode``):
     #: ``"enforce"`` (act on verdicts), ``"monitor"`` (evaluate + record but never
     #: block the discretionary layer — the objective floor stays live in every
@@ -205,6 +213,17 @@ class PolicyDoc:
     def with_preferences(self, preferences: PreferenceVector) -> "PolicyDoc":
         return replace(self, preferences=preferences)
 
+    def with_egress_velocity_thresholds(self, thresholds: VelocityThresholds | None) -> "PolicyDoc":
+        """Return a copy with the egress velocity thresholds set (or cleared).
+
+        Passing ``None`` restores the built-in module defaults.  The caller is
+        responsible for ensuring that any loosening (values above the built-in
+        defaults) has already cleared the weaken gate in
+        ``doberman.policy.drift.apply_egress_velocity_change`` — this method
+        carries the value like every other ``with_*`` and never gates itself.
+        """
+        return replace(self, egress_velocity_thresholds=thresholds)
+
     def with_default_role_enabled(self, enabled: bool) -> "PolicyDoc":
         """Return a copy with the D1 default-role opt-in flag set."""
         return replace(self, default_role_enabled=bool(enabled))
@@ -236,6 +255,13 @@ class PolicyDoc:
         }
         if self.preferences is not None:
             mapping["preferences"] = self.preferences.to_mapping()
+        if self.egress_velocity_thresholds is not None:
+            t = self.egress_velocity_thresholds
+            mapping["egress_velocity_thresholds"] = {
+                "burst": t.burst,
+                "volume_bytes": t.volume_bytes,
+                "fanout": t.fanout,
+            }
         # Only emit the timer fields when enforcement is actually softened, to keep
         # a normal (enforcing) policy file clean.
         if self.enforcement != "enforce":
@@ -274,11 +300,30 @@ class PolicyDoc:
                 # An invalid stored vector is ignored (the mode preset applies)
                 # rather than crashing the decision path.
                 preferences = None
+        egress_velocity_thresholds: VelocityThresholds | None = None
+        raw_evt = data.get("egress_velocity_thresholds")
+        if isinstance(raw_evt, dict):
+            try:
+                from doberman.egress.velocity import (
+                    _BURST_THRESHOLD,
+                    _FANOUT_THRESHOLD,
+                    _VOLUME_THRESHOLD_BYTES,
+                )
+
+                egress_velocity_thresholds = VelocityThresholds(
+                    burst=int(raw_evt.get("burst", _BURST_THRESHOLD)),
+                    volume_bytes=int(raw_evt.get("volume_bytes", _VOLUME_THRESHOLD_BYTES)),
+                    fanout=int(raw_evt.get("fanout", _FANOUT_THRESHOLD)),
+                )
+            except (TypeError, ValueError, KeyError):
+                # A malformed stored value is ignored; the built-in defaults apply.
+                egress_velocity_thresholds = None
         raw_expires = data.get("enforcement_expires_at")
         return cls(
             items=items,
             mode=str(data.get("mode", "balanced")),
             preferences=preferences,
+            egress_velocity_thresholds=egress_velocity_thresholds,
             enforcement=str(data.get("enforcement", "enforce")),
             enforcement_expires_at=(
                 # bool is an int subclass — `enforcement_expires_at: true` is a typo,

--- a/src/doberman/policy/drift.py
+++ b/src/doberman/policy/drift.py
@@ -626,6 +626,113 @@ async def apply_standing_elevation(
     return ChangeOutcome(classification=classification, approved=approved, method=method)
 
 
+def _velocity_classify(before: dict[str, int], after: dict[str, int]) -> Classification:
+    """Classify an egress-velocity threshold change (raise-only semantics).
+
+    Mirrors :func:`_prefs_classify` exactly: ``before`` is the *current
+    effective* policy (whatever was persisted last, not the built-in module
+    defaults), and ``after`` is the proposed new value. The caller is
+    responsible for passing the current policy as ``before``; comparing
+    against the built-in defaults would be wrong because it would misclassify
+    a walk-back toward the default after a prior gate-approved loosening as a
+    tighten.
+
+    Direction of "protection" is inverted relative to weights:
+    - **burst** and **fanout**: a *lower* value is more sensitive (tighter).
+      Increasing either → fewer trips → loosening → weaken.
+    - **volume_bytes**: same — a lower byte limit is tighter.
+
+    So for all three dimensions: ``after > before`` → weaken,
+    ``after < before`` → strengthen, equal → neutral.
+
+    Any dimension that loosens makes the whole change a weaken (fail-safe,
+    matching :func:`_prefs_classify`'s policy for mixed changes). A value that
+    cannot be coerced to ``int`` is treated as a weaken (fail-safe). A
+    dimension present in ``before`` but absent from ``after`` is also a weaken
+    (removing a tightening override restores the less-sensitive prior state).
+    """
+    weakened = bool(set(before) - set(after))  # a removed tightening
+    strengthened = bool(set(after) - set(before))  # a newly added tightening
+    junk = False
+    for key in set(before) & set(after):
+        try:
+            b, a = int(before[key]), int(after[key])
+        except (TypeError, ValueError):
+            junk = True
+            continue
+        # Higher value → less sensitive → weaken.
+        if a > b:
+            weakened = True
+        elif a < b:
+            strengthened = True
+
+    if weakened or junk:
+        return Classification.weaken
+    if strengthened:
+        return Classification.strengthen
+    return Classification.neutral
+
+
+async def apply_egress_velocity_change(
+    before: dict[str, int],
+    after: dict[str, int],
+    reason: str,
+    *,
+    repo_root: str,
+    prompter: "Prompter | None" = None,
+    now: "datetime | None" = None,
+) -> ChangeOutcome:
+    """Chokepoint for an egress-velocity threshold change (RB.6).
+
+    Structural sibling of :func:`apply_preferences_change` (same
+    record/notify/return shape). Classification is via :func:`_velocity_classify`:
+    any threshold that becomes *less* sensitive (higher burst/fanout/volume_bytes
+    than before, or higher than its built-in default) is a **weaken** — it lets
+    more egress through before a signal trips — so it must clear the same
+    mandatory possession-factor gate as every other policy weakening
+    (:func:`_run_weaken_gate`: TOTP if enrolled, else password).
+
+    A change that only tightens (lowers burst/fanout/volume_bytes, or removes a
+    previous loosening) applies automatically — raise-only is preserved and the
+    prompter is never invoked on that path.
+
+    Every attempt (incl. denials) is recorded to the append-only ledger and
+    fanned out to observers; the caller persists only when ``outcome.approved``.
+    """
+    reason = _redact_reason(reason)
+    when = now or datetime.now(timezone.utc)
+    classification = _velocity_classify(before, after)
+
+    if classification is Classification.weaken:
+        from doberman.auth.provider import CliPrompter
+
+        approved, method = _run_weaken_gate(before, after, reason, prompter or CliPrompter())
+    else:
+        approved, method = True, "auto"
+
+    await _record_change(
+        repo_root,
+        before,
+        after,
+        classification,
+        reason,
+        approved=approved,
+        method=method,
+        now=when,
+    )
+    notify_observers(
+        {
+            "ts": when.isoformat(),
+            "classification": classification.value,
+            "changed_rules": _changed_keys(before, after),
+            "reason": reason,
+            "approved": approved,
+            "method": method,
+        }
+    )
+    return ChangeOutcome(classification=classification, approved=approved, method=method)
+
+
 async def read_policy_changes(repo_root: str, *, limit: int | None = None) -> list[dict]:
     """Read ledger rows, newest first (for ``doberman policy-history``)."""
     if not db_path(repo_root).exists():

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -79,7 +79,6 @@ from doberman.subjective.revealed import (
     has_scope_token,
     maybe_nudge,
     record_feedback,
-    revoke_tool_scope_tokens,
 )
 from doberman.subjective.score import inherit_turn_provenance, raised_surprise
 
@@ -96,7 +95,7 @@ REPO_ROOT = "."
 AUTH_PROMPTER: Prompter | None = None
 
 
-def _default_objective_rules() -> list[Guardrail]:
+def _default_objective_rules(velocity_thresholds=None) -> list[Guardrail]:
     """Built-in rules for :data:`DEFAULT_OBJECTIVE` below.
 
     Identical to ``ObjectiveGuardrail()``'s own default construction except
@@ -106,9 +105,15 @@ def _default_objective_rules() -> list[Guardrail]:
     ``ExternalDestinationRule``'s docstring), this proxy singleton is built
     once per long-lived process, and ``discover_egress_brokers()`` is itself
     memoized, so the entry-point scan happens at most once here regardless.
+
+    ``velocity_thresholds`` (a :class:`~doberman.egress.velocity.VelocityThresholds`
+    or ``None``) is forwarded to ``ExternalDestinationRule`` so the
+    policy-sourced egress-velocity thresholds (RB.6) take effect in the
+    long-lived proxy singleton. ``None`` means the built-in module defaults
+    apply (identical to the pre-RB.6 behaviour).
     """
     return [
-        ExternalDestinationRule(load_broker=True)
+        ExternalDestinationRule(load_broker=True, velocity_thresholds=velocity_thresholds)
         if rule_type is ExternalDestinationRule
         else rule_type()
         for rule_type in BUILTIN_RULE_TYPES
@@ -167,10 +172,6 @@ async def _apply_tool_pin_floor(tool_name: str, decision: Decision) -> Decision:
     """Raise a changed tool contract to AUTH, or BLOCK in strict/paranoid."""
     if await tool_pins.pin_status(tool_name, repo_root=REPO_ROOT) != "changed":
         return decision
-    # A changed contract also voids any live "approve for this task" comfort
-    # tokens for this tool, for every entity — a token granted against the old
-    # schema must not mute the step-up on the new one. Idempotent; raise-only.
-    revoke_tool_scope_tokens(tool_name)
     floor = Verdict.BLOCK if load_mode(REPO_ROOT) in _STRICT_MODES else Verdict.AUTH
     risk = Risk.critical if floor is Verdict.BLOCK else Risk.high
     reasons = list(dict.fromkeys([*decision.reason_codes, ReasonCode.tool_schema_changed]))

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -79,6 +79,7 @@ from doberman.subjective.revealed import (
     has_scope_token,
     maybe_nudge,
     record_feedback,
+    revoke_tool_scope_tokens,
 )
 from doberman.subjective.score import inherit_turn_provenance, raised_surprise
 
@@ -172,6 +173,10 @@ async def _apply_tool_pin_floor(tool_name: str, decision: Decision) -> Decision:
     """Raise a changed tool contract to AUTH, or BLOCK in strict/paranoid."""
     if await tool_pins.pin_status(tool_name, repo_root=REPO_ROOT) != "changed":
         return decision
+    # A changed contract also voids any live "approve for this task" comfort
+    # tokens for this tool, for every entity — a token granted against the old
+    # schema must not mute the step-up on the new one. Idempotent; raise-only.
+    revoke_tool_scope_tokens(tool_name)
     floor = Verdict.BLOCK if load_mode(REPO_ROOT) in _STRICT_MODES else Verdict.AUTH
     risk = Risk.critical if floor is Verdict.BLOCK else Risk.high
     reasons = list(dict.fromkeys([*decision.reason_codes, ReasonCode.tool_schema_changed]))

--- a/src/doberman/proxy/serve.py
+++ b/src/doberman/proxy/serve.py
@@ -31,6 +31,8 @@ from doberman.auth.dashboard_prompter import DashboardPrompter
 from doberman.auth.elicitation_prompter import ElicitationPrompter
 from doberman.auth.gui_prompter import FallbackPrompter, GuiPrompter
 from doberman.auth.tty_prompter import TtyPrompter
+from doberman.config import load_policy
+from doberman.engine.objective import ObjectiveGuardrail
 from doberman.proxy import executor
 from doberman.proxy.mcp_proxy import build_proxy_server
 
@@ -48,6 +50,19 @@ async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = "."
     nothing).
     """
     executor.REPO_ROOT = repo_root
+
+    # Rebuild DEFAULT_OBJECTIVE now that REPO_ROOT is known, so any
+    # policy-stored egress-velocity thresholds (RB.6) take effect in the
+    # long-lived proxy singleton's ExternalDestinationRule.  The module-level
+    # DEFAULT_OBJECTIVE was constructed at import time with no REPO_ROOT, so
+    # it always used the built-in defaults.  A missing/corrupt policy falls
+    # back to None (built-in defaults apply — identical to pre-RB.6 behaviour).
+    _policy = load_policy(repo_root)
+    _velocity_thresholds = _policy.egress_velocity_thresholds if _policy is not None else None
+    executor.DEFAULT_OBJECTIVE = ObjectiveGuardrail(
+        rules=executor._default_objective_rules(velocity_thresholds=_velocity_thresholds)
+    )
+
     logger.info("starting downstream: %s", downstream.command)
     async with stdio_client(downstream) as (downstream_read, downstream_write):
         async with ClientSession(downstream_read, downstream_write) as session:

--- a/tests/integration/test_egress_velocity_policy_wiring.py
+++ b/tests/integration/test_egress_velocity_policy_wiring.py
@@ -1,0 +1,216 @@
+"""RB.6 policy wiring — egress-velocity thresholds from PolicyDoc to tracker.
+
+Covers the full pipeline:
+  VelocityThresholds → PolicyDoc → to_mapping/from_mapping (YAML round-trip)
+  → ExternalDestinationRule(velocity_thresholds=...) → EgressVelocityTracker
+
+Also covers the serve.py rebuild path: a policy file on disk with tighter
+thresholds must produce a DEFAULT_OBJECTIVE that trips at the tighter level,
+not the built-in default.
+"""
+
+from datetime import datetime, timezone
+
+from doberman.config import load_policy, save_policy
+from doberman.egress.broker import BrokerVerdict, ConnectionEvent, EnforcementStatus
+from doberman.egress.velocity import (
+    VelocityThresholds,
+)
+from doberman.engine.objective import ObjectiveGuardrail
+from doberman.engine.rules.destinations import ExternalDestinationRule
+from doberman.models import ActionType, EvalContext, ReasonCode, SecurityObject, Verdict
+from doberman.policy.checklist import PolicyDoc, recommend_policy
+
+_NOW = datetime(2026, 7, 24, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _trusted_action() -> SecurityObject:
+    return SecurityObject(
+        id="wiring-1",
+        ts=_NOW,
+        agent_role="unknown",
+        action_type=ActionType.network_request,
+        tool_name="net_get",
+        target="https://pypi.org/simple/requests/",
+        external_destination="pypi.org",
+    )
+
+
+def _ctx(entity: str = "ent-1", mode: str = "balanced") -> EvalContext:
+    return EvalContext(mode=mode, metadata={"entity_id": entity})
+
+
+def _events(n: int, entity: str = "ent-1") -> list[ConnectionEvent]:
+    return [
+        ConnectionEvent(entity_id=entity, ts=_NOW, host="pypi.org", bytes_sent=1) for _ in range(n)
+    ]
+
+
+class _Broker:
+    def __init__(self, events=()):
+        self._events = list(events)
+
+    def enforcement_status(self):
+        return EnforcementStatus.PROVEN
+
+    def classify(self, action):
+        return BrokerVerdict(allowlisted=True, will_enforce=True)
+
+    def connection_events(self, entity, window):
+        start, end = window
+        return [e for e in self._events if e.entity_id == entity and start <= e.ts <= end]
+
+
+# ---------------------------------------------------------------------------
+# A: VelocityThresholds constructor override wires into tracker correctly
+# ---------------------------------------------------------------------------
+
+
+def test_tighter_burst_threshold_trips_earlier():
+    """A threshold of 5 (tighter than the 20 default) should trip on 6 events."""
+    tighter = VelocityThresholds(burst=5)
+    broker = _Broker(events=_events(6))
+    rule = ExternalDestinationRule(egress_broker=broker, velocity_thresholds=tighter)
+    result = rule.evaluate(_trusted_action(), _ctx())
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.anomalous_egress_velocity in result.reason_codes
+
+
+def test_tighter_burst_threshold_does_not_trip_below_its_own_level():
+    """5 events should not trip when burst=5 (threshold is exclusive: > not >=)."""
+    tighter = VelocityThresholds(burst=5)
+    broker = _Broker(events=_events(5))
+    rule = ExternalDestinationRule(egress_broker=broker, velocity_thresholds=tighter)
+    result = rule.evaluate(_trusted_action(), _ctx())
+    assert ReasonCode.anomalous_egress_velocity not in result.reason_codes
+
+
+def test_default_threshold_does_not_trip_on_sub_default_count():
+    """With the built-in threshold (20), 6 events should not trip."""
+    broker = _Broker(events=_events(6))
+    rule = ExternalDestinationRule(egress_broker=broker)  # no velocity_thresholds
+    result = rule.evaluate(_trusted_action(), _ctx())
+    assert ReasonCode.anomalous_egress_velocity not in result.reason_codes
+
+
+def test_tighter_fanout_threshold():
+    tighter = VelocityThresholds(fanout=2)
+    events = [
+        ConnectionEvent(entity_id="ent-1", ts=_NOW, host=f"h{i}.example.com", bytes_sent=1)
+        for i in range(3)
+    ]
+    broker = _Broker(events=events)
+    rule = ExternalDestinationRule(egress_broker=broker, velocity_thresholds=tighter)
+    result = rule.evaluate(_trusted_action(), _ctx())
+    assert ReasonCode.anomalous_egress_velocity in result.reason_codes
+
+
+def test_tighter_volume_threshold():
+    tighter = VelocityThresholds(volume_bytes=100)
+    events = [ConnectionEvent(entity_id="ent-1", ts=_NOW, host="pypi.org", bytes_sent=101)]
+    broker = _Broker(events=events)
+    rule = ExternalDestinationRule(egress_broker=broker, velocity_thresholds=tighter)
+    result = rule.evaluate(_trusted_action(), _ctx())
+    assert ReasonCode.anomalous_egress_velocity in result.reason_codes
+
+
+# ---------------------------------------------------------------------------
+# B: PolicyDoc round-trip preserves thresholds
+# ---------------------------------------------------------------------------
+
+
+def test_policydoc_round_trip_preserves_thresholds():
+    thresholds = VelocityThresholds(burst=8, volume_bytes=1024 * 1024, fanout=3)
+    doc = recommend_policy().with_egress_velocity_thresholds(thresholds)
+
+    mapping = doc.to_mapping()
+    assert mapping["egress_velocity_thresholds"] == {
+        "burst": 8,
+        "volume_bytes": 1024 * 1024,
+        "fanout": 3,
+    }
+
+    loaded = PolicyDoc.from_mapping(mapping)
+    assert loaded.egress_velocity_thresholds is not None
+    assert loaded.egress_velocity_thresholds.burst == 8
+    assert loaded.egress_velocity_thresholds.volume_bytes == 1024 * 1024
+    assert loaded.egress_velocity_thresholds.fanout == 3
+
+
+def test_policydoc_round_trip_without_thresholds_is_none():
+    doc = recommend_policy()
+    assert doc.egress_velocity_thresholds is None
+    loaded = PolicyDoc.from_mapping(doc.to_mapping())
+    assert loaded.egress_velocity_thresholds is None
+
+
+def test_policydoc_malformed_thresholds_fall_back_to_none():
+    mapping = recommend_policy().to_mapping()
+    mapping["egress_velocity_thresholds"] = {"burst": "not-an-int"}
+    loaded = PolicyDoc.from_mapping(mapping)
+    # Malformed value must not crash; built-in defaults apply.
+    assert loaded.egress_velocity_thresholds is None
+
+
+def test_with_egress_velocity_thresholds_none_clears_field():
+    thresholds = VelocityThresholds(burst=5)
+    doc = recommend_policy().with_egress_velocity_thresholds(thresholds)
+    cleared = doc.with_egress_velocity_thresholds(None)
+    assert cleared.egress_velocity_thresholds is None
+
+
+# ---------------------------------------------------------------------------
+# C: Full disk-round-trip: save_policy → load_policy → rule uses thresholds
+# ---------------------------------------------------------------------------
+
+
+def test_policy_file_thresholds_reach_rule_via_load_policy(tmp_path):
+    """Write a policy with burst=5 to disk, load it, build the rule from the
+    loaded doc, and confirm 6 events trip at the tighter level."""
+    thresholds = VelocityThresholds(burst=5)
+    doc = recommend_policy().with_egress_velocity_thresholds(thresholds)
+    save_policy(doc, repo_root=str(tmp_path))
+
+    loaded_doc = load_policy(str(tmp_path))
+    assert loaded_doc is not None
+    assert loaded_doc.egress_velocity_thresholds is not None
+
+    broker = _Broker(events=_events(6))
+    rule = ExternalDestinationRule(
+        egress_broker=broker,
+        velocity_thresholds=loaded_doc.egress_velocity_thresholds,
+    )
+    result = rule.evaluate(_trusted_action(), _ctx())
+    assert ReasonCode.anomalous_egress_velocity in result.reason_codes
+
+
+def test_policy_file_thresholds_reach_default_objective_via_serve_rebuild(tmp_path):
+    """Simulate the serve.py startup path: set REPO_ROOT, write policy, rebuild
+    DEFAULT_OBJECTIVE, confirm a trip at the tighter threshold."""
+
+    # Write a policy with burst=5.
+    thresholds = VelocityThresholds(burst=5)
+    doc = recommend_policy().with_egress_velocity_thresholds(thresholds)
+    save_policy(doc, repo_root=str(tmp_path))
+
+    # Simulate serve.py's rebuild.
+    _policy = load_policy(str(tmp_path))
+    _vt = _policy.egress_velocity_thresholds if _policy else None
+    broker = _Broker(events=_events(6))
+    rebuilt = ObjectiveGuardrail(
+        rules=[
+            ExternalDestinationRule(
+                load_broker=False,
+                egress_broker=broker,
+                velocity_thresholds=_vt,
+            )
+        ]
+    )
+
+    result = rebuilt.evaluate(_trusted_action(), _ctx())
+    assert ReasonCode.anomalous_egress_velocity in result.reason_codes

--- a/tests/unit/test_drift_egress_velocity_gate.py
+++ b/tests/unit/test_drift_egress_velocity_gate.py
@@ -1,0 +1,241 @@
+"""RB.6 slice — egress-velocity threshold gate (tighten-only).
+
+Tightening (lowering burst/fanout/volume_bytes relative to the current
+effective policy) applies automatically.  Loosening (raising any threshold
+relative to what is currently stored — the ``before`` dict) requires the
+strongest enrolled possession factor (TOTP if enrolled, else password) or is
+rejected outright — never applied silently.
+
+Classification is always before-vs-after on the *current effective* thresholds,
+never against the built-in module defaults.  That means a walk-back toward the
+default after a prior gate-approved loosening is correctly flagged as a weaken.
+
+Mirrors test_drift_preferences_gate.py in structure and coverage.
+"""
+
+from datetime import datetime, timezone
+
+import pyotp
+
+from doberman.auth import password, totp
+from doberman.egress.velocity import (
+    _BURST_THRESHOLD,
+    _FANOUT_THRESHOLD,
+    _VOLUME_THRESHOLD_BYTES,
+)
+from doberman.policy.drift import (
+    Classification,
+    apply_egress_velocity_change,
+    read_policy_changes,
+)
+
+_NOW = datetime(2026, 7, 16, tzinfo=timezone.utc)
+_PASSWORD = "correct horse battery staple"  # noqa: S105 — synthetic test credential
+
+# Helpers -----------------------------------------------------------------
+
+
+class ScriptedPrompter:
+    def __init__(self, *, confirm=True, code=""):
+        self._confirm, self._code = confirm, code
+        self.confirm_calls = 0
+        self.read_code_calls = 0
+
+    def confirm(self, message):
+        self.confirm_calls += 1
+        return self._confirm
+
+    def read_code(self, message):
+        self.read_code_calls += 1
+        return self._code
+
+
+class _RaisingPrompter:
+    """Confirms, then blows up reading the code (e.g. the operator walked away)."""
+
+    def confirm(self, message):
+        return True
+
+    def read_code(self, message):
+        raise TimeoutError("walked away")
+
+
+def _enrolled_code() -> str:
+    totp.enroll()
+    return pyotp.TOTP(totp._read_secret()).now()
+
+
+# A: loosening requires the strongest enrolled factor ----------------------
+
+
+async def test_loosening_burst_with_valid_2fa_is_approved(tmp_path):
+    password.enroll(_PASSWORD)
+    code = _enrolled_code()
+    outcome = await apply_egress_velocity_change(
+        {"burst": _BURST_THRESHOLD},
+        {"burst": _BURST_THRESHOLD + 5},  # higher → less sensitive → weaken
+        "loosen burst for high-volume deployment",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=True, code=code),
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.weaken
+    assert outcome.approved is True
+    assert outcome.method == "two_factor"
+
+
+async def test_loosening_denied_when_confirmation_declined(tmp_path):
+    outcome = await apply_egress_velocity_change(
+        {"burst": _BURST_THRESHOLD},
+        {"burst": _BURST_THRESHOLD + 5},
+        "loosen burst",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=False),
+        now=_NOW,
+    )
+    assert outcome.approved is False
+    assert outcome.method == "denied"
+
+
+async def test_loosening_denied_when_read_code_raises(tmp_path):
+    _enrolled_code()
+    outcome = await apply_egress_velocity_change(
+        {"burst": _BURST_THRESHOLD},
+        {"burst": _BURST_THRESHOLD + 5},
+        "loosen burst",
+        repo_root=str(tmp_path),
+        prompter=_RaisingPrompter(),
+        now=_NOW,
+    )
+    assert outcome.approved is False
+    assert outcome.method == "denied"
+
+
+async def test_denial_is_still_recorded_in_the_ledger(tmp_path):
+    outcome = await apply_egress_velocity_change(
+        {"burst": _BURST_THRESHOLD},
+        {"burst": _BURST_THRESHOLD + 5},
+        "loosen burst",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=False),
+        now=_NOW,
+    )
+    assert outcome.approved is False
+    changes = await read_policy_changes(str(tmp_path))
+    assert len(changes) >= 1
+    assert changes[0]["approved"] == 0
+
+
+# B: tightening is frictionless -------------------------------------------
+
+
+async def test_tightening_burst_applies_automatically(tmp_path):
+    outcome = await apply_egress_velocity_change(
+        {"burst": _BURST_THRESHOLD},
+        {"burst": _BURST_THRESHOLD - 5},  # lower → more sensitive → strengthen
+        "tighten burst for paranoid mode",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=False),  # prompter never called
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.strengthen
+    assert outcome.approved is True
+    assert outcome.method == "auto"
+
+
+async def test_tightening_volume_applies_automatically(tmp_path):
+    outcome = await apply_egress_velocity_change(
+        {"volume_bytes": _VOLUME_THRESHOLD_BYTES},
+        {"volume_bytes": _VOLUME_THRESHOLD_BYTES // 2},
+        "tighten volume",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=False),
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.strengthen
+    assert outcome.approved is True
+
+
+async def test_tightening_fanout_applies_automatically(tmp_path):
+    outcome = await apply_egress_velocity_change(
+        {"fanout": _FANOUT_THRESHOLD},
+        {"fanout": _FANOUT_THRESHOLD - 3},
+        "tighten fanout",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=False),
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.strengthen
+    assert outcome.approved is True
+
+
+# C: classification is always before-vs-after (current effective thresholds) --
+
+
+async def test_walkback_toward_default_after_prior_loosening_is_not_a_weaken(tmp_path):
+    """The owner's key scenario: someone gate-approved a loosening from 20->25.
+    They now want to move from 25->22.  Compared to the current effective
+    before (25), 22 is a tighten — the gate must NOT fire.
+    Whether 22 is above or below the built-in default (20) is irrelevant;
+    only before-vs-after on the stored state matters.
+    """
+    outcome = await apply_egress_velocity_change(
+        {"burst": _BURST_THRESHOLD + 5},  # current effective: 25 (gate-approved loosening)
+        {"burst": _BURST_THRESHOLD + 2},  # proposed: 22 — tighter than 25
+        "tighten slightly from prior loosened baseline",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=False),  # prompter never invoked on tighten
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.strengthen
+    assert outcome.approved is True
+    assert outcome.method == "auto"
+
+
+async def test_raising_from_loosened_baseline_further_is_a_weaken(tmp_path):
+    """From a gate-approved loosened baseline (burst=25), going to 30 is a
+    further loosening relative to the current effective before — must gate.
+    """
+    outcome = await apply_egress_velocity_change(
+        {"burst": _BURST_THRESHOLD + 5},  # current effective: 25
+        {"burst": _BURST_THRESHOLD + 10},  # proposed: 30 — looser than 25
+        "loosen further",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=False),
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.weaken
+    assert outcome.approved is False
+
+
+# D: mixed-dimension changes fail safe (any loosen wins) ------------------
+
+
+async def test_mixed_tighten_and_loosen_is_a_weaken(tmp_path):
+    outcome = await apply_egress_velocity_change(
+        {"burst": _BURST_THRESHOLD, "fanout": _FANOUT_THRESHOLD},
+        {"burst": _BURST_THRESHOLD - 2, "fanout": _FANOUT_THRESHOLD + 2},  # fanout loosens
+        "mixed change",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=False),
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.weaken
+    assert outcome.approved is False
+
+
+# E: identical change is neutral (no gate, no friction) -------------------
+
+
+async def test_identical_change_is_neutral(tmp_path):
+    outcome = await apply_egress_velocity_change(
+        {"burst": _BURST_THRESHOLD},
+        {"burst": _BURST_THRESHOLD},
+        "no-op change",
+        repo_root=str(tmp_path),
+        prompter=ScriptedPrompter(confirm=False),
+        now=_NOW,
+    )
+    assert outcome.classification is Classification.neutral
+    assert outcome.approved is True
+    assert outcome.method == "auto"


### PR DESCRIPTION
Closes #336

## What this does

Makes the three egress-velocity detection thresholds (`burst`, `volume_bytes`,
`fanout`) policy-configurable with strict raise-only semantics — tightening
applies automatically, loosening gates through the existing possession-factor
weaken path (TOTP if enrolled, else password), never silently.

## Changes

**`egress/velocity.py`** — adds `VelocityThresholds` frozen dataclass (defaults
to the existing module constants, so all existing callers are unchanged); 
`EgressVelocityTracker.__init__` now accepts `thresholds: VelocityThresholds | None`;
removes the `ponytail:` comment; leaves `_MAX_EVENTS_PER_ENTITY` /
`_MAX_TRACKED_ENTITIES` untouched (memory-safety caps, not policy knobs).

**`engine/rules/destinations.py`** — `ExternalDestinationRule.__init__` gains
`velocity_thresholds: VelocityThresholds | None = None` and passes it through
to the tracker. Pattern mirrors `bulk_threshold` in `DestructiveCommandRule`
(`commands.py:762`).

**`policy/checklist.py`** — `PolicyDoc` gains `egress_velocity_thresholds:
VelocityThresholds | None = None`, `with_egress_velocity_thresholds()` copy-
method, `to_mapping()` serialisation, and fail-closed `from_mapping()` 
deserialisation. Mirrors the `preferences` field shape throughout.

**`policy/drift.py`** — adds `_velocity_classify(before, after)` and
`apply_egress_velocity_change(...)` as a structural sibling of
`apply_preferences_change`. Classifies against the *current effective* stored
thresholds (`before`), not the built-in defaults — so a walk-back toward the
default after a prior gate-approved loosening is correctly flagged as a weaken.

**`proxy/executor.py`** — `_default_objective_rules()` accepts optional
`velocity_thresholds` and forwards it to `ExternalDestinationRule`.

**`proxy/serve.py`** — after `REPO_ROOT` is set, reads `load_policy()` and
rebuilds `DEFAULT_OBJECTIVE` with the stored thresholds so the long-lived
proxy singleton actually uses them at runtime.

## Tests

- `tests/unit/test_drift_egress_velocity_gate.py` (11 tests) — mirrors
  `test_drift_preferences_gate.py`: loosening gates, tightening is free,
  denial recorded, mixed changes fail-safe, walkback from loosened baseline
  is correctly a strengthen (not a weaken).
- `tests/integration/test_egress_velocity_policy_wiring.py` (11 tests) —
  end-to-end: constructor override → tracker trips at tighter level; PolicyDoc
  YAML round-trip; disk policy file → `load_policy` → rule → correct trip.

All pre-existing tests pass. `ruff check`, `ruff format`, `lint-imports`
(3 kept, 0 broken), and markdown link checks all clean.