### PR TITLE
feat(cli): doberman uninstall --global — device-wide removal, then the package itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
 [git log](https://github.com/DobermanCore/Doberman-Core/commits/main) and
 [releases](https://github.com/DobermanCore/Doberman-Core/releases) (latest: **v0.18.3**, the second friction-reduction patch — opt-in tap-to-approve 2FA (a Windows Hello / Touch ID biometric can stand in for the TOTP code) — atop **v0.18.2**'s friction-reduction patch — spurious secret-detector prompts on ordinary ids/paths/UUIDs fixed, and the detector now self-checks and fails closed — atop **v0.18.1**'s README-image docs patch and **v0.18.0**'s security-audit wave — the proxy output-secret gate closed over error and structured/embedded channels, per-user auth state and Windows-separator paths brought under control-plane protection — plus the RAND-aligned guardrail rehaul and the UX/contributor work since 0.17.1).
 
+## Unreleased
+
+- **Device-wide uninstall:** `doberman uninstall --global` now removes writable Claude Code and Codex
+  hooks, project state, possession factors, the fingerprint key, and device state before removing the
+  package through pip or pipx. The same fail-closed factor gate runs before any removal; `--yes` skips
+  only the typed `DOBERMAN` confirmation, `--dry-run` changes nothing, and `--keep-package` preserves
+  the package. Codex plugin hooks remain under `codex plugin` control.
+
 ## v0.18.3 — 2026-08-26
 
 > **Friction reduction, part two.** The second factor no longer has to be a typed code. Turn on an

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ pip install doberman-core
 After installing, run `doberman --install-completion` to enable shell tab completion.
 
 > **Note**
-> Run `doberman uninstall-hooks` before `pip uninstall doberman-core`. Uninstalling the package first
-> leaves the hook entries in `settings.json` pointing at a binary that's gone, and every tool call
-> then fails with `doberman: command not found`. Already hit this? `pip install doberman-core` again;
-> the existing entries are still correct and start working immediately, no repair needed. More
-> recovery steps: [Recover](docs/RECOVERY.md).
+> Run `doberman uninstall --global` to remove Doberman from the whole machine. It removes the
+> writable Claude Code and Codex hooks, project and device state, and enrolled factors before it
+> removes the `doberman-core` package with pip or pipx. Uninstalling the package first leaves hooks
+> pointing at a missing binary. Already hit this? Reinstall `doberman-core`, then run the global
+> uninstall. More recovery steps: [Recover](docs/RECOVERY.md).
 
 | Your agent | How Doberman plugs in | Get started |
 |---|---|---|

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -61,7 +61,7 @@ Gated recovery actions for a stuck or compromised state. Each requires an enroll
 | `doberman tools approve TOOL_NAME` | Approve a changed MCP tool fingerprint after possession-factor verification. | `--path`/`-p` |
 | `doberman memory reset` | Wipe learned behavioral memory for this repo. Raise-safe by construction: a colder baseline scores everything as more novel, never less protected. | `--entity`, `--path`/`-p` |
 | `doberman memory prune` | Drop stale entities' learned memory past a retention window. A maintenance operation, so it is not gated. | `--older-than-days` (required), `--path`/`-p` |
-| `doberman uninstall` | Fully remove Doberman from this project: host hooks plus `.doberman/`. Does not touch `--global` hooks or your device-wide password, 2FA, or fingerprint key. | `--path`/`-p`, `--yes`/`-y`, `--dry-run` |
+| `doberman uninstall` | Remove Doberman from one project, or use `--global` for ordered machine-wide removal: all writable hooks, project and device state, enrolled factors, then the pip/pipx package. Codex plugin hooks remain under `codex plugin` control. | `--path`/`-p`, `--yes`/`-y`, `--dry-run`, `--global`/`-g`, `--keep-package` |
 
 ## Host hooks
 

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -50,11 +50,10 @@ never shell out to run them itself.
 ## Fully removing a project, `doberman uninstall`
 
 > **Note**
-> Run `doberman uninstall-hooks` *before* `pip uninstall doberman-core`, not after. Uninstalling the
-> package first leaves the hook entries in `settings.json` pointing at a binary that's gone, and every
-> tool call then fails with `doberman: command not found`. Already hit this? `pip install
-> doberman-core` again restores the binary; the existing hook entries are still correct and start
-> working immediately, no repair needed.
+> Run `doberman uninstall --global` instead of uninstalling `doberman-core` directly. Removing the
+> package first leaves hook entries pointing at a missing binary, and every tool call then fails with
+> `doberman: command not found`. Already hit this? Reinstall `doberman-core`; the existing entries
+> start working again. Then run the global uninstall below.
 
 `doberman uninstall-hooks` only strips the hook entries: it never touches `.doberman/`, and needs no
 authentication, which means nothing stops a protected agent that reaches a shell from disabling its
@@ -63,8 +62,37 @@ project- and local-scope hooks and the project's `.doberman/` control plane (pol
 database) in one step, gated behind an enrolled possession factor, with no confirm-only fallback and
 a hard fail-closed refusal if neither factor is enrolled. Because it's destructive and irreversible,
 it also asks you to type the project directory name back before proceeding (`--yes` skips that
-prompt; it never skips the factor check). It is deliberately project-scoped only: `--global` hooks
-and your device-wide password, 2FA, fingerprint key, and `~/.doberman/metrics.db` are shared across
-every project Doberman protects on the machine and are never touched, even on success. `uninstall` is
-itself control-plane-blocked, so a mediated agent can never shell out to run it. Same protection as
+prompt; it never skips the factor check). Without `--global`, the command remains project-scoped:
+global hooks and device-wide password, 2FA, fingerprint key, and state survive unchanged. `uninstall`
+is itself control-plane-blocked, so a mediated agent can never shell out to run it. Same protection as
 `uninstall-hooks`.
