### PR TITLE
fix(cli): preview the real session-summary hook

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -41,6 +41,7 @@ from doberman.config import (
 from doberman.demo import format_outcome_line, format_summary_table, run_demo
 from doberman.discovery.mcp_scan import MCP_CONFIG_FILES, scan_mcp_configs
 from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, render_risk_map
+from doberman.hosthooks.install import DASHBOARD_COMMAND
 from doberman.policy.checklist import recommend_policy
 from doberman.policy.drift import (
     _verify_possession_factor,
@@ -1690,7 +1691,7 @@ def install_hooks(
         typer.echo("[dry-run] would add:")
         typer.echo("  PreToolUse   -> doberman hook pre")
         typer.echo("  PostToolUse  -> doberman hook post")
-        typer.echo("  SessionStart -> doberman dashboard")
+        typer.echo(f"  SessionStart -> {DASHBOARD_COMMAND}")
         return
 
     write_settings(settings_path, merged)
@@ -1849,7 +1850,7 @@ def uninstall_hooks(
         typer.echo("[dry-run] would remove:")
         typer.echo("  PreToolUse   -> doberman hook pre")
         typer.echo("  PostToolUse  -> doberman hook post")
-        typer.echo("  SessionStart -> doberman dashboard")
+        typer.echo(f"  SessionStart -> {DASHBOARD_COMMAND}")
         return
 
     write_settings(settings_path, cleaned)

--- a/tests/unit/test_install_hooks.py
+++ b/tests/unit/test_install_hooks.py
@@ -330,6 +330,8 @@ class TestInstallHooksCLI:
         )
         assert "doberman hook pre" in result.output
         assert "doberman hook post" in result.output
+        assert DASHBOARD_COMMAND in result.output
+        assert "doberman dashboard" not in result.output
 
     def test_install_is_idempotent(self, tmp_path):
         runner.invoke(cli_module.app, ["install-hooks", "--path", str(tmp_path)])


### PR DESCRIPTION
Closes #429

## What
- Imports `DASHBOARD_COMMAND` from the installer so `install-hooks` and `uninstall-hooks` dry runs display the same command the merge logic writes.
- Replaces the hardcoded stale preview (`doberman dashboard`) with `doberman session-summary`.

## Tests
- Extends `tests/unit/test_install_hooks.py` to assert the install dry run contains the real command and no longer contains the hidden alias.

## Verification
- `.venv/bin/pytest tests/unit/test_install_hooks.py` — 43 passed.
- `.venv/bin/ruff check src/doberman/cli/main.py tests/unit/test_install_hooks.py`
- `.venv/bin/ruff format --check src/doberman/cli/main.py tests/unit/test_install_hooks.py`
