### PR TITLE
docs: add an index page for docs/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Documentation
+
+Use this index to find the right Doberman documentation for your task.
+
+| Document | When to open it |
+| --- | --- |
+| [SETUP.md](SETUP.md) | Open this when installing Doberman, connecting it to a coding agent, setting up recovery, or confirming your installation works. |
+| [CLI.md](CLI.md) | Open this when you need to find a `doberman` command, understand its options, or script against its JSON output and exit codes. |
+| [REASON_CODES.md](REASON_CODES.md) | Open this when reading a Doberman decision or log and you need to understand why an action received `AUTH` or `BLOCK`. |
+| [PARITY.md](PARITY.md) | Open this when checking which security guarantees are proven on each supported host and where coverage gaps remain. |
+| [ADAPTER_GUIDE.md](ADAPTER_GUIDE.md) | Open this when building or understanding a coding-agent host integration and need to see how tool calls flow through Doberman's decision spine. |
+| [BENCHMARKS.md](BENCHMARKS.md) | Open this when evaluating Doberman's protection results, reproducing benchmark numbers, or understanding what those metrics do and do not prove. |
+| [RELEASING.md](RELEASING.md) | Open this when preparing and publishing a Doberman-Core release and verifying the required checks and evidence. |
+| [audit_otel.md](audit_otel.md) | Open this when sending Doberman's redacted decision records to an OpenTelemetry-compatible collector. |


### PR DESCRIPTION
## Summary

- Added `docs/README.md` as an index for the documentation.
- Included a short description for each document explaining when to open it.
- Kept the descriptions based on each document's opening section.

## Note

The current `docs/` directory contains additional documentation files beyond the eight referenced in the issue. I kept this PR scoped to the eight documents mentioned in the issue.

Closes #409 