+
+## Removing Doberman from the whole machine — `doberman uninstall --global`
+
+Run this command from a regular terminal outside the protected agent session:
+
+```bash
+doberman uninstall --global --path /path/to/project
+```
+
+The command first prints every target and the package-removal command. `--dry-run` stops there and
+changes nothing. Otherwise, it requires the enrolled possession factor before removing anything,
+then asks you to type the literal word `DOBERMAN`. `--yes` skips only that typed confirmation; it
+never skips the factor check.
+
+After approval, Doberman removes these targets in order:
+
+1. Claude Code hooks from the global, project, and local settings for `--path`.
+2. Codex hooks from the user and repository settings. Plugin-scope hooks are read-only; run the
+   printed `codex plugin remove` command separately.
+3. The project's `.doberman/` directory.
+4. The TOTP enrollment, password enrollment, fingerprint key, and device-wide `.doberman/` state.
+5. The `doberman-core` package through pipx or the active Python's pip.
+
+On Windows, package removal starts in a detached helper after the command exits, which lets Windows
+release the running executable. On POSIX, removal runs before the command returns. Development
+checkouts stay installed. Add `--keep-package` to remove hooks and state but keep the package.
+
+The command continues after an individual removal failure, reports every error, and exits 1 if any
+target remains. Removing device state deletes 2FA enrollment, the password, and the fingerprint key;
+a fresh `doberman setup` enrolls new factors.

--- a/src/doberman/auth/password.py
+++ b/src/doberman/auth/password.py
@@ -60,6 +60,11 @@ def _secret_path() -> Path:
     return Path(override) if override else _default_secret_path()
 
 
+def resolve_path() -> Path:
+    """Resolve the active password enrollment file, including env overrides."""
+    return _secret_path()
+
+
 def _read_record() -> tuple[int, bytes, bytes] | None:
     """Return ``(iterations, salt, hash)`` or ``None`` if absent/malformed."""
     path = _secret_path()

--- a/src/doberman/auth/totp.py
+++ b/src/doberman/auth/totp.py
@@ -72,6 +72,11 @@ def _secret_path() -> Path:
     return Path(override) if override else _default_secret_path()
 
 
