### PR TITLE
ci: faster, deeper, trustworthy CI — fast half-space trees in tests, one coverage leg, per-test timeouts, nightly deep run

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -1,0 +1,87 @@
+name: CI nightly (deep)
+
+# The slow, wide, adversarial run that PR CI deliberately is not. PR CI answers
+# "did this change break anything?" in ~10 minutes; this answers "is the suite
+# itself still trustworthy?" once a day:
+#   - every OS/Python combination PR CI skips (Windows 3.11/3.13, macOS, 3.14)
+#   - random test order (pytest-randomly): an order-dependent test fails HERE,
+#     not as an xdist "flake" on somebody's PR
+#   - warnings promoted to errors: a deprecation lands as a red nightly, not as
+#     a broken install after the next dependency release
+#   - production-size half-space trees for the whole suite (PR CI shrinks them
+#     for speed — see tests/conftest.py::_fast_hst); this guards that shortcut
+#   - a dependency vulnerability audit (pip-audit), blocking here and only here
+# A red nightly means "look before the next release", never "rerun until green".
+on:
+  schedule:
+    - cron: "23 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-nightly
+  cancel-in-progress: true
+
+jobs:
+  deep:
+    name: deep (${{ matrix.os }}, ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    # 3.14 is advisory until the ML dependency chain (river/scipy) ships wheels
+    # for it everywhere; promote it by deleting `experimental` once it is green.
+    continue-on-error: ${{ matrix.experimental == true }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: "ubuntu-latest", python-version: "3.11" }
+          - { os: "ubuntu-latest", python-version: "3.13" }
+          - { os: "windows-latest", python-version: "3.11" }
+          - { os: "windows-latest", python-version: "3.13" }
+          - { os: "macos-latest", python-version: "3.12" }
+          - { os: "ubuntu-latest", python-version: "3.14", experimental: true }
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]" pytest-randomly
+      - name: Standalone guarantee (no enterprise installed)
+        run: |
+          if pip list | grep -qi doberman-enterprise; then
+            echo "FAIL: enterprise package found in core environment"
+            exit 1
+          fi
+      # -p randomly prints its seed at the top of the log; reproduce an order
+      # failure locally with `pytest -p randomly -p "randomly_seed=<seed>"`.
+      # The one ignored warning is Starlette's httpx -> httpx2 test-client
+      # deprecation, tracked as a dependency follow-up, not a suite defect.
+      - name: Full suite — random order, warnings as errors, production-size trees
+        env:
+          DOBERMAN_TEST_REAL_HST: "1"
+        run: >
+          pytest -n auto -p randomly --timeout=900 --durations=40 --durations-min=5.0
+          -W error
+          -W "ignore:Using .httpx. with .starlette.testclient.*"
+
+  dependency-audit:
+    name: Dependency vulnerability audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install --upgrade pip pip-audit && pip install -e .
+      # Blocking on the schedule only: the publish workflow keeps its SBOM step
+      # advisory so a fresh CVE cannot silently stop a reviewed release, but a
+      # daily red here is the prompt to go and look.
+      - run: pip-audit --strict --desc on .

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           DOBERMAN_TEST_REAL_HST: "1"
         run: >
-          pytest -n auto -p randomly --timeout=900 --durations=40 --durations-min=5.0
+          pytest -n auto --dist loadgroup -p randomly --timeout=900 --durations=40 --durations-min=5.0
           -W error
           -W "ignore:Using .httpx. with .starlette.testclient.*"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,13 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.11", "3.12", "3.13"]
-        coverage: [false]
         include:
           # Coverage is measured on ONE leg. Branch-coverage tracing costs ~25% of
           # the suite's wall-clock (measured 2026-08-03, ADR 0055) and the number
           # is identical on every leg, so paying it four times bought nothing.
+          # `coverage` is deliberately NOT a base matrix key: an include entry that
+          # only ADDS a key merges into the existing ubuntu/3.12 combination, while
+          # one that overrides a base key would create a fifth, duplicate leg.
           - os: "ubuntu-latest"
             python-version: "3.12"
             coverage: true
