### PR TITLE
ci(publish): keep the SBOM out of dist/ and add a manual target=pypi republish path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,17 @@ name: Publish
 on:
   release:
     types: [published]     # tag a GitHub Release -> publish to PyPI
-  workflow_dispatch: {}    # manual run -> dry-run publish to TestPyPI
+  workflow_dispatch:       # manual run -> TestPyPI dry run by default; target=pypi republishes
+    inputs:
+      target:
+        description: "Where to publish (testpypi is a dry run; pypi republishes main's version)"
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
+      tag:
+        description: "Existing release tag to attach the SBOM to when target=pypi (e.g. v0.18.4)"
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -32,19 +42,27 @@ jobs:
         # continue-on-error (not `|| true`) so a finding still shows as a warning in the run,
         # instead of a clean green check hiding it. Add a blocking `pip-audit` step separately
         # if/when an actual release gate is wanted.
+        # The SBOM lives OUTSIDE dist/: the publish action uploads every file in dist/ and
+        # rejects anything that is not a wheel or sdist (this broke v0.18.2–v0.18.4).
         continue-on-error: true
         run: |
           python -m pip install --upgrade pip-audit
-          pip-audit -f cyclonedx-json -o dist/sbom.json .
+          mkdir -p sbom
+          pip-audit -f cyclonedx-json -o sbom/sbom.json .
       - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
+      - uses: actions/upload-artifact@v4
+        if: hashFiles('sbom/sbom.json') != ''
+        with:
+          name: sbom
+          path: sbom/sbom.json
 
   pypi-publish:
     name: Publish to PyPI
     needs: build
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -57,17 +75,28 @@ jobs:
         with:
           name: dist
           path: dist/
+      - uses: actions/download-artifact@v4
+        continue-on-error: true   # no SBOM artifact when pip-audit failed in build
+        with:
+          name: sbom
+          path: sbom/
       - uses: pypa/gh-action-pypi-publish@release/v1
       - name: Attach SBOM to the GitHub Release
-        if: hashFiles('dist/sbom.json') != ''
+        if: hashFiles('sbom/sbom.json') != ''
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" dist/sbom.json --clobber
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          if [ -n "$TAG" ]; then
+            gh release upload "$TAG" sbom/sbom.json --clobber
+          else
+            echo "no release tag given; SBOM kept as a workflow artifact only"
+          fi
 
   testpypi-publish:
     name: Publish to TestPyPI (dry run)
     needs: build
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.target != 'pypi'
     runs-on: ubuntu-latest
     environment:
       name: testpypi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -18,12 +18,13 @@ The checklist for cutting a release, kept in sync with `.github/workflows/publis
 Publishing uses **PyPI Trusted Publishing (OIDC)** via `.github/workflows/publish.yml`. No API tokens are stored in this repo.
 
 1. Commit the version bump from step 4 above and merge to `main`.
-2. Optional dry run: GitHub -> Actions -> Publish -> Run workflow, on `main`. This builds and uploads to **TestPyPI**. Verify:
+2. Optional dry run: GitHub -> Actions -> Publish -> Run workflow, on `main`, target `testpypi` (the default). This builds and uploads to **TestPyPI**. Verify:
    ```bash
    pip install -i https://test.pypi.org/simple/ \
        --extra-index-url https://pypi.org/simple/ doberman-core
    ```
 3. Create a **GitHub Release** with tag `vX.Y.Z` (matching the version). Publishing the release triggers the `pypi-publish` job, which uploads to PyPI and attaches a CycloneDX SBOM (`sbom.json`) to the release as a downloadable asset. The public core must build, test, and run with zero enterprise code installed (the standalone guarantee); CI's standalone step enforces this.
+   **If that run fails after the tag exists** (a trusted-publisher or workflow bug), fix `main`, then run the workflow manually with target `pypi` and `tag` set to the release tag (`gh workflow run publish.yml -f target=pypi -f tag=vX.Y.Z`). A rerun of the failed run reuses the old workflow snapshot and cannot pick up the fix; the manual run builds `main`, whose `pyproject.toml` already carries the version.
 4. Verify from a clean environment:
    ```bash
    python -m venv /tmp/dob && /tmp/dob/bin/pip install doberman-core


### PR DESCRIPTION
PyPI has served 0.18.1 since 2026-08-15: every release run since then failed. Cause one was the trusted publisher on PyPI naming the pre-org-move repo (fixed on PyPI). Cause two is in this repo: the SBOM step from #402 writes `sbom.json` into `dist/`, and `pypa/gh-action-pypi-publish` uploads everything in `dist/`, so it fails with `Unknown distribution format: 'sbom.json'`. This PR moves the SBOM to `sbom/` as its own artifact (still attached to the GitHub Release) and adds `workflow_dispatch` inputs `target` (testpypi|pypi) and `tag` so a failed release run can be republished from `main` — a rerun reuses the old workflow snapshot and cannot pick up the fix. `docs/RELEASING.md` documents the republish path. After merge: `gh workflow run publish.yml -f target=pypi -f tag=v0.18.4`.