### PR TITLE
ci(secret-scan): run the gitleaks CLI instead of gitleaks-action (unblocks fork PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
-      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+      # The gitleaks CLI, not gitleaks-action: the action demands GITLEAKS_LICENSE on
+      # org repos, and fork PRs cannot read secrets, so every contributor PR failed here
+      # after the 2026-08-25 org move. The CLI (MIT) needs no key. Pinned + checksum-verified.
+      - name: Install gitleaks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}  # org repos need a (free) key: gitleaks.io
-          GITLEAKS_ENABLE_COMMENTS: "false"
-          GITLEAKS_ENABLE_SUMMARY: "true"
+          GITLEAKS_VERSION: "8.30.1"
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP"
+          curl -sSfL -o gitleaks.tar.gz             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+          ./gitleaks version
+      - name: Scan the full git history
+        run: |
+          "$RUNNER_TEMP/gitleaks" git --no-banner --redact --exit-code 1             --report-format json --report-path "$RUNNER_TEMP/gitleaks-report.json" .


### PR DESCRIPTION
## Why

Every contributor PR has failed `secret-scan` since the repo moved to the `DobermanCore` org on 2026-08-25: `gitleaks-action` requires `GITLEAKS_LICENSE` on organization repos, and **fork pull requests cannot read repository/org secrets**. Same-repo PRs kept passing (they can read the secret), which hid the breakage. 13 open PRs are red for this reason alone.

## What

The job now runs the gitleaks **CLI** (MIT-licensed tool; no key required) instead of the action:

- download the pinned release `v8.30.1` (`linux_x64`), verify its published sha256, run `gitleaks version`;
- `gitleaks git --no-banner --redact --exit-code 1 .` over the **full git history** (`fetch-depth: 0` unchanged), using the repo's existing `.gitleaks.toml`;
- job id/name `secret-scan` unchanged, so branch protection keeps requiring it.

Nothing is skipped or weakened: the scan still runs on every push to `main` and every PR, and still fails the build on any finding. The action's PR-comment feature was already off; its job summary is replaced by the redacted CLI output in the job log.

This PR's own run exercises the new job. After merge, the open contributor PRs need a fresh `pull_request` event (rebase/push, or close-and-reopen) to pick up the workflow from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7XD6aDzEdRfMz7H2XJ8L3
