### PR TITLE
fix(auth): auth providers are opt-in by name, with a local co-gate for role elevation

### DIFF
--- a/changelog.d/520.md
+++ b/changelog.d/520.md
@@ -1,0 +1,3 @@
+- **Auth providers are opt-in.** A package registered under `doberman.auth_providers` runs only when
+  its entry-point name is listed in `DOBERMAN_AUTH_PROVIDER`; unlisted providers are never imported.
+  Role elevation always also asks the built-in local provider, whichever plugin is active (#520)

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -66,3 +66,12 @@ Additional sinks register the same way, through the **`doberman.audit_sinks`** e
 sink and the built-in OpenTelemetry sink (config-gated via `.doberman/audit_otel.yaml`, see
 [the OTel guide](audit_otel.md)); a sink that isn't shaped like an `AuditSink` (no callable `emit`),
 or whose `emit` raises, is logged and skipped, and never affects the decision itself.
+
+## Auth providers
+
+Alternative backends (SSO/RBAC, hosted/push approvals) register through the **`doberman.auth_providers`**
+entry-point group. Unlike rules and sinks, a registered provider is **opt-in by name**: installing the
+package isn't enough — set `DOBERMAN_AUTH_PROVIDER=<entry-point name>` (comma-separated for more than
+one, in preference order) to activate it. Unset/empty, or no opted-in provider found, and the built-in
+local (CLI + TOTP) provider runs unchanged. Whichever plugin is active, `AuthTier.role_elevation` always
+*also* asks the local provider — a plugin can never grant elevated privileges on its own.

--- a/src/doberman/auth/provider.py
+++ b/src/doberman/auth/provider.py
@@ -6,18 +6,30 @@ live in separately-installed packages that register an :class:`AuthProvider`
 through the ``doberman.auth_providers`` entry-point group — so core never
 imports them by name (the repo-boundary rule).
 
+A registered provider is **opt-in by name**: it is only used when its
+entry-point name is listed in ``DOBERMAN_AUTH_PROVIDER`` (comma-separated).
+Installing a package is never enough on its own — otherwise any installed
+package could silently become the sole authenticator. A chosen provider is
+wrapped in :class:`CoGatedProvider`, which additionally requires the built-in
+local provider's consent for :attr:`~doberman.auth.challenge.AuthTier.role_elevation`,
+so a compromised or malicious plugin can never grant itself elevated privileges
+alone.
+
 SECURITY: a provider can only **grant or deny**. It cannot change the decision's
 verdict or the required :class:`~doberman.auth.challenge.AuthTier`, and it
 receives only the already-final :class:`~doberman.models.Decision` plus the
 redacted action. If a provider raises, times out, or returns a non-approval, the
-action is **denied** (fail closed). With nothing registered, the local provider
-runs and behavior is identical to core-only.
+action is **denied** (fail closed). With the env var unset/empty, or no
+opted-in provider found, the local provider runs and behavior is identical to
+core-only.
 
 This module imports the F3 entry-point registry for discovery but never imports
 ``doberman.proxy``.
 """
 
 import logging
+import os
+import re
 from datetime import datetime, timezone
 from typing import Protocol, runtime_checkable
 
@@ -28,6 +40,14 @@ from doberman.explain import _describe_reason
 from doberman.models import ActionType, Decision, SecurityObject
 
 logger = logging.getLogger("doberman.auth.provider")
+
+#: Comma-separated ``doberman.auth_providers`` entry-point names to trust, in
+#: preference order. Unset/empty means no plugin is opted in — see
+#: :func:`active_provider`.
+AUTH_PROVIDER_ENV = "DOBERMAN_AUTH_PROVIDER"
+
+#: A safe entry-point-name shape (mirrors typical Python entry-point names).
+_PROVIDER_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
 
 
 @runtime_checkable
@@ -215,19 +235,109 @@ def _looks_like_auth_provider(obj: object) -> bool:
     return callable(getattr(obj, "authenticate", None))
 
 
-def active_provider() -> AuthProvider:
-    """Return the active provider: the first registered one, else local.
+def _allowed_provider_names() -> list[str]:
+    """Parse ``DOBERMAN_AUTH_PROVIDER`` into an ordered, deduplicated allowlist.
 
-    Discovery uses the F3 entry-point registry (group
-    ``doberman.auth_providers``); a registered provider that is not
-    auth-provider-shaped is skipped. With nothing installed, returns the local
-    provider — standalone behavior is unchanged.
+    Unset/empty -> ``[]``. Each comma-separated token is stripped; empty
+    tokens are dropped; a token that doesn't match a safe entry-point-name
+    shape is rejected with a warning (never raised) rather than handed to
+    discovery.
     """
