### PR TITLE
fix(deps): cap river below 0.26 on Python 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
 
 ## Unreleased (merged since v0.18.1)
 
+- **Deps: `river` capped below 0.26 on Python 3.11.** river 0.26.0 subscripts
+  `csv.DictReader` at import time, which only Python >= 3.12 supports, so any
+  import of the subjective layer (and therefore the whole test suite) died on
+  3.11 with `TypeError: type 'DictReader' is not subscriptable`. 3.12+ keeps
+  the unpinned floor.
 - **Auth dialog: the highlighted button takes the click again.** The Canvas focus ring was
   drawn on top of the keyboard-highlighted button, and Tk hit-tests a polygon's whole interior
   even when unfilled — so clicking Deny (or Approve, after Tab) did nothing and the hover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,11 @@ dependencies = [
     "pyotp",
     "pyyaml",
     "typer",
-    "river>=0.21",
+    "river>=0.21; python_version >= '3.12'",
+    # river 0.26.0 subscripts csv.DictReader at import time (PEP 585 on a stdlib
+    # class that only grew __class_getitem__ in 3.12), so it cannot even be
+    # imported on 3.11. Cap it there; lift when river ships a 3.11-safe release.
+    "river>=0.21,<0.26; python_version < '3.12'",
     "numpy",
     "scipy",
 ]


### PR DESCRIPTION
## What

Splits the `river` dependency by Python version: 3.12+ keeps the unpinned `>=0.21` floor; 3.11 gets `>=0.21,<0.26`.

## Why

river 0.26.0's `stream/iter_csv.py` declares `class DictReader(csv.DictReader["FeatureName"])` — a class-level subscript that `csv.DictReader` only supports on Python >= 3.12. On 3.11 the import dies with `TypeError: type 'DictReader' is not subscriptable`, which takes down every import of `doberman.subjective` and, with it, test collection for the whole suite (~230 modules, 2,860 collection errors).

The 3.11 CI leg already fails on every fresh-cache run — see the red legs on #445, #446, #447 (all pre-diagnosed as unrelated to those diffs). `main` itself is one pip-cache miss away from the same failure.

Root cause was diagnosed by @blackcoderx on #447 — this PR just lands the pin.

## Verification

- CI on this PR is the test: the 3.11 leg resolves `river<0.26` and collects again; 3.12/3.13 stay on the current floor.
- No code changes; CHANGELOG bullet included.

Lift the cap when river ships a 3.11-safe release.