### PR TITLE
fix(dash): keep the decision counters in step with the live feed

### DIFF
--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -501,6 +501,14 @@ _HTML_SHELL = """<!doctype html>
       }
       refreshStats();
       setInterval(refreshStats, STATS_REFRESH_MS);
+      // The counters follow the feed: a new row re-fetches the stats right away
+      // (trailing-debounced, so a backfill burst on connect costs one request)
+      // instead of lagging up to STATS_REFRESH_MS behind the list.
+      var statsSyncTimer = null;
+      function syncStatsSoon() {
+        clearTimeout(statsSyncTimer);
+        statsSyncTimer = setTimeout(refreshStats, 150);
+      }
 
       // Mode control: fetch the valid mode names once to populate the
       // selector, then let the user pick a new one. Raising strictness is
@@ -783,6 +791,7 @@ _HTML_SHELL = """<!doctype html>
           if (nearBottom) {
             feedEl.scrollTop = feedEl.scrollHeight;
           }
+          syncStatsSoon();
         });
       } catch (e) {
         // EventSource unsupported/blocked - the feed just stays empty.

--- a/tests/unit/test_dash_serve.py
+++ b/tests/unit/test_dash_serve.py
@@ -98,6 +98,16 @@ def test_index_serves_the_brand_mark_inline(client: TestClient):
     assert base64.b64decode(payload, validate=True).startswith(png_signature)
 
 
+def test_index_feed_handler_keeps_stats_in_step(client: TestClient):
+    """A new feed row schedules a (debounced) stats refresh, so the counters never sit
+    up to STATS_REFRESH_MS behind the list. The JS ships inline in the shell, so the
+    served page is the only place this wiring can be checked without a browser."""
+    shell = client.get("/").text
+    assert "function syncStatsSoon()" in shell
+    decision_handler = shell[shell.index('source.addEventListener("decision"') :]
+    assert "syncStatsSoon();" in decision_handler
+
+
 def test_cli_dash_missing_extra_exits_nonzero_with_install_hint(monkeypatch):
     from doberman.cli.main import app as cli_app
 


### PR DESCRIPTION
## What

The stats strip (`decisions: N · PASS · AUTH · BLOCK`) refreshed only on a 5 s interval, so after a decision landed in the live feed the counters could sit up to five seconds behind the list. A new feed row now schedules a stats refresh immediately (trailing-debounced at 150 ms so the backfill burst on connect costs one request); the interval stays as the fallback.

## Test plan

- [x] `tests/unit/test_dash_serve.py::test_index_feed_handler_keeps_stats_in_step` — the served shell defines the debounced refresh and the `decision` handler calls it.
- [x] `pytest tests/unit/test_dash_serve.py tests/unit/test_dash_project_title.py` green locally; ruff clean.
- [x] Watched live: counters now change within ~1 s of a row appearing (recorded for the launch reel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7XD6aDzEdRfMz7H2XJ8L3