### PR TITLE
feat(doctor): critical "Hook command" check catches dangling hook entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
 
 ## Unreleased
 
+- **`doberman doctor` catches dangling hook entries.** New critical `Hook command` check: when hooks are
+  installed but the bare `doberman` they invoke is not on PATH (package removed, bin dir not on PATH), the
+  host fails the hook and carries on unmediated, so `doctor` now fails and names the fix - put the binary
+  back on PATH, or strip the entries with `doberman uninstall-hooks`. Diagnosis only; `doctor` stays
+  read-only.
 - **Device-wide uninstall:** `doberman uninstall --global` now removes writable Claude Code and Codex
   hooks, project state, possession factors, the fingerprint key, and device state before removing the
   package through pip or pipx. The same fail-closed factor gate runs before any removal; `--yes` skips

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ After installing, run `doberman --install-completion` to enable shell tab comple
 > writable Claude Code and Codex hooks, project and device state, and enrolled factors before it
 > removes the `doberman-core` package with pip or pipx. Uninstalling the package first leaves hooks
 > pointing at a missing binary. Already hit this? Reinstall `doberman-core`, then run the global
-> uninstall. More recovery steps: [Recover](docs/RECOVERY.md).
+> uninstall; `doberman doctor` flags any hook entry whose `doberman` is not on PATH. More recovery
+> steps: [Recover](docs/RECOVERY.md).
 
 | Your agent | How Doberman plugs in | Get started |
 |---|---|---|

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -128,7 +128,7 @@ Capabilities are sorted by `(category, name)` for deterministic output. Each cap
 
 ### `doberman doctor --json`
 
-Emits `{version, path, ok, checks[], critical_failures[]}`. `ok` is `true` only when every critical check (host hooks, config, decision DB) passed. Exit code stays non-zero when a critical check fails, even though the payload still prints.
+Emits `{version, path, ok, checks[], critical_failures[]}`. `ok` is `true` only when every critical check (host hooks, hook command, config, decision DB) passed. Exit code stays non-zero when a critical check fails, even though the payload still prints.
 
 ### `doberman log --jsonl`
 

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -53,7 +53,8 @@ never shell out to run them itself.
 > Run `doberman uninstall --global` instead of uninstalling `doberman-core` directly. Removing the
 > package first leaves hook entries pointing at a missing binary, and every tool call then fails with
 > `doberman: command not found`. Already hit this? Reinstall `doberman-core`; the existing entries
-> start working again. Then run the global uninstall below.
+> start working again. Then run the global uninstall below. `doberman doctor` confirms the entries
+> resolve (its `Hook command` line) and fails, naming the fix, when `doberman` is not on PATH for the host.
 
 `doberman uninstall-hooks` only strips the hook entries: it never touches `.doberman/`, and needs no
 authentication, which means nothing stops a protected agent that reaches a shell from disabling its

--- a/src/doberman/cli/doctor.py
+++ b/src/doberman/cli/doctor.py
@@ -18,6 +18,7 @@ Two safety rules, straight from the Prime Directives:
 from __future__ import annotations
 
 import os
+import shutil
 import sqlite3
 import stat
 from dataclasses import dataclass
@@ -75,6 +76,43 @@ def _check_hooks(path: str) -> CheckResult:
         "Host hooks",
         CheckStatus.FAIL,
         "not installed in any scope — run `doberman install-hooks` (add `--host codex` for Codex)",
+        critical=True,
+    )
+
+
+def _check_hook_command(path: str) -> CheckResult:
+    """Every hook entry runs the bare ``doberman`` command, so the host can only
+    execute them if ``doberman`` is on PATH. A dangling entry (package removed, or
+    its bin dir not on PATH) makes the host fail the hook and carry on
+    **unmediated** - critical whenever hooks are installed (ADR 0086 follow-up).
+
+    Diagnosis only: the fix is putting the binary back on PATH or stripping the
+    entries with ``uninstall-hooks``; ``doctor`` never edits settings. Resolution
+    happens on *this* process's PATH, which can differ from the host's, so the
+    detail says so.
+    """
+    from doberman.hosthooks.install import hook_install_states
+    from doberman.hosthooks.install_codex import codex_hook_install_states
+
+    resolved = shutil.which("doberman")
+    if resolved:
+        return CheckResult("Hook command", CheckStatus.OK, f"`doberman` resolves to {resolved}")
+    installed = any(ok for _scope, _p, ok in hook_install_states(path)) or any(
+        ok for scope, _p, ok in codex_hook_install_states(path) if scope != "plugin"
+    )
+    if not installed:
+        return CheckResult(
+            "Hook command",
+            CheckStatus.WARN,
+            "`doberman` is not on PATH (checked from this shell) - hooks installed later would not run",
+        )
+    return CheckResult(
+        "Hook command",
+        CheckStatus.FAIL,
+        "hooks call `doberman`, which is not on PATH (checked from this shell): the host cannot run "
+        "them, so tool calls go unmediated. Put the install's bin dir on PATH (or `pipx install "
+        "doberman-core`), or strip the dangling entries with `doberman uninstall-hooks` "
+        "(`--global` for the user-wide ones)",
         critical=True,
     )
 