+def resolve_path() -> Path:
+    """Resolve the active TOTP enrollment file, including env overrides."""
+    return _secret_path()
+
+
 def _lockout_path(secret_path: Path) -> Path:
     """Lockout-state file colocated with the secret (same dir, same isolation).
 

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -10,14 +10,18 @@ import asyncio
 import importlib.util
 import json
 import logging
+import os
 import secrets
+import shlex
 import shutil
+import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import typer
 
+import doberman
 from doberman import __version__
 from doberman.auth import password, totp
 from doberman.auth.challenge import TIMEOUT_METHOD
@@ -83,6 +87,8 @@ def _ensure_encode_safe_stdio() -> None:
 
 
 _ensure_encode_safe_stdio()
+
+_WINDOWS = os.name == "nt"
 
 app = typer.Typer(
     help="Doberman - adaptive authorization layer for coding agents.",
@@ -1977,6 +1983,217 @@ def _project_uninstall_targets(path: str) -> list[tuple[str, str]]:
     return targets
 
 
+def _path_is_in_pipx_venv(value: str | None) -> bool:
+    if not value:
+        return False
+    parts = {part.casefold() for part in Path(value).parts}
+    return "pipx" in parts and "venvs" in parts
+
+
+def _package_remover() -> tuple[str, list[str]]:
+    """Return the detected package-install kind and its removal argv."""
+    if _path_is_in_pipx_venv(sys.executable) or _path_is_in_pipx_venv(shutil.which("doberman")):
+        return "pipx", ["pipx", "uninstall", "doberman-core"]
+
+    package_file = Path(doberman.__file__ or "").resolve()
+    package_dir = package_file.parent
+    if (
+        package_dir.name == "doberman"
+        and package_dir.parent.name == "src"
+        and (package_dir.parent.parent / "pyproject.toml").is_file()
+    ):
+        return "development", []
+
+    return "pip", [sys.executable, "-m", "pip", "uninstall", "-y", "doberman-core"]
+
+
+def _format_command(argv: list[str]) -> str:
+    return subprocess.list2cmdline(argv) if _WINDOWS else shlex.join(argv)
+
+
+def _global_uninstall_targets(path: str) -> tuple[list[tuple[str, str]], str, list[str]]:
+    """Every global-uninstall plan entry, including absent and read-only targets."""
+    from doberman.hosthooks.install_codex import codex_hook_install_states
+    from doberman.storage import device_metrics, fingerprint
+
+    claude_states = {scope: settings_path for scope, settings_path, _ in _hook_install_states(path)}
+    codex_states = {scope: hooks_path for scope, hooks_path, _ in codex_hook_install_states(path)}
+    kind, argv = _package_remover()
+    targets = [
+        ("Claude Code hooks (global)", claude_states["global"]),
+        ("Claude Code hooks (project)", claude_states["project"]),
+        ("Claude Code hooks (local)", claude_states["local"]),
+        ("Codex CLI hooks (user)", codex_states["user"]),
+        ("Codex CLI hooks (repo)", codex_states["repo"]),
+        ("Codex CLI hooks (plugin scope; not writable)", codex_states["plugin"]),
+        (".doberman/ (policy + decision database)", str(Path(path) / CONFIG_DIR)),
+        ("TOTP enrollment", str(totp.resolve_path())),
+        ("password enrollment", str(password.resolve_path())),
+        ("fingerprint key", str(fingerprint.resolve_path())),
+        ("device-wide state directory", str(device_metrics.resolve_path())),
+        ("package", _format_command(argv) if argv else "development install; left in place"),
+    ]
+    return targets, kind, argv
+
+
+def _remove_file(path: Path, errors: list[str]) -> None:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        errors.append(f"{path}: {exc}")
+
+
+def _launch_package_removal(argv: list[str], errors: list[str]) -> None:
+    command = _format_command(argv)
+    typer.echo(f"package removal command: {command}")
+    if _WINDOWS:
+        try:
+            subprocess.Popen(  # noqa: S603 — fixed package-manager argv, delayed for locked files
+                ["cmd", "/c", f"ping -n 3 127.0.0.1 >nul & {command}"],  # noqa: S607 — ping = 2 s delay; `timeout` aborts on redirected stdin
+                creationflags=getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+                | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200),
+                close_fds=True,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except OSError as exc:
+            errors.append(f"package removal ({command}): {exc}")
+            return
+        typer.echo(f"package removal scheduled: {command} (runs after this command exits)")
+        return
+
+    try:
+        completed = subprocess.run(argv, check=False)  # noqa: S603 — fixed package-manager argv
+    except OSError as exc:
+        errors.append(f"package removal ({command}): {exc}")
+        return
+    typer.echo(f"package removal exit code: {completed.returncode}")
+    if completed.returncode != 0:
+        errors.append(f"package removal ({command}): exit code {completed.returncode}")
+
+
+def _uninstall_global(path: str, yes: bool, dry_run: bool, keep_package: bool) -> None:
+    from doberman.hosthooks.install import (
+        load_settings,
+        remove_doberman_hooks,
+        resolve_settings_path,
+        write_settings,
+    )
+    from doberman.hosthooks.install_codex import (
+        codex_hook_install_states,
+        remove_codex_hooks,
+        resolve_codex_hooks_path,
+    )
+    from doberman.storage import device_metrics, fingerprint
+
+    targets, package_kind, package_argv = _global_uninstall_targets(path)
+    typer.echo(f"Doberman GLOBAL UNINSTALL requested for this device ({Path(path).resolve()}):")
+    for description, target_path in targets:
+        typer.echo(f"  - {description}: {target_path}")
+    typer.echo("")
+    typer.echo("Codex plugin-scope hooks are not writable by Doberman.")
+    typer.echo("  Run `codex plugin remove doberman` if that plugin is installed.")
+
+    if dry_run:
+        typer.echo("")
+        typer.echo("[dry-run] nothing removed.")
+        return
+
+    if not totp.is_enrolled() and not password.is_enrolled():
+        typer.echo(
+            "\nerror: uninstalling requires an enrolled possession factor - "
+            "run `doberman 2fa setup` or `doberman password set` first",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    prompter = CliPrompter()
+    try:
+        if not yes:
+            typed = typer.prompt("Type DOBERMAN to confirm device-wide removal")
+            if typed.strip() != "DOBERMAN":
+                typer.echo("error: uninstall denied (DOBERMAN did not match); unchanged", err=True)
+                raise typer.Exit(code=1)
+        approved, method = _verify_possession_factor(
+            prompter, action_label="uninstalling Doberman from this device"
+        )
+    except typer.Exit:
+        raise
+    except Exception:  # noqa: BLE001 — any input/EOF/timeout error denies the uninstall
+        approved, method = False, "denied"
+    if not approved:
+        typer.echo(f"error: uninstall denied ({method}); unchanged", err=True)
+        raise typer.Exit(code=1)
+
+    errors: list[str] = []
+    claude_installed = {
+        scope: installed for scope, _settings_path, installed in _hook_install_states(path)
+    }
+    for scope in ("global", "project", "local"):
+        if not claude_installed.get(scope):
+            continue
+        target = resolve_settings_path(scope, path)
+        try:
+            write_settings(target, remove_doberman_hooks(load_settings(target)))
+        except (ValueError, OSError) as exc:
+            errors.append(f"{target}: {exc}")
+
+    codex_installed = {
+        scope: installed
+        for scope, _hooks_path, installed in codex_hook_install_states(path)
+        if scope != "plugin"
+    }
+    for scope in ("user", "repo"):
+        if not codex_installed.get(scope):
+            continue
+        target = resolve_codex_hooks_path(scope, path)
+        try:
+            write_settings(target, remove_codex_hooks(load_settings(target)))
+        except (ValueError, OSError) as exc:
+            errors.append(f"{target}: {exc}")
+
+    project_dir = Path(path) / CONFIG_DIR
+    if project_dir.exists():
+        try:
+            shutil.rmtree(project_dir)
+        except OSError as exc:
+            errors.append(f"{project_dir}: {exc}")
+
+    for target in (totp.resolve_path(), password.resolve_path(), fingerprint.resolve_path()):
+        _remove_file(target, errors)
+
+    device_dir = device_metrics.resolve_path()
+    if device_dir.exists():
+        try:
+            shutil.rmtree(device_dir)
+        except OSError as exc:
+            errors.append(f"{device_dir}: {exc}")
+
+    typer.echo(
+        "warning: device-wide 2FA enrollment, password, and fingerprint key are removed; "
+        "a fresh `doberman setup` re-enrolls them."
+    )
+
+    if keep_package:
+        if package_argv:
+            typer.echo(f"package left in place (--keep-package): {_format_command(package_argv)}")
+        else:
+            typer.echo("development install detected; package left in place")
+    elif package_kind == "development":
+        typer.echo("development install detected; package left in place")
+    else:
+        _launch_package_removal(package_argv, errors)
+
+    if errors:
+        typer.echo("error: uninstall finished with errors - some items were NOT removed:", err=True)
+        for error in errors:
+            typer.echo(f"  - {error}", err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo("\nDoberman removed from this device.")
+
+
 @app.command(rich_help_panel="Getting started")
 def uninstall(
     path: str = typer.Option(".", "--path", "-p", help="Project root (default: current dir)."),
@@ -1988,6 +2205,12 @@ def uninstall(
     ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print what would be removed; remove nothing."
+    ),
+    global_: bool = typer.Option(
+        False, "--global", "-g", help="Remove Doberman from the whole device."
+    ),
+    keep_package: bool = typer.Option(
+        False, "--keep-package", help="Remove hooks and state, but leave the package installed."
     ),
 ) -> None:
     """Fully remove Doberman from this project: host hooks + `.doberman/`.
