### PR TITLE
feat(cli): add --quiet to doberman demo (#441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
 
 ## Unreleased (merged since v0.18.1)
 
+- **`doberman demo --quiet`:** suppresses the banner, the per-scenario narration, and the closing
+  `doberman dash` hint, keeping only the summary line/table (silent on a full match, loud on a
+  mismatch) and the exit code — so `demo` can run as a CI smoke test ("is the engine alive")
+  without polluting build logs. Mirrors `scan --quiet`; display-only, the scenarios and the engine
+  path are untouched.
 - **Auth dialog: the highlighted button takes the click again.** The Canvas focus ring was
   drawn on top of the keyboard-highlighted button, and Tk hit-tests a polygon's whole interior
   even when unfilled — so clicking Deny (or Approve, after Tab) did nothing and the hover

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -60,7 +60,7 @@ Low-level harness integration (also installed via `install-hooks` / `setup`).
 |------|----------|-------|
 | `--json` | `status`, `scan`, `doctor`, `policy-history`, `tune` | One JSON document on stdout |
 | `--jsonl` | `log` | One redacted decision object per line (empty if none) |
-| `--quiet` / `-q` | `scan` | No human map; exit code preserved |
+| `--quiet` / `-q` | `scan`, `demo` | No human map/narration; exit code preserved |
 | `--path` / `-p` | most commands | Repository root (default `.`) |
 
 When both are passed, `--json` wins over `--quiet`: machine-readable JSON is still emitted.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -60,7 +60,7 @@ Low-level harness integration (also installed via `install-hooks` / `setup`).
 |------|----------|-------|
 | `--json` | `status`, `scan`, `doctor`, `policy-history`, `tune` | One JSON document on stdout |
 | `--jsonl` | `log` | One redacted decision object per line (empty if none) |
-| `--quiet` / `-q` | `scan`, `demo` | No human map/narration; exit code preserved |
+| `--quiet` / `-q` | `scan`, `demo` | `scan`: no human map. `demo`: no banner/narration/hint, summary line/table still printed. Exit code preserved either way |
 | `--path` / `-p` | most commands | Repository root (default `.`) |
 
 When both are passed, `--json` wins over `--quiet`: machine-readable JSON is still emitted.

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1433,6 +1433,12 @@ def demo(
         "balanced", "--mode", help="Security mode to evaluate scenarios under."
     ),
     fast: bool = typer.Option(False, "--fast", help="Skip the pacing delay between scenarios."),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress human-readable stdout (exit code unchanged; useful for CI).",
+    ),
 ) -> None:
     """Run a scripted attack reel through the REAL decision engine.
 
@@ -1453,20 +1459,23 @@ def demo(
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
-    typer.echo("Doberman demo -- scripted attack reel (real engine, nothing executed)")
-    typer.echo("")
+    if not quiet:
+        typer.echo("Doberman demo -- scripted attack reel (real engine, nothing executed)")
+        typer.echo("")
 
     outcomes = run_demo(
         mode=resolved_mode.value,
         repo_root=path,
         fast=fast,
-        on_scenario=lambda outcome: typer.echo(format_outcome_line(outcome)),
+        on_scenario=None if quiet else lambda outcome: typer.echo(format_outcome_line(outcome)),
     )
 
-    typer.echo("")
+    if not quiet:
+        typer.echo("")
     typer.echo(format_summary_table(outcomes))
-    typer.echo("")
-    typer.echo("Run `doberman dash` in another terminal to watch this live.")
+    if not quiet:
+        typer.echo("")
+        typer.echo("Run `doberman dash` in another terminal to watch this live.")
 
     if not all(outcome.matched for outcome in outcomes):
         raise typer.Exit(code=1)

--- a/tests/unit/test_cli_demo_quiet.py
+++ b/tests/unit/test_cli_demo_quiet.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 from typer.testing import CliRunner
 
+import doberman.demo as demo
 from doberman.cli.main import app
+from doberman.demo import SCENARIOS, Scenario
+from doberman.models import Verdict
 
 runner = CliRunner()
 
@@ -31,3 +34,27 @@ def test_demo_quiet_still_reports_the_summary(tmp_path):
     result = runner.invoke(app, ["demo", "--path", str(tmp_path), "--fast", "--quiet"])
     assert result.exit_code == 0
     assert "scenarios matched" in result.stdout
+
+
+def test_mismatch_still_reported_loudly_under_quiet(tmp_path, monkeypatch):
+    """The one behavior --quiet exists to preserve: a scenario mismatch still fails
+    loudly (nonzero exit, MISMATCH detail) even with narration suppressed. Same
+    mismatch-forcing technique as test_demo.py's mismatch tests.
+    """
+    bad_scenarios = tuple(
+        Scenario(
+            name=s.name,
+            tool_name=s.tool_name,
+            args=s.args,
+            expected_verdict=Verdict.AUTH if s.name == "Benign file read" else s.expected_verdict,
+            label=s.label,
+        )
+        for s in SCENARIOS
+    )
+    monkeypatch.setattr(demo, "SCENARIOS", bad_scenarios)
+
+    result = runner.invoke(app, ["demo", "--path", str(tmp_path), "--fast", "--quiet"])
+    assert result.exit_code != 0
+    assert "MISMATCH" in result.output
+    assert "expected AUTH" in result.output
+    assert "got PASS" in result.output

--- a/tests/unit/test_cli_demo_quiet.py
+++ b/tests/unit/test_cli_demo_quiet.py
@@ -1,0 +1,33 @@
+"""`doberman demo --quiet` suppresses narration while keeping exit semantics (#441).
+
+Mirrors `test_cli_scan_quiet.py`'s approach: invoke the real `demo` command against
+a real repo root, not a mocked one, so this covers the actual CLI wiring. `--fast`
+skips the pacing delay between scenarios, same as `test_demo.py` does.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from doberman.cli.main import app
+
+runner = CliRunner()
+
+
+def test_demo_quiet_prints_far_fewer_lines_than_default(tmp_path):
+    quiet = runner.invoke(app, ["demo", "--path", str(tmp_path), "--fast", "--quiet"])
+    loud = runner.invoke(app, ["demo", "--path", str(tmp_path), "--fast"])
+
+    assert quiet.exit_code == loud.exit_code == 0
+    quiet_lines = quiet.stdout.splitlines()
+    loud_lines = loud.stdout.splitlines()
+    assert len(quiet_lines) < len(loud_lines)
+    # The banner and the closing "doberman dash" hint are narration, not the summary.
+    assert "Doberman demo" not in quiet.stdout
+    assert "doberman dash" not in quiet.stdout
+
+
+def test_demo_quiet_still_reports_the_summary(tmp_path):
+    result = runner.invoke(app, ["demo", "--path", str(tmp_path), "--fast", "--quiet"])
+    assert result.exit_code == 0
+    assert "scenarios matched" in result.stdout


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: #441 — `doberman demo --quiet`

## What this PR does
Adds a `--quiet` / `-q` flag to `doberman demo`, mirroring `scan --quiet`. When
set, it suppresses the opening banner, the per-scenario narration line, and the
closing "Run `doberman dash`" hint — keeping only the summary (silent on a full
match, loud with details on a mismatch) and the exit code. This lets `demo` run
as a CI smoke test ("is the engine alive") without polluting build logs.
Display-only: the scenarios and the engine decision path are untouched.

## Tests added (run in CI)
- `tests/unit/test_cli_demo_quiet.py` — `demo --fast --quiet` produces far
  fewer stdout lines than `demo --fast` (banner/narration/hint gone), exit
  codes match between quiet and loud runs, and the quiet run still reports the
  summary line.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Covered: quiet mode still surfaces the mismatch summary (loud, with per-scenario detail) if a scenario disagrees with its expected verdict — only the narration is suppressed, not failure visibility.
- No deviations from the issue's proposed approach.
- No risks: purely a CLI display change, no engine/rule/decision-path changes.

Written with Claude Code assistance.

Closes #441
