### PR TITLE
chore(release): v0.18.2 — friction-reduction patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,18 @@
 Shipped history for Doberman. Planned work lives on the [roadmap](README.md#roadmap) and the
 [project board](https://github.com/users/fu351/projects/5); exact per-commit detail is in the
 [git log](https://github.com/DobermanCore/Doberman-Core/commits/main) and
-[releases](https://github.com/DobermanCore/Doberman-Core/releases) (latest: **v0.18.1**, a docs patch fixing the README images on PyPI, atop **v0.18.0**'s security-audit wave — the proxy output-secret gate closed over error and structured/embedded channels, per-user auth state and Windows-separator paths brought under control-plane protection — plus the RAND-aligned guardrail rehaul and the UX/contributor work since 0.17.1).
+[releases](https://github.com/DobermanCore/Doberman-Core/releases) (latest: **v0.18.2**, the friction-reduction patch — spurious secret-detector prompts on ordinary ids/paths/UUIDs fixed, and the detector now self-checks and fails closed — atop **v0.18.1**'s README-image docs patch and **v0.18.0**'s security-audit wave — the proxy output-secret gate closed over error and structured/embedded channels, per-user auth state and Windows-separator paths brought under control-plane protection — plus the RAND-aligned guardrail rehaul and the UX/contributor work since 0.17.1).
 
-## Unreleased (merged since v0.18.1)
+## Unreleased
+
+_Nothing yet._
+
+## v0.18.2 — 2026-08-25
+
+> **Friction reduction.** This release is about getting out of your way. The secret detector no longer
+> fires spurious approval prompts on ordinary identifiers, paths, and UUIDs — the single biggest source
+> of click-through fatigue — and it now self-checks at import so a bad change can't silently break it.
+> The opt-in usage telemetry and the rewritten docs from the last cycle ride along.
 
 - **Weak-secret false positives on identifiers, paths, and ids fixed; the rule now self-checks.** The
   generic high-entropy heuristic no longer steps an ordinary identifier, a relative path, a UUID/digest,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doberman-core"
-version = "0.18.1"
+version = "0.18.2"
 description = "Adaptive authorization layer for coding agents (open core)"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## v0.18.2 — friction-reduction patch

Cuts the current `Unreleased` section into **v0.18.2** and bumps `pyproject.toml` (0.18.1 → 0.18.2).

### Headline (why this is a patch worth shipping now)
The secret detector was firing spurious approval prompts on ordinary identifiers, paths, and UUIDs — the biggest source of click-through fatigue and a real churn factor. This release fixes that (raise-only: every real credential still fires) and makes the rule **self-check at import and fail closed** if it's ever broken. See #464.

### What's in it
- **Weak-secret false positives on ids/paths/UUIDs fixed; rule self-checks** (#464).
- **Opt-in anonymous CLI telemetry** and the **docs rewrite + docs site** from the last cycle (already merged, released here).
- The smaller items already in `Unreleased` (dashboard per-project tab title, the #399 macOS GUI-dialog thread-safety fix, the `river` cap).

### Verification
- `main` is green (the FP fix landed via #464 with full CI green).
- Synthetic benchmark re-run (`--suite synthetic --profile before_after`): **attacks_stopped = 1.0, unchanged** — the fix only removes false *AUTH* prompts on benign shapes and touches no BLOCK verdict, so detection is unaffected. No `BENCHMARKS.md` change needed.

### Release (after merge)
`gh release create v0.18.2` → the `publish.yml` OIDC Trusted-Publishing flow builds + uploads to PyPI, gated by the `pypi` GitHub Environment's human approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
