### PR TITLE
chore(changelog): fragments for the 2026-08-27 sweep + compiler spacing fix

### DIFF
--- a/changelog.d/456.md
+++ b/changelog.d/456.md
@@ -1,2 +1,0 @@
-- **Changelog entries no longer collide on every parallel pull request.** Each PR now adds its
-  own `changelog.d/<PR-number>.md`, and release tooling compiles those fragments together.

--- a/changelog.d/459.md
+++ b/changelog.d/459.md
@@ -1,0 +1,6 @@
+- **`doberman egress-velocity [KNOB] [VALUE]`:** show or set the `burst`, `volume-bytes`, and
+  `fanout` detection thresholds from the CLI. Lowering a threshold applies at once; raising one
+  crosses the same possession-factor gate as every other loosening (TOTP if enrolled, else the
+  password), is recorded in the policy-change ledger, and is saved only when approved, so
+  hand-editing the policy file is no longer the only way to set them (thanks @Maqbool61, #459,
+  closes #457)

--- a/changelog.d/463.md
+++ b/changelog.d/463.md
@@ -1,0 +1,3 @@
+- **`install-hooks --dry-run` previews the command the installer really writes.** The SessionStart
+  line now comes from the same `DASHBOARD_COMMAND` constant as the write path (`doberman
+  session-summary`), so the preview cannot drift again (thanks @slegarraga, #463, closes #429)

--- a/changelog.d/468.md
+++ b/changelog.d/468.md
@@ -1,0 +1,4 @@
+- **Tests:** the data-class rule's two documented non-detections are now proven: a six-digit
+  one-time code bound for an external host stays PASS, and the valid SSN's digits without dashes
+  stay PASS, so the rule is pinned to the dashed shape rather than the value (thanks @slegarraga,
+  #468, closes #405)

--- a/changelog.d/470.md
+++ b/changelog.d/470.md
@@ -1,0 +1,2 @@
+- **`tune --json` is compact** like every other JSON command (`separators=(",", ":")`), keeping
+  the machine-readable output contract in docs/CLI.md (thanks @slegarraga, #470, closes #431)

--- a/changelog.d/472.md
+++ b/changelog.d/472.md
@@ -1,0 +1,3 @@
+- **`doberman log` columns no longer shift** for the 15-character action types (`network_request`,
+  `package_install`): the action column width now comes from the `ActionType` enum, the way verdict
+  labels already do (thanks @slegarraga, #472, closes #428)

--- a/changelog.d/473.md
+++ b/changelog.d/473.md
@@ -1,0 +1,2 @@
+- **Docs:** five stale "(a later slice)" comments that promised features which have since shipped
+  now describe what the code does today (thanks @slegarraga, #473, closes #426)

--- a/changelog.d/474.md
+++ b/changelog.d/474.md
@@ -1,0 +1,3 @@
+- **`doberman doctor` reports the password factor:** a `Password` row next to `2FA`, OK when
+  enrolled, a non-critical WARN with the `doberman password set` hint when not; presence only, never
+  the secret (thanks @slegarraga, #474, closes #439)

--- a/changelog.d/475.md
+++ b/changelog.d/475.md
@@ -1,0 +1,3 @@
+- **`doberman doctor` reports the optional UI extras:** `Dash extra` and `TUI extra` rows say
+  whether `starlette`/`textual` are installed (via `find_spec`, nothing imported) and print the
+  `pip install 'doberman[dash]'`/`[tui]` hint when not (thanks @slegarraga, #475, closes #440)

--- a/changelog.d/476.md
+++ b/changelog.d/476.md
@@ -1,0 +1,3 @@
+- **Changelog entries no longer collide on every parallel pull request.** Each PR now adds its
+  own `changelog.d/<PR-number>.md`, and release tooling compiles those fragments together
+  (thanks @slegarraga, #476, closes #456)

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,7 +1,7 @@
 # Changelog fragments
 
 Add one Markdown file named after your pull request (for example,
-`456.md`) instead of editing `CHANGELOG.md`. Start the file with one or more
+`476.md`) instead of editing `CHANGELOG.md`. Start the file with one or more
 Markdown bullets describing the user-facing change. Maintainers compile these
 files into `CHANGELOG.md` during release; this README is documentation, not a
 fragment.

--- a/scripts/compile_changelog.py
+++ b/scripts/compile_changelog.py
@@ -76,7 +76,7 @@ def compile_changelog(changelog: str, fragments: list[Fragment]) -> str:
         sections.append(existing)
 
     compiled_body = "\n\n".join(sections)
-    return "".join(lines[:body_start]) + f"\n\n{compiled_body}\n" + "".join(lines[body_end:])
+    return "".join(lines[:body_start]) + f"\n{compiled_body}\n\n" + "".join(lines[body_end:])
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/unit/test_cli_approvals.py
+++ b/tests/unit/test_cli_approvals.py
@@ -42,6 +42,9 @@ class _Boom:
 
 
 def _seed(root: str) -> None:
+    # Take the clock here, not at import: `approvals status` compares against the real
+    # clock, and a slow CI run can start this test >5 min after collection.
+    now = datetime.now(timezone.utc)
     asyncio.run(
         remember(
             "hmac:cli-test",
@@ -50,8 +53,8 @@ def _seed(root: str) -> None:
             required_tier="local_auth",
             action_type="shell_exec",
             method="local_auth",
-            approved_at=NOW,
-            expires_at=NOW + timedelta(minutes=5),
+            approved_at=now,
+            expires_at=now + timedelta(minutes=5),
         )
     )
 

--- a/tests/unit/test_compile_changelog.py
+++ b/tests/unit/test_compile_changelog.py
@@ -115,3 +115,19 @@ def test_cli_dry_run_preserves_files(tmp_path: Path) -> None:
     assert "Ready to compile #456" in stdout
     assert fragment.exists()
     assert "_Nothing yet._" in (root / "CHANGELOG.md").read_text(encoding="utf-8")
+
+
+def test_cli_write_keeps_one_blank_line_around_the_compiled_block(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "CHANGELOG.md").write_text("# Changelog\n\n## v1.0.0\n\n- Shipped.\n", encoding="utf-8")
+    fragment_dir = root / "changelog.d"
+    fragment_dir.mkdir()
+    (fragment_dir / "456.md").write_text("- First.\n", encoding="utf-8")
+    (fragment_dir / "457.md").write_text("- Second.\n", encoding="utf-8")
+
+    returncode, _, stderr = run_compiler(root, write=True)
+
+    assert returncode == 0, stderr
+    assert (root / "CHANGELOG.md").read_text(encoding="utf-8") == (
+        "# Changelog\n\n## Unreleased\n\n- First.\n\n- Second.\n\n## v1.0.0\n\n- Shipped.\n"
+    )


### PR DESCRIPTION
Follow-up to #476 (changelog fragments).

- `scripts/compile_changelog.py`: the compiled block now gets one blank line after `## Unreleased` and one before the next version heading (it produced two after and none before). New test pins the exact output.
- `changelog.d/`: fragments for today's contributor sweep (#459 #463 #468 #470 #472 #473 #474 #475 #476), and #476's own fragment renamed from `456.md` (the issue) to `476.md` (the PR), matching the README convention.

Verified: `pytest tests/unit/test_compile_changelog.py` 7 passed; `--write` dry run against the real CHANGELOG produces the expected spacing.
