### PR TITLE
feat(doctor): report optional password enrollment

### DIFF
--- a/src/doberman/cli/doctor.py
+++ b/src/doberman/cli/doctor.py
@@ -220,6 +220,16 @@ def _check_2fa() -> CheckResult:
     )
 
 
+def _check_password() -> CheckResult:
+    from doberman.auth import password
+
+    if password.is_enrolled():
+        return CheckResult("Password", CheckStatus.OK, "set")
+    return CheckResult(
+        "Password", CheckStatus.WARN, "not set (optional) — run `doberman password set`"
+    )
+
+
 def _check_fingerprint_key() -> CheckResult:
     from doberman.storage.fingerprint import _key_path
 
@@ -257,6 +267,7 @@ def run_checks(path: str = ".") -> list[CheckResult]:
         _safe_check("Decision DB", True, lambda: _check_db(path)),
         _safe_check("Enforcement", False, lambda: _check_enforcement(path)),
         _safe_check("2FA", False, _check_2fa),
+        _safe_check("Password", False, _check_password),
         _safe_check("Fingerprint key", False, _check_fingerprint_key),
         _safe_check("Codex CLI", False, _check_codex_version),
     ]

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -228,6 +228,36 @@ def test_doctor_reports_2fa_state(tmp_path):
     assert "not enrolled" in twofa.detail
 
 
+def test_doctor_reports_password_set(tmp_path, monkeypatch):
+    monkeypatch.setattr("doberman.auth.password.is_enrolled", lambda: True)
+
+    results = run_checks(str(tmp_path))
+
+    password_check = next(result for result in results if result.name == "Password")
+    assert password_check.status is CheckStatus.OK
+    assert password_check.detail == "set"
+    assert password_check.critical is False
+
+
+def test_doctor_reports_missing_optional_password(tmp_path, monkeypatch):
+    monkeypatch.setattr("doberman.auth.password.is_enrolled", lambda: False)
+
+    results = run_checks(str(tmp_path))
+
+    password_check = next(result for result in results if result.name == "Password")
+    assert password_check.status is CheckStatus.WARN
+    assert "not set (optional)" in password_check.detail
+    assert "`doberman password set`" in password_check.detail
+    assert password_check.critical is False
+
+
+def test_doctor_lists_password_next_to_2fa(tmp_path):
+    results = run_checks(str(tmp_path))
+    names = [result.name for result in results]
+
+    assert names.index("Password") == names.index("2FA") + 1
+
+
 @pytest.mark.skipif(
     os.name == "nt", reason="POSIX file-permission bits are not enforced on Windows (NTFS)"
 )

--- a/tests/unit/test_cli_doctor_json.py
+++ b/tests/unit/test_cli_doctor_json.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from typer.testing import CliRunner
 
 from doberman.cli.main import app
 
 runner = CliRunner()
+
+
+def _check_by_name(payload: dict[str, Any], name: str) -> dict[str, Any]:
+    return next(check for check in payload["checks"] if check["name"] == name)
 
 
 def test_doctor_json_is_parseable(tmp_path):
@@ -24,3 +29,25 @@ def test_doctor_json_is_parseable(tmp_path):
         assert result.exit_code == 0
     else:
         assert result.exit_code == 1
+
+
+def test_doctor_json_reports_enrolled_password(tmp_path, monkeypatch):
+    monkeypatch.setattr("doberman.auth.password.is_enrolled", lambda: True)
+
+    result = runner.invoke(app, ["doctor", "--path", str(tmp_path), "--json"])
+
+    payload = json.loads(result.stdout)
+    check = _check_by_name(payload, "Password")
+    assert check["status"] == "ok"
+    assert check["detail"] == "set"
+
+
+def test_doctor_json_reports_missing_password(tmp_path, monkeypatch):
+    monkeypatch.setattr("doberman.auth.password.is_enrolled", lambda: False)
+
+    result = runner.invoke(app, ["doctor", "--path", str(tmp_path), "--json"])
+
+    payload = json.loads(result.stdout)
+    check = _check_by_name(payload, "Password")
+    assert check["status"] == "warn"
+    assert check["detail"] == "not set (optional) — run `doberman password set`"


### PR DESCRIPTION
Closes #439

## What
- Adds a read-only `Password` doctor check beside `2FA`.
- Reports OK when the local password factor is enrolled and a non-critical warning with setup guidance when it is not.
- Uses the existing `password.is_enrolled()` presence check; it never reads or exposes the secret.

## Tests
- Unit coverage for enrolled and missing states.
- Ordering coverage that `Password` appears immediately after `2FA`.
- JSON output coverage for both states.

## Verification
- `.venv/bin/pytest tests/unit -k doctor` — 23 passed, 1 skipped.
- `.venv/bin/pytest tests/unit/test_cli_doctor.py tests/unit/test_cli_doctor_json.py` — 21 passed.
- `.venv/bin/ruff check` and `.venv/bin/ruff format --check` pass on changed files.
