### PR TITLE
fix(storage): make --last 0 return zero rows instead of every row

### DIFF
--- a/src/doberman/policy/drift.py
+++ b/src/doberman/policy/drift.py
@@ -634,7 +634,7 @@ async def read_policy_changes(repo_root: str, *, limit: int | None = None) -> li
         "SELECT ts, rule_id, from_state, to_state, classification, reason, "
         "approval_method, approved, approved_by FROM policy_changes ORDER BY id DESC"
     )
-    if limit:
+    if limit is not None:
         query += f" LIMIT {int(limit)}"
     cols = [
         "ts",

--- a/src/doberman/storage/log.py
+++ b/src/doberman/storage/log.py
@@ -284,7 +284,7 @@ async def read_decisions(repo_root: str, *, limit: int | None = None) -> list[di
 
     if not db_path(repo_root).exists():
         return []
-    query = _SELECT_DECISIONS + (f" LIMIT {int(limit)}" if limit else "")
+    query = _SELECT_DECISIONS + (f" LIMIT {int(limit)}" if limit is not None else "")
     try:
         async with open_db(repo_root) as conn:
             async with conn.execute(query) as cur:
@@ -307,7 +307,7 @@ async def read_decisions_since(
 
     if not db_path(repo_root).exists():
         return []
-    query = _SELECT_DECISIONS_SINCE + (f" LIMIT {int(limit)}" if limit else "")
+    query = _SELECT_DECISIONS_SINCE + (f" LIMIT {int(limit)}" if limit is not None else "")
     try:
         async with open_db(repo_root) as conn:
             async with conn.execute(query, (since_id,)) as cur:

--- a/tests/unit/test_cli_log_jsonl.py
+++ b/tests/unit/test_cli_log_jsonl.py
@@ -177,6 +177,16 @@ def test_log_jsonl_omits_columns_outside_the_allowlist(tmp_path):
     assert "source_context" not in obj
 
 
+def test_log_last_zero_prints_no_rows(tmp_path):
+    """`--last 0` asks for zero rows; truthiness used to turn it into ALL rows (#430)."""
+    root = str(tmp_path)
+    _seed_secret_read(root)
+
+    result = runner.invoke(app, ["log", "--path", root, "--jsonl", "--last", "0"])
+    assert result.exit_code == 0
+    assert result.stdout == ""
+
+
 def test_log_default_human_empty_message(tmp_path):
     import doberman.cli.main as main_mod
 

--- a/tests/unit/test_storage_last_zero.py
+++ b/tests/unit/test_storage_last_zero.py
@@ -1,0 +1,114 @@
+"""`limit=0` means zero rows, not every row (#430).
+
+The LIMIT clause was guarded by truthiness (`if limit`), so an explicit
+"show me none" dropped the clause entirely and returned the whole table.
+The documented contract on these helpers is ``None`` = unlimited and
+``0`` = none; these tests pin that contract at the storage layer where
+the meaning lives (every ``--last`` caller passes through here).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    Risk,
+    SecurityObject,
+    SourceContext,
+    Verdict,
+)
+from doberman.policy.drift import read_policy_changes
+from doberman.storage.db import open_db
+from doberman.storage.log import read_decisions, read_decisions_since, record_decision
+
+_NOW = datetime(2026, 7, 30, tzinfo=timezone.utc)
+
+_INSERT_CHANGE = (
+    "INSERT INTO policy_changes "
+    "(ts, rule_id, from_state, to_state, classification, reason, approval_method, "
+    "approved, approved_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+)
+
+
+async def _seed_decision(root: str, action_id: str) -> None:
+    objective = GuardrailResult(
+        verdict=Verdict.PASS, risk=Risk.low, reason_codes=[], explanation="seeded"
+    )
+    decision = Decision(
+        action_id=action_id,
+        final_verdict=Verdict.PASS,
+        final_risk=Risk.low,
+        objective=objective,
+        reason_codes=[],
+        explanation="seeded",
+        decided_at=_NOW,
+    )
+    action = SecurityObject(
+        id=action_id,
+        ts=_NOW,
+        agent_role="cli",
+        action_type=ActionType.file_read,
+        tool_name="fs_read",
+        target="src/main.py",
+        source_context=SourceContext.user,
+    )
+    await record_decision(decision, action, repo_root=root)
+
+
+async def _seed_decisions(root: str, n: int) -> None:
+    for i in range(n):
+        await _seed_decision(root, f"act-{i}")
+
+
+async def _seed_policy_changes(root: str, n: int) -> None:
+    async with open_db(root) as conn:
+        for i in range(n):
+            await conn.execute(
+                _INSERT_CHANGE,
+                (
+                    _NOW.isoformat(),
+                    f"rule-{i}",
+                    "monitor",
+                    "enforce",
+                    "strengthening",
+                    "seeded",
+                    "password",
+                    1,
+                    "local",
+                ),
+            )
+        await conn.commit()
+
+
+async def test_read_decisions_limit_contract_zero_none_one(tmp_path):
+    root = str(tmp_path)
+    await _seed_decisions(root, 3)
+
+    assert len(await read_decisions(root, limit=None)) == 3  # None: unlimited
+    assert len(await read_decisions(root)) == 3  # default stays unlimited
+    assert len(await read_decisions(root, limit=1)) == 1
+    assert await read_decisions(root, limit=0) == []
+
+
+async def test_read_decisions_since_limit_contract_zero_none_one(tmp_path):
+    root = str(tmp_path)
+    await _seed_decisions(root, 3)
+
+    rows = await read_decisions_since(root, 0, limit=None)
+    assert len(rows) == 3  # None: unlimited
+    assert len(await read_decisions_since(root, 0)) == 3
+    assert len(await read_decisions_since(root, 0, limit=1)) == 1
+    assert await read_decisions_since(root, 0, limit=0) == []
+
+
+async def test_read_policy_changes_limit_contract_zero_none_one(tmp_path):
+    root = str(tmp_path)
+    await _seed_policy_changes(root, 2)
+
+    assert len(await read_policy_changes(root, limit=None)) == 2  # None: unlimited
+    assert len(await read_policy_changes(root)) == 2
+    assert len(await read_policy_changes(root, limit=1)) == 1
+    assert await read_policy_changes(root, limit=0) == []


### PR DESCRIPTION
Fixes #430

## Root cause

Every `--last` flag flows into a storage reader whose LIMIT clause was guarded by truthiness:

```python
query = _SELECT_DECISIONS + (f" LIMIT {int(limit)}" if limit else "")
```

`limit=0` is falsy, so the clause was dropped and "show me zero rows" returned every row. The signature already documents the intended contract (`limit: int | None = None`, `None` = unlimited), so the guard now reads `if limit is not None`.

## Changes

- `src/doberman/storage/log.py`: `read_decisions` and `read_decisions_since` use `limit is not None`.
- `src/doberman/policy/drift.py`: `read_policy_changes` had the same pattern; fixed there too, which covers `policy-history --last 0`.
- `tests/unit/test_storage_last_zero.py` (new): pins the 0/None/1 contract for all three readers against a real seeded DB. These tests fail on `main` without the fix.
- `tests/unit/test_cli_log_jsonl.py`: `log --jsonl --last 0` must print nothing (fails on main without the fix).

No field or schema changes; behavior only changes for `limit=0`, which previously returned data nobody asked for.

## Verification

Reproduced before fixing: `doberman demo --fast --path <tmp>`, then `log --last 0` printed all 8 rows, byte-identical to `log --last 100`.

With the fix, on this machine:

- `pytest tests/unit/test_storage_last_zero.py tests/unit/test_cli_log_jsonl.py`: 10 passed.
- `pytest tests/unit -k "log or decisions or drift or policy or tune"`: 212 passed, 1 skipped.
- Full suite: `pytest tests/unit` = **2713 passed, 3 skipped**, excluding `test_hosthook_codex.py` and `test_hosthook_taint_floor.py`, which abort natively on this Mac even on a clean checkout of `main`; CI arbitrates those two.
- `ruff check` and `ruff format --check` clean on all touched files.
- End-to-end after the fix: `doberman log --last 0 --path <seeded tmp>` now prints `(no decisions recorded yet)`.
