### PR TITLE
fix(storage): prune any AUTH row with a recorded outcome; calendar-independent CLI prune test

### DIFF
--- a/changelog.d/502.md
+++ b/changelog.d/502.md
@@ -1,0 +1,3 @@
+- `doberman decision-log-prune` now prunes every AUTH decision that recorded an outcome (approval
+  method, denied, blocked, error, executed), not only the three literal values it accepted before;
+  pending AUTH rows are still never deleted (#502)

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1914,7 +1914,7 @@ def decision_log_prune(
         None,
         "--older-than-days",
         min=1,
-        help="Delete resolved decisions whose timestamp is this many days old or older.",
+        help="Delete resolved decisions older than this many days (a row exactly at the cutoff is kept).",
     ),
     max_rows: int | None = typer.Option(
         None,

--- a/src/doberman/storage/log.py
+++ b/src/doberman/storage/log.py
@@ -79,11 +79,11 @@ _SELECT_SESSION_DECISIONS = (
 )
 
 # Maintenance deletes only fully-resolved decision rows. Every verdict except
-# AUTH is final; an AUTH row remains eligible only when its challenge already
-# produced an explicit outcome. A missing auth_result is deliberately kept.
-_RESOLVED_DECISIONS_PREDICATE = (
-    "(final_verdict <> 'AUTH' OR auth_result IN ('approved', 'denied', 'executed'))"
-)
+# AUTH is final; an AUTH row remains eligible only once it has an explicit
+# auth outcome (any non-NULL auth_result — the auth tier/method name,
+# "blocked", "error", "approved", "denied", "executed", ...). A NULL
+# auth_result (still pending) is deliberately kept.
+_RESOLVED_DECISIONS_PREDICATE = "(final_verdict <> 'AUTH' OR auth_result IS NOT NULL)"
 _DELETE_RESOLVED_DECISIONS = "DELETE FROM decisions WHERE " + _RESOLVED_DECISIONS_PREDICATE  # noqa: S608 — fixed clause, params bound
 _DECISION_COLUMNS = [
     "id",
@@ -296,8 +296,9 @@ async def prune_decisions(
 
     This is an operator-initiated maintenance operation, not part of the hot
     decision path. It only removes rows whose verdict is final (or whose AUTH
-    outcome is explicitly denied/approved/executed); unresolved AUTH rows are
-    never deleted. The append-only ``policy_changes`` ledger is not touched.
+    row has an explicit auth outcome — any non-NULL ``auth_result``); unresolved
+    AUTH rows are never deleted. The append-only ``policy_changes`` ledger is
+    not touched.
 
     ``older_than_days`` uses the same ISO-8601 timestamp convention as the rest
     of storage: exact cutoff stays, one second older goes. With ``max_rows``,

--- a/tests/integration/test_cli_views.py
+++ b/tests/integration/test_cli_views.py
@@ -22,7 +22,7 @@ _NOW = datetime(2026, 6, 8, tzinfo=timezone.utc)
 _SECRET = "AKIA-FAKE-CLIVIEW-SECRET-321"  # noqa: S105 — synthetic test value
 
 
-def _seed_auth_secret_read(root: str) -> None:
+def _seed_auth_secret_read(root: str, *, ts: datetime = _NOW) -> None:
     objective = GuardrailResult(
         verdict=Verdict.AUTH,
         risk=Risk.high,
@@ -36,18 +36,21 @@ def _seed_auth_secret_read(root: str) -> None:
         objective=objective,
         reason_codes=[ReasonCode.sensitive_secret_access],
         explanation="local secret access",
-        decided_at=_NOW,
+        decided_at=ts,
     )
     action = SecurityObject(
         id="act-1",
-        ts=_NOW,
+        ts=ts,
         agent_role="backend",
         action_type=ActionType.file_read,
         tool_name="fs_read",
         target="backend/secrets/local.env",
         payload_fingerprints=["hmac:abc123"],
     )
-    asyncio.run(record_decision(decision, action, repo_root=root, auth_result="denied"))
+    # `now=ts` is what actually lands in the persisted `ts` column (record_decision
+    # falls back to the real wall clock otherwise) — pass it explicitly so callers
+    # that need a deterministic row timestamp (e.g. the prune test) get one.
+    asyncio.run(record_decision(decision, action, repo_root=root, auth_result="denied", now=ts))
 
 
 def test_log_empty_when_nothing_recorded(tmp_path):
@@ -75,7 +78,11 @@ def test_decision_log_prune_requires_a_policy(tmp_path):
 
 def test_decision_log_prune_reports_count_only(tmp_path):
     root = str(tmp_path)
-    _seed_auth_secret_read(root)
+    # Deliberately NOT `_NOW` (2026-06-08): the CLI prunes against the real
+    # clock (no `now=` override), so a fixed past seed date eventually falls
+    # outside `--older-than-days 90` and the "0 row(s)" assertion below would
+    # start failing. Seed "now" instead so the row is always fresh.
+    _seed_auth_secret_read(root, ts=datetime.now(timezone.utc))
 
     result = runner.invoke(
         app,

--- a/tests/integration/test_decision_log.py
+++ b/tests/integration/test_decision_log.py
@@ -229,6 +229,33 @@ async def test_prune_deletes_resolved_auth(tmp_path):
     assert await read_decisions(root) == []
 
 
+async def test_prune_deletes_auth_rows_with_any_recorded_outcome(tmp_path):
+    # The real proxy/executor/hosthooks vocabulary is far wider than the three
+    # literal values ("approved", "denied", "executed") the predicate used to
+    # check for: successful auth persists the tier/method name (e.g.
+    # "soft_confirm"), and failure paths persist "blocked"/"error". Any of
+    # those is an explicit outcome and should be prunable; only a NULL
+    # auth_result (still pending) must be kept.
+    root = str(tmp_path)
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(days=365)
+
+    for action_id, auth_result in (
+        ("soft-confirm-auth", "soft_confirm"),
+        ("blocked-auth", "blocked"),
+        ("pending-auth", None),
+    ):
+        decision, action = _decision_and_action(Verdict.AUTH, action_id)
+        await record_decision(decision, action, repo_root=root, auth_result=auth_result, now=old)
+
+    result = await prune_decisions(root, older_than_days=1, now=now)
+
+    rows = await read_decisions(root)
+    assert result == {"age_deleted": 2, "overflow_deleted": 0}
+    assert {row["action_id"] for row in rows} == {"pending-auth"}
+    assert rows[0]["auth_result"] is None
+
+
 async def test_prune_requires_at_least_one_policy(tmp_path):
     raised = False
     try:


### PR DESCRIPTION
## Summary

Three small fast-follow fixes for `doberman decision-log-prune` (added in #461).

**1. The resolved-AUTH predicate didn't match what auth writers actually persist.** `_RESOLVED_DECISIONS_PREDICATE` in `src/doberman/storage/log.py:84-86` only treated `auth_result IN ('approved', 'denied', 'executed')` as a resolved outcome. But the real writers of `auth_result` never persist those exact three values for the common case: `proxy/executor.py:715,747,780` persist the auth tier/approval-method name (e.g. `"soft_confirm"`, `"local_auth"`, `"<method.name>"`, `"<method.name>+elevation"` — see `auth/provider.py:189-198`), `executor.py:766,775,886,894` and the hosthooks persist `"blocked"`, and `executor.py`'s error path persists `"error"`. The comment above the predicate already stated the correct intent ("an AUTH row remains eligible only when its challenge already produced an explicit outcome... a missing auth_result is deliberately kept") — the enumerated literal list just didn't implement it. Fixed to `(final_verdict <> 'AUTH' OR auth_result IS NOT NULL)`, which is exactly "any explicit outcome, pending stays".

**2. `test_decision_log_prune_reports_count_only` was calendar-fragile.** `_seed_auth_secret_read` (in `tests/integration/test_cli_views.py`) hardcoded a `_NOW = 2026-06-08` timestamp on the `Decision`/`SecurityObject` it builds, but neither of those values is what lands in the persisted `ts` column the prune predicate compares — `record_decision`'s `now` keyword is (`src/doberman/storage/log.py:172-198`, `record["ts"] = now.isoformat()`), and the seed helper never passed it, so it silently fell back to the real wall clock every time. That happened to make the prune test self-consistent today, but it's an accident of the current default, not something the test asserts — a future change to that fallback (e.g. deriving it from `decided_at` instead) would make the row's stored `ts` snap back to the stale `_NOW` and eventually push it past the `--older-than-days 90` cutoff, breaking the `"0 row(s)"` assertion. Made it robust either way: `_seed_auth_secret_read` now takes an optional `ts` parameter and threads it into `record_decision(..., now=ts)` too, and the prune test seeds with `datetime.now(timezone.utc)` explicitly instead of relying on an implicit fallback.

**3. Misleading help text.** `src/doberman/cli/main.py:1917` said "this many days old or older", but `prune_decisions` (`src/doberman/storage/log.py:302-303,323`, `ts < cutoff`) keeps a row exactly at the cutoff — it's a strict `<`, not `<=`. Reworded to "older than this many days (a row exactly at the cutoff is kept)".

## Changes

- `src/doberman/storage/log.py`: fix `_RESOLVED_DECISIONS_PREDICATE` to `auth_result IS NOT NULL`; update the comment and `prune_decisions` docstring to describe "any non-NULL auth_result" instead of enumerating three literal values.
- `tests/integration/test_decision_log.py`: add `test_prune_deletes_auth_rows_with_any_recorded_outcome`, seeding `soft_confirm`/`blocked`/`None` AUTH rows and asserting only the two non-NULL ones are pruned.
- `tests/integration/test_cli_views.py`: give `_seed_auth_secret_read` an optional `ts` parameter that also flows into `record_decision(..., now=ts)`; `test_decision_log_prune_reports_count_only` now seeds with `datetime.now(timezone.utc)` instead of relying on an unstated fallback.
- `src/doberman/cli/main.py`: correct the `--older-than-days` help text to describe the strict cutoff.
- `changelog.d/502.md`: user-facing changelog fragment.

Follow-up to #461 (#213).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