@@ -66,7 +68,6 @@ jobs:
           # (The nightly deep workflow adds Windows 3.11/3.13 and macOS.)
           - os: "windows-latest"
             python-version: "3.12"
-            coverage: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -82,7 +83,9 @@ jobs:
           fi
           echo "ok: core has no enterprise dependency"
       # --timeout: a single stuck test dies in 5 min with a traceback naming it,
-      # instead of taking the whole leg to the job timeout with no diagnosis.
+      # instead of taking the whole leg to the job timeout with no diagnosis. The
+      # production-size gate modules carry their own `timeout` marker (see their
+      # `pytestmark`) because their module-scoped eval fixture lands on one item.
       # --durations: every run reports its slowest tests, so a creeping suite is
       # visible in the log before it becomes a timeout.
       - name: Test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,18 +4,45 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
 permissions:
   contents: read
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Supersede a stale PR run, but never cancel a main-branch run: every commit on
+  # main keeps its own verdict (a cancelled main run is a commit nobody tested).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
+  static:
+    name: Lint, boundaries, docs, parity
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+      - name: Offline Markdown link check
+        run: python scripts/check_markdown_links.py
+      - name: Architecture & repo boundaries
+        run: lint-imports
+      - name: Parity matrix is current
+        run: python -m tools.parity.generate_parity --check
+      - name: Installed dependency set is consistent
+        run: python -m pip check
   test:
