### PR TITLE
feat(telemetry): on by default with a one-time first-run notice; ship the PostHog key

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -19,3 +19,8 @@ description = "Synthetic, secret-shaped test fixtures (not real credentials)"
 paths = [
   '''tests/.*''',
 ]
+# PostHog project keys (`phc_…`) are public ingestion keys, committed by design so the
+# CLI and landing page can report anonymous usage (ADR 0084 / 0087; docs/TELEMETRY.md).
+regexes = [
+  '''phc_[A-Za-z0-9]{40,}''',
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Shipped history for Doberman. Planned work lives on the [roadmap](README.md#road
 
 ## Unreleased
 
+- **Telemetry is now on by default (opt-out).** Anonymous usage counts (the same five allowlisted
+  events, no paths, prompts, secrets, or profiles) are sent unless you turn them off; the first CLI
+  command prints a one-line notice to stderr before anything is sent, `doberman setup` asks with a
+  default of Yes, and `doberman telemetry off`, `DO_NOT_TRACK`, `DOBERMAN_TELEMETRY=0`, and `CI`
+  still switch it off. The PostHog project key ships in the package, so events flow from this
+  version on.
 - **`doberman demo --quiet`:** suppresses the banner, the per-scenario narration, and the closing
   `doberman dash` hint, keeping only the summary line/table (silent on a full match, loud on a
   mismatch) and the exit code — so `demo` can run as a CI smoke test ("is the engine alive")

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ After installing, run `doberman --install-completion` to enable shell tab comple
 doberman setup      # pick a strictness mode, tune guardrails, wire the hooks
 ```
 
-Setup asks once whether to send anonymous usage counts (off by default); see [Telemetry](docs/TELEMETRY.md).
+Anonymous usage counts are on by default (command names and daily totals, never paths, prompts, or
+secrets); the first command prints a notice, and `doberman telemetry off` or `DO_NOT_TRACK=1` turns
+them off. See [Telemetry](docs/TELEMETRY.md).
 
 Doberman now reviews every tool call your agent makes. Confirm it with `doberman doctor`, or watch
 real verdicts with `doberman demo`. MCP-proxy wiring, the dashboard, the TUI, scan, and 2FA are in the

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,8 +1,11 @@
 # Telemetry
 
 Doberman can send anonymous usage counts so we know which commands and modes people use, and
-whether they keep using it. Telemetry is off by default. `doberman setup` asks once on its
-interactive path; `doberman setup --yes` leaves it off and does not ask.
+whether they keep using it. Telemetry is **on by default**: the first command you run prints a
+one-line notice saying so, and nothing is sent until that notice has been shown. `doberman setup`
+asks once on its interactive path (default Yes); `doberman setup --yes` keeps the default and
+prints the notice instead of asking. Turn it off at any time with `doberman telemetry off` or any
+kill switch below; that choice is recorded and never asked again.
 
 ## What is sent
 
@@ -53,7 +56,8 @@ doberman telemetry status
 doberman telemetry off
 ```
 
-The interactive `doberman setup` flow can also turn it on. The default answer is No.
+`doberman telemetry status` says `enabled (default; ...)` until you make an explicit choice. The
+interactive `doberman setup` flow asks once; the default answer is Yes.
 
 These environment variables force telemetry off even when the local state says enabled:
 

--- a/src/doberman/cli/telemetry_cmd.py
+++ b/src/doberman/cli/telemetry_cmd.py
@@ -1,11 +1,12 @@
-"""Typer commands and small CLI-only wiring for opt-in telemetry."""
+"""Typer commands and small CLI-only wiring for default-on, opt-out telemetry."""
 
 from __future__ import annotations
 
 import typer
 
 telemetry_app = typer.Typer(
-    help="Anonymous usage telemetry (off by default).", no_args_is_help=True
+    help="Anonymous usage telemetry (on by default; `doberman telemetry off` stops it).",
+    no_args_is_help=True,
 )
 
 _NESTED_GROUPS = ("2fa", "password", "taint", "tools", "memory", "role")
@@ -17,6 +18,9 @@ def _record_command(command: str | None) -> None:
         return
     from doberman import telemetry
 
+    notice = telemetry.first_run_notice()
+    if notice:
+        typer.echo(notice, err=True)
     telemetry.capture("cli_command", {"command": command})
     telemetry.maybe_send_usage_summary()
 
@@ -43,17 +47,20 @@ def register_cli_telemetry(root_app: typer.Typer, *sub_apps: typer.Typer) -> Non
 
 
 def configure_setup_consent(non_interactive: bool) -> None:
-    """Ask the setup-only consent question; ``--yes`` stays silent and off."""
-    if non_interactive:
-        return
+    """Ask the setup-only consent question; ``--yes`` keeps the default (on) and prints the notice."""
     from doberman import telemetry
 
+    if non_interactive:
+        notice = telemetry.first_run_notice()
+        if notice:
+            typer.echo(notice, err=True)
+        return
     typer.echo("")
     typer.echo(
         "Counts and command names only. Never paths, prompts, secrets, or reason payloads. "
         "See docs/TELEMETRY.md."
     )
-    if typer.confirm("Send anonymous usage stats to help improve Doberman?", default=False):
+    if typer.confirm("Send anonymous usage stats to help improve Doberman?", default=True):
         telemetry.enable()
     else:
         telemetry.disable()
@@ -99,7 +106,11 @@ def telemetry_status() -> None:
     from doberman import telemetry
 
     state = telemetry.status()
-    typer.echo(f"Telemetry: {'enabled' if telemetry.is_enabled() else 'disabled'}")
+    enabled = telemetry.is_enabled()
+    label = "enabled" if enabled else "disabled"
+    if enabled and state.consent_at is None:
+        label += " (default; `doberman telemetry off` to stop)"
+    typer.echo(f"Telemetry: {label}")
     typer.echo(f"Distinct id: {state.distinct_id or '(not created)'}")
     for reason in state.forced_off_reasons:
         typer.echo(f"Forced off: {reason}")

--- a/src/doberman/telemetry.py
+++ b/src/doberman/telemetry.py
@@ -24,8 +24,16 @@ from doberman import __version__
 from doberman.storage.device_metrics import HOME_ENV, read_metrics
 
 POSTHOG_HOST = "https://us.i.posthog.com"
-POSTHOG_PROJECT_KEY = "phc_REPLACE_ME"
+POSTHOG_PROJECT_KEY = "phc_znQ8ksFQhXYhQKTvA3Qr8QpqH5NfbE9cQropAxefUDWs"
 ENV_KEY = "DOBERMAN_POSTHOG_KEY"
+_PLACEHOLDER_PREFIX = "phc_REPLACE"
+
+#: Printed once, to stderr, by the first CLI command that runs under the default-on state.
+FIRST_RUN_NOTICE = (
+    "Doberman sends anonymous usage counts (command names and daily totals; never paths, "
+    "prompts, or secrets). Turn it off with `doberman telemetry off` or DO_NOT_TRACK=1. "
+    "Details: docs/TELEMETRY.md"
+)
 
 _STATE_NAME = "telemetry.json"
 _VALUE_PATTERN = re.compile(r"^[A-Za-z0-9_.+-]*$")
@@ -43,12 +51,17 @@ _SUMMARY_LOCK = threading.Lock()
 
 @dataclass(frozen=True)
 class TelemetryState:
-    """Local consent state; ``forced_off_reasons`` is computed, never persisted."""
+    """Local consent state; ``forced_off_reasons`` is computed, never persisted.
 
-    enabled: bool = False
+    Default-on: with no state file telemetry is enabled, ``consent_at`` stays ``None`` until
+    the person makes an explicit choice, and ``notice_shown`` records the one-time notice.
+    """
+
+    enabled: bool = True
     distinct_id: str = ""
     consent_at: datetime | None = None
     last_summary_at: datetime | None = None
+    notice_shown: bool = False
     forced_off_reasons: tuple[str, ...] = ()
 
 
@@ -83,10 +96,11 @@ def _read_state(home: Path | None = None) -> TelemetryState:
     try:
         raw = json.loads(_state_path(home).read_text(encoding="utf-8"))
         return TelemetryState(
-            enabled=raw.get("enabled") is True,
+            enabled=raw.get("enabled") is not False,
             distinct_id=raw.get("distinct_id") if isinstance(raw.get("distinct_id"), str) else "",
             consent_at=_parse_time(raw.get("consent_at")),
             last_summary_at=_parse_time(raw.get("last_summary_at")),
+            notice_shown=raw.get("notice_shown") is True,
         )
     except Exception:  # noqa: BLE001 — telemetry state must never affect the CLI
         return TelemetryState()
@@ -103,6 +117,7 @@ def _write_state(state: TelemetryState, home: Path | None = None) -> None:
                     "distinct_id": state.distinct_id,
                     "consent_at": _iso(state.consent_at),
                     "last_summary_at": _iso(state.last_summary_at),
+                    "notice_shown": state.notice_shown,
                 },
                 separators=(",", ":"),
             ),