+    raw = os.environ.get(AUTH_PROVIDER_ENV, "")
+    names: list[str] = []
+    seen: set[str] = set()
+    for token in raw.split(","):
+        name = token.strip()
+        if not name:
+            continue
+        if not _PROVIDER_NAME_RE.match(name):
+            logger.warning("ignoring malformed %s entry: %r", AUTH_PROVIDER_ENV, name)
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
+    return names
+
+
+class CoGatedProvider:
+    """Wraps an opted-in plugin provider; adds a local co-gate for role elevation.
+
+    A registered plugin can grant/deny any tier on its own EXCEPT
+    ``AuthTier.role_elevation``: for that tier it must additionally win consent
+    from the built-in :data:`LOCAL_PROVIDER`, so a compromised or malicious
+    plugin can never grant itself elevated privileges alone. Never raises: a
+    wrapped provider's exception, a non-approval, or a mismatched action id is
+    turned into a denial (fail closed).
+    """
+
+    def __init__(self, inner: AuthProvider) -> None:
+        self.inner = inner
+
+    def authenticate(
+        self,
+        decision: Decision,
+        action: SecurityObject,
+        tier: AuthTier,
+        *,
+        prompter: Prompter | None = None,
+        at: datetime | None = None,
+        message_tone: str = "human",
+    ) -> AuthResult:
+        when = at or datetime.now(timezone.utc)
+        try:
+            result = self.inner.authenticate(
+                decision, action, tier, prompter=prompter, at=at, message_tone=message_tone
+            )
+        except Exception:  # noqa: BLE001 — a plugin error must not crash the auth path
+            logger.warning("auth provider %r raised; denying", type(self.inner).__name__)
+            return AuthResult(
+                approved=False, tier=tier, method="error", at=when, action_id=action.id
+            )
+
+        if not result.approved or result.action_id != action.id:
+            return AuthResult(
+                approved=False, tier=tier, method=result.method, at=when, action_id=action.id
+            )
+
+        if tier is AuthTier.role_elevation:
+            local_result = LOCAL_PROVIDER.authenticate(
+                decision, action, tier, prompter=prompter, at=at, message_tone=message_tone
+            )
+            return AuthResult(
+                approved=local_result.approved,
+                tier=tier,
+                method=f"{result.method}+local",
+                at=when,
+                action_id=action.id,
+            )
+
+        return result
+
+
+def active_provider() -> AuthProvider:
+    """Return the active provider: an opted-in plugin (co-gated), else local.
+
+    A registered ``doberman.auth_providers`` plugin is used only if its name is
+    listed in ``DOBERMAN_AUTH_PROVIDER`` — installing the package is never
+    enough on its own. The chosen plugin is wrapped in :class:`CoGatedProvider`,
+    which requires the local provider's additional consent for
+    ``AuthTier.role_elevation``. Unset/empty env var, or no opted-in provider
+    found, returns the local provider unchanged (fail closed).
+    """
+    names = _allowed_provider_names()
+    if not names:
+        return LOCAL_PROVIDER
+
     # Lazy import: the registry lives in the engine layer.
     from doberman.engine.registry import discover_auth_providers
 
-    for candidate in discover_auth_providers():
+    for candidate in discover_auth_providers(names):
         if _looks_like_auth_provider(candidate):
-            return candidate  # type: ignore[return-value]
+            return CoGatedProvider(candidate)  # type: ignore[arg-type]
         logger.warning("skipping auth provider %r: not auth-provider-shaped", candidate)
+
+    logger.warning(
+        "no opted-in auth provider found for %s=%r; using local", AUTH_PROVIDER_ENV, names
+    )
     return LOCAL_PROVIDER

