### PR TITLE
fix(dash): confirm copied approval details

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ them off. See [Telemetry](docs/TELEMETRY.md).
 Doberman now reviews every tool call your agent makes. Confirm it with `doberman doctor`, or watch
 real verdicts with `doberman demo`. MCP-proxy wiring, the dashboard, the TUI, scan, and 2FA are in the
 [Setup guide](docs/SETUP.md). Pending-approval cards in the dashboard can copy their already-redacted
-decision details as JSON for review handoffs without exposing raw targets or paths.
+decision details as JSON for review handoffs without exposing raw targets or paths. The copy button
+briefly confirms success with `Copied!` so the reviewer knows the JSON reached the clipboard.
 
 ---
 

--- a/changelog.d/506.md
+++ b/changelog.d/506.md
@@ -1,0 +1,3 @@
+- Pending-approval cards now show `Copied!` for 1.5 seconds after their redacted JSON is
+  successfully copied, so reviewers get visible confirmation without exposing additional data
+  (#506)

--- a/src/doberman/dash/app.py
+++ b/src/doberman/dash/app.py
@@ -715,6 +715,7 @@ _HTML_SHELL = """<!doctype html>
           copyBtn.type = "button";
           copyBtn.className = "btn btn-copy";
           copyBtn.textContent = "Copy details";
+          var copyTimer = null;
           copyBtn.addEventListener("click", async function () {
             try {
               await navigator.clipboard.writeText(JSON.stringify({
@@ -725,6 +726,11 @@ _HTML_SHELL = """<!doctype html>
                 reason_codes: row.reason_codes,
                 explanation: row.explanation
               }, null, 2));
+              clearTimeout(copyTimer);
+              copyBtn.textContent = "Copied!";
+              copyTimer = setTimeout(function () {
+                copyBtn.textContent = "Copy details";
+              }, 1500);
             } catch (e) { /* clipboard unavailable: keep the approval card usable */ }
           });
           li.appendChild(copyBtn);

--- a/tests/unit/test_dash_polish.py
+++ b/tests/unit/test_dash_polish.py
@@ -124,6 +124,9 @@ def test_pending_card_can_copy_only_redacted_details(tmp_path):
         assert f"{field}: row.{field}" in copy_block
     assert "target" not in copy_block
     assert "path" not in copy_block
+    assert 'copyBtn.textContent = "Copied!";' in copy_block
+    assert 'copyBtn.textContent = "Copy details";' in copy_block
+    assert "}, 1500);" in copy_block
     assert "catch (e)" in copy_block
 
 


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: #503 — transient copied feedback for pending approval cards
- Plan reference: issue #503

## What this PR does

After a pending card's redacted JSON is written to the clipboard, the copy button now displays `Copied!` for 1.5 seconds and then restores `Copy details`. Repeated successful copies restart the timer, while clipboard failures leave the button text unchanged.

The existing dashboard polish regression test now verifies the success text and timeout without changing the copied JSON fields. The README describes the visible confirmation.

Closes #503

## Tests added (run in CI)
- Updated `tests/unit/test_dash_polish.py::test_pending_card_can_copy_only_redacted_details` to cover the transient success label and 1.5-second reset.
- `pytest tests/unit/test_dash_polish.py -q` — 18 passed.
- Full Windows run: 3366 passed, 7 skipped, coverage 91.55%; one unrelated existing integration test failed because its nested temporary virtualenv could not import `doberman` (`test_real_plugin_install_discovery.py`). The same test was rerun alone and reproduced the environment-only `ModuleNotFoundError`.
- `ruff check .` and `ruff format --check .`
- `lint-imports`
- `python scripts/check_markdown_links.py`
- `python -m tools.parity.generate_parity --check`

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (this UI-only change does not alter decision execution; clipboard failure changes no approval state)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no guardrail or learning behavior changed)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Repeated successful copies clear the previous timer before starting a new one.
- Clipboard rejection stays on the existing catch path and does not show a false success state.
- No deviations or new security risk; copied fields remain the existing redacted allowlist.

## AI assistance

This change was implemented with AI assistance and manually reviewed. All commands and verification results above were run locally.