@@ -130,7 +145,7 @@ def _forced_off_reasons() -> tuple[str, ...]:
         reasons.append("DOBERMAN_TELEMETRY disables telemetry")
     if os.environ.get("CI", ""):
         reasons.append("CI is set")
-    if _project_key() == POSTHOG_PROJECT_KEY:
+    if _project_key().startswith(_PLACEHOLDER_PREFIX):
         reasons.append("PostHog project key is still the placeholder")
     return tuple(reasons)
 
@@ -147,9 +162,31 @@ def is_enabled(home: Path | None = None) -> bool:
     """Return whether consent, environment, and project key permit a send."""
     try:
         state = status(home)
-        return state.enabled and not state.forced_off_reasons and bool(state.distinct_id)
+        return state.enabled and not state.forced_off_reasons
     except Exception:  # noqa: BLE001 — telemetry must default off
         return False
+
+
+def _ensure_id(home: Path | None = None) -> TelemetryState:
+    """Return the state with a persisted anonymous id, creating one on the first send."""
+    current = _read_state(home)
+    if current.distinct_id:
+        return current
+    state = replace(current, distinct_id=str(uuid.uuid4()))
+    _write_state(state, home)
+    return state
+
+
+def first_run_notice(home: Path | None = None) -> str | None:
+    """Return the one-time notice the first time the default-on state can actually send."""
+    try:
+        state = _read_state(home)
+        if state.notice_shown or not is_enabled(home):
+            return None
+        _write_state(replace(state, notice_shown=True), home)
+        return FIRST_RUN_NOTICE
+    except Exception:  # noqa: BLE001 — a notice must never affect the CLI
+        return None
 
 
 def enable(home: Path | None = None) -> TelemetryState:
@@ -161,6 +198,7 @@ def enable(home: Path | None = None) -> TelemetryState:
             enabled=True,
             distinct_id=current.distinct_id or str(uuid.uuid4()),
             consent_at=current.consent_at or _utc_now(),
+            notice_shown=True,
             forced_off_reasons=(),
         )
         _write_state(state, home)
@@ -176,7 +214,15 @@ def disable(home: Path | None = None) -> TelemetryState:
         current = _read_state(home)
         if current.enabled:
             capture("telemetry_disabled", home=home)
-        _write_state(replace(current, enabled=False), home)
+        _write_state(
+            replace(
+                current,
+                enabled=False,
+                consent_at=current.consent_at or _utc_now(),
+                notice_shown=True,
+            ),
+            home,
+        )
         return status(home)
     except Exception:  # noqa: BLE001 — telemetry controls must never affect the CLI
         return status(home)
@@ -239,7 +285,7 @@ def capture(
         event_properties = base_properties() | extras
         if not all(_valid_value(value) for value in event_properties.values()):
             return
-        state = _read_state(home)
+        state = _ensure_id(home)
         uuid.UUID(state.distinct_id, version=4)
         payload = json.dumps(
             {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,3 +205,10 @@ def assert_json_stdout(result: Result, *, jsonl: bool = False) -> Any:
             )
             records.append(obj)
         return records
+
+
+@pytest.fixture(autouse=True)
+def _telemetry_forced_off(monkeypatch):
+    """Telemetry is on by default, so every test runs with the kill switch set; the telemetry
+    tests that exercise sending clear it explicitly and stub the transport."""
+    monkeypatch.setenv("DOBERMAN_TELEMETRY", "0")

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -272,7 +272,7 @@ def test_interactive_telemetry_yes_persists_and_emits_setup_event(
 
     assert result.exit_code == 0, result.output
     assert telemetry.status().enabled is True
-    question = "Send anonymous usage stats to help improve Doberman? [y/N]"
+    question = "Send anonymous usage stats to help improve Doberman? [Y/n]"
     note = "Counts and command names only. Never paths, prompts, secrets, or reason payloads."
     assert result.output.index(note) < result.output.index(question)
     assert (
@@ -287,7 +287,7 @@ def test_interactive_telemetry_yes_persists_and_emits_setup_event(
     ) in events
 
 
-def test_interactive_telemetry_default_no_persists_disabled(tmp_path: Path) -> None:
+def test_interactive_telemetry_default_yes_records_the_choice(tmp_path: Path) -> None:
     from doberman import telemetry
 
     result = runner.invoke(
@@ -295,19 +295,33 @@ def test_interactive_telemetry_default_no_persists_disabled(tmp_path: Path) -> N
         ["setup", "--path", str(tmp_path)],
         input="balanced\n\nn\nn\n",
     )
+    assert result.exit_code == 0, result.output
+    state = telemetry.status()
+    assert state.enabled is True
+    assert state.consent_at is not None  # an explicit yes, not the silent default
 
+
+def test_interactive_telemetry_no_persists_disabled(tmp_path: Path) -> None:
+    from doberman import telemetry
+
+    result = runner.invoke(
+        app,
+        ["setup", "--path", str(tmp_path)],
+        input="balanced\nn\nn\nn\n",
+    )
     assert result.exit_code == 0, result.output
     assert telemetry.status().enabled is False
 
 
-def test_yes_does_not_prompt_for_or_enable_telemetry(tmp_path: Path) -> None:
+def test_yes_does_not_prompt_and_keeps_the_default(tmp_path: Path) -> None:
     from doberman import telemetry
 
     result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)], input="")
-
     assert result.exit_code == 0, result.output
-    assert "anonymous usage" not in result.output
-    assert telemetry.status().enabled is False
+    assert "Send anonymous usage stats" not in result.output  # no question asked
+    state = telemetry.status()
+    assert state.enabled is True
+    assert state.consent_at is None  # default kept, nothing recorded as a choice
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,4 +1,4 @@
-"""Tests for opt-in, anonymous CLI telemetry."""
+"""Tests for default-on, opt-out, anonymous CLI telemetry."""
 
 from __future__ import annotations
 
@@ -56,9 +56,36 @@ def _bodies(telemetry, requests):
     return [json.loads(request.data) for request, _timeout in requests]
 
 
-def test_default_off_and_capture_does_not_call_http(tmp_path, monkeypatch):
+def _clear_kill_switches(monkeypatch):
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("DOBERMAN_TELEMETRY", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+
+
+def test_default_on_first_capture_creates_id_and_posts(tmp_path, monkeypatch):
     from doberman import telemetry
 
+    _clear_kill_switches(monkeypatch)
+    monkeypatch.setenv(telemetry.ENV_KEY, _KEY)
+    requests = _capture_requests(telemetry, monkeypatch)
+
+    assert telemetry.is_enabled(home=tmp_path) is True
+    assert telemetry.status(home=tmp_path).distinct_id == ""  # nothing persisted before a send
+    telemetry.capture("cli_command", {"command": "doctor"}, home=tmp_path)
+
+    bodies = _bodies(telemetry, requests)
+    assert [body["event"] for body in bodies] == ["cli_command"]
+    uuid.UUID(bodies[0]["distinct_id"], version=4)
+    persisted = telemetry.status(home=tmp_path)
+    assert persisted.distinct_id == bodies[0]["distinct_id"]
+    assert persisted.consent_at is None  # default-on is not a recorded choice
+
+
+def test_kill_switch_wins_over_the_default(tmp_path, monkeypatch):
+    from doberman import telemetry
+
+    _clear_kill_switches(monkeypatch)
+    monkeypatch.setenv("DOBERMAN_TELEMETRY", "0")
     monkeypatch.setenv(telemetry.ENV_KEY, _KEY)
     monkeypatch.setattr(
         "urllib.request.urlopen",
@@ -66,6 +93,59 @@ def test_default_off_and_capture_does_not_call_http(tmp_path, monkeypatch):
     )
     assert telemetry.is_enabled(home=tmp_path) is False
     telemetry.capture("cli_command", {"command": "doctor"}, home=tmp_path)
+    telemetry._join_sender_threads(timeout=1.0)
+
+
+def test_opted_out_state_blocks_http(tmp_path, monkeypatch):
+    from doberman import telemetry
+
+    _clear_kill_switches(monkeypatch)
+    telemetry.disable(home=tmp_path)  # placeholder key here, so the final event is a no-op
+    monkeypatch.setenv(telemetry.ENV_KEY, _KEY)
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("HTTP called")),
+    )
+    assert telemetry.is_enabled(home=tmp_path) is False
+    assert telemetry.status(home=tmp_path).consent_at is not None
+    telemetry.capture("cli_command", {"command": "doctor"}, home=tmp_path)
+    telemetry._join_sender_threads(timeout=1.0)
+
+
+def test_first_run_notice_prints_once_and_never_after_a_choice(tmp_path, monkeypatch):
+    from doberman import telemetry
+
+    _clear_kill_switches(monkeypatch)
+    monkeypatch.setenv(telemetry.ENV_KEY, _KEY)
+    assert telemetry.first_run_notice(home=tmp_path) == telemetry.FIRST_RUN_NOTICE
+    assert telemetry.first_run_notice(home=tmp_path) is None
+    assert telemetry.status(home=tmp_path).notice_shown is True
+
+    opted_out = tmp_path / "opted-out"
+    monkeypatch.delenv(telemetry.ENV_KEY, raising=False)
+    telemetry.disable(home=opted_out)
+    monkeypatch.setenv(telemetry.ENV_KEY, _KEY)
+    assert telemetry.first_run_notice(home=opted_out) is None
+
+    forced = tmp_path / "forced"
+    monkeypatch.setenv("CI", "1")
+    assert telemetry.first_run_notice(home=forced) is None  # cannot send, so nothing to announce
+
+
+def test_first_cli_command_prints_the_notice_to_stderr_once(tmp_path, monkeypatch):
+    from doberman import telemetry
+
+    _clear_kill_switches(monkeypatch)
+    monkeypatch.setenv("DOBERMAN_HOME", str(tmp_path))
+    monkeypatch.setenv(telemetry.ENV_KEY, _KEY)
+    _capture_requests(telemetry, monkeypatch)
+
+    first = runner.invoke(cli_module.app, ["status", "--path", str(tmp_path)])
+    second = runner.invoke(cli_module.app, ["status", "--path", str(tmp_path)])
+    assert telemetry.FIRST_RUN_NOTICE in first.stderr
+    assert telemetry.FIRST_RUN_NOTICE not in first.stdout
+    assert telemetry.FIRST_RUN_NOTICE not in second.stderr
+    telemetry._join_sender_threads(timeout=1.0)
 
 
 def test_enable_and_capture_posts_allowlisted_payload(tmp_path, monkeypatch):