--- a/src/doberman/engine/registry.py
+++ b/src/doberman/engine/registry.py
@@ -23,7 +23,7 @@ SECURITY:
 """
 
 import logging
-from collections.abc import Iterator
+from collections.abc import Collection, Iterator
 from functools import lru_cache
 from importlib.metadata import EntryPoint, entry_points
 
@@ -211,22 +211,33 @@ def discover_policy_sources() -> list[object]:
     return sources
 
 
-def discover_auth_providers() -> list[object]:
-    """Discover registered auth providers (Feature 7.6, group ``doberman.auth_providers``).
+def discover_auth_providers(allowed: Collection[str]) -> list[object]:
+    """Discover OPTED-IN auth providers (Feature 7.6, group ``doberman.auth_providers``).
 
-    Loaded defensively like rules/sources: an import/constructor failure, or an
-    object that is not auth-provider-shaped (no callable ``authenticate``), is
-    logged and skipped. Returns ``[]`` when nothing is installed — the auth
-    layer then falls back to the built-in local provider. Core never imports a
-    provider by name.
+    Opt-in only: an entry point is loaded (imported and constructed) only if its
+    ``.name`` is in ``allowed`` — a package merely being installed is never
+    enough to make it an authenticator. Non-allowed entry points are skipped
+    before any import/construction happens, so an unlisted package's code never
+    runs. Allowed candidates are still loaded defensively like rules/sources: an
+    import/constructor failure, or an object that is not auth-provider-shaped
+    (no callable ``authenticate``), is logged and skipped. ``allowed`` empty
+    returns ``[]`` without iterating entry points at all — the auth layer then
+    falls back to the built-in local provider. Core never imports a provider by
+    name.
     """
+    if not allowed:
+        return []
+
     # Local import avoids an engine<->auth import cycle at module load.
     from doberman.auth.provider import _looks_like_auth_provider
 
     providers: list[object] = []
     seen: set[str] = set()
     for entry_point in _iter_entry_points(AUTH_PROVIDER_GROUP):
-        key = f"{AUTH_PROVIDER_GROUP}:{getattr(entry_point, 'name', id(entry_point))}"
+        name = getattr(entry_point, "name", None)
+        if name not in allowed:
+            continue
+        key = f"{AUTH_PROVIDER_GROUP}:{name if name is not None else id(entry_point)}"
         if key in seen:
             continue
         seen.add(key)

--- a/tests/unit/test_auth_provider.py
+++ b/tests/unit/test_auth_provider.py
@@ -6,7 +6,14 @@ import pyotp
 
 from doberman.auth import totp
 from doberman.auth.challenge import AuthResult, AuthTier
