### PR TITLE
fix(cli): align hook dry-run with installed command

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -41,6 +41,7 @@ from doberman.config import (
 from doberman.demo import format_outcome_line, format_summary_table, run_demo
 from doberman.discovery.mcp_scan import MCP_CONFIG_FILES, scan_mcp_configs
 from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, render_risk_map
+from doberman.hosthooks.install import DASHBOARD_COMMAND
 from doberman.policy.checklist import recommend_policy
 from doberman.policy.drift import (
     _verify_possession_factor,
@@ -1690,7 +1691,7 @@ def install_hooks(
         typer.echo("[dry-run] would add:")
         typer.echo("  PreToolUse   -> doberman hook pre")
         typer.echo("  PostToolUse  -> doberman hook post")
-        typer.echo("  SessionStart -> doberman dashboard")
+        typer.echo(f"  SessionStart -> {DASHBOARD_COMMAND}")
         return
 
     write_settings(settings_path, merged)
@@ -1849,7 +1850,7 @@ def uninstall_hooks(
         typer.echo("[dry-run] would remove:")
         typer.echo("  PreToolUse   -> doberman hook pre")
         typer.echo("  PostToolUse  -> doberman hook post")
-        typer.echo("  SessionStart -> doberman dashboard")
+        typer.echo(f"  SessionStart -> {DASHBOARD_COMMAND}")
         return
 
     write_settings(settings_path, cleaned)

--- a/tests/unit/test_install_hooks.py
+++ b/tests/unit/test_install_hooks.py
@@ -331,6 +331,15 @@ class TestInstallHooksCLI:
         assert "doberman hook pre" in result.output
         assert "doberman hook post" in result.output
 
+    def test_dry_run_shows_the_command_the_installer_writes(self, tmp_path):
+        result = runner.invoke(
+            cli_module.app, ["install-hooks", "--path", str(tmp_path), "--dry-run"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert f"SessionStart -> {DASHBOARD_COMMAND}" in result.output
+        assert "doberman dashboard" not in result.output
+
     def test_install_is_idempotent(self, tmp_path):
         runner.invoke(cli_module.app, ["install-hooks", "--path", str(tmp_path)])
         runner.invoke(cli_module.app, ["install-hooks", "--path", str(tmp_path)])
@@ -424,6 +433,8 @@ class TestUninstallHooksCLI:
         )
         assert result.exit_code == 0
         assert "[dry-run]" in result.output
+        assert f"SessionStart -> {DASHBOARD_COMMAND}" in result.output
+        assert "doberman dashboard" not in result.output
         assert settings_path.read_text(encoding="utf-8") == content_before
 
     def test_creates_bak_on_uninstall(self, tmp_path):


### PR DESCRIPTION
Closes #429

## What
- Uses `DASHBOARD_COMMAND` in both install and uninstall dry-run previews so the displayed SessionStart command is the same one the installer writes.
- Adds regression coverage asserting the preview contains `doberman session-summary` and no longer mentions `doberman dashboard`.

## Verification
- `.venv/bin/pytest tests/unit/test_install_hooks.py` — 44 passed.
- `.venv/bin/pytest tests/unit -k 'install_hooks or cli_help or cli_encode_safe'` — 117 passed, 1 skipped.
- `.venv/bin/ruff check src tests` — passed.
- `.venv/bin/ruff format --check src/doberman/cli/main.py tests/unit/test_install_hooks.py` — passed.
