### PR TITLE
test(approvals): seed the approval-memory entry from a per-test clock

### DIFF
--- a/tests/unit/test_cli_approvals.py
+++ b/tests/unit/test_cli_approvals.py
@@ -42,6 +42,9 @@ class _Boom:
 
 
 def _seed(root: str) -> None:
+    # Take the clock here, not at import: `approvals status` compares against the real
+    # clock, and a slow CI run can start this test >5 min after collection.
+    now = datetime.now(timezone.utc)
     asyncio.run(
         remember(
             "hmac:cli-test",
@@ -50,8 +53,8 @@ def _seed(root: str) -> None:
             required_tier="local_auth",
             action_type="shell_exec",
             method="local_auth",
-            approved_at=NOW,
-            expires_at=NOW + timedelta(minutes=5),
+            approved_at=now,
+            expires_at=now + timedelta(minutes=5),
         )
     )
 


### PR DESCRIPTION
`tests/unit/test_cli_approvals.py` computed `NOW` once at import and seeded an approval that expires five minutes later, while `approvals status` counts live entries against the real clock. On a slow `-n auto` run the test starts more than five minutes after collection, the seed has expired, and `live entries: 0` fails the `"1" in output` assertion. It went red on `main` at 05a48c6 (all four test legs) and on every PR run that reached the test late (#493, #494, #495) after being green at 15ffeb7.

Fix: `_seed` takes the clock when it runs, so the window is the test's own runtime. `test_clear_is_ungated_strengthening` still compares against the module `NOW` (earlier than the seed, so the entry is live for it until cleared).

`pytest tests/unit/test_cli_approvals.py`: 6 passed.
