### PR TITLE
test(examples): restore the hard audit-sink standalone guarantee; cover the tutorial without installing it

### DIFF
--- a/changelog.d/501.md
+++ b/changelog.d/501.md
@@ -1,0 +1,3 @@
+- **Tests:** the core standalone-guarantee test asserts no `doberman.audit_sinks` plugin is
+  registered by default again; the plugin-audit-sink tutorial is now covered by a CI-visible test
+  that never installs it (#501)

--- a/examples/plugin-audit-sink/README.md
+++ b/examples/plugin-audit-sink/README.md
@@ -87,8 +87,10 @@ pip uninstall -y doberman-example-plugin-audit-sink
 > **Important:** while this package is installed, core's "no sinks installed"
 > standalone checks (`discover_audit_sinks() == []`) will fail — that is
 > expected.  Uninstall before re-running the full core suite.  Default CI does
-> **not** install this package; it only imports the sink class directly for
-> emit/never-raises checks.
+> **not** install this package; `tests/unit/test_examples_plugin_audit_sink.py`
+> covers it instead by importing the sink class straight from this checkout
+> (`sys.path`, no install) for layout/entry-point/protocol/emit/never-raises
+> checks, so the standalone guarantee stays intact.
 
 ## How registration works
 

--- a/tests/unit/test_core_is_standalone.py
+++ b/tests/unit/test_core_is_standalone.py
@@ -81,15 +81,9 @@ def test_no_algebra_adapters_registered_by_default():
 def test_no_audit_sinks_registered_by_default():
     # Slice 8.4 standalone guarantee: with no enterprise package installed, the
     # audit-sink registry discovers nothing — only the local decision log runs.
-    # Tutorial example packages (example_audit_sink, etc.) are excluded: they are
-    # local development installs, not enterprise sinks, and their own tests cover
-    # discovery. This mirrors the rules check above.
     from doberman.engine.registry import discover_audit_sinks
 
-    non_example_sinks = [
-        s for s in discover_audit_sinks() if not type(s).__module__.startswith("example_")
-    ]
-    assert non_example_sinks == []
+    assert discover_audit_sinks() == []
 
 
 def test_objective_guardrail_runs_with_only_builtins():

--- a/tests/unit/test_examples_plugin_audit_sink.py
+++ b/tests/unit/test_examples_plugin_audit_sink.py
@@ -1,0 +1,134 @@
+"""CI-visible checks for the tutorial plugin under examples/plugin-audit-sink (#442).
+
+The example package is **opt-in** (``pip install -e examples/plugin-audit-sink``).
+These tests never install its entry point into the active environment — that would
+make ``discover_audit_sinks()`` non-empty for every other test in the suite,
+including the standalone guarantee in ``test_core_is_standalone.py``.
+
+They do prove:
+
+* the package layout and ``doberman.audit_sinks`` entry-point declaration are correct;
+* ``ExampleAuditSink`` satisfies the core ``AuditSink`` protocol;
+* ``emit`` never raises, including on a malformed record;
+* the sink's output never echoes a raw secret placed in the record.
+
+Full entry-point discovery after a real install is covered by the example's own
+tests (``examples/plugin-audit-sink/tests/``) and documented in its README.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from doberman.engine.registry import discover_audit_sinks
+from doberman.storage.sinks import AuditSink
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLE_ROOT = _REPO_ROOT / "examples" / "plugin-audit-sink"
+_EXAMPLE_SRC = _EXAMPLE_ROOT / "src"
+_EXAMPLE_PYPROJECT = _EXAMPLE_ROOT / "pyproject.toml"
+
+_SAMPLE_RECORD = {
+    "ts": "2026-08-21T12:00:00+00:00",
+    "action_id": "act-001",
+    "agent_role": "unknown",
+    "action_type": "file_write",
+    "target_path_class": "general",
+    "risk": "low",
+    "source_context": "unknown",
+    "final_verdict": "PASS",
+    "decided_layer": "guardrail",
+    "reason_codes": [],
+    "auth_required": False,
+    "auth_result": None,
+    "elevation_id": None,
+    "entity_id": "hmac:abc123",
+    "session_id": "sess-001",
+}
+
+_SECRET_MARKER = "SYNTHETIC-SECRET-9f3a"  # noqa: S105 — test fixture, not a real credential
+
+
+@pytest.fixture(scope="module")
+def example_sink_cls():
+    """Import ExampleAuditSink from the checkout without installing the package."""
+    assert _EXAMPLE_SRC.is_dir(), f"missing tutorial package at {_EXAMPLE_SRC}"
+    inserted = str(_EXAMPLE_SRC)
+    sys.path.insert(0, inserted)
+    try:
+        sys.modules.pop("example_audit_sink", None)
+        sys.modules.pop("example_audit_sink.sinks", None)
+        module = importlib.import_module("example_audit_sink.sinks")
+        return module.ExampleAuditSink
+    finally:
+        # Leave the module importable for the rest of this module's tests, but
+        # drop the path entry so we do not permanently shadow site-packages.
+        if sys.path and sys.path[0] == inserted:
+            sys.path.pop(0)
+
+
+def test_example_package_layout_exists():
+    assert (_EXAMPLE_ROOT / "README.md").is_file()
+    assert (_EXAMPLE_SRC / "example_audit_sink" / "sinks.py").is_file()
+    assert (_EXAMPLE_ROOT / "tests" / "test_example_sink.py").is_file()
+    assert _EXAMPLE_PYPROJECT.is_file()
+
+
+def test_example_pyproject_declares_doberman_audit_sinks_entry_point():
+    data = tomllib.loads(_EXAMPLE_PYPROJECT.read_text(encoding="utf-8"))
+    eps = data["project"]["entry-points"]["doberman.audit_sinks"]
+    assert eps["example_sink"] == "example_audit_sink.sinks:ExampleAuditSink"
+    # Mirror the core package name so ``pip install -e`` resolves against this repo.
+    assert "doberman-core" in data["project"]["dependencies"]
+
+
+def test_example_sink_satisfies_audit_sink_protocol(example_sink_cls):
+    assert isinstance(example_sink_cls(), AuditSink)
+
+
+def test_example_sink_emit_never_raises(example_sink_cls, tmp_path, monkeypatch):
+    from example_audit_sink.sinks import SINK_FILE_ENV
+
+    monkeypatch.setenv(SINK_FILE_ENV, str(tmp_path / "audit.jsonl"))
+    sink = example_sink_cls()
+    sink.emit(dict(_SAMPLE_RECORD))  # well-formed record
+    sink.emit({})  # malformed / empty record — must not raise
+    sink.emit({"unexpected": object()})  # non-JSON-native value — must not raise
+
+
+def test_example_sink_failure_log_never_echoes_a_secret(
+    example_sink_cls, tmp_path, monkeypatch, caplog
+):
+    """On a failed write the sink logs a WARNING (never raises) — that log line
+    is the only side channel besides the JSONL file, and it must not echo the
+    record's content, secret or not.
+
+    ``Path.open`` is patched to force the failure deterministically (a real
+    permission-denied path is OS-specific and unreliable on the Windows CI leg).
+    """
+    from example_audit_sink.sinks import SINK_FILE_ENV
+
+    monkeypatch.setenv(SINK_FILE_ENV, str(tmp_path / "audit.jsonl"))
+
+    def _raise(*_args, **_kwargs):
+        raise OSError("simulated unwritable sink")
+
+    monkeypatch.setattr(pathlib.Path, "open", _raise)
+    sink = example_sink_cls()
+    record = dict(_SAMPLE_RECORD, entity_id=_SECRET_MARKER)
+    with caplog.at_level("WARNING"):
+        sink.emit(record)  # write fails; must not raise
+
+    assert _SECRET_MARKER not in caplog.text
+
+
+def test_sys_path_import_does_not_register_the_entry_point(example_sink_cls):
+    """Importing via sys.path (this module's approach) must not make the tutorial
+    discoverable — only a real ``pip install`` populates importlib.metadata."""
+    assert discover_audit_sinks() == []


### PR DESCRIPTION
PR #499 added `examples/plugin-audit-sink/` (a tutorial `doberman.audit_sinks` plugin) and, in core proper, loosened the standalone guarantee test `test_no_audit_sinks_registered_by_default` from a hard `assert discover_audit_sinks() == []` to a filter excluding any sink whose module starts with `"example_"`. That loosening was unnecessary: default CI never installs the tutorial package (`testpaths = ["tests", "tools"]`), so `discover_audit_sinks()` is always empty in CI regardless. The comment claimed the change "mirrors the rules check above," but `test_default_plugin_registry_has_no_enterprise_plugins` is still a hard `== []` — so the audit-sink guarantee was the only one weakened. `examples/plugin-guardrail` already has a CI-visible test (`tests/unit/test_examples_plugin_guardrail.py`) that covers its tutorial via a `sys.path` import, never installing it into the active environment — this PR gives `plugin-audit-sink` the same treatment.

- Restore `test_no_audit_sinks_registered_by_default` to the hard `assert discover_audit_sinks() == []`.
- Add `tests/unit/test_examples_plugin_audit_sink.py`, modelled on `test_examples_plugin_guardrail.py`: package layout, the `doberman.audit_sinks` entry-point declaration, `ExampleAuditSink` satisfying the `AuditSink` protocol, `emit()` never raising (including on a malformed/empty record), a failure-path log check that a secret placed in the record never leaks into the WARNING log line, and a check that the `sys.path` import itself does not register the entry point (`discover_audit_sinks()` stays `[]`).
- Update `examples/plugin-audit-sink/README.md`'s CI note to name the new test instead of the vague, previously-false claim that core "only imports the sink class directly for emit/never-raises checks."

Follow-up to #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
