### PR TITLE
ci(publish): set GH_REPO so the SBOM attach step works without a checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,7 @@ jobs:
         if: hashFiles('sbom/sbom.json') != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}   # no checkout in this job, so gh cannot infer the repo
           TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           if [ -n "$TAG" ]; then


### PR DESCRIPTION
Follow-up to #486. The v0.18.4 manual publish reached PyPI, but the SBOM attach step failed: the publish job has no checkout, so `gh release upload` cannot infer the repository. One env line fixes it. The v0.18.4 SBOM was attached to the release by hand.