### PR TITLE
feat(dash): copy pending approval details

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ them off. See [Telemetry](docs/TELEMETRY.md).
 
 Doberman now reviews every tool call your agent makes. Confirm it with `doberman doctor`, or watch
 real verdicts with `doberman demo`. MCP-proxy wiring, the dashboard, the TUI, scan, and 2FA are in the
-[Setup guide](docs/SETUP.md).
+[Setup guide](docs/SETUP.md). Pending-approval cards in the dashboard can copy their already-redacted
+decision details as JSON for review handoffs without exposing raw targets or paths.
 
 ---
 

--- a/changelog.d/498.md
+++ b/changelog.d/498.md
@@ -1,0 +1,1 @@
+- Add a dashboard **Copy details** action for pending approvals that copies only the existing redacted fields as formatted JSON.

--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -257,6 +257,8 @@ _HTML_SHELL = """<!doctype html>
   #pending-list button.deny:hover { border-color: var(--block); background: var(--block-bg); }
   #pending-list button.approve { background: var(--auth); border: 1px solid var(--auth); color: var(--ink-0); }
   #pending-list button.approve:hover { background: var(--tan-hi); border-color: var(--tan-hi); }
+  #pending-list button.btn-copy { background: transparent; border: 1px solid var(--rule); color: var(--fg-2); }
+  #pending-list button.btn-copy:hover { border-color: var(--auth); color: var(--fg); }
   .section-head { display: flex; align-items: center; justify-content: space-between; gap: .5rem; margin-top: 1.4rem; }
   #refresh-btn {
     font-family: var(--font); font-size: .86rem; font-weight: 600; padding: .35rem 1rem;
@@ -708,6 +710,24 @@ _HTML_SHELL = """<!doctype html>
             resolveApproval(row.id, "denied", totpInput ? totpInput.value : null, li);
           });
           li.appendChild(denyBtn);
+
+          var copyBtn = document.createElement("button");
+          copyBtn.type = "button";
+          copyBtn.className = "btn btn-copy";
+          copyBtn.textContent = "Copy details";
+          copyBtn.addEventListener("click", async function () {
+            try {
+              await navigator.clipboard.writeText(JSON.stringify({
+                id: row.id,
+                tier: row.tier,
+                risk: row.risk,
+                action_type: row.action_type,
+                reason_codes: row.reason_codes,
+                explanation: row.explanation
+              }, null, 2));
+            } catch (e) { /* clipboard unavailable: keep the approval card usable */ }
+          });
+          li.appendChild(copyBtn);
 
           pendingList.appendChild(li);
         });

--- a/tests/unit/test_dash_polish.py
+++ b/tests/unit/test_dash_polish.py
@@ -104,6 +104,29 @@ def test_pending_card_mirrors_terminal_risk_badge_convention(tmp_path):
     assert '"RISK: " + (row.risk || "-").toUpperCase()' in html
 
 
+def test_pending_card_can_copy_only_redacted_details(tmp_path):
+    html = _index_html(tmp_path)
+    assert 'copyBtn.className = "btn btn-copy";' in html
+
+    start = html.index('copyBtn.addEventListener("click"')
+    end = html.index("li.appendChild(copyBtn);", start)
+    copy_block = html[start:end]
+
+    assert "await navigator.clipboard.writeText(JSON.stringify({" in copy_block
+    for field in (
+        "id",
+        "tier",
+        "risk",
+        "action_type",
+        "reason_codes",
+        "explanation",
+    ):
+        assert f"{field}: row.{field}" in copy_block
+    assert "target" not in copy_block
+    assert "path" not in copy_block
+    assert "catch (e)" in copy_block
+
+
 def test_feed_and_pending_rows_still_use_textcontent_only(tmp_path):
     html = _index_html(tmp_path)
     # The no-innerHTML-assignment discipline must survive the restyle: every


### PR DESCRIPTION
Closes #443

# Pull Request

## Slice

- Repo: doberman-core
- Feature / Slice: #443 — Copy details from pending-approval cards
- Plan reference: issue #443

## What this PR does

- Adds a neutral **Copy details** button beside each card's existing Approve/Deny actions.
- Copies formatted JSON containing only `id`, `tier`, `risk`, `action_type`, `reason_codes`, and `explanation` from the already-redacted `/api/pending` row.
- Handles unavailable or rejecting clipboard APIs without disrupting the approval card.
- Documents the review-handoff workflow in the README.
- Adds the required `changelog.d/498.md` release fragment.

## Tests added (run in CI)

- Extends `test_dash_polish.py` to verify the button is served, the clipboard write is defensive, all six allowed fields are present, and no target/path field enters the copied block.
- Targeted dashboard polish suite: **18 passed**.
- `ruff check .` and `ruff format --check .`: passed (401 files formatted).
- Markdown links: 43 files checked, no broken internal links.
- Import contracts: 4 kept, 0 broken.
- Parity generation check: passed.
- Full sequential suite reached 100% with **90.68% coverage**. Its only failure is the existing real-plugin installation test (`ModuleNotFoundError: doberman` inside the isolated plugin environment); the same failure reproduces unchanged from a clean `origin/main` worktree on Python 3.13.

## Public-release safety (doberman-core only)

- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist

- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening; no guardrail/learning behavior changes here)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced

- Clipboard API missing or rejecting: caught locally; Approve/Deny remain usable.
- Copy payload is deliberately allowlisted and excludes raw targets and paths.
- No decision-path, redaction, authentication, or endpoint behavior changes.

## AI assistance

AI infrastructure assisted with implementation and test review; the resulting diff and validations were reviewed locally.