+    # Explicit name so the matrix's extra `coverage` key does not change the job
+    # names that branch protection and the merge queue key on.
+    name: test (${{ matrix.os }}, ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40   # the Windows leg takes ~22 min; a hang must not run to the 6 h default
+    timeout-minutes: 30
     # Windows runners default `run:` to PowerShell; pin bash (Git Bash ships on
-    # GitHub's Windows images) so the shell-scripted steps below — the `grep`-based
-    # standalone-guarantee check in particular — behave identically on every OS.
+    # GitHub's Windows images) so the shell-scripted steps behave identically on
+    # every OS.
     defaults:
       run:
         shell: bash
@@ -24,13 +51,22 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.11", "3.12", "3.13"]
-        # Doberman is a local-first tool that runs on developer machines of every
-        # OS, and it carries OS-specific code (e.g. the Windows O_BINARY key-write
-        # path in storage/fingerprint.py). Guard that surface with one Windows leg
-        # so cross-platform regressions surface in CI, not on a contributor's box.
+        coverage: [false]
         include:
+          # Coverage is measured on ONE leg. Branch-coverage tracing costs ~25% of
+          # the suite's wall-clock (measured 2026-08-03, ADR 0055) and the number
+          # is identical on every leg, so paying it four times bought nothing.
+          - os: "ubuntu-latest"
+            python-version: "3.12"
+            coverage: true
+          # Doberman is a local-first tool that runs on developer machines of every
+          # OS, and it carries OS-specific code (e.g. the Windows O_BINARY key-write
+          # path in storage/fingerprint.py). Guard that surface with one Windows leg
+          # so cross-platform regressions surface in CI, not on a contributor's box.
+          # (The nightly deep workflow adds Windows 3.11/3.13 and macOS.)
           - os: "windows-latest"
             python-version: "3.12"
+            coverage: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -45,18 +81,25 @@ jobs:
             exit 1
           fi
           echo "ok: core has no enterprise dependency"
-      - run: ruff check .
-      - run: ruff format --check .
-      - name: Offline Markdown link check
-        run: python scripts/check_markdown_links.py
-      - name: Architecture & repo boundaries
-        run: lint-imports
-      - run: pytest -n auto --cov=doberman --cov-report=term-missing --cov-fail-under=80
-      - name: Parity matrix is current
-        run: python -m tools.parity.generate_parity --check
+      # --timeout: a single stuck test dies in 5 min with a traceback naming it,
+      # instead of taking the whole leg to the job timeout with no diagnosis.
+      # --durations: every run reports its slowest tests, so a creeping suite is
+      # visible in the log before it becomes a timeout.
+      - name: Test suite
+        run: >
+          pytest -n auto --timeout=300 --durations=25 --durations-min=2.0
+          ${{ matrix.coverage && '--cov=doberman --cov-report=term-missing --cov-fail-under=90' || '' }}
   package-smoke-test:
-    runs-on: ubuntu-latest
+    name: package-smoke-test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -67,16 +110,22 @@ jobs:
       - run: python -m build
       - name: Install wheel into a clean environment
         run: |
-          python -m venv /tmp/wheel-env
-          /tmp/wheel-env/bin/pip install dist/*.whl
+          python -m venv "$RUNNER_TEMP/wheel-env"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            echo "WHEEL_ENV_BIN=$RUNNER_TEMP/wheel-env/Scripts" >> "$GITHUB_ENV"
+            "$RUNNER_TEMP/wheel-env/Scripts/pip" install dist/*.whl
+          else
+            echo "WHEEL_ENV_BIN=$RUNNER_TEMP/wheel-env/bin" >> "$GITHUB_ENV"
+            "$RUNNER_TEMP/wheel-env/bin/pip" install dist/*.whl
+          fi
       - name: Smoke test — CLI entry point works standalone
-        run: /tmp/wheel-env/bin/doberman --version
+        run: '"$WHEEL_ENV_BIN/doberman" --version'
       # `--version` only proves the modules shipped: it never reads package DATA.
       # builtin_roles.yaml is loaded lazily (roles.py), so dropping it from the
       # wheel would leave the check above green while every role lookup crashes.
       - name: Smoke test — bundled package data ships in the wheel
         run: >
-          /tmp/wheel-env/bin/python -c
+          "$WHEEL_ENV_BIN/python" -c
           "from doberman.roles.roles import load_builtin_roles;
           assert load_builtin_roles(), 'builtin_roles.yaml missing from the wheel'"
   secret-scan:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       # visible in the log before it becomes a timeout.
       - name: Test suite
         run: >
-          pytest -n auto --timeout=300 --durations=25 --durations-min=2.0
+          pytest -n auto --dist loadgroup --timeout=300 --durations=25 --durations-min=2.0
           ${{ matrix.coverage && '--cov=doberman --cov-report=term-missing --cov-fail-under=90' || '' }}
   package-smoke-test:
     name: package-smoke-test (${{ matrix.os }})

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,7 +101,7 @@ jobs:
             echo "::error::pyproject version $version does not match tag $TAG"
             exit 1
           fi
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       - name: Attach SBOM to the GitHub Release
         if: hashFiles('sbom/sbom.json') != ''
         env:
@@ -131,6 +131,6 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,16 @@ ruff check .
 ruff format --check .
 python scripts/check_markdown_links.py
 lint-imports
-pytest -n auto --cov=doberman --cov-report=term-missing --cov-fail-under=80
+pytest -n auto --cov=doberman --cov-report=term-missing --cov-fail-under=90
 python -m tools.parity.generate_parity --check
 ```
 
-CI runs exactly these (on Linux 3.11–3.13 and Windows 3.12) plus a wheel smoke test and a
-full-history secret scan. The optional extras `explain` (Anthropic SDK) and `winhello`
+CI runs exactly these: the lint, boundary, link, and parity checks once on Linux; the
+test suite on Linux 3.11–3.13 and Windows 3.12 (coverage is measured on the Linux 3.12 leg;
+every test has a 5-minute timeout); a wheel smoke test on Linux and Windows; and a
+full-history secret scan. A nightly deep run adds Windows 3.11/3.13, macOS, Python 3.14,
+random test order, warnings-as-errors, production-size half-space trees, and a dependency
+vulnerability audit — a red nightly is a bug in the suite or a dependency, not a rerun. The optional extras `explain` (Anthropic SDK) and `winhello`
 (Windows Hello) are not installed in CI; their tests use fakes, so exercise the real thing
 locally when you touch them.
 
@@ -95,7 +99,7 @@ verification process. Before marking a pull request ready for review, run:
 ruff check .
 ruff format --check .
 lint-imports
-pytest -n auto --cov=doberman --cov-report=term-missing --cov-fail-under=80
+pytest -n auto --cov=doberman --cov-report=term-missing --cov-fail-under=90
 ```
 
 The Markdown check is intentionally offline: it validates repository-local Markdown files and

--- a/changelog.d/518.md
+++ b/changelog.d/518.md
@@ -1,0 +1,6 @@
+- **CI is faster and stricter.** The test suite sizes the subjective layer's half-space trees to
+  river's defaults for ordinary tests (the production 25 × height 15 model is still used for the
+  benchmark and gate modules, and for the whole suite in a new nightly deep run), every test has a
+  5-minute timeout, coverage is measured once with the floor raised to 90%, the wheel smoke test
+  also runs on Windows, and a nightly workflow adds macOS, Windows 3.11/3.13, Python 3.14, random
+  test order, warnings-as-errors, and a dependency vulnerability audit (#518)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,7 +4,7 @@ The checklist for cutting a release, kept in sync with `.github/workflows/publis
 
 ## Before tagging
 
-1. **Green `main`.** CI passes on `main`: `ruff check .`, `ruff format --check .`, the offline Markdown link check, `lint-imports`, `pytest -n auto --cov=doberman --cov-report=term-missing --cov-fail-under=80`, the parity `--check` step, and the secret scan.
+1. **Green `main`.** CI passes on `main`: `ruff check .`, `ruff format --check .`, the offline Markdown link check, `lint-imports`, `pytest -n auto --cov=doberman --cov-report=term-missing --cov-fail-under=90`, the parity `--check` step, and the secret scan.
 2. **Parity matrix current.** `python -m tools.parity.generate_parity --check` passes (CI enforces it). Every checkmark in [`PARITY.md`](PARITY.md) still resolves to a collected test.
 3. **Refresh the benchmark numbers.** Re-run the suites per [`BENCHMARKS.md`](BENCHMARKS.md) and update its Results tables in the release PR:
    - Synthetic (deterministic, from a cold clone): `python -m tests.benchmarks.run --suite synthetic --profile before_after`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ markers = [
     "guarantee(name, host): claims a parity-matrix cell; collected by tools/parity (docs/PARITY.md)",
     "real_hst: build the production-size half-space trees (25 × height 15) instead of the fast test default",
     "timeout(seconds): per-item ceiling honoured by pytest-timeout (CI passes --timeout); registered here so --strict-markers accepts it without the plugin",
+    "xdist_group(name): pytest-xdist scheduling group (CI passes --dist loadgroup); registered here so --strict-markers accepts it without the plugin",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-xdist", "ruff>=0.15,<0.16", "import-linter", "textual", "hypothesis", "starlette", "uvicorn", "httpx"]
+dev = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-xdist", "pytest-timeout", "ruff>=0.15,<0.16", "import-linter", "textual", "hypothesis", "starlette", "uvicorn", "httpx"]
 explain = ["anthropic"]
 tui = ["textual"]
 dash = ["starlette", "uvicorn"]
@@ -87,9 +87,10 @@ include = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests", "tools"]   # tools/ holds rule-lab tooling + its co-located tests
-addopts = "-q"
+addopts = "-q --strict-markers --strict-config"
 markers = [
     "guarantee(name, host): claims a parity-matrix cell; collected by tools/parity (docs/PARITY.md)",
+    "real_hst: build the production-size half-space trees (25 × height 15) instead of the fast test default",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ addopts = "-q --strict-markers --strict-config"
 markers = [
     "guarantee(name, host): claims a parity-matrix cell; collected by tools/parity (docs/PARITY.md)",
     "real_hst: build the production-size half-space trees (25 × height 15) instead of the fast test default",
+    "timeout(seconds): per-item ceiling honoured by pytest-timeout (CI passes --timeout); registered here so --strict-markers accepts it without the plugin",
 ]
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ need to exercise key generation/rotation override this with their own
 
 import json as _json
 import logging
+import os
 from typing import Any
 
 import pytest
@@ -241,3 +242,48 @@ def _isolated_doberman_logger_state(monkeypatch):
     monkeypatch.setattr(root, "handlers", root.handlers[:])
     monkeypatch.setattr(doberman_logger, "handlers", doberman_logger.handlers[:])
     monkeypatch.setattr(doberman_logger, "propagate", doberman_logger.propagate)
+
+
+# --- half-space trees: fast by default, production-size on request -------------
+#
+# Production builds HST_TREES x 2**(HST_HEIGHT+1) nodes (25 x 65k = 1.6M) on the
+# first observation per entity, per process - the single largest cost in the
+# suite (seconds per test on every leg, ~15 s on a loaded Windows box), paid by
+# every test that reaches ``baseline.observe``. Tests use river's defaults instead
+# (10 x height 8: ~30 ms). Where the model's shape is the thing under test - the
+# benchmark and gate modules - ``pytestmark = pytest.mark.real_hst`` keeps the
+# production size; the nightly deep workflow sets ``DOBERMAN_TEST_REAL_HST=1`` to
+# run the whole suite at production size and guard this shortcut.
+#
+# Done as a setup HOOK, not a fixture: module-scoped fixtures (the poisoning
+# eval, the subjective benchmark) are built before any function-scoped fixture
+# runs, so a fixture could not reach them. ``tryfirst`` puts this before the
+# runner's own setup, i.e. before ANY fixture of the item.
+#
+# The per-entity model cache is process-global; clearing it around each test
+# keeps learned state from leaking between tests that reuse an entity id (an
+# xdist-ordering flake source otherwise).
+
+_HST_PRODUCTION = (25, 15)
+_HST_FAST = (10, 8)
+
+
+def _apply_hst_size(trees: int, height: int) -> None:
+    from doberman.subjective import baseline
+
+    baseline.reset_hst()
+    baseline.HST_TREES = trees
+    baseline.HST_HEIGHT = height
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    real = item.get_closest_marker("real_hst") is not None or bool(
+        os.environ.get("DOBERMAN_TEST_REAL_HST")
+    )
+    _apply_hst_size(*(_HST_PRODUCTION if real else _HST_FAST))
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_teardown(item: pytest.Item) -> None:
+    _apply_hst_size(*_HST_PRODUCTION)

--- a/tests/integration/test_benchmark_synthetic_gate.py
+++ b/tests/integration/test_benchmark_synthetic_gate.py
@@ -23,7 +23,10 @@ from tests.benchmarks.profiles import build_pipeline
 from tests.benchmarks.runner import run_before_after, run_profiles
 from tests.benchmarks.suites.synthetic import PAYLOAD_MARKER, SyntheticAdapter
 
-pytestmark = pytest.mark.real_hst  # these gates measure the model's shape: production-size trees
+pytestmark = [
+    pytest.mark.real_hst,
+    pytest.mark.xdist_group("real_hst"),
+]  # production-size trees, one worker
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_benchmark_synthetic_gate.py
+++ b/tests/integration/test_benchmark_synthetic_gate.py
@@ -23,6 +23,8 @@ from tests.benchmarks.profiles import build_pipeline
 from tests.benchmarks.runner import run_before_after, run_profiles
 from tests.benchmarks.suites.synthetic import PAYLOAD_MARKER, SyntheticAdapter
 
+pytestmark = pytest.mark.real_hst  # these gates measure the model's shape: production-size trees
+
 
 @pytest.fixture(scope="module")
 def report() -> dict:

--- a/tests/integration/test_poisoning_gate.py
+++ b/tests/integration/test_poisoning_gate.py
@@ -29,6 +29,8 @@ import pytest
 
 import tests.benchmarks.poisoning_runner as pr
 
+pytestmark = pytest.mark.real_hst  # these gates measure the model's shape: production-size trees
+
 
 @pytest.fixture(scope="module")
 def report():

--- a/tests/integration/test_poisoning_gate.py
+++ b/tests/integration/test_poisoning_gate.py
@@ -29,7 +29,10 @@ import pytest
 
 import tests.benchmarks.poisoning_runner as pr
 
-pytestmark = pytest.mark.real_hst  # these gates measure the model's shape: production-size trees
+# These gates measure the model's shape, so they keep production-size trees; the
+# module-scoped eval fixture then lands on the first collected item, which needs
+# more than CI's default per-test timeout.
+pytestmark = [pytest.mark.real_hst, pytest.mark.timeout(1200)]
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_poisoning_gate.py
+++ b/tests/integration/test_poisoning_gate.py
@@ -32,7 +32,13 @@ import tests.benchmarks.poisoning_runner as pr
 # These gates measure the model's shape, so they keep production-size trees; the
 # module-scoped eval fixture then lands on the first collected item, which needs
 # more than CI's default per-test timeout.
-pytestmark = [pytest.mark.real_hst, pytest.mark.timeout(1200)]
+pytestmark = [
+    pytest.mark.real_hst,
+    pytest.mark.timeout(1200),
+    # One xdist worker builds the module fixture once (--dist loadgroup); without
+    # the group every worker that draws an item from this module rebuilds it.
+    pytest.mark.xdist_group("real_hst"),
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/test_benchmark_agentdojo_live.py
+++ b/tests/unit/test_benchmark_agentdojo_live.py
@@ -21,7 +21,10 @@ from tests.benchmarks.subjective_runner import (  # noqa: E402 — after the imp
 )
 from tests.benchmarks.suites.agentdojo import AgentDojoAdapter  # noqa: E402
 
-pytestmark = pytest.mark.real_hst  # these gates measure the model's shape: production-size trees
+# These gates measure the model's shape, so they keep production-size trees; the
+# module-scoped eval fixture then lands on the first collected item, which needs
+# more than CI's default per-test timeout.
+pytestmark = [pytest.mark.real_hst, pytest.mark.timeout(1200)]
 
 
 def test_subjective_eval_reports_all_suites_and_both_arms():

--- a/tests/unit/test_benchmark_agentdojo_live.py
+++ b/tests/unit/test_benchmark_agentdojo_live.py
@@ -21,6 +21,8 @@ from tests.benchmarks.subjective_runner import (  # noqa: E402 — after the imp
 )
 from tests.benchmarks.suites.agentdojo import AgentDojoAdapter  # noqa: E402
 
+pytestmark = pytest.mark.real_hst  # these gates measure the model's shape: production-size trees
+
 
 def test_subjective_eval_reports_all_suites_and_both_arms():
     report = run_subjective_eval(AgentDojoAdapter())

--- a/tests/unit/test_benchmark_agentdojo_live.py
+++ b/tests/unit/test_benchmark_agentdojo_live.py
@@ -24,7 +24,13 @@ from tests.benchmarks.suites.agentdojo import AgentDojoAdapter  # noqa: E402
 # These gates measure the model's shape, so they keep production-size trees; the
 # module-scoped eval fixture then lands on the first collected item, which needs
 # more than CI's default per-test timeout.
-pytestmark = [pytest.mark.real_hst, pytest.mark.timeout(1200)]
+pytestmark = [
+    pytest.mark.real_hst,
+    pytest.mark.timeout(1200),
+    # One xdist worker builds the module fixture once (--dist loadgroup); without
+    # the group every worker that draws an item from this module rebuilds it.
+    pytest.mark.xdist_group("real_hst"),
+]
 
 
 def test_subjective_eval_reports_all_suites_and_both_arms():

--- a/tests/unit/test_benchmark_subjective.py
+++ b/tests/unit/test_benchmark_subjective.py
@@ -17,7 +17,13 @@ from tests.benchmarks.subjective_runner import HOLDOUT_EVERY, _prepared, run_sub
 # These gates measure the model's shape, so they keep production-size trees; the
 # module-scoped eval fixture then lands on the first collected item, which needs
 # more than CI's default per-test timeout.
-pytestmark = [pytest.mark.real_hst, pytest.mark.timeout(1200)]
+pytestmark = [
+    pytest.mark.real_hst,
+    pytest.mark.timeout(1200),
+    # One xdist worker builds the module fixture once (--dist loadgroup); without
+    # the group every worker that draws an item from this module rebuilds it.
+    pytest.mark.xdist_group("real_hst"),
+]
 
 # --- fixture ------------------------------------------------------------
 # A repetitive benign workflow (file_read of notes.txt, sometimes followed by

--- a/tests/unit/test_benchmark_subjective.py
+++ b/tests/unit/test_benchmark_subjective.py
@@ -14,7 +14,10 @@ from tests.benchmarks.adapter import BenchmarkCase, CandidateAction
 from tests.benchmarks.mapping import to_security_object
 from tests.benchmarks.subjective_runner import HOLDOUT_EVERY, _prepared, run_subjective_eval
 
-pytestmark = pytest.mark.real_hst  # these gates measure the model's shape: production-size trees
+# These gates measure the model's shape, so they keep production-size trees; the
+# module-scoped eval fixture then lands on the first collected item, which needs
+# more than CI's default per-test timeout.
+pytestmark = [pytest.mark.real_hst, pytest.mark.timeout(1200)]
 
 # --- fixture ------------------------------------------------------------
 # A repetitive benign workflow (file_read of notes.txt, sometimes followed by

--- a/tests/unit/test_benchmark_subjective.py
+++ b/tests/unit/test_benchmark_subjective.py
@@ -14,6 +14,8 @@ from tests.benchmarks.adapter import BenchmarkCase, CandidateAction
 from tests.benchmarks.mapping import to_security_object
 from tests.benchmarks.subjective_runner import HOLDOUT_EVERY, _prepared, run_subjective_eval
 
+pytestmark = pytest.mark.real_hst  # these gates measure the model's shape: production-size trees
+
 # --- fixture ------------------------------------------------------------
 # A repetitive benign workflow (file_read of notes.txt, sometimes followed by
 # a second read for Markov transition coverage) plus a handful of

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -351,7 +351,7 @@ def test_importing_cli_does_not_load_telemetry_hot_path_module():
         ],
         capture_output=True,
         text=True,
-        timeout=10,
+        timeout=60,  # a cold interpreter + CLI import on a loaded Windows runner can exceed 10 s
         check=False,
     )
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Why

An audit of the last 300 CI runs (65 failures) found that "Windows keeps failing" was four different things, none of them a recurring Windows bug:

- **17 `secret-scan` reds** on 2026-08-25/26: the gitleaks-action license requirement after the org move. Already fixed by the CLI switch (#480).
- **22 all-OS reds**: ordinary broken branches (a `ruff` F821, a CLI assertion). Not Windows.
- **2 Windows-only reds**: one deterministic test bug (illegal NTFS path characters, fixed on the branch the same day) and one still open on #506 — `test_importing_cli_does_not_load_telemetry_hot_path_module` gives a cold `python -c "import doberman.cli.main"` a **10 s** budget on the slowest, most contended leg.
- **The 40-minute job timeout** cancelling a Windows leg that was still progressing (2026-08-29): the suite is just slow — 23 of the Windows job's 24.5 minutes are the `pytest` step, 15 of 16 on Ubuntu.

Profiling the suite (`--durations`, then `cProfile` on one 15-second "unit" test) found the cost: the subjective layer's half-space-tree model is built with **25 trees × height 15 = 1.6M nodes** on the first observation per entity, per process (`baseline._hst_for`). That first `learn_one` costs seconds on Linux and ~15 s on a loaded Windows box, and ~55 test files reach it. `open_db`'s per-open schema ensure (28 ms) is the second-order cost and is left for a follow-up (product code).

Separately, `main` has **no branch protection** — no required checks — so no leg has ever actually blocked a merge, and the concurrency group cancels a main-branch run when the next merge lands, leaving commits with no verdict.

## What changed

**Test suite (the big lever)**
- `tests/conftest.py`: a `tryfirst` `pytest_runtest_setup` hook sizes the half-space trees to river's defaults (10 × height 8, ~30 ms) for every test, and restores production size on teardown. The benchmark and gate modules opt back in with `pytestmark = pytest.mark.real_hst` so the security numbers are never measured on a shrunken model; `DOBERMAN_TEST_REAL_HST=1` runs the whole suite at production size (the nightly does). Done as a hook, not a fixture, because module-scoped fixtures (the poisoning eval, the subjective benchmark) are built before any function fixture runs. The hook also clears the process-global per-entity model cache around every test, which removes a class of xdist-ordering flakes.
- Local full suite (`-n 6`, Windows, memory-constrained box): **755 s → 529 s**, same tests, no new failures.
- `tests/unit/test_telemetry.py`: the cold-interpreter subprocess budget 10 s → 60 s (the assertion is about *which modules load*, not speed).
- `pyproject.toml`: `--strict-markers --strict-config` in `addopts`; `real_hst` and `timeout` markers registered; `pytest-timeout` added to the `dev` extra.

**`ci.yml`**
- `static` job: ruff, format, Markdown links, import-linter, parity `--check`, and `pip check` run **once** on Linux instead of on all four test legs.
- Test legs run only the suite. **Coverage is measured on one leg** (Ubuntu 3.12) — branch tracing costs ~25% of wall-clock (ADR 0055) and the number is identical everywhere. Floor raised **80 → 90** (main sits at 91%; raise-only).
- `--timeout=300` per test: a stuck test dies in 5 minutes *with a traceback naming it* instead of taking the leg to the job timeout with no diagnosis. The three production-size gate modules carry `pytest.mark.timeout(1200)` because their module-scoped eval fixture lands on the first collected item (251 s / 177 s locally). `--durations=25` on every run so a creeping suite is visible before it becomes a timeout. Job timeout 40 → 30 min.
- `cancel-in-progress` only for pull requests: every commit on `main` keeps its own verdict.
- `package-smoke-test` also runs on Windows (entry-point `.exe` generation and package data are OS-specific surfaces).
- `workflow_dispatch` for manual reruns. Job names kept stable (`test (ubuntu-latest, 3.12)`) so branch protection can key on them.

**`ci-nightly.yml` (new, daily + manual)** — the deep run PR CI deliberately is not: Windows 3.11/3.13, macOS 3.12, Python 3.14 (advisory until the river/scipy wheels are everywhere), **random test order** (`pytest-randomly`, seed in the log), **warnings as errors** (one known Starlette httpx→httpx2 test-client deprecation ignored explicitly), **production-size trees for the whole suite**, and a blocking `pip-audit`. A red nightly means "look before the next release", never "rerun until green".

**`publish.yml`**: `pypa/gh-action-pypi-publish@release/v1` (a floating branch) pinned to the v1.14.2 commit SHA like every other action here.

**Docs**: CONTRIBUTING and RELEASING describe the new shape and the 90% floor.

## Not in this PR (follow-ups)

1. **Turn on branch protection for `main`** — required checks: the four `test (...)` legs, `Lint, boundaries, docs, parity`, both `package-smoke-test (...)`, `secret-scan`; strict up-to-date branches. Without it, CI is advisory. (Repo setting, maintainer action.)
2. **`open_db` schema fast path** (product code): every `open_db` re-runs 26 `CREATE IF NOT EXISTS` + migration probes + a commit (28 ms measured); a `schema_version` check first would make tests that observe hundreds of times per entity several times faster and shave the same off every proxy observation. Needs its own review.
3. **HST sizing** is a security-model parameter (the HS-Trees paper defaults) over a 6-feature space; whether 25 × 15 is the right production size is an ADR question, not a CI one.
4. **`httpx2`** for the Starlette test client (the one warning the nightly ignores).

## Verification

- A fresh-context Sonnet review of the diff found two real defects, both fixed in the second commit: the matrix `include` had created a duplicate Ubuntu 3.12 job under the same name, and the gate modules needed a per-item timeout above 300 s.
- Second run (33567799707), all 8 checks green: static 0.7 min · Ubuntu legs 4.3 / 6.8 (coverage, 91%) / 4.2 min · Windows 19.1 min · smokes 0.5 / 1.0 · secret-scan 0.1 — against 15–17 / 24.5 min before. The Windows leg is now bounded by per-observation `open_db` cost (follow-up 2) and, in that run, by the poisoning gate's module fixture being built on two xdist workers; the third commit groups the production-size modules onto one worker (`--dist loadgroup`).

- `ruff check` / `ruff format --check` / strict collection (3432 tests) clean locally.
- Full local suite green apart from the two known env-only tests (`test_benchmark_agentdojo_live`, `test_version_is_exposed` on this box's stale second `doberman.exe`).
- Env-override probe: the same module at 12.6 s (fast) vs 25.6 s (`DOBERMAN_TEST_REAL_HST=1`).
- CI on this PR is the first Linux measurement of the new shape; the `--durations` block in each leg's log is the profile going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6w2pfW6ZdjJCrup7dDkth