@@ -253,6 +291,7 @@ def run_checks(path: str = ".") -> list[CheckResult]:
     """Run every health check against *path* and return the results in display order."""
     return [
         _safe_check("Host hooks", True, lambda: _check_hooks(path)),
+        _safe_check("Hook command", True, lambda: _check_hook_command(path)),
         _safe_check("Config", True, lambda: _check_config(path)),
         _safe_check("Decision DB", True, lambda: _check_db(path)),
         _safe_check("Enforcement", False, lambda: _check_enforcement(path)),

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -44,6 +44,22 @@ runner = CliRunner()
 _NOW = datetime(2026, 7, 11, tzinfo=timezone.utc)
 
 
+@pytest.fixture(autouse=True)
+def _doberman_on_path(monkeypatch):
+    """Pin `doberman` as resolvable so the healthy fixture never depends on the test
+    runner's PATH; the hook-command tests below override this explicitly."""
+    import shutil
+
+    real_which = shutil.which
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda name, *a, **k: (
+            "/venv/bin/doberman" if name == "doberman" else real_which(name, *a, **k)
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fixture builders
 # ---------------------------------------------------------------------------
@@ -320,3 +336,61 @@ def test_doctor_hooks_detected_per_scope(tmp_path, scope):
     hooks = next(r for r in results if r.name == "Host hooks")
     assert hooks.status is CheckStatus.OK
     assert scope in hooks.detail
+
+
+# ---------------------------------------------------------------------------
+# Hook command: the bare `doberman` the host will run must resolve (ADR 0086 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def test_hook_command_resolves_reports_ok(tmp_path, monkeypatch):
+    import shutil
+
+    monkeypatch.setattr(
+        shutil, "which", lambda name: "/venv/bin/doberman" if name == "doberman" else None
+    )
+
+    results = run_checks(str(tmp_path))
+    check = next(r for r in results if r.name == "Hook command")
+    assert check.status is CheckStatus.OK
+    assert "/venv/bin/doberman" in check.detail
+
+
+def test_dangling_hooks_fail_critical_and_name_the_fix(tmp_path, monkeypatch):
+    import shutil
+
+    root = str(tmp_path)
+    _make_healthy(root)  # hooks installed and everything else green
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+
+    result = runner.invoke(app, ["doctor", "--path", root])
+    assert result.exit_code == 1
+    assert "[FAIL] Hook command: hooks call `doberman`" in result.stdout
+    assert "uninstall-hooks" in result.stdout
+    assert "error: 1 critical check(s) not healthy" in result.stdout
+
+
+def test_missing_binary_without_hooks_only_warns(tmp_path, monkeypatch):
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+
+    results = run_checks(str(tmp_path))
+    check = next(r for r in results if r.name == "Hook command")
+    assert check.status is CheckStatus.WARN
+    assert not check.critical
+
+
+def test_dangling_hooks_surface_in_json(tmp_path, monkeypatch):
+    import json
+    import shutil
+
+    root = str(tmp_path)
+    _make_healthy(root)
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+
+    result = runner.invoke(app, ["doctor", "--path", root, "--json"])
+    payload = json.loads(result.stdout)
+    assert result.exit_code == 1
+    assert payload["ok"] is False
+    assert "Hook command" in payload["critical_failures"]


### PR DESCRIPTION
## Why

Follow-up to #477 (ADR 0086). Hook entries are the bare `doberman hook …`, so when the package is removed — or its bin dir is not on the host's PATH — Claude Code / Codex fail the hook and **carry on unmediated**. Nothing surfaced that state; `doberman doctor` reported "Host hooks: installed" and looked green.

## What

- New **`Hook command`** check in `doberman doctor` (`src/doberman/cli/doctor.py`), listed right after `Host hooks`:
  - `[ ok ]` — `doberman` resolves on PATH; the detail prints the resolved path (a second, stale install earlier on PATH becomes visible here).
  - `[FAIL]` (**critical**, exit 1) — hooks are installed in any writable Claude/Codex scope but `doberman` does not resolve. The detail names both fixes: put the install's bin dir on PATH (or `pipx install doberman-core`), or strip the dangling entries with `doberman uninstall-hooks` (`--global` for user-wide ones).
  - `[warn]` (non-critical) — nothing installed and no `doberman` on PATH.
  - Resolution uses this process's PATH, which can differ from the host's; the detail says so.
- **Diagnosis only.** `doctor` keeps its read-only contract — it never edits settings. Stripping stays with the existing, gated `uninstall-hooks` / `uninstall` commands.
- Docs: `docs/CLI.md` (critical-check list for `--json`), `docs/RECOVERY.md` + README pip-uninstall notes, CHANGELOG Unreleased.

## Tests

`tests/unit/test_cli_doctor.py`: resolvable → OK with the path; installed + unresolvable → critical FAIL, exit 1, message names `uninstall-hooks`; unresolvable without hooks → WARN, non-critical; `--json` lists `Hook command` under `critical_failures`. An autouse fixture pins `shutil.which("doberman")` so the healthy fixture never depends on the test runner's PATH. Read-only invariant test unchanged and still passing.

Not covered here: the case where the package is already gone — `doctor` cannot run without a binary; the docs keep saying "reinstall first".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7XD6aDzEdRfMz7H2XJ8L3
