### PR TITLE
fix(cli): emit compact tune JSON

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1217,7 +1217,14 @@ def tune(
 
     report = build_friction_report(rows)
     if json_out:
-        typer.echo(json.dumps({**report, "proposals": proposals}, sort_keys=True, default=str))
+        typer.echo(
+            json.dumps(
+                {**report, "proposals": proposals},
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            )
+        )
         return
 
     if not rows:

--- a/tests/unit/test_cli_tune_json.py
+++ b/tests/unit/test_cli_tune_json.py
@@ -1,0 +1,35 @@
+"""`doberman tune --json` compact output contract (#431)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+
+from typer.testing import CliRunner
+
+from doberman.cli.main import app
+from doberman.storage.db import active_elevations
+
+runner = CliRunner()
+
+
+def _seed_approved_decisions(root) -> None:
+    from tests.unit.test_friction_tune import _seed_five_approved_migrations
+
+    _seed_five_approved_migrations(root)
+
+
+def test_tune_json_is_compact(tmp_path):
+    root = str(tmp_path)
+    _seed_approved_decisions(root)
+
+    result = runner.invoke(app, ["tune", "--path", root, "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert "proposals" in payload
+    assert '", "' not in result.stdout
+    assert '": "' not in result.stdout
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert asyncio.run(active_elevations(root, now)) == []


### PR DESCRIPTION
Closes #431

## What
- Adds `separators=(",", ":")` to the `tune --json` serialization.
- Keeps sorted keys, default string conversion, fields, and schema unchanged.

## Tests
- Adds `tests/unit/test_cli_tune_json.py`, shaped like the scan JSON test: seeds decisions through storage, parses the CLI output, and asserts neither spaced JSON separator appears.

## Verification
- `.venv/bin/pytest tests/unit/test_cli_tune_json.py` — 1 passed.
- `.venv/bin/pytest tests/unit/test_friction_tune.py tests/unit/test_cli_tune_json.py` — 24 passed.
- Full local suite: 3,180 passed, 12 skipped; one unrelated integration plugin-discovery test also fails on clean `main` in this environment because its isolated Python cannot import `doberman`.
- `.venv/bin/ruff check` and `.venv/bin/ruff format --check` pass on changed files.
