### PR TITLE
docs(contributors): add @AmirF194

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ testing, or ideas. Thank you. 🐕
 
 In alphabetical order by handle (ordering is not a ranking):
 
+- [@AmirF194](https://github.com/AmirF194)
 - [@AshSgDe29071999](https://github.com/AshSgDe29071999)
 - [@averyquinnhq](https://github.com/averyquinnhq)
 - [@Bestpart-Irene](https://github.com/Bestpart-Irene)


### PR DESCRIPTION
Adds @AmirF194 to CONTRIBUTORS.md after #445 (calibrate_perplexity_threshold, issue #234). Alphabetical by handle.