### PR TITLE
fix(cli): align log action column

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -41,6 +41,7 @@ from doberman.config import (
 from doberman.demo import format_outcome_line, format_summary_table, run_demo
 from doberman.discovery.mcp_scan import MCP_CONFIG_FILES, scan_mcp_configs
 from doberman.discovery.scan import enumerate_capabilities, rate_capabilities, render_risk_map
+from doberman.models import ActionType
 from doberman.policy.checklist import recommend_policy
 from doberman.policy.drift import (
     _verify_possession_factor,
@@ -1275,6 +1276,10 @@ def tune(
 # ``build_record`` — no raw target, argument, or secret reaches the table at all.
 _JSONL_EXTRA_COLUMNS = ("id", "agent_role", "risk")
 
+# Keep every action type in one column even when a new enum member outgrows the
+# historical 13-character values (network_request/package_install are 15).
+_ACTION_WIDTH = max(len(action.value) for action in ActionType)
+
 
 @app.command(rich_help_panel="Daily")
 def log(
@@ -1325,7 +1330,7 @@ def log(
         reasons = ", ".join(json.loads(row["reason_codes_json"] or "[]")) or "-"
         auth = f"; auth={row['auth_result']}" if row["auth_result"] else ""
         typer.echo(
-            f"{row['ts']}  {verdict_label_str(row['final_verdict'])} {row['action_type']:<13} "
+            f"{row['ts']}  {verdict_label_str(row['final_verdict'])} {row['action_type']:<{_ACTION_WIDTH}} "
             f"{target}  [{reasons}]{auth}"
         )
 

--- a/tests/unit/test_cli_log_jsonl.py
+++ b/tests/unit/test_cli_log_jsonl.py
@@ -197,3 +197,36 @@ def test_log_default_human_empty_message(tmp_path):
         result = runner.invoke(app, ["log", "--path", str(tmp_path)])
     assert result.exit_code == 0
     assert "(no decisions recorded yet)" in result.stdout
+
+
+def test_log_human_action_column_does_not_shift_for_long_types(tmp_path):
+    """`network_request` is wider than `git_op`; both targets must align (#428)."""
+    import doberman.cli.main as main_mod
+
+    def _row(action_type: str, action_id: str, ts: str):
+        return {
+            "id": int(action_id.split("-")[1]),
+            "ts": ts,
+            "action_id": action_id,
+            "agent_role": "backend",
+            "action_type": action_type,
+            "final_verdict": "ALLOW",
+            "target_path_class": "src/**/*.py",
+            "reason_codes_json": "[]",
+            "auth_result": None,
+        }
+
+    async def _rows(*_a, **_k):
+        return [
+            _row("network_request", "act-2", "2026-07-30T00:00:02Z"),
+            _row("git_op", "act-1", "2026-07-30T00:00:01Z"),
+        ]
+
+    with patch.object(main_mod, "read_decisions", _rows):
+        result = runner.invoke(app, ["log", "--path", str(tmp_path)])
+
+    assert result.exit_code == 0
+    lines = [line for line in result.stdout.splitlines() if " src/**/*.py" in line]
+    assert len(lines) == 2
+    offsets = [line.index(" src/**/*.py") for line in lines]
+    assert offsets[0] == offsets[1]


### PR DESCRIPTION
Closes #428

## What
- Derives the `log` action-column width from `ActionType` instead of hardcoding 13 characters.
- Keeps targets aligned for the 15-character enum values (`network_request`, `package_install`) while automatically accommodating future members.
- Leaves the JSONL contract untouched.

## Tests
- Adds a human-output regression test with `network_request` and `git_op` rows, asserting both target columns start at the same offset.

## Verification
- `.venv/bin/pytest tests/unit -k cli_log` — 8 passed, 1 skipped.
- `.venv/bin/ruff check src/doberman/cli/main.py tests/unit/test_cli_log_jsonl.py`
- `.venv/bin/ruff format --check src/doberman/cli/main.py tests/unit/test_cli_log_jsonl.py`
