### PR TITLE
fix(auth): refuse GUI auth dialog off the main thread on macOS (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
 
 ## Unreleased (merged since v0.18.1)
 
+- **Security fix (#399): a GUI auth dialog can no longer silently misbehave off the main thread on macOS.** Every real caller runs a `Prompter` on a background daemon thread (`doberman.auth.challenge._run_with_deadline`, or `asyncio.to_thread` on the MCP-proxy path) so a wall-clock deadline can be enforced on a channel that might otherwise block forever. Cocoa's Tk backend requires its event loop to start on the process's real main thread; constructing `Tk()` off it is a documented hazard that does not reliably surface as a catchable error the way a missing `$DISPLAY` does — it can silently fail to render, or abort the process, either of which could leave an `AUTH`-tier action looking approved with no human ever having seen a dialog. `GuiPrompter` now refuses before ever touching `tkinter` when it detects this exact condition (macOS + off the main thread), reporting the channel unavailable so `FallbackPrompter` moves on to the terminal — and if that is also unavailable, the action is denied. Windows/Linux behavior is unchanged.
 - **Auth dialog: the highlighted button takes the click again.** The Canvas focus ring was
   drawn on top of the keyboard-highlighted button, and Tk hit-tests a polygon's whole interior
   even when unfilled — so clicking Deny (or Approve, after Tab) did nothing and the hover

--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -30,10 +30,17 @@ be re-asked on another — that would be answer-shopping.
 
 SECURITY: nothing here reads ``sys.stdin`` or writes ``sys.stdout`` (the agent's
 MCP channel). tkinter is stdlib; no new dependency.
+
+SECURITY (#399): every real caller runs this prompter on a background daemon
+thread (see :func:`_open_root`'s docstring) so :func:`~doberman.auth.challenge`'s
+wall-clock deadline can be enforced. On macOS, opening ``Tk()`` off the process's
+real main thread is a Cocoa-level hazard that :func:`_open_root` refuses before
+it ever happens — see that function for the full rationale.
 """
 
 import importlib.resources as _ir
 import sys
+import threading
 from collections.abc import Iterable
 from typing import Any
 
@@ -103,7 +110,29 @@ def _open_root() -> Any:
     A fresh root per challenge (never cached): Tk objects are not thread-safe to
     share and a display that was missing earlier may be available now. The caller
     must destroy it.
+
+    macOS thread-affinity guard (#399): every real caller reaches this function
+    from a background daemon thread, never the process's main thread —
+    :func:`~doberman.auth.challenge.run_auth_challenge` always dispatches the
+    challenge through :func:`~doberman.auth.challenge._run_with_deadline`
+    (a spawned ``threading.Thread``) precisely so a wall-clock deadline can be
+    enforced on a channel that might otherwise block forever, and the MCP-proxy
+    path does the equivalent via ``asyncio.to_thread``. Tk's Cocoa (macOS)
+    backend requires its ``NSApplication`` event loop to start on the real OS
+    main thread; constructing ``Tk()`` off it is a documented hazard that does
+    **not** reliably surface as a catchable ``TclError`` the way a missing
+    ``$DISPLAY`` does on X11 — it can silently fail to render (the dialog never
+    appears, but the call also never raises) or abort the whole process, either
+    of which defeats the fail-closed contract this module exists to provide.
+    Refuse before ever touching ``tkinter`` so this channel reports itself
+    unavailable — exactly like the "no display" case below — so
+    :class:`FallbackPrompter` moves on to the terminal, and if that is also
+    unavailable, the action is denied (never silently approved).
     """
+    if sys.platform == "darwin" and threading.current_thread() is not threading.main_thread():
+        raise PrompterUnavailableError(
+            "GUI auth dialog cannot safely open off the main thread on macOS"
+        )
     try:
         import tkinter
     except Exception as exc:  # pragma: no cover — needs a tkinter-less interpreter

--- a/tests/unit/test_gui_prompter.py
+++ b/tests/unit/test_gui_prompter.py
@@ -19,6 +19,7 @@ The tkinter machinery is monkeypatched at module seams (mirroring how the TTY te
 fake ``_open_tty``) so everything here runs headless and deterministically.
 """
 
+import threading
 import types
 
 import pytest
@@ -105,6 +106,160 @@ def test_open_root_raises_prompter_unavailable_when_tk_init_fails(monkeypatch):
     monkeypatch.setattr(tkinter, "Tk", _boom)
     with pytest.raises(PrompterUnavailableError):
         gui_prompter._open_root()
+
+
+# --- GuiPrompter: macOS thread-affinity guard (#399) -------------------------------
+#
+# Every real caller reaches GuiPrompter on a background daemon thread by
+# construction (doberman.auth.challenge._run_with_deadline / asyncio.to_thread),
+# never the process's main thread. Cocoa's Tk backend requires its event loop to
+# start on the real OS main thread; opening Tk() off it is a documented hazard
+# that does not reliably raise a catchable error the way a missing $DISPLAY does
+# -- it can silently fail to render or abort the process, which is how an AUTH
+# challenge could resolve as approved without a human ever seeing a dialog. The
+# guard must refuse BEFORE tkinter is ever touched.
+
+
+def test_macos_off_main_thread_refuses_before_touching_tkinter(monkeypatch):
+    tkinter = pytest.importorskip("tkinter")
+    monkeypatch.setattr(gui_prompter.sys, "platform", "darwin")
+    monkeypatch.setattr(gui_prompter.threading, "current_thread", lambda: object())
+    monkeypatch.setattr(gui_prompter.threading, "main_thread", lambda: object())
+
+    def _boom(*_a, **_k):
+        raise AssertionError("tkinter.Tk() must never be called off the main thread on macOS")
+
+    monkeypatch.setattr(tkinter, "Tk", _boom)
+    with pytest.raises(PrompterUnavailableError):
+        gui_prompter._open_root()
+
+
+def test_macos_on_main_thread_is_unaffected(monkeypatch):
+    """The guard checks thread AFFINITY, not platform alone -- on the real main
+    thread, macOS proceeds to the normal Tk-open attempt exactly as before."""
+    tkinter = pytest.importorskip("tkinter")
+    monkeypatch.setattr(gui_prompter.sys, "platform", "darwin")
+    same = object()
+    monkeypatch.setattr(gui_prompter.threading, "current_thread", lambda: same)
+    monkeypatch.setattr(gui_prompter.threading, "main_thread", lambda: same)
+
+    attempted = []
+    monkeypatch.setattr(tkinter, "Tk", lambda: attempted.append(True) or object())
+    gui_prompter._open_root()
+    assert attempted == [True]
+
+
+@pytest.mark.parametrize("platform", ["win32", "linux"])
+def test_non_macos_off_main_thread_is_unaffected(monkeypatch, platform):
+    """Windows/Linux users see zero behavior change -- this hazard is macOS-only."""
+    tkinter = pytest.importorskip("tkinter")
+    monkeypatch.setattr(gui_prompter.sys, "platform", platform)
+    monkeypatch.setattr(gui_prompter.threading, "current_thread", lambda: object())
+    monkeypatch.setattr(gui_prompter.threading, "main_thread", lambda: object())
+
+    attempted = []
+    monkeypatch.setattr(tkinter, "Tk", lambda: attempted.append(True) or object())
+    gui_prompter._open_root()
+    assert attempted == [True]
+
+
+def test_real_background_thread_on_macos_is_refused(monkeypatch):
+    """End to end against the REAL stdlib threading module (no identity mocking):
+    a genuine background thread is refused when the platform is macOS."""
+    tkinter = pytest.importorskip("tkinter")
+    monkeypatch.setattr(gui_prompter.sys, "platform", "darwin")
+
+    def _boom(*_a, **_k):
+        raise AssertionError("tkinter.Tk() must never be called off the main thread on macOS")
+
+    monkeypatch.setattr(tkinter, "Tk", _boom)
+
+    outcome: dict = {}
+
+    def _worker():
+        try:
+            gui_prompter._open_root()
+        except BaseException as exc:  # noqa: BLE001 — captured for the caller's thread to assert
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join(timeout=5)
+    assert isinstance(outcome.get("error"), PrompterUnavailableError)
+
+
+def test_gui_prompter_confirm_refuses_off_main_thread_on_macos(monkeypatch):
+    """The guard is reachable through the public GuiPrompter API, not just _open_root."""
+    monkeypatch.setattr(gui_prompter.sys, "platform", "darwin")
+    monkeypatch.setattr(gui_prompter.threading, "current_thread", lambda: object())
+    monkeypatch.setattr(gui_prompter.threading, "main_thread", lambda: object())
+    with pytest.raises(PrompterUnavailableError):
+        GuiPrompter().confirm("Approve?")
+
+
+def test_fallback_chain_falls_through_gui_to_tty_on_macos_background_thread(monkeypatch):
+    """The #399 shape: GuiPrompter is refused (macOS, background thread), and the
+    chain falls through to the next channel rather than silently approving."""
+    monkeypatch.setattr(gui_prompter.sys, "platform", "darwin")
+    monkeypatch.setattr(gui_prompter.threading, "current_thread", lambda: object())
+    monkeypatch.setattr(gui_prompter.threading, "main_thread", lambda: object())
+
+    tty = _Recorder(confirm=True)
+    assert FallbackPrompter([GuiPrompter(), tty]).confirm("Approve?") is True
+    assert tty.calls == ["confirm"]
+
+
+def test_fallback_chain_denies_when_gui_and_tty_both_unavailable_on_macos(monkeypatch):
+    """Full #399 reproduction: macOS + background thread + no real terminal either
+    -- both channels report unavailable, and the provider denies, never approves."""
+    from datetime import datetime, timezone
+
+    from doberman.auth.challenge import AuthTier
+    from doberman.auth.provider import LocalAuthProvider
+    from doberman.models import (
+        ActionType,
+        Decision,
+        GuardrailResult,
+        ReasonCode,
+        Risk,
+        SecurityObject,
+        Verdict,
+    )
+
+    monkeypatch.setattr(gui_prompter.sys, "platform", "darwin")
+    monkeypatch.setattr(gui_prompter.threading, "current_thread", lambda: object())
+    monkeypatch.setattr(gui_prompter.threading, "main_thread", lambda: object())
+
+    now = datetime(2026, 6, 10, tzinfo=timezone.utc)
+    action = SecurityObject(
+        id="act-399-1",
+        ts=now,
+        agent_role="webdev",
+        action_type=ActionType.file_write,
+        tool_name="fs_write",
+        target="migrations/anything.sql",
+    )
+    objective = GuardrailResult(
+        verdict=Verdict.AUTH,
+        risk=Risk.medium,
+        reason_codes=[ReasonCode.sensitive_path_access],
+        explanation="why",
+    )
+    decision = Decision(
+        action_id="act-399-1",
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.medium,
+        objective=objective,
+        reason_codes=[ReasonCode.sensitive_path_access],
+        explanation="why",
+        decided_at=now,
+    )
+    no_tty = _Recorder(raises=PrompterUnavailableError("no controlling terminal"))
+    chain = FallbackPrompter([GuiPrompter(), no_tty])
+    result = LocalAuthProvider().authenticate(
+        decision, action, AuthTier.local_auth, prompter=chain, at=now
+    )
+    assert result.approved is False
 
 
 # --- GuiPrompter: custom dialog internals (faked root + faked widget builders) -----


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: #399 — [bug] AUTH-tier decisions execute without human confirmation in the Claude Code host-hook path (fail-closed violation)
- Plan reference: n/a (bug fix)

## What this PR does

Traced the reported bug to its root cause and fixes it.

**Root cause:** Every real caller of the auth-challenge prompter chain runs it on a background daemon thread — `run_auth_challenge` dispatches through `_run_with_deadline` (`src/doberman/auth/challenge.py`), which spawns a `threading.Thread` specifically so a wall-clock deadline can be enforced on a channel that might otherwise block forever; the MCP-proxy path does the equivalent via `asyncio.to_thread`. `GuiPrompter` therefore always constructs its `Tk()` root **off the process's main thread**.

Cocoa's Tk backend (macOS) requires its `NSApplication` event loop to start on the real OS main thread. Constructing `Tk()` off it is a documented hazard that does **not** reliably surface as a catchable `TclError` the way a missing `$DISPLAY` does on X11 — it can silently fail to render (no window ever appears, but the call also never raises) or abort the whole process. Either outcome could leave an `AUTH`-tier decision recorded as approved with no human ever having seen a dialog — exactly the fail-closed violation reported, and consistent with every piece of evidence in the issue:
- `BLOCK` verdicts never touch this code path at all (`decision_payload` returns synchronously, no Tk) — matching the report's control group, which worked every time.
- `AUTH` always resolved `auth=executed` with zero denials/timeouts across weeks of history — consistent with a near-instant native-level failure rather than a slow hang that the 120s dialog timeout or 1200s outer deadline would otherwise catch and log as `timeout`.
- macOS-specific, matching the report's platform.

**Fix:** `_open_root()` (`src/doberman/auth/gui_prompter.py`) now refuses — raising the existing `PrompterUnavailableError` — *before ever importing `tkinter`* when it detects `sys.platform == "darwin"` and the current thread is not the main thread. This slots into the already-correct existing contract: `FallbackPrompter` falls through to the terminal prompter, and if that is also unavailable, `resolve_auth`/the provider denies with the existing, already-worded "approval dialog could not be shown" message. Windows and Linux are completely unaffected — the guard only fires on the one platform where this is a documented hazard, and only when genuinely off the main thread.

I could not reproduce the live macOS symptom directly (no macOS hardware), but the fix removes the hazardous call path unconditionally regardless of exactly which native failure mode manifests, and is covered by tests proving the guard fires (including via a real background `threading.Thread`, not just mocked thread identity) and that the rest of the fallback/deny chain behaves correctly once it does.

## Tests added (run in CI)
- `tests/unit/test_gui_prompter.py` — 9 new tests:
  - the guard refuses before `tkinter.Tk()` is ever called (mocked thread identity, and via a **real** background `threading.Thread`)
  - inert on the real main thread (macOS) — `tkinter.Tk()` is still attempted, proving the guard checks thread affinity, not platform alone
  - inert on non-macOS platforms (`win32`, `linux`) even off the main thread — zero behavior change for those users
  - reachable through the public `GuiPrompter.confirm()` API, not just `_open_root()`
  - full-chain: `FallbackPrompter([GuiPrompter(), tty])` falls through to the terminal when GUI is refused
  - full-chain: `LocalAuthProvider.authenticate()` denies (never approves) when both GUI and terminal are unavailable under the exact #399 conditions

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty — the exact point of this fix: an unsafe channel now reports itself unavailable instead of risking undefined behavior
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening) — this only removes a way an `AUTH` could resolve as approved without a real answer; it never turns an existing approval path into a denial under normal (main-thread-safe) conditions
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — unchanged; this fix is upstream of verdict formation, in the challenge-resolution layer
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- **Could not reproduce on macOS hardware** — this fix is based on static tracing of the code path plus the well-documented Cocoa/Tk main-thread requirement, not a live repro. Flagging this explicitly per the issue's own request for maintainer instrumentation; happy to iterate further if a live repro surfaces a different or additional failure point.
- **Secondary observation, not fixed here (out of scope for this PR):** `TtyPrompter._open_tty()` (`src/doberman/auth/tty_prompter.py`) raises a bare `OSError` rather than `PrompterUnavailableError` when no controlling terminal is attached. This does **not** cause a fail-open — `LocalAuthProvider.authenticate()`'s own broad `except Exception` still catches it and denies — but it means `TtyPrompter` doesn't participate in `FallbackPrompter`'s "try the next channel" semantics the same way `GuiPrompter` does. Low severity today (it's the last channel in the chain), but worth a follow-up if a channel is ever added after it.
- No behavior change for Windows/Linux, or for macOS on the main thread — verified by dedicated tests above.
