### PR TITLE
feat(cli): add --json to doberman memory

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -58,7 +58,7 @@ Low-level harness integration (also installed via `install-hooks` / `setup`).
 ## Machine-readable flags
 | Flag | Commands | Notes |
 |------|----------|-------|
-| `--json` | `status`, `scan`, `doctor`, `policy-history`, `tune` | One JSON document on stdout |
+| `--json` | `status`, `scan`, `doctor`, `policy-history`, `tune`, `memory` | One JSON document on stdout |
 | `--jsonl` | `log` | One redacted decision object per line (empty if none) |
 | `--quiet` / `-q` | `scan` | No human map; exit code preserved |
 | `--path` / `-p` | most commands | Repository root (default `.`) |
@@ -93,7 +93,7 @@ All four machine-readable modes share one contract. Understanding it once covers
 
 ### Flag naming
 
-- **`--json`** (`status`, `scan`, `doctor`, `policy-history`, `tune`) — emits **one JSON document** on
+- **`--json`** (`status`, `scan`, `doctor`, `policy-history`, `tune`, `memory`) — emits **one JSON document** on
   stdout: a single JSON object or array that can be piped directly into `jq`,
   `python -m json.tool`, or any JSON-aware tool.
 - **`--jsonl`** (`log`) — emits **one JSON object per line** (JSON Lines / NDJSON). Each line is

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1476,6 +1476,11 @@ def demo(
 def memory(
     ctx: typer.Context,
     path: str = typer.Option(".", "--path", "-p", help="Repository root."),
+    as_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the learned-memory summary as one JSON document.",
+    ),
 ) -> None:
     """Show a plain-language, redaction-safe profile of what Doberman has learned.
 
@@ -1490,6 +1495,10 @@ def memory(
     if ctx.invoked_subcommand is not None:
         return
     summary = asyncio.run(memory_summary(path))
+    if as_json:
+        # Same style as ``scan --json`` / ``status --json`` (#178 / #179).
+        typer.echo(json.dumps(summary, sort_keys=True, separators=(",", ":")))
+        return
     typer.echo("Doberman learned memory")
     typer.echo("=" * 32)
     typer.echo(f"Decisions recorded: {summary['decisions']}")

--- a/tests/unit/test_cli_memory_json.py
+++ b/tests/unit/test_cli_memory_json.py
@@ -1,0 +1,63 @@
+"""`doberman memory --json` (#438)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from doberman.cli.main import app
+
+runner = CliRunner()
+
+
+def _seed(tmp_path):
+    """Run the scripted demo through the real engine so memory has rows to summarize."""
+    seed = runner.invoke(app, ["demo", "--path", str(tmp_path), "--fast"])
+    assert seed.exit_code == 0
+
+
+def test_memory_json_is_one_compact_document(tmp_path):
+    _seed(tmp_path)
+    result = runner.invoke(app, ["memory", "--path", str(tmp_path), "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    # The four documented keys, nothing more.
+    assert set(payload) == {"decisions", "verdicts", "top_path_classes", "secrets_seen"}
+    # The JSON path exposes counts and classes only, and stays consistent with
+    # what the demo seeded: the verdict mix must account for every decision.
+    assert payload["decisions"] > 0
+    assert sum(payload["verdicts"].values()) == payload["decisions"]
+    assert isinstance(payload["secrets_seen"], int)
+    # Compact separators (same style as ``scan --json``): no spaces after the
+    # "," / ":" separators anywhere in the document.
+    assert ", " not in result.stdout
+    assert '": ' not in result.stdout
+    # Deterministic across runs of the same store.
+    again = runner.invoke(app, ["memory", "--path", str(tmp_path), "--json"])
+    assert again.exit_code == 0
+    assert again.stdout == result.stdout
+
+
+def test_memory_default_is_text_not_json(tmp_path):
+    _seed(tmp_path)
+    result = runner.invoke(app, ["memory", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "Doberman learned memory" in result.stdout
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.stdout)
+
+
+def test_memory_json_empty_store(tmp_path):
+    # No demo seed: an empty store is still exactly one JSON document, not a
+    # traceback and not empty stdout.
+    result = runner.invoke(app, ["memory", "--path", str(tmp_path), "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "decisions": 0,
+        "verdicts": {},
+        "top_path_classes": [],
+        "secrets_seen": 0,
+    }


### PR DESCRIPTION
## What

Adds `--json` to `doberman memory`, closing #438. When set, the command emits the `memory_summary` payload as one compact, sorted JSON document and skips the human text view:

```
{"decisions":8,"secrets_seen":0,"top_path_classes":[["src/doberman/*.py",1],[".env",1]],"verdicts":{"AUTH":1,"BLOCK":5,"PASS":2}}
```

Same call shape as the other five (`status`, `scan`, `doctor`, `policy-history`, `tune`), so it lands inside the shared JSON-output contract in docs/CLI.md.

## Why

`memory` was the only Daily/Policy panel view without a machine-readable mode, so scripts had to scrape its text output. `memory_summary` already returns counts and classes only, so the JSON path exposes nothing the text path doesn't.

## How

- `as_json` typer option on `memory()`, copied from `status`'s option.
- Before the human output: `if as_json: typer.echo(json.dumps(summary, sort_keys=True, separators=(",", ":"))); return`, same style as `scan --json` / `status --json`.
- docs/CLI.md: added `memory` to both machine-readable lists (the flag table and the flag-naming section).
- New tests/unit/test_cli_memory_json.py, shaped like test_cli_scan_json.py.

## Verification

Real execution locally (Python 3.11, uv-synced venv):

- `doberman demo --path <tmp> --fast` seeds 8 decisions, exit 0; then `memory --json` emits exactly one compact JSON document that round-trips through `python -m json.tool`, with verdicts summing to `decisions`.
- Determinism checked: two consecutive runs produce byte-identical stdout.
- Empty store still yields one valid document (`{"decisions":0,...}`), not a traceback or empty stdout.
- Default (no flag) path unchanged: banner + summary table render as before.
- `tests/unit/test_cli_memory_json.py`: 3 passed.
- Full unit suite green (exit 0) except tests/unit/test_hosthook_codex.py and test_hosthook_taint_floor.py, which abort natively on this macOS machine even on unmodified main; CI on Linux is the arbiter there.
- `ruff check` and `ruff format --check` clean on touched files.

Display only: scenarios, engine path, and exit codes untouched.
