### PR TITLE
fix(rules): classify command payloads by shape, not by tool label

### DIFF
--- a/changelog.d/519.md
+++ b/changelog.d/519.md
@@ -1,0 +1,3 @@
+- **The destructive-command rule classifies by payload, not by tool label.** A command-shaped
+  argument (`command`/`cmd`/`script`/`args`) is scanned whatever the tool was called, and
+  `package_install` actions get the same command scan as `shell_exec` (#519)

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -85,6 +85,12 @@ _DOBERMAN_CONTROL_SUBCOMMANDS = {
 #: command steps up to AUTH. Overridable (F6 wires this from policy/mode).
 DEFAULT_BULK_THRESHOLD = 25
 
+#: Action types the proxy itself labels as command-bearing (normalize.py's
+#: ``_COMMAND_EGRESS_ACTIONS``) — these get the ``action.target`` fallback too.
+_COMMAND_ACTION_TYPES = frozenset(
+    {ActionType.shell_exec, ActionType.git_op, ActionType.package_install}
+)
+
 #: Branch names whose history is protected — a force-push here is catastrophic.
 DEFAULT_PROTECTED_BRANCHES: tuple[str, ...] = ("main", "master", "release", "develop")
 
@@ -823,8 +829,8 @@ def _auth(reason: ReasonCode, explanation: str) -> GuardrailResult:
     )
 
 
-def _command_text(action: SecurityObject, ctx: EvalContext) -> str | None:
-    """Extract the raw command string (from un-redacted context, else target)."""
+def _raw_command_payload(ctx: EvalContext) -> str | None:
+    """Extract a command-shaped string from the un-redacted raw arguments, if any."""
     raw_arguments = ctx.metadata.get("raw_arguments") if isinstance(ctx.metadata, dict) else None
     if isinstance(raw_arguments, dict):
         for key in ("command", "cmd", "script", "args"):
@@ -833,6 +839,14 @@ def _command_text(action: SecurityObject, ctx: EvalContext) -> str | None:
                 return value
             if isinstance(value, (list, tuple)) and value:
                 return " ".join(str(v) for v in value)
+    return None
+
+
+def _command_text(action: SecurityObject, ctx: EvalContext) -> str | None:
+    """Extract the raw command string (from un-redacted context, else target)."""
+    payload = _raw_command_payload(ctx)
+    if payload is not None:
+        return payload
     if action.target:
         return action.target
     return None
@@ -852,11 +866,15 @@ class DestructiveCommandRule:
         self._bulk_threshold_override = bulk_threshold
 
     def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:
-        # Only relevant to shell/git actions. A non-command action abstains.
-        if action.action_type not in (ActionType.shell_exec, ActionType.git_op):
-            return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
-
-        command = _command_text(action, ctx)
+        # Classify by payload shape, not by the tool's declared action type: a
+        # command-bearing action type (shell_exec/git_op/package_install) also
+        # gets the action.target fallback, but ANY action type carrying a
+        # command-shaped raw_arguments payload (command/cmd/script/args) must
+        # still be scanned — a tool label is not a safety boundary.
+        if action.action_type in _COMMAND_ACTION_TYPES:
+            command = _command_text(action, ctx)
+        else:
+            command = _raw_command_payload(ctx)
         if not command or not command.strip():
             return GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
 

--- a/tests/unit/test_rule_commands.py
+++ b/tests/unit/test_rule_commands.py
@@ -16,9 +16,11 @@ from doberman.models import (
     ActionType,
     EvalContext,
     ReasonCode,
+    Risk,
     SecurityObject,
     Verdict,
 )
+from doberman.proxy.normalize import normalize
 
 RULE = DestructiveCommandRule()
 
@@ -336,3 +338,57 @@ def test_env_with_only_assignment_and_no_command_is_still_a_dump():
 def test_environment_dump_explanation_never_echoes_command_text():
     result = _cmd("env")
     assert "env" not in result.explanation.lower().split()
+
+
+def test_package_install_action_with_command_payload_blocks():
+    # package_install is a command-bearing action type per the proxy's own
+    # normalize.py (_COMMAND_EGRESS_ACTIONS) — its raw command must be
+    # classified the same as shell_exec, not silently abstained on.
+    result = _cmd("rm -rf /", action_type=ActionType.package_install)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.destructive_command in result.reason_codes
+
+
+def test_other_action_type_with_command_shaped_payload_blocks():
+    # ANY action type carrying a command-shaped raw_arguments payload must be
+    # scanned — classification is by payload shape, not by the tool label.
+    action = SecurityObject(
+        id="x",
+        ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.other,
+        tool_name="helper",
+    )
+    ctx = EvalContext(metadata={"raw_arguments": {"command": "rm -rf ~"}})
+    result = RULE.evaluate(action, ctx)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.destructive_command in result.reason_codes
+
+
+def test_file_write_target_without_raw_command_still_abstains():
+    # The action.target fallback stays limited to command action types: a
+    # file_write target is a file path, not a command line, even one that
+    # happens to look destructive.
+    action = SecurityObject(
+        id="x",
+        ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.file_write,
+        tool_name="fs_write",
+        target="rm -rf /",
+    )
+    result = RULE.evaluate(action, EvalContext())
+    assert result.verdict is Verdict.PASS
+    assert result.risk is Risk.low
+
+
+def test_normalized_package_install_command_blocks_end_to_end(tmp_path):
+    obj = normalize("install_helper", {"command": "rm -rf /"}, {"repo_root": str(tmp_path)})
+    assert obj.action_type is ActionType.package_install
+
+    ctx = EvalContext(
+        metadata={"raw_arguments": {"command": "rm -rf /"}, "repo_root": str(tmp_path)}
+    )
+    result = RULE.evaluate(obj, ctx)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.destructive_command in result.reason_codes


### PR DESCRIPTION
## What

`DestructiveCommandRule` decided whether to look at a command by the action-type label the proxy attached to the tool call. It now decides by the payload:

- `package_install` counts as a command-bearing action type, the same as `shell_exec` and `git_op` (it already is in the proxy's own `_COMMAND_EGRESS_ACTIONS`), so its command text is classified.
- Any other action type whose raw arguments carry a command-shaped payload (`command` / `cmd` / `script` / `args`) is classified too. The `action.target` fallback stays limited to the command-bearing types, so a file path target is never read as a command line.

Raise-only: nothing that blocked before passes now; some calls that abstained before now get the same verdict a `shell_exec` call would.

## Tests

Four new unit tests in `tests/unit/test_rule_commands.py`: a `package_install` action with a destructive payload blocks, an `other` action with a command-shaped payload blocks, a `file_write` target without a raw command still abstains, and an end-to-end `normalize(...)` → rule case.

Part of the private-patch set from the 2026-08-31 internal security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JMUDjz7a6xFiHDoQCuY1B