### PR TITLE
docs: index additional documentation pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,3 +12,8 @@ Use this index to find the right Doberman documentation for your task.
 | [BENCHMARKS.md](BENCHMARKS.md) | Open this when evaluating Doberman's protection results, reproducing benchmark numbers, or understanding what those metrics do and do not prove. |
 | [RELEASING.md](RELEASING.md) | Open this when preparing and publishing a Doberman-Core release and verifying the required checks and evidence. |
 | [audit_otel.md](audit_otel.md) | Open this when sending Doberman's redacted decision records to an OpenTelemetry-compatible collector. |
+| [PLUGINS.md](PLUGINS.md) | Open this when writing a custom guardrail rule or forwarding Doberman's redacted audit log to your own pipeline. |
+| [RECOVERY.md](RECOVERY.md) | Open this when clearing sticky taint, approving a changed MCP tool, resetting learned memory, or removing Doberman from a project. |
+| [TELEMETRY.md](TELEMETRY.md) | Open this when you want to understand what anonymous usage data Doberman sends, what it never sends, or how to control telemetry. |
+| [TUNING.md](TUNING.md) | Open this when adjusting Doberman's strictness, enforcement, roles, preference weights, friction settings, or message tone to match your risk tolerance. |
+| [TURN_GATE.md](TURN_GATE.md) | Open this when you want to understand how Doberman inspects conversation turns before inference and how the turn gate works alongside the tool-call action gate. |


### PR DESCRIPTION
## Summary

- Added index entries for PLUGINS, RECOVERY, TELEMETRY, TUNING, and TURN_GATE.
- Kept each description focused on when a reader should open the document.
- Based the descriptions on each document's opening section.

Follow-up to #409 .