### PR TITLE
chore(release): v0.18.3 — tap-to-approve 2FA (Windows Hello)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@
 Shipped history for Doberman. Planned work lives on the [roadmap](README.md#roadmap) and the
 [project board](https://github.com/users/fu351/projects/5); exact per-commit detail is in the
 [git log](https://github.com/DobermanCore/Doberman-Core/commits/main) and
-[releases](https://github.com/DobermanCore/Doberman-Core/releases) (latest: **v0.18.2**, the friction-reduction patch — spurious secret-detector prompts on ordinary ids/paths/UUIDs fixed, and the detector now self-checks and fails closed — atop **v0.18.1**'s README-image docs patch and **v0.18.0**'s security-audit wave — the proxy output-secret gate closed over error and structured/embedded channels, per-user auth state and Windows-separator paths brought under control-plane protection — plus the RAND-aligned guardrail rehaul and the UX/contributor work since 0.17.1).
+[releases](https://github.com/DobermanCore/Doberman-Core/releases) (latest: **v0.18.3**, the second friction-reduction patch — opt-in tap-to-approve 2FA (a Windows Hello / Touch ID biometric can stand in for the TOTP code) — atop **v0.18.2**'s friction-reduction patch — spurious secret-detector prompts on ordinary ids/paths/UUIDs fixed, and the detector now self-checks and fails closed — atop **v0.18.1**'s README-image docs patch and **v0.18.0**'s security-audit wave — the proxy output-secret gate closed over error and structured/embedded channels, per-user auth state and Windows-separator paths brought under control-plane protection — plus the RAND-aligned guardrail rehaul and the UX/contributor work since 0.17.1).
 
-## Unreleased
+## v0.18.3 — 2026-08-26
+
+> **Friction reduction, part two.** The second factor no longer has to be a typed code. Turn on an
+> approval method and a single Windows Hello / Touch ID tap satisfies a 2FA-tier challenge — presence
+> and possession in one gesture — with TOTP still there as the fallback. Opt-in, fail-closed, and
+> pluggable, so phone-push backends can register without touching the core.
 
 - **Approve 2FA with a tap instead of a code (opt-in, pluggable).** A new approval-method framework lets
   a Windows Hello / Touch ID biometric — or a future push channel — stand in for the TOTP code on a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doberman-core"
-version = "0.18.2"
+version = "0.18.3"
 description = "Adaptive authorization layer for coding agents (open core)"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Release cut for **v0.18.3**, the second friction-reduction patch.

- `pyproject.toml`: 0.18.2 → 0.18.3
- `CHANGELOG.md`: Unreleased 2FA entry moved into the dated `v0.18.3` section; header 'latest' line updated.

Ships the opt-in approval-method framework + Windows Hello backend (#467): on a 2FA-tier challenge a Windows Hello / Touch ID tap can replace the TOTP code — fail-closed, opt-in, TOTP fallback. Phone-push backends (ntfy, Telegram) land in v0.18.4.

Merging this triggers the `v0.18.3` GitHub Release + the OIDC PyPI publish (gated by the `pypi` environment approval).