### PR TITLE
fix(auth): add auth dialog window icon

### DIFF
--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -158,7 +158,7 @@ def _configure_window(root: Any) -> None:
             icon = tk.PhotoImage(file=str(p))
             root.iconphoto(True, icon)
             root._icon_ref = icon
-    except Exception:   # noqa: S110 — cosmetic only; icon failure must not block the dialog
+    except Exception:  # noqa: S110 — cosmetic only; icon failure must not block the dialog
         pass
 
 

--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -152,13 +152,13 @@ def _configure_window(root: Any) -> None:
     _apply_dark_title_bar(root)
 
     try:
-        import tkinter as tk 
+        import tkinter as tk
 
         with _ir.as_file(_ir.files("doberman.auth").joinpath("_assets/doberman-mark.png")) as p:
             icon = tk.PhotoImage(file=str(p))
             root.iconphoto(True, icon)
             root._icon_ref = icon
-    except Exception:
+    except Exception:   # noqa: S110 — cosmetic only; icon failure must not block the dialog
         pass
 
 

--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -151,6 +151,16 @@ def _configure_window(root: Any) -> None:
     root.attributes("-topmost", True)  # the dialog must pop OVER the agent's terminal
     _apply_dark_title_bar(root)
 
+    try:
+        import tkinter as tk 
+
+        with _ir.as_file(_ir.files("doberman.auth").joinpath("_assets/doberman-mark.png")) as p:
+            icon = tk.PhotoImage(file=str(p))
+            root.iconphoto(True, icon)
+            root._icon_ref = icon
+    except Exception:
+        pass
+
 
 def _apply_dark_title_bar(root: Any) -> None:
     """Best-effort dark title bar on Windows 11/10; purely cosmetic, never fatal."""

--- a/tests/unit/test_gui_prompter.py
+++ b/tests/unit/test_gui_prompter.py
@@ -473,6 +473,21 @@ def test_configure_window_sets_icon(monkeypatch):
     assert default is True
 
 
+def test_configure_window_continues_when_icon_load_fails(monkeypatch):
+    tkinter = pytest.importorskip("tkinter")
+
+    def _boom(*_a):
+        raise RuntimeError("Icon load failed")
+
+    monkeypatch.setattr(tkinter, "PhotoImage", _boom)
+
+    root = _FakeRoot()
+    gui_prompter._configure_window(root)
+
+    assert root.titles == [gui_prompter._TITLE]
+    assert root.iconphoto_calls == []
+
+
 class _FakeCanvas:
     """Records the Canvas display list (bottom → top) and mirrors Tk's ``tag_lower``."""
 

--- a/tests/unit/test_gui_prompter.py
+++ b/tests/unit/test_gui_prompter.py
@@ -279,6 +279,7 @@ class _FakeRoot:
         self.geometries: list[str] = []
         self.close_on_mainloop = False
         self.scheduled: list[int] = []
+        self.iconphoto_calls: list = []
 
     def after(self, delay_ms, callback):  # noqa: ARG002 — the timeout never fires here
         # The dialog now schedules its own deny-on-silence bound; these tests
@@ -305,6 +306,9 @@ class _FakeRoot:
 
     def geometry(self, spec):
         self.geometries.append(spec)
+
+    def iconphoto(self, default, image):
+        self.iconphoto_calls.append((default, image))
 
     def update_idletasks(self):
         pass
@@ -454,6 +458,19 @@ def test_real_dialog_widgets_dark_theme_and_masked_entry(monkeypatch):
         assert root.cget("bg") == gui_prompter._BG
     finally:
         root.destroy()
+
+
+def test_configure_window_sets_icon(monkeypatch):
+    tkimage = pytest.importorskip("tkinter")
+    monkeypatch.setattr(tkimage, "PhotoImage", lambda **_kw: _kw.get("file"))
+
+    root = _FakeRoot()
+    gui_prompter._configure_window(root)
+
+    assert len(root.iconphoto_calls) == 1
+
+    default, _ = root.iconphoto_calls[0]
+    assert default is True
 
 
 class _FakeCanvas:


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: #432 — auth dialog taskbar/title-bar icon
- Plan reference: #432 

## What this PR does

Adds the Doberman mark as the auth dialog window icon using Tk's `iconphoto()` API.

The icon uses the existing bundled `doberman-mark.png` asset and keeps a reference on the root window so Tk does not drop the image. Icon setup is best-effort and will not prevent the auth dialog from opening if loading or setting the icon fails.

## Tests added (run in CI)
- Added coverage asserting `_configure_window()` calls `iconphoto()` once with the default flag enabled.
- Added coverage ensuring an icon load failure does not interrupt normal window configuration.
- `tests/unit/test_gui_prompter.py`: 37 passed locally.
- Ruff lint and formatting checks pass.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Icon loading is cosmetic and failure is intentionally ignored so it cannot prevent the auth dialog from opening.
- Developed and tested on Fedora with GNOME. GNOME does not display the window icon in the same way as Windows, so Windows taskbar/title-bar appearance was not visually verified.
- `iconphoto()` behavior is covered by the faked-root unit test.
- No changes to authorization behavior or verdict logic.

Closes #432