### PR TITLE
test: isolate the doberman logger state so in-process hook runs stop breaking caplog

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ need to exercise key generation/rotation override this with their own
 """
 
 import json as _json
+import logging
 from typing import Any
 
 import pytest
@@ -212,3 +213,24 @@ def _telemetry_forced_off(monkeypatch):
     """Telemetry is on by default, so every test runs with the kill switch set; the telemetry
     tests that exercise sending clear it explicitly and stub the transport."""
     monkeypatch.setenv("DOBERMAN_TELEMETRY", "0")
+
+
+@pytest.fixture(autouse=True)
+def _isolated_doberman_logger_state(monkeypatch):
+    """Restore the shared ``doberman``/root loggers after every test.
+
+    ``cli.main._configure_stderr_logging`` (run by the ``hook pre/post/openclaw/
+    codex-pre`` and ``serve`` commands) permanently flips
+    ``logging.getLogger("doberman").propagate`` to ``False`` and replaces its
+    handlers — correct for a real one-shot hook/serve subprocess, but Typer's
+    ``CliRunner`` invokes the command function in-process, so without this fixture
+    the mutation leaks into every later test in the same pytest worker. Concretely:
+    once ``propagate`` is ``False``, records from a ``doberman.*`` child logger
+    (e.g. ``doberman.storage.sinks``) never reach ``caplog``'s handler on the root
+    logger, so an unrelated later test's ``caplog.records`` assertion goes empty.
+    """
+    root = logging.getLogger()
+    doberman_logger = logging.getLogger("doberman")
+    monkeypatch.setattr(root, "handlers", root.handlers[:])
+    monkeypatch.setattr(doberman_logger, "handlers", doberman_logger.handlers[:])
+    monkeypatch.setattr(doberman_logger, "propagate", doberman_logger.propagate)


### PR DESCRIPTION
Root cause of the order-dependent `test_webhook_audit_sink.py::*_is_swallowed` failures: `test_telemetry.py::test_cli_command_emitted_for_doctor_but_not_hook` runs `hook pre` through Typer's in-process `CliRunner`, which calls `_configure_stderr_logging()` and sets `logging.getLogger('doberman').propagate = False` — right for a real one-shot hook subprocess, but never restored in tests. Every later test in that xdist worker asserting on `caplog.records` for a `doberman.*` logger then sees nothing. Deterministic repro: run that telemetry test followed by the sink file in one process. Fix: an autouse fixture in `tests/conftest.py` snapshots and restores the `doberman` logger's handlers/propagate and the root handlers, matching the existing isolation fixtures for other global state. Test-only change; production behaviour untouched. Verified: repro green, sink file green alone, four related files green under -n 4 three times, ruff clean.