-from doberman.auth.provider import LocalAuthProvider, active_provider
+from doberman.auth.provider import (
+    AUTH_PROVIDER_ENV,
+    LOCAL_PROVIDER,
+    CoGatedProvider,
+    LocalAuthProvider,
+    active_provider,
+)
+from doberman.engine import registry
 from doberman.models import (
     ActionType,
     Decision,
@@ -203,19 +210,154 @@ def test_challenge_message_human_tone_is_plain_and_names_target_and_reason():
     assert "outside" in message and "scope" in message  # the plain-language reason
 
 
+class _StubProvider:
+    """A fake ``AuthProvider`` returning a canned result, recording every call."""
+
+    def __init__(self, *, approved=True, method="stub", action_id="act-7"):
+        self._approved = approved
+        self._method = method
+        self._action_id = action_id
+        self.calls: list[AuthTier] = []
+
+    def authenticate(self, decision, action, tier, *, prompter=None, at=None, message_tone="human"):
+        self.calls.append(tier)
+        return AuthResult(
+            approved=self._approved,
+            tier=tier,
+            method=self._method,
+            at=at or _NOW,
+            action_id=self._action_id,
+        )
+
+
+class _BoomProvider:
+    def authenticate(self, decision, action, tier, *, prompter=None, at=None, message_tone="human"):
+        raise RuntimeError("plugin exploded")
+
+
+class _FakeAuthEntryPoint:
+    def __init__(self, name, loader):
+        self.name = name
+        self._loader = loader
+
+    def load(self):
+        return self._loader()
+
+
+class _FakeAuthEntryPoints:
+    """Mimics importlib.metadata.entry_points() with a .select(group=...)."""
+
+    def __init__(self, entries):
+        self._entries = list(entries)
+
+    def select(self, *, group):
+        return list(self._entries) if group == registry.AUTH_PROVIDER_GROUP else []
+
+
 def test_registered_provider_is_preferred(monkeypatch):
-    sentinel = object()
+    stub = _StubProvider()
+    monkeypatch.setattr("doberman.engine.registry.discover_auth_providers", lambda names: [stub])
 
-    class StubProvider:
-        def authenticate(self, decision, action, tier, *, prompter=None, at=None):
-            return sentinel
+    # env var unset -> the registered provider is ignored entirely.
+    monkeypatch.delenv(AUTH_PROVIDER_ENV, raising=False)
+    assert active_provider() is LOCAL_PROVIDER
 
-    monkeypatch.setattr(
-        "doberman.engine.registry.discover_auth_providers", lambda: [StubProvider()]
-    )
-    assert isinstance(active_provider(), StubProvider)
+    # opted in by name -> wrapped in CoGatedProvider, wrapping the discovered stub.
+    monkeypatch.setenv(AUTH_PROVIDER_ENV, "stub")
+    provider = active_provider()
+    assert isinstance(provider, CoGatedProvider)
+    assert provider.inner is stub
 
 
 def test_non_provider_shaped_registration_is_skipped(monkeypatch):
-    monkeypatch.setattr("doberman.engine.registry.discover_auth_providers", lambda: [object()])
+    monkeypatch.setenv(AUTH_PROVIDER_ENV, "bogus")
+    monkeypatch.setattr(
+        "doberman.engine.registry.discover_auth_providers", lambda names: [object()]
+    )
     assert isinstance(active_provider(), LocalAuthProvider)
+
+
+def test_disallowed_provider_entry_point_is_never_loaded(monkeypatch):
+    def _must_not_load():
+        raise AssertionError("a non-allowed entry point must never be loaded")
+
+    allowed_ep = _FakeAuthEntryPoint("allowed", _StubProvider)
+    disallowed_ep = _FakeAuthEntryPoint("not-allowed", _must_not_load)
+    monkeypatch.setattr(
+        registry, "entry_points", lambda: _FakeAuthEntryPoints([allowed_ep, disallowed_ep])
+    )
+
+    result = registry.discover_auth_providers(["allowed"])
+    assert len(result) == 1
+    assert isinstance(result[0], _StubProvider)
+
+
+def test_empty_allowlist_returns_nothing_without_loading(monkeypatch):
+    def _must_not_load():
+        raise AssertionError("nothing may load when the allowlist is empty")
+
+    monkeypatch.setattr(
+        registry,
+        "entry_points",
+        lambda: _FakeAuthEntryPoints([_FakeAuthEntryPoint("x", _must_not_load)]),
+    )
+    assert registry.discover_auth_providers([]) == []
+
+
+def test_malformed_env_value_is_ignored(monkeypatch):
+    monkeypatch.setenv(AUTH_PROVIDER_ENV, "bad name;rm")
+    assert isinstance(active_provider(), LocalAuthProvider)
+
+
+def test_role_elevation_requires_local_consent_too():
+    totp.enroll()
+    secret = totp._read_secret()
+    code = pyotp.TOTP(secret).now()
+
+    plugin = _StubProvider(approved=True, method="sso")
+    gated = CoGatedProvider(plugin)
+
+    # plugin approves, but the local human declines -> not approved.
+    denied = gated.authenticate(
+        _auth_decision(), _action(), AuthTier.role_elevation, prompter=FakePrompter(confirm=False)
+    )
+    assert denied.approved is False
+
+    # plugin approves AND local approves (confirm + valid TOTP) -> approved.
+    approved = gated.authenticate(
+        _auth_decision(),
+        _action(),
+        AuthTier.role_elevation,
+        prompter=FakePrompter(confirm=True, code=code),
+    )
+    assert approved.approved is True
+    assert approved.method == "sso+local"
+
+
+def test_two_factor_uses_the_plugin_result_alone():
+    plugin = _StubProvider(approved=True, method="sso")
+    gated = CoGatedProvider(plugin)
+    # A prompter that would deny locally must not even be consulted for two_factor.
+    result = gated.authenticate(
+        _auth_decision(), _action(), AuthTier.two_factor, prompter=FakePrompter(confirm=False)
+    )
+    assert result.approved is True
+    assert result.method == "sso"
+
+
+def test_plugin_raising_is_denied_with_error_method():
+    gated = CoGatedProvider(_BoomProvider())
+    result = gated.authenticate(
+        _auth_decision(), _action(), AuthTier.soft_confirm, prompter=FakePrompter()
+    )
+    assert result.approved is False
+    assert result.method == "error"
+
+
+def test_plugin_approving_a_different_action_id_is_denied():
+    plugin = _StubProvider(approved=True, method="sso", action_id="some-other-action")
+    gated = CoGatedProvider(plugin)
+    result = gated.authenticate(
+        _auth_decision(), _action(), AuthTier.soft_confirm, prompter=FakePrompter()
+    )
+    assert result.approved is False

--- a/tests/unit/test_core_is_standalone.py
+++ b/tests/unit/test_core_is_standalone.py
@@ -45,13 +45,18 @@ def test_default_plugin_registry_has_no_enterprise_plugins():
 
 
 def test_default_auth_provider_is_local_with_no_enterprise():
-    # Slice 7.6 standalone guarantee: with no enterprise package installed AND
-    # no DOBERMAN_AUTH_PROVIDER opt-in, the auth-provider registry discovers
-    # nothing (an empty allowlist) and the local provider is active.
+    # Slice 7.6 standalone guarantee: with no enterprise package installed the
+    # auth-provider entry-point group is empty, so even an allowlist naming a
+    # provider finds nothing, and the local provider is active.
     from doberman.auth.provider import LocalAuthProvider, active_provider
-    from doberman.engine.registry import discover_auth_providers
+    from doberman.engine.registry import (
+        AUTH_PROVIDER_GROUP,
+        _iter_entry_points,
+        discover_auth_providers,
+    )
 
-    assert discover_auth_providers([]) == []
+    assert list(_iter_entry_points(AUTH_PROVIDER_GROUP)) == []
+    assert discover_auth_providers(["enterprise"]) == []
     assert isinstance(active_provider(), LocalAuthProvider)
 
 

--- a/tests/unit/test_core_is_standalone.py
+++ b/tests/unit/test_core_is_standalone.py
@@ -45,12 +45,13 @@ def test_default_plugin_registry_has_no_enterprise_plugins():
 
 
 def test_default_auth_provider_is_local_with_no_enterprise():
-    # Slice 7.6 standalone guarantee: with no enterprise package installed, the
-    # auth-provider registry discovers nothing and the local provider is active.
+    # Slice 7.6 standalone guarantee: with no enterprise package installed AND
+    # no DOBERMAN_AUTH_PROVIDER opt-in, the auth-provider registry discovers
+    # nothing (an empty allowlist) and the local provider is active.
     from doberman.auth.provider import LocalAuthProvider, active_provider
     from doberman.engine.registry import discover_auth_providers
 
-    assert discover_auth_providers() == []
+    assert discover_auth_providers([]) == []
     assert isinstance(active_provider(), LocalAuthProvider)
 
 


### PR DESCRIPTION
## What

A package registered under the `doberman.auth_providers` entry-point group used to become the active authenticator the moment it was installed. Two changes:

- **Opt-in by name.** A provider runs only if its entry-point name is listed in `DOBERMAN_AUTH_PROVIDER` (comma-separated, preference order). Entry points not on that list are skipped *before* they are imported or constructed. Unset, or no listed provider found, means the built-in local provider, exactly as core-only behaves today.
- **Local co-gate for role elevation.** The chosen provider is wrapped in `CoGatedProvider`: for `AuthTier.role_elevation` the local provider must approve as well (`method` becomes `<plugin>+local`). Other tiers are the plugin's call. A plugin that raises, denies, or answers for a different action id is a denial.

`discover_auth_providers` now takes the allowlist; its only in-tree caller is `active_provider`. `docs/PLUGINS.md` gains a short "Auth providers" section.

## Tests

`tests/unit/test_auth_provider.py`: unset env ignores a registered provider; opted-in provider is used, wrapped; non-listed entry points are never loaded (their `load()` would assert); malformed env values fall back to local; co-gate approve/deny matrix for role elevation vs two-factor; plugin exception and wrong-action-id denials. The standalone-guarantee test now asserts the entry-point group itself is empty. `lint-imports`: 4 contracts kept.

Part of the private-patch set from the 2026-08-31 internal security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JMUDjz7a6xFiHDoQCuY1B