### PR TITLE
chore(changelog): adopt per-PR fragments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,7 @@ metadata, classifications, and fingerprints are fine; raw secrets are not.
   or `docs(contributing): add onboarding guide`.
 - Tests travel with the code, and docs or README updates travel with behavior
   changes.
+- Add a `changelog.d/<PR-number>.md` fragment instead of editing `CHANGELOG.md`. Start it with one or more user-facing Markdown bullets; maintainers compile fragments during release.
 - Fill out the PR template, including the public-release safety and security
   checklists.
 - Note any AI assistance in the PR description.

--- a/changelog.d/456.md
+++ b/changelog.d/456.md
@@ -1,0 +1,2 @@
+- **Changelog entries no longer collide on every parallel pull request.** Each PR now adds its
+  own `changelog.d/<PR-number>.md`, and release tooling compiles those fragments together.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,7 @@
+# Changelog fragments
+
+Add one Markdown file named after your pull request (for example,
+`456.md`) instead of editing `CHANGELOG.md`. Start the file with one or more
+Markdown bullets describing the user-facing change. Maintainers compile these
+files into `CHANGELOG.md` during release; this README is documentation, not a
+fragment.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -10,7 +10,7 @@ The checklist for cutting a release, kept in sync with `.github/workflows/publis
    - Synthetic (deterministic, from a cold clone): `python -m tests.benchmarks.run --suite synthetic --profile before_after`.
    - AgentDojo (operator-supplied): `pip install agentdojo` at a pinned commit, then `python -m tests.benchmarks.run --suite agentdojo --profile before_after`. Record the pinned commit and the run date. Keep the raw run out of git (`test-logs/`); transcribe only the aggregate numbers.
    - Update the "Fixed bypasses" wall with anything disclosed and fixed since the last release.
-4. **Version and changelog.** Bump `version` in `pyproject.toml` (follow semver). Move shipped items into `CHANGELOG.md`. Confirm the README roadmap and versioning reflect reality.
+4. **Version and changelog.** Run `python scripts/compile_changelog.py --write` to collect all pending `changelog.d/<PR-number>.md` files into a fresh `Unreleased` section; review that output before promoting it to the new version heading. Bump `version` in `pyproject.toml` (follow semver). Confirm the README roadmap and versioning reflect reality.
 5. **Docs sweep.** Every protection claim in the README resolves to a parity cell or a benchmark number. No orphan adjectives.
 
 ## Cut a release

--- a/scripts/compile_changelog.py
+++ b/scripts/compile_changelog.py
@@ -1,0 +1,125 @@
+"""Compile pending changelog fragments into ``CHANGELOG.md``."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+PLACEHOLDER = "_Nothing yet._"
+
+
+@dataclass(frozen=True)
+class Fragment:
+    number: int
+    path: Path
+    content: str
+
+
+def _fragment_number(path: Path) -> int:
+    if not path.stem.isdigit():
+        raise ValueError(f"{path}: fragment names must be a PR number, such as 456.md")
+    return int(path.stem)
+
+
+def collect_fragments(fragment_dir: Path) -> list[Fragment]:
+    """Load and order the PR fragments pending compilation."""
+
+    fragments: list[Fragment] = []
+    for path in sorted(fragment_dir.glob("*.md")):
+        if path.name.casefold() == "readme.md":
+            continue
+
+        content = path.read_text(encoding="utf-8").strip()
+        if not content:
+            raise ValueError(f"{path}: fragment is empty")
+        if not content.startswith("- "):
+            raise ValueError(f"{path}: fragments must start with a Markdown bullet")
+
+        fragments.append(Fragment(_fragment_number(path), path, content))
+
+    return sorted(fragments, key=lambda fragment: fragment.number)
+
+
+def compile_changelog(changelog: str, fragments: list[Fragment]) -> str:
+    """Return *changelog* with fragment bullets inserted under Unreleased."""
+
+    ordered_fragments = sorted(fragments, key=lambda fragment: fragment.number)
+    if not ordered_fragments:
+        return changelog
+
+    lines = changelog.splitlines(keepends=True)
+    heading_index = next(
+        (i for i, line in enumerate(lines) if line.rstrip() == "## Unreleased"), None
+    )
+    if heading_index is None:
+        first_version_index = next(
+            (i for i, line in enumerate(lines) if line.startswith("## v")), len(lines)
+        )
+        lines.insert(first_version_index, "## Unreleased\n")
+        heading_index = first_version_index
+
+    body_start = heading_index + 1
+    body_end = len(lines)
+    for index in range(body_start, len(lines)):
+        if lines[index].startswith("## "):
+            body_end = index
+            break
+
+    existing = "".join(lines[body_start:body_end]).strip()
+    if existing == PLACEHOLDER:
+        existing = ""
+
+    sections = [fragment.content for fragment in ordered_fragments]
+    if existing:
+        sections.append(existing)
+
+    compiled_body = "\n\n".join(sections)
+    return "".join(lines[:body_start]) + f"\n\n{compiled_body}\n" + "".join(lines[body_end:])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="repository root")
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="update CHANGELOG.md and remove compiled fragments; default is a dry run",
+    )
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    changelog_path = root / "CHANGELOG.md"
+    fragment_dir = root / "changelog.d"
+    try:
+        fragments = collect_fragments(fragment_dir)
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+    if not fragments:
+        print("No changelog fragments to compile.")
+        return 0
+
+    changelog = changelog_path.read_text(encoding="utf-8")
+    try:
+        compiled = compile_changelog(changelog, fragments)
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+    numbers = ", ".join(f"#{fragment.number}" for fragment in fragments)
+
+    if not args.write:
+        print(f"Ready to compile {numbers} into CHANGELOG.md.")
+        return 0
+
+    changelog_path.write_text(compiled, encoding="utf-8")
+    for fragment in fragments:
+        fragment.path.unlink()
+
+    print(f"Compiled {numbers} into CHANGELOG.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_compile_changelog.py
+++ b/tests/unit/test_compile_changelog.py
@@ -1,0 +1,117 @@
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from scripts.compile_changelog import (
+    Fragment,
+    collect_fragments,
+    compile_changelog,
+    main,
+)
+
+
+def run_compiler(root: Path, *, write: bool = False) -> tuple[int, str, str]:
+    stdout = StringIO()
+    stderr = StringIO()
+    argv = ["--root", str(root)]
+    if write:
+        argv.append("--write")
+
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        returncode = main(argv)
+    return returncode, stdout.getvalue(), stderr.getvalue()
+
+
+def test_compile_replaces_placeholder_with_number_ordered_fragments() -> None:
+    changelog = "# Changelog\n\n## Unreleased\n\n_Nothing yet._\n\n## v1.0.0\n\n- Shipped.\n"
+    fragments = [
+        Fragment(457, Path("457.md"), "- Later contribution.\n"),
+        Fragment(456, Path("456.md"), "- First contribution.\n"),
+    ]
+
+    result = compile_changelog(changelog, fragments)
+
+    assert result.index("- First contribution.") < result.index("- Later contribution.")
+    assert "_Nothing yet._" not in result
+    assert "- Shipped." in result
+    assert "## v1.0.0" in result
+
+
+def test_cli_rejects_non_numeric_fragment_name(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "CHANGELOG.md").write_text("# Changelog\n\n## Unreleased\n\n", encoding="utf-8")
+    fragment = root / "changelog.d" / "feature.md"
+    fragment.parent.mkdir()
+    fragment.write_text("- New contribution.\n", encoding="utf-8")
+
+    returncode, _, stderr = run_compiler(root)
+
+    assert returncode != 0
+    assert "must be a PR number" in stderr
+
+
+def test_cli_creates_missing_unreleased_heading(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "CHANGELOG.md").write_text("# Changelog\n\n## v1.0.0\n", encoding="utf-8")
+    fragment = root / "changelog.d" / "456.md"
+    fragment.parent.mkdir()
+    fragment.write_text("- New contribution.\n", encoding="utf-8")
+
+    returncode, _, stderr = run_compiler(root, write=True)
+
+    assert returncode == 0, stderr
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert changelog.index("## Unreleased") < changelog.index("## v1.0.0")
+    assert "- New contribution." in changelog
+
+
+def test_compile_preserves_existing_unreleased_entries(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## Unreleased\n\n- Already merged.\n\n## v1.0.0\n", encoding="utf-8"
+    )
+    fragment_dir = root / "changelog.d"
+    fragment_dir.mkdir()
+    (fragment_dir / "456.md").write_text("- New contribution.\n", encoding="utf-8")
+
+    fragments = collect_fragments(fragment_dir)
+    original = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    result = compile_changelog(original, fragments)
+
+    assert result.index("- New contribution.") < result.index("- Already merged.")
+    assert "## v1.0.0" in result
+
+
+def test_cli_write_compiles_and_removes_fragments(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## Unreleased\n\n_Nothing yet._\n", encoding="utf-8"
+    )
+    fragment = root / "changelog.d" / "456.md"
+    fragment.parent.mkdir()
+    fragment.write_text("- New contribution.\n", encoding="utf-8")
+
+    returncode, _, stderr = run_compiler(root, write=True)
+
+    assert returncode == 0, stderr
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "- New contribution." in changelog
+    assert not fragment.exists()
+
+
+def test_cli_dry_run_preserves_files(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## Unreleased\n\n_Nothing yet._\n", encoding="utf-8"
+    )
+    fragment = root / "changelog.d" / "456.md"
+    fragment.parent.mkdir()
+    fragment.write_text("- New contribution.\n", encoding="utf-8")
+
+    returncode, stdout, stderr = run_compiler(root)
+
+    assert returncode == 0, stderr
+    assert "Ready to compile #456" in stdout
+    assert fragment.exists()
+    assert "_Nothing yet._" in (root / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #456

## What
- Adds `changelog.d/<PR-number>.md` as the contribution workflow for changelog entries.
- Adds a deterministic stdlib compiler that orders fragments by PR number and removes them after compilation.
- Supports both the legacy `Unreleased` section and the current release history without one, creating a fresh section at compile time.
- Updates contributor and maintainer workflows; this PR ships its own `456.md` fragment to exercise the convention.

## Validation
- `.venv/bin/pytest tests/unit/test_compile_changelog.py` — 6 passed.
- `.venv/bin/ruff check .` — passed.
- `.venv/bin/ruff format --check .` — 393 files already formatted.
- `python scripts/check_markdown_links.py` — checked 33 Markdown files, no broken links.
- `.venv/bin/lint-imports` — all 4 contracts kept.
- Full suite: **3213 passed, 12 skipped**, coverage **90.59%**. One unrelated integration test fails on a clean `origin/main` checkout in this local environment (`doberman` missing from an isolated plugin env); it is not touched by this diff.