@@ -2004,6 +2227,10 @@ def uninstall(
     irreversible action, so it also asks you to type the project directory name
     back before proceeding (skippable with `--yes`; the factor check is not).
     """
+    if global_:
+        _uninstall_global(path, yes, dry_run, keep_package)
+        return
+
     targets = _project_uninstall_targets(path)
     if not targets:
         typer.echo("Nothing to remove for this project.")

--- a/src/doberman/storage/device_metrics.py
+++ b/src/doberman/storage/device_metrics.py
@@ -38,6 +38,11 @@ def _db_path(home: Path | None = None) -> Path:
     return base / ".doberman" / _DB_NAME
 
 
+def resolve_path() -> Path:
+    """Resolve the device-wide state directory, including ``DOBERMAN_HOME``."""
+    return _db_path().parent
+
+
 def _restrict_permissions(path: Path) -> None:
     """Best-effort tighten the metrics dir/file to owner-only (no-op on Windows ACLs)."""
     try:

--- a/src/doberman/storage/fingerprint.py
+++ b/src/doberman/storage/fingerprint.py
@@ -66,6 +66,11 @@ def _key_path() -> Path:
     return Path(override) if override else _default_key_path()
 
 
+def resolve_path() -> Path:
+    """Resolve the active fingerprint key file, including env overrides."""
+    return _key_path()
+
+
 def _load_or_create_key() -> bytes:
     """Return the local HMAC key, generating it on first use.
 

--- a/tests/unit/test_cli_uninstall.py
+++ b/tests/unit/test_cli_uninstall.py
@@ -1,4 +1,4 @@
-"""``doberman uninstall`` (#250) — the gated, project-scoped full removal.
+"""``doberman uninstall`` — gated project or device-wide removal.
 
 Unlike `doberman uninstall-hooks` (which only strips hook entries and needs no
 auth), this command also removes the project's `.doberman/` control plane
@@ -6,22 +6,24 @@ auth), this command also removes the project's `.doberman/` control plane
 check as `doberman taint clear` / `doberman memory reset` (2FA if enrolled,
 otherwise the local password; fails closed with neither enrolled).
 
