### PR TITLE
docs: remove stale shipped-feature promises

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -938,7 +938,7 @@ def hook_codex_pre() -> None:
     objective floor (no numpy/scipy/river) and fails closed on any malformed
     input or engine error.
 
-    Wire it in with ``doberman install-hooks --host codex`` (a later slice).
+    Wire it in with ``doberman install-hooks --host codex``.
     """
     _configure_stderr_logging()
     from doberman.hosthooks.codex import run_codex_pre

--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -93,7 +93,7 @@ _FEED_BACKFILL_LIMIT = 50
 #: much shorter one so the feed test doesn't wait on the wall clock).
 _FEED_POLL_INTERVAL_S = 1.0
 
-# ponytail: one inline page, no build toolchain - real UI lands in a later slice.
+# ponytail: one inline page, no build toolchain.
 _HTML_SHELL = """<!doctype html>
 <html lang="en">
 <head>

--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -2,10 +2,10 @@
 calls without the agent opting in.
 
 Claude Code can run a command as a ``PreToolUse`` hook *before* every tool call.
-Wired in (see ``doberman install-hooks``, a later slice), the harness invokes
-``doberman hook pre`` and hands this adapter the tool call on stdin. We translate
-it into a :class:`~doberman.models.SecurityObject`, run the **deterministic
-objective floor**, and answer in Claude Code's hook protocol:
+Wired in by ``doberman install-hooks``, the harness invokes ``doberman hook pre``
+and hands this adapter the tool call on stdin. We translate it into a
+:class:`~doberman.models.SecurityObject`, run the **deterministic objective
+floor**, and answer in Claude Code's hook protocol:
 
 * ``PASS``  -> abstain (no output). Doberman is **raise-only**: it never removes
   the harness's own permission prompts, it only *adds* friction.
@@ -56,7 +56,7 @@ if TYPE_CHECKING:  # annotations only — keeps the hot path free of the auth st
 #: Claude Code built-in tools whose *action* we gate before execution. Pure reads
 #: (Read / Glob / Grep) are deliberately NOT gated here — a read cannot destroy or
 #: exfiltrate on its own; its *output* is the concern, scanned by the PostToolUse
-#: hook (a later slice). Internal tools (TodoWrite, Task, …) are not real-resource
+#: hook. Internal tools (TodoWrite, Task, …) are not real-resource
 #: actions and abstain too.
 GATED_BUILTINS: frozenset[str] = frozenset(
     {"Bash", "Edit", "Write", "NotebookEdit", "WebFetch", "WebSearch"}

--- a/src/doberman/hosthooks/codex.py
+++ b/src/doberman/hosthooks/codex.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:  # annotations only — keeps the hot path free of the auth st
 _EVENT = "PreToolUse"
 
 #: Supported Codex CLI version range (inclusive min, exclusive max). ``doberman
-#: doctor`` (a later slice) reports an installed Codex outside this range as a
+#: doctor`` reports an installed Codex outside this range as a
 #: WARN, never a critical failure — a newer Codex is not "Doberman may not be
 #: protecting you". Verified against 0.146.1; widen the max as the CI canary
 #: stays green on newer releases.


### PR DESCRIPTION
Closes #426

## What
- Removes the four stale "(a later slice)" promises for features that already shipped: Codex hook installation, Claude Code wiring, PostToolUse scanning, and `doctor` version checks.
- Also removes the fifth match found by the issue's repository-wide search in the dashboard comment, where the inline page already exists.
- Keeps each sentence focused on current behavior; no code paths change.

## Verification
- `rg "later slice" src/` — no matches.
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest tests/unit/test_cli_help.py` — 51 passed.
