### PR TITLE
ci: cheap wins from the CI review — timeouts, SHA pins, canary key, version==tag guard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Keeps the SHA-pinned actions current through reviewable PRs (the pins carry a
+# `# vX.Y.Z` comment, which Dependabot updates alongside the SHA). Python deps are
+# deliberately not here: maintainer dep bumps conflict with open contributor PRs
+# (ADR 0080), so they stay a deliberate, sweep-first change.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 40   # the Windows leg takes ~22 min; a hang must not run to the 6 h default
     # Windows runners default `run:` to PowerShell; pin bash (Git Bash ships on
     # GitHub's Windows images) so the shell-scripted steps below — the `grep`-based
     # standalone-guarantee check in particular — behave identically on every OS.
@@ -31,8 +32,8 @@ jobs:
           - os: "windows-latest"
             python-version: "3.12"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -55,9 +56,10 @@ jobs:
         run: python -m tools.parity.generate_parity --check
   package-smoke-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -79,8 +81,9 @@ jobs:
           assert load_builtin_roles(), 'builtin_roles.yaml missing from the wheel'"
   secret-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { fetch-depth: 0 }
       # The gitleaks CLI, not gitleaks-action: the action demands GITLEAKS_LICENSE on
       # org repos, and fork PRs cannot read secrets, so every contributor PR failed here

--- a/.github/workflows/codex-canary.yml
+++ b/.github/workflows/codex-canary.yml
@@ -12,14 +12,19 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: codex-canary
+  cancel-in-progress: true
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # Off until the owner opts in (needs a Codex-auth secret). No secret => no run.
     if: ${{ vars.CODEX_CANARY_ENABLED == 'true' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - run: pip install -e .
@@ -27,11 +32,17 @@ jobs:
         run: npm install -g @openai/codex # ALWAYS latest — that is the point
       - name: Live smoke (yellow-tolerant)
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # The repo secret was created as OPEN_API_KEY; accept either name so the canary
+          # stops reporting an empty key as a green "inconclusive" run every day.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || secrets.OPEN_API_KEY }}
         run: |
           set +e
           python tools/codex_canary/smoke.py
           code=$?
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            echo "::error::codex canary has no API key (set OPENAI_API_KEY or OPEN_API_KEY); this run proves nothing"
+            exit 1
+          fi
           if [ "$code" = "2" ]; then
             echo "::warning::codex canary inconclusive (model refused / tool unavailable — not churn evidence)"
             exit 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,13 +21,19 @@ on:
 permissions:
   contents: read
 
+# Never cancel a publish in flight; queue a second one behind it instead.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build sdist + wheel
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - run: python -m pip install --upgrade pip build
@@ -49,11 +55,11 @@ jobs:
           python -m pip install --upgrade pip-audit
           mkdir -p sbom
           pip-audit -f cyclonedx-json -o sbom/sbom.json .
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: hashFiles('sbom/sbom.json') != ''
         with:
           name: sbom
@@ -62,6 +68,7 @@ jobs:
   pypi-publish:
     name: Publish to PyPI
     needs: build
+    timeout-minutes: 15
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
     runs-on: ubuntu-latest
     environment:
@@ -71,15 +78,29 @@ jobs:
       id-token: write     # required for Trusted Publishing (OIDC)
       contents: write     # required to attach the SBOM to the GitHub Release
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true   # no SBOM artifact when pip-audit failed in build
         with:
           name: sbom
           path: sbom/
+      - name: Version matches the release tag
+        # A manual target=pypi run builds main; refuse to upload if main's version and the
+        # tag it is meant for disagree (the SBOM would otherwise land on the wrong release).
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          wheel=$(ls dist/*.whl)
+          version=$(basename "$wheel" | cut -d- -f2)
+          echo "wheel version: $version; tag: ${TAG:-<none>}"
+          if [ -n "$TAG" ] && [ "v$version" != "$TAG" ]; then
+            echo "::error::pyproject version $version does not match tag $TAG"
+            exit 1
+          fi
       - uses: pypa/gh-action-pypi-publish@release/v1
       - name: Attach SBOM to the GitHub Release
         if: hashFiles('sbom/sbom.json') != ''
@@ -97,6 +118,7 @@ jobs:
   testpypi-publish:
     name: Publish to TestPyPI (dry run)
     needs: build
+    timeout-minutes: 15
     if: github.event_name == 'workflow_dispatch' && inputs.target != 'pypi'
     runs-on: ubuntu-latest
     environment:
@@ -105,7 +127,7 @@ jobs:
     permissions:
       id-token: write     # required for Trusted Publishing (OIDC)
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,13 @@ ruff format --check .
 python scripts/check_markdown_links.py
 lint-imports
 pytest -n auto --cov=doberman --cov-report=term-missing --cov-fail-under=80
+python -m tools.parity.generate_parity --check
 ```
+
+CI runs exactly these (on Linux 3.11–3.13 and Windows 3.12) plus a wheel smoke test and a
+full-history secret scan. The optional extras `explain` (Anthropic SDK) and `winhello`
+(Windows Hello) are not installed in CI; their tests use fakes, so exercise the real thing
+locally when you touch them.
 
 `-n auto` runs the suite in parallel (pytest-xdist ships in the `dev` extra), the
 same way CI runs it.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -23,7 +23,7 @@ Publishing uses **PyPI Trusted Publishing (OIDC)** via `.github/workflows/publis
    pip install -i https://test.pypi.org/simple/ \
        --extra-index-url https://pypi.org/simple/ doberman-core
    ```
-3. Create a **GitHub Release** with tag `vX.Y.Z` (matching the version). Publishing the release triggers the `pypi-publish` job, which uploads to PyPI and attaches a CycloneDX SBOM (`sbom.json`) to the release as a downloadable asset. The public core must build, test, and run with zero enterprise code installed (the standalone guarantee); CI's standalone step enforces this.
+3. Create a **GitHub Release** with tag `vX.Y.Z` (matching the version; the publish job refuses to upload when `pyproject.toml`'s version and the tag disagree). Publishing the release triggers the `pypi-publish` job, which uploads to PyPI and attaches a CycloneDX SBOM (`sbom.json`) to the release as a downloadable asset. The public core must build, test, and run with zero enterprise code installed (the standalone guarantee); CI's standalone step enforces this.
    **If that run fails after the tag exists** (a trusted-publisher or workflow bug), fix `main`, then run the workflow manually with target `pypi` and `tag` set to the release tag (`gh workflow run publish.yml -f target=pypi -f tag=vX.Y.Z`). A rerun of the failed run reuses the old workflow snapshot and cannot pick up the fix; the manual run builds `main`, whose `pyproject.toml` already carries the version.
 4. Verify from a clean environment:
    ```bash


### PR DESCRIPTION
From a review of the CI system after the last three weeks of change (org move, gitleaks CLI, manual publish path, telemetry default-on). This PR is the mechanical half; the judgment items are listed at the end for a separate decision.

## What

- **`timeout-minutes` on every job** in `ci.yml`, `publish.yml`, `codex-canary.yml` — none existed; the Windows leg takes ~22 min, so a hang would have run to the 6-hour default. **`concurrency`** on publish (never cancel an in-flight publish) and the canary.
- **All `actions/*` pinned to commit SHAs and upgraded to current majors** (`checkout` v7.0.1, `setup-python` v7.0.0, `upload-artifact` v7.0.1, `download-artifact` v8.0.1). The v4/v5 pins ran on the deprecated Node 20 runtime — the warning has been in every run log. `pypa/gh-action-pypi-publish@release/v1` stays on the vendor-recommended ref. **`.github/dependabot.yml`** (github-actions only, weekly, limit 3) keeps the pins current; Python deps deliberately excluded (maintainer dep bumps conflict with open contributor PRs, ADR 0080).
- **codex-canary actually needs a key to be green.** The repo secret is `OPEN_API_KEY`; the workflow read `OPENAI_API_KEY`, so every daily run since it was enabled has been a green "inconclusive" with an empty key. Now accepts either name and fails loudly when the key is empty.
- **Version == tag guard in `publish.yml`**: the manual `target=pypi` path builds `main`; the upload now refuses when the wheel's version and the tag disagree, so an SBOM can't land on the wrong release.
- **Docs:** CONTRIBUTING lists `python -m tools.parity.generate_parity --check` (CI enforces it, the doc didn't mention it) and names the extras CI does not install (`explain`, `winhello`); RELEASING mentions the version guard.

## Not in this PR (need a maintainer decision, tracked separately)

- `main` has **no branch protection** and the `pypi`/`testpypi` environments have **no protection rules** — both are GitHub settings, not files.
- The `test_webhook_audit_sink.py::*_is_swallowed` order-dependent flake — root-cause fix in progress on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7XD6aDzEdRfMz7H2XJ8L3