-It is deliberately project-scoped only: `--global` hooks and device-wide state
-(password hash, TOTP secret, fingerprint key, `~/.doberman/metrics.db`) are
-never touched, even on a successful run — those protect every project on the
-machine, not just this one. Every test that exercises a successful removal
-also asserts that scope boundary held.
+Without ``--global`` the command remains strictly project-scoped.  The global
+form deliberately removes every writable hook scope and device-wide secret/state
+before scheduling package removal, behind the same fail-closed factor gate.
 """
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from doberman.auth import password
 from doberman.cli import main as cli_main
 from doberman.cli.main import app
 from doberman.config import save_policy
+from doberman.hosthooks import install_codex
 from doberman.hosthooks.install import merge_doberman_hooks, resolve_settings_path, write_settings
 from doberman.hosthooks.install_codex import merge_codex_hooks, resolve_codex_hooks_path
 from doberman.policy.checklist import recommend_policy
@@ -29,6 +31,16 @@ from doberman.policy.checklist import recommend_policy
 runner = CliRunner()
 
 _PASSWORD = "correct horse battery staple"  # noqa: S105 — synthetic test credential
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """No uninstall probe may inspect the real Claude/Codex user settings."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(exist_ok=True)
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    monkeypatch.setattr(install_codex, "_PLUGIN_ROOT", fake_home / ".codex" / "plugins" / "cache")
+    return fake_home
 
 
 class _WrongCode:
@@ -72,6 +84,14 @@ def _install_local_hooks(root: str) -> None:
 
 def _install_codex_repo_hooks(root: str) -> None:
     write_settings(resolve_codex_hooks_path("repo", root), merge_codex_hooks({}))
+
+
+def _install_global_hooks(root: str) -> None:
+    write_settings(resolve_settings_path("global", root), merge_doberman_hooks({"theme": "dark"}))
+
+
+def _install_codex_user_hooks(root: str) -> None:
+    write_settings(resolve_codex_hooks_path("user", root), merge_codex_hooks({"notify": "foreign"}))
 
 
 def _make_doberman_dir(root: str) -> None:
@@ -322,3 +342,372 @@ def test_denied_output_never_contains_the_password(tmp_path, monkeypatch):
 
     assert result.exit_code == 1
     assert _PASSWORD not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Device-wide removal (--global)
+# ---------------------------------------------------------------------------
+
+
+def _seed_global_targets(
+    tmp_path,
+    monkeypatch,
+    isolated_totp_secret,
+    isolated_password_hash,
+    isolated_fingerprint_key,
+    isolated_device_metrics_home,
+):
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir(exist_ok=True)
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    root = tmp_path / "project"
+    root.mkdir(exist_ok=True)
+    root_text = str(root)
+
+    password.enroll(_PASSWORD)
+    isolated_totp_secret.write_text("", encoding="utf-8")  # target exists, but is not enrolled
+    isolated_fingerprint_key.write_bytes(b"x" * 32)
+    device_dir = isolated_device_metrics_home / ".doberman"
+    device_dir.mkdir(parents=True)
+    (device_dir / "metrics.db").write_bytes(b"metrics")
+    (device_dir / "telemetry-state.json").write_text("{}", encoding="utf-8")
+
+    for scope in ("project", "local"):
+        write_settings(
+            resolve_settings_path(scope, root_text),
+            merge_doberman_hooks({"foreign": scope}),
+        )
+    _install_global_hooks(root_text)
+    write_settings(
+        resolve_codex_hooks_path("repo", root_text),
+        merge_codex_hooks({"foreign": "repo"}),
+    )
+    _install_codex_user_hooks(root_text)
+    _make_doberman_dir(root_text)
+    return root_text, device_dir
+
+
+def _plain_package(monkeypatch):
+    argv = [sys.executable, "-m", "pip", "uninstall", "-y", "doberman-core"]
+    monkeypatch.setattr(cli_main, "_package_remover", lambda: ("pip", argv))
+    return argv
+
+
+def test_global_dry_run_lists_every_target_and_removes_nothing(
+    tmp_path,
+    monkeypatch,
+    isolated_totp_secret,
+    isolated_password_hash,
+    isolated_fingerprint_key,
+    isolated_device_metrics_home,
+):
+    root, device_dir = _seed_global_targets(
+        tmp_path,
+        monkeypatch,
+        isolated_totp_secret,
+        isolated_password_hash,
+        isolated_fingerprint_key,
+        isolated_device_metrics_home,
+    )
+    argv = _plain_package(monkeypatch)
+
+    result = runner.invoke(app, ["uninstall", "--global", "--path", root, "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    for label in (
+        "Claude Code hooks (global)",
+        "Claude Code hooks (project)",
+        "Claude Code hooks (local)",
+        "Codex CLI hooks (user)",
+        "Codex CLI hooks (repo)",
+        "Codex CLI hooks (plugin scope; not writable)",
+        ".doberman/ (policy + decision database)",
+        "TOTP enrollment",
+        "password enrollment",
+        "fingerprint key",
+        "device-wide state directory",
+        "package",
+    ):
+        assert label in result.output
+    assert "codex plugin remove" in result.output
+    assert subprocess.list2cmdline(argv) in result.output
+    assert _doberman_dir_exists(root)
+    assert isolated_totp_secret.exists()
+    assert isolated_password_hash.exists()
+    assert isolated_fingerprint_key.exists()
+    assert device_dir.exists()
+    assert json.loads(resolve_settings_path("global", root).read_text(encoding="utf-8"))["hooks"]
+
+
+def test_global_no_factor_refuses_without_removing_anything(
+    tmp_path, monkeypatch, isolated_totp_secret, isolated_fingerprint_key
+):
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    root = str(tmp_path / "project")
+    Path(root).mkdir()
+    _install_global_hooks(root)
+    _make_doberman_dir(root)
+    isolated_totp_secret.write_text("", encoding="utf-8")
+    isolated_fingerprint_key.write_bytes(b"x" * 32)
+    _plain_package(monkeypatch)
+
+    result = runner.invoke(app, ["uninstall", "--global", "--path", root, "--yes"])
+
+    assert result.exit_code == 1
+    assert "2fa setup" in result.output or "password set" in result.output
+    assert _doberman_dir_exists(root)
+    assert isolated_totp_secret.exists()
+    assert isolated_fingerprint_key.exists()
+    assert json.loads(resolve_settings_path("global", root).read_text(encoding="utf-8"))["hooks"]
+
+
+def test_global_wrong_factor_keeps_factor_files_and_all_targets(
+    tmp_path,
+    monkeypatch,
+    isolated_totp_secret,
+    isolated_password_hash,
+    isolated_fingerprint_key,
+    isolated_device_metrics_home,
+):
+    root, device_dir = _seed_global_targets(
+        tmp_path,
+        monkeypatch,
+        isolated_totp_secret,
+        isolated_password_hash,
+        isolated_fingerprint_key,
+        isolated_device_metrics_home,
+    )
+    _plain_package(monkeypatch)
+    _use_prompter(monkeypatch, lambda: _WrongCode())
+
+    result = runner.invoke(app, ["uninstall", "--global", "--path", root, "--yes"])
+
+    assert result.exit_code == 1
+    assert "denied" in result.output
+    assert isolated_totp_secret.exists()
+    assert isolated_password_hash.exists()
+    assert isolated_fingerprint_key.exists()
+    assert device_dir.exists()
+    assert _doberman_dir_exists(root)
+
+
+def test_global_typed_word_mismatch_refuses_unchanged(
+    tmp_path,
+    monkeypatch,
+    isolated_totp_secret,
+    isolated_password_hash,
+    isolated_fingerprint_key,
+    isolated_device_metrics_home,
+):
+    root, device_dir = _seed_global_targets(
+        tmp_path,
+        monkeypatch,
+        isolated_totp_secret,
+        isolated_password_hash,
+        isolated_fingerprint_key,
+        isolated_device_metrics_home,
+    )
+    _plain_package(monkeypatch)
+    _use_prompter(monkeypatch, lambda: _CorrectCode(_PASSWORD))
+
+    result = runner.invoke(app, ["uninstall", "--global", "--path", root], input="NOT-DOBERMAN\n")
+
+    assert result.exit_code == 1
+    assert "did not match" in result.output
+    assert isolated_password_hash.exists()
+    assert device_dir.exists()
+    assert _doberman_dir_exists(root)
+
+
+def test_global_success_removes_all_writable_targets_then_schedules_package(
+    tmp_path,
+    monkeypatch,
+    isolated_totp_secret,
+    isolated_password_hash,
+    isolated_fingerprint_key,
+    isolated_device_metrics_home,
+):
+    root, device_dir = _seed_global_targets(
+        tmp_path,
+        monkeypatch,
+        isolated_totp_secret,
+        isolated_password_hash,
+        isolated_fingerprint_key,
+        isolated_device_metrics_home,
+    )
+    argv = _plain_package(monkeypatch)
+    _use_prompter(monkeypatch, lambda: _CorrectCode(_PASSWORD))
+    monkeypatch.setattr(cli_main, "_WINDOWS", True)
+    popen_calls = []
+    monkeypatch.setattr(cli_main.subprocess, "Popen", lambda *a, **kw: popen_calls.append((a, kw)))
+    monkeypatch.setattr(
+        cli_main.subprocess,
+        "run",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("must not run synchronously")),
+    )
+
+    result = runner.invoke(app, ["uninstall", "--global", "--path", root, "--yes"])
+
+    assert result.exit_code == 0, result.output
+    for scope in ("global", "project", "local"):
+        data = json.loads(resolve_settings_path(scope, root).read_text(encoding="utf-8"))
+        assert not data.get("hooks", {}).get("PreToolUse")
+        assert data.get("foreign") == scope or data.get("theme") == "dark"
+    for scope in ("user", "repo"):
+        data = json.loads(resolve_codex_hooks_path(scope, root).read_text(encoding="utf-8"))
+        assert not data.get("hooks", {}).get("PreToolUse")
+        assert data.get("notify") == "foreign" or data.get("foreign") == "repo"
+    assert not _doberman_dir_exists(root)
+    assert not isolated_totp_secret.exists()
+    assert not isolated_password_hash.exists()
+    assert not isolated_fingerprint_key.exists()
+    assert not device_dir.exists()
+    assert len(popen_calls) == 1
+    popen_args, popen_kwargs = popen_calls[0]
+    assert popen_args[0][:2] == ["cmd", "/c"]
+    assert subprocess.list2cmdline(argv) in popen_args[0][2]
+    assert popen_kwargs["stdin"] is subprocess.DEVNULL
+    assert "package removal scheduled" in result.output
+    assert "fresh `doberman setup` re-enrolls" in result.output
+
+
+def test_global_keep_package_prints_command_without_spawning(
+    tmp_path, monkeypatch, isolated_password_hash
+):
+    root = str(tmp_path / "project")
+    Path(root).mkdir()
+    password.enroll(_PASSWORD)
+    _make_doberman_dir(root)
+    _use_prompter(monkeypatch, lambda: _CorrectCode(_PASSWORD))
+    argv = _plain_package(monkeypatch)
+    monkeypatch.setattr(
+        cli_main.subprocess,
+        "Popen",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("must not spawn")),
+    )
+    monkeypatch.setattr(
+        cli_main.subprocess,
+        "run",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("must not run")),
+    )
+
+    result = runner.invoke(
+        app, ["uninstall", "--global", "--keep-package", "--path", root, "--yes"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert subprocess.list2cmdline(argv) in result.output
+    assert "package left in place (--keep-package)" in result.output
+
+
+def test_package_remover_detects_pipx_from_python_or_console_script(monkeypatch, tmp_path):
+    pipx_python = tmp_path / "pipx" / "venvs" / "doberman-core" / "Scripts" / "python.exe"
+    monkeypatch.setattr(cli_main.sys, "executable", str(pipx_python))
+    monkeypatch.setattr(cli_main.shutil, "which", lambda _name: None)
+    assert cli_main._package_remover() == ("pipx", ["pipx", "uninstall", "doberman-core"])
+
+    monkeypatch.setattr(cli_main.sys, "executable", str(tmp_path / "python.exe"))
+    console = tmp_path / "PIPX" / "VENVS" / "doberman-core" / "bin" / "doberman"
+    monkeypatch.setattr(cli_main.shutil, "which", lambda _name: str(console))
+    assert cli_main._package_remover() == ("pipx", ["pipx", "uninstall", "doberman-core"])
+
+
+def test_package_remover_detects_editable_checkout(monkeypatch, tmp_path):
+    checkout = tmp_path / "checkout"
+    package = checkout / "src" / "doberman"
+    package.mkdir(parents=True)
+    init_file = package / "__init__.py"
+    init_file.write_text("", encoding="utf-8")
+    (checkout / "pyproject.toml").write_text("[project]\nname='doberman-core'\n", encoding="utf-8")
+    monkeypatch.setattr(cli_main.sys, "executable", str(tmp_path / "python"))
+    monkeypatch.setattr(cli_main.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(cli_main.doberman, "__file__", str(init_file))
+
+    assert cli_main._package_remover() == ("development", [])
+
+
+def test_package_remover_defaults_to_current_python_pip(monkeypatch, tmp_path):
+    python = tmp_path / "python"
+    monkeypatch.setattr(cli_main.sys, "executable", str(python))
+    monkeypatch.setattr(cli_main.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        cli_main.doberman, "__file__", str(tmp_path / "site" / "doberman" / "__init__.py")
+    )
+
+    assert cli_main._package_remover() == (
+        "pip",
+        [str(python), "-m", "pip", "uninstall", "-y", "doberman-core"],
+    )
+
+
+def test_posix_package_removal_runs_synchronously_and_reports_exit(monkeypatch):
+    argv = ["python", "-m", "pip", "uninstall", "-y", "doberman-core"]
+    calls = []
+
+    class _Completed:
+        returncode = 7
+
+    monkeypatch.setattr(cli_main, "_WINDOWS", False)
+    monkeypatch.setattr(
+        cli_main.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or _Completed(),
+    )
+    errors = []
+
+    cli_main._launch_package_removal(argv, errors)
+
+    assert calls == [((argv,), {"check": False})]
+    assert errors == ["package removal (python -m pip uninstall -y doberman-core): exit code 7"]
+
+
+def test_global_failure_continues_and_reports_error(
+    tmp_path,
+    monkeypatch,
+    isolated_totp_secret,
+    isolated_password_hash,
+    isolated_fingerprint_key,
+    isolated_device_metrics_home,
+):
+    root, device_dir = _seed_global_targets(
+        tmp_path,
+        monkeypatch,
+        isolated_totp_secret,
+        isolated_password_hash,
+        isolated_fingerprint_key,
+        isolated_device_metrics_home,
+    )
+    _plain_package(monkeypatch)
+    _use_prompter(monkeypatch, lambda: _CorrectCode(_PASSWORD))
+    monkeypatch.setattr(cli_main, "_WINDOWS", True)
+    popen_calls = []
+    monkeypatch.setattr(
+        cli_main.subprocess, "Popen", lambda *a, **kw: popen_calls.append((a, kw)) or object()
+    )
+    real_rmtree = cli_main.shutil.rmtree
+    project_state = Path(root) / ".doberman"
+
+    def fail_one_rmtree(path):
+        if Path(path) == project_state:
+            raise OSError("synthetic rmtree failure")
+        return real_rmtree(path)
+
+    monkeypatch.setattr(cli_main.shutil, "rmtree", fail_one_rmtree)
+
+    result = runner.invoke(app, ["uninstall", "--global", "--path", root, "--yes"])
+
+    assert result.exit_code == 1
+    assert "synthetic rmtree failure" in result.output
+    assert project_state.exists()
+    assert not isolated_totp_secret.exists()
+    assert not isolated_password_hash.exists()
+    assert not isolated_fingerprint_key.exists()
+    assert not device_dir.exists()
+    assert len(popen_calls) == 1
+    assert (
+        not json.loads(resolve_settings_path("global", root).read_text(encoding="utf-8"))
+        .get("hooks", {})
+        .get("PreToolUse")
+    )

--- a/tests/unit/test_rule_commands_control_plane.py
+++ b/tests/unit/test_rule_commands_control_plane.py
@@ -192,6 +192,7 @@ def test_doberman_setup_is_blocked():
         "doberman tools approve fs_read",
         "doberman uninstall",
         "doberman uninstall --yes",
+        "doberman uninstall --global",
     ],
 )
 def test_doberman_posture_and_auth_mutating_verbs_are_blocked(command):


### PR DESCRIPTION
## Why

`pip uninstall doberman-core` runs no code, so anyone who removes the package first is left with hook entries pointing at a missing binary and every tool call failing with `doberman: command not found` (README / RECOVERY already warn about it). The only place that can enforce the right order is Doberman itself.

## What

`doberman uninstall --global` (`-g`) removes, in order:

1. Claude Code hooks in all three scopes for `--path` (global, project, local)
2. Codex CLI hooks (user, repo; the plugin scope is read-only and is reported with the `codex plugin remove` hint)
3. the project's `.doberman/`
4. the TOTP file, password file, fingerprint key, then the whole device state directory (each resolved through its own module, so `DOBERMAN_HOME` / `DOBERMAN_TOTP_FILE` / `DOBERMAN_PASSWORD_FILE` overrides are honoured)
5. the package: `pipx uninstall doberman-core` when installed via pipx, `python -m pip uninstall -y doberman-core` otherwise; dev/editable checkouts are left in place. On Windows the removal is scheduled in a detached `cmd` helper (2 s `ping` delay — `timeout` aborts on redirected stdin) because the running exe is locked; on POSIX it runs synchronously and reports the exit code. `--keep-package` stops before this step.

Gate (the project flow's or stronger): the possession factor is verified **before** anything is removed (the TOTP secret is among the targets); typed `DOBERMAN` confirmation (`--yes` skips only the typing, never the factor); `--dry-run` prints the full plan; refuses with neither factor enrolled; still control-plane-blocked for a mediated agent. Removal continues past individual failures and exits 1 with the list. Without `--global`, behaviour is unchanged.

## Tests

`tests/unit/test_cli_uninstall.py` (+11): dry-run lists every target and removes nothing; no factor / wrong code / typed-word mismatch refuse with the factor files still present; success removes every writable target and schedules the remover with the expected argv (Popen mocked, `subprocess.run` asserted never called); `--keep-package`; pipx / editable / pip detection; POSIX synchronous path reports a non-zero exit; a mid-way rmtree failure still removes the rest and exits 1. Control-plane test extended with `doberman uninstall --global`. All tests monkeypatch `Path.home` and the state envs into `tmp_path`.

Locally: `ruff check` / `ruff format --check` / `lint-imports` (4 kept) / focused suites green; full suite green at 91.57% coverage.

## Docs

`docs/CLI.md` row, `docs/RECOVERY.md` "Removing Doberman from the whole machine", README note now points at `--global`, CHANGELOG Unreleased. Design: ADR 0086 (memory repo).

Follow-up (not here): `doberman doctor` could detect hook entries pointing at a missing binary for users who already ran `pip uninstall` first.