@@ -179,8 +259,9 @@ def test_kill_switches_prevent_http_and_status_names_reason(
 def test_placeholder_key_prevents_http(tmp_path, monkeypatch):
     from doberman import telemetry
 
+    _clear_kill_switches(monkeypatch)
     telemetry.enable(home=tmp_path)
-    monkeypatch.delenv(telemetry.ENV_KEY, raising=False)
+    monkeypatch.setenv(telemetry.ENV_KEY, "phc_REPLACE_ME")
     requests = _capture_requests(telemetry, monkeypatch)
     telemetry.capture("cli_command", {"command": "doctor"}, home=tmp_path)
     assert requests == []


### PR DESCRIPTION
## Why

Opt-in telemetry produced no data; ADR 0084 predicted that and named the next step: a first-run notice with opt-out. fu351 decided to go there today (ADR 0087 in the memory vault). The PostHog project key — a public ingestion key — ships in the package from this version.

## What

- **No state file = enabled.** `consent_at` stays `None` until an explicit choice, so `doberman telemetry status` can say `enabled (default; …)` and distinguish it from an opt-in.
- **One-time notice** (`FIRST_RUN_NOTICE`, stderr only) from the first CLI command that can actually send; never on `hook`/`serve`, never under a kill switch. The anonymous uuid4 is created lazily on that first send.
- `doberman setup` asks once with default **Yes**; `--yes` keeps the default and prints the notice instead of asking. `doberman telemetry off` records the opt-out (`consent_at`, `notice_shown`) — never asked again.
- Unchanged: `DO_NOT_TRACK`, `DOBERMAN_TELEMETRY=0`, `CI` force off; the five allowlisted events and their property allowlists; no profiles, no GeoIP; stdlib transport in a daemon thread; hot-path isolation (import-linter contract still kept).
- Placeholder detection keys on the `phc_REPLACE` prefix so the real key can live in `POSTHOG_PROJECT_KEY`.

## Tests

`tests/unit/test_telemetry.py`: default-on posts after creating the id (no `consent_at`); kill switch beats the default; opted-out state blocks HTTP; notice prints exactly once, never after a choice, never when forced off; the first CLI command prints it to stderr only. `tests/unit/test_setup_wizard.py`: default Yes records the choice, explicit No disables, `--yes` keeps the default silently. `tests/conftest.py` forces `DOBERMAN_TELEMETRY=0` for every test so the suite never sends.

## Docs

`docs/TELEMETRY.md` (on by default, how to stop it), README telemetry line, CHANGELOG Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7XD6aDzEdRfMz7H2XJ8L3
