### PR TITLE
feat(doctor): report optional UI extras

### DIFF
--- a/src/doberman/cli/doctor.py
+++ b/src/doberman/cli/doctor.py
@@ -22,6 +22,7 @@ import sqlite3
 import stat
 from dataclasses import dataclass
 from enum import Enum
+from importlib.util import find_spec
 from pathlib import Path
 
 
@@ -139,6 +140,25 @@ def _version_tuple(v: str) -> tuple[int, ...]:
         return tuple(int(p) for p in v.split("."))
     except ValueError:
         return (0,)
+
+
+def _check_optional_extra(name: str, module: str, install_extra: str) -> CheckResult:
+    """Report an optional UI dependency without importing it."""
+    if find_spec(module) is not None:
+        return CheckResult(name, CheckStatus.OK, "installed")
+    return CheckResult(
+        name,
+        CheckStatus.WARN,
+        f"not installed (optional) - pip install 'doberman[{install_extra}]'",
+    )
+
+
+def _check_dash_extra() -> CheckResult:
+    return _check_optional_extra("Dash extra", "starlette", "dash")
+
+
+def _check_tui_extra() -> CheckResult:
+    return _check_optional_extra("TUI extra", "textual", "tui")
 
 
 def _check_config(path: str) -> CheckResult:
@@ -259,6 +279,8 @@ def run_checks(path: str = ".") -> list[CheckResult]:
         _safe_check("2FA", False, _check_2fa),
         _safe_check("Fingerprint key", False, _check_fingerprint_key),
         _safe_check("Codex CLI", False, _check_codex_version),
+        _safe_check("Dash extra", False, _check_dash_extra),
+        _safe_check("TUI extra", False, _check_tui_extra),
     ]
 
 

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -296,6 +296,52 @@ def test_codex_cli_not_found_when_which_resolves_nothing(tmp_path, monkeypatch):
     assert "not found" in codex_check.detail
 
 
+@pytest.mark.parametrize(
+    ("row_name", "module", "install_hint"),
+    [
+        ("Dash extra", "starlette", "doberman[dash]"),
+        ("TUI extra", "textual", "doberman[tui]"),
+    ],
+)
+def test_doctor_reports_optional_extra_missing(
+    tmp_path, monkeypatch, row_name, module, install_hint
+):
+    monkeypatch.setattr("doberman.cli.doctor.find_spec", lambda name: None)
+
+    results = run_checks(str(tmp_path))
+
+    check = next(result for result in results if result.name == row_name)
+    assert check.status is CheckStatus.WARN
+    assert check.detail == f"not installed (optional) - pip install '{install_hint}'"
+    assert check.critical is False
+
+
+@pytest.mark.parametrize(
+    ("row_name", "module"),
+    [
+        ("Dash extra", "starlette"),
+        ("TUI extra", "textual"),
+    ],
+)
+def test_doctor_reports_optional_extra_installed(tmp_path, monkeypatch, row_name, module):
+    monkeypatch.setattr("doberman.cli.doctor.find_spec", lambda name: object())
+
+    results = run_checks(str(tmp_path))
+
+    check = next(result for result in results if result.name == row_name)
+    assert check.status is CheckStatus.OK
+    assert check.detail == "installed"
+    assert check.critical is False
+
+
+def test_doctor_lists_optional_extras_after_codex_cli(tmp_path):
+    results = run_checks(str(tmp_path))
+    names = [result.name for result in results]
+
+    assert names.index("Dash extra") == names.index("Codex CLI") + 1
+    assert names.index("TUI extra") == names.index("Dash extra") + 1
+
+
 # ---------------------------------------------------------------------------
 # Read-only invariant: diagnosing never mutates state
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #440

## What
- Adds read-only doctor rows for the optional `dash` and `tui` extras.
- Uses `importlib.util.find_spec` so diagnosis never imports either UI dependency.
- Reports missing extras as non-critical warnings with the matching install hint.

## Tests
- `.venv/bin/pytest tests/unit/test_cli_doctor.py` — 20 passed.
- `.venv/bin/ruff check src/doberman/cli/doctor.py tests/unit/test_cli_doctor.py` — passed.
- `.venv/bin/ruff format --check src/doberman/cli/doctor.py tests/unit/test_cli_doctor.py` — passed.

