### PR TITLE
ci: warnings are errors on every leg; fix the two findings from the nightly's first run

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -6,8 +6,7 @@ name: CI nightly (deep)
 #   - every OS/Python combination PR CI skips (Windows 3.11/3.13, macOS, 3.14)
 #   - random test order (pytest-randomly): an order-dependent test fails HERE,
 #     not as an xdist "flake" on somebody's PR
-#   - warnings promoted to errors: a deprecation lands as a red nightly, not as
-#     a broken install after the next dependency release
+#   - (warnings are errors on every leg, PR CI included — pyproject `filterwarnings`)
 #   - production-size half-space trees for the whole suite (PR CI shrinks them
 #     for speed — see tests/conftest.py::_fast_hst); this guards that shortcut
 #   - a dependency vulnerability audit (pip-audit), blocking here and only here
@@ -60,15 +59,14 @@ jobs:
           fi
       # -p randomly prints its seed at the top of the log; reproduce an order
       # failure locally with `pytest -p randomly -p "randomly_seed=<seed>"`.
-      # The one ignored warning is Starlette's httpx -> httpx2 test-client
-      # deprecation, tracked as a dependency follow-up, not a suite defect.
-      - name: Full suite — random order, warnings as errors, production-size trees
+      # Warnings are errors on every leg via pyproject's `filterwarnings` (with the
+      # tracked ignores listed after "error"); nothing to add here. A `-W error` on
+      # the command line would outrank the ini and re-raise every ignored warning.
+      - name: Full suite — random order, production-size trees
         env:
           DOBERMAN_TEST_REAL_HST: "1"
         run: >
           pytest -n auto --dist loadgroup -p randomly --timeout=900 --durations=40 --durations-min=5.0
-          -W error
-          -W "ignore:Using .httpx. with .starlette.testclient.*"
 
   dependency-audit:
     name: Dependency vulnerability audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,11 @@ jobs:
     # names that branch protection and the merge queue key on.
     name: test (${{ matrix.os }}, ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # Per-OS job ceiling: Linux legs run 4-7 min, Windows ~18 min, and a slow
+    # Windows runner has been 1.7x that (a 30-min cap cancelled a green run at
+    # 99%). The per-test --timeout below is what catches a hang; this only bounds
+    # a pathological runner.
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 45 || 20 }}
     # Windows runners default `run:` to PowerShell; pin bash (Git Bash ships on
     # GitHub's Windows images) so the shell-scripted steps behave identically on
     # every OS.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,16 @@ include = [
 asyncio_mode = "auto"
 testpaths = ["tests", "tools"]   # tools/ holds rule-lab tooling + its co-located tests
 addopts = "-q --strict-markers --strict-config"
+# Every warning raised during collection or a test is an error — on every leg,
+# locally too. A deprecation lands as a red run with a traceback, not as a broken
+# install after the next dependency release. Later entries win, so a known,
+# tracked warning is ignored by listing it AFTER "error" (regex on the message).
+filterwarnings = [
+    "error",
+    # Starlette's test client prefers httpx2; moving the dev extra is a dependency
+    # follow-up (#518), not a suite defect.
+    "ignore:Using `httpx` with `starlette.testclient` is deprecated",
+]
 markers = [
     "guarantee(name, host): claims a parity-matrix cell; collected by tools/parity (docs/PARITY.md)",
     "real_hst: build the production-size half-space trees (25 × height 15) instead of the fast test default",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,14 @@ addopts = "-q --strict-markers --strict-config"
 # tracked warning is ignored by listing it AFTER "error" (regex on the message).
 filterwarnings = [
     "error",
+    # Finalizer-time warnings (an unclosed file/socket/sqlite connection surfacing
+    # from __del__) stay visible warnings, not errors: garbage-collection timing
+    # decides WHICH test gets blamed, so as an error they are a flake, not a gate.
+    # The nightly's first run (2026-09-01) surfaced three real leaks this way, each
+    # blamed on an unrelated test — tracked as follow-ups: an asyncio StreamWriter
+    # in the egress proxy path, a sqlite3 connection on the policy-catalogue path,
+    # a tempfile in the webhook audit sink.
+    "default::pytest.PytestUnraisableExceptionWarning",
     # Starlette's test client prefers httpx2; moving the dev extra is a dependency
     # follow-up (#518), not a suite defect.
     "ignore:Using `httpx` with `starlette.testclient` is deprecated",

--- a/tests/integration/test_benchmark_synthetic_gate.py
+++ b/tests/integration/test_benchmark_synthetic_gate.py
@@ -25,7 +25,7 @@ from tests.benchmarks.suites.synthetic import PAYLOAD_MARKER, SyntheticAdapter
 
 pytestmark = [
     pytest.mark.real_hst,
-    pytest.mark.xdist_group("real_hst_synthetic"),
+    pytest.mark.xdist_group("real_hst"),
 ]  # production-size trees, one worker
 
 

--- a/tests/integration/test_benchmark_synthetic_gate.py
+++ b/tests/integration/test_benchmark_synthetic_gate.py
@@ -25,7 +25,7 @@ from tests.benchmarks.suites.synthetic import PAYLOAD_MARKER, SyntheticAdapter
 
 pytestmark = [
     pytest.mark.real_hst,
-    pytest.mark.xdist_group("real_hst"),
+    pytest.mark.xdist_group("real_hst_synthetic"),
 ]  # production-size trees, one worker
 
 

--- a/tests/integration/test_poisoning_gate.py
+++ b/tests/integration/test_poisoning_gate.py
@@ -35,11 +35,12 @@ import tests.benchmarks.poisoning_runner as pr
 pytestmark = [
     pytest.mark.real_hst,
     pytest.mark.timeout(1200),
-    # One xdist worker builds the module fixture once (--dist loadgroup); without
-    # the group every worker that draws an item from this module rebuilds it. One
-    # group PER module, so the production-size modules still run in parallel with
-    # each other instead of trailing the suite as one serial chain.
-    pytest.mark.xdist_group("real_hst_poisoning"),
+    # ONE shared xdist group for every production-size module (--dist loadgroup):
+    # the module fixture is built once, and the four heavy builds run serially on
+    # one worker. A group per module (tried 2026-09-01) pegged every vCPU of the
+    # 4-core Windows runner at once and stalled the leg past its cap three times;
+    # the shared group ran green in 19.8 min on the same pool.
+    pytest.mark.xdist_group("real_hst"),
 ]
 
 

--- a/tests/integration/test_poisoning_gate.py
+++ b/tests/integration/test_poisoning_gate.py
@@ -36,8 +36,10 @@ pytestmark = [
     pytest.mark.real_hst,
     pytest.mark.timeout(1200),
     # One xdist worker builds the module fixture once (--dist loadgroup); without
-    # the group every worker that draws an item from this module rebuilds it.
-    pytest.mark.xdist_group("real_hst"),
+    # the group every worker that draws an item from this module rebuilds it. One
+    # group PER module, so the production-size modules still run in parallel with
+    # each other instead of trailing the suite as one serial chain.
+    pytest.mark.xdist_group("real_hst_poisoning"),
 ]
 
 

--- a/tests/unit/test_benchmark_agentdojo_live.py
+++ b/tests/unit/test_benchmark_agentdojo_live.py
@@ -28,8 +28,10 @@ pytestmark = [
     pytest.mark.real_hst,
     pytest.mark.timeout(1200),
     # One xdist worker builds the module fixture once (--dist loadgroup); without
-    # the group every worker that draws an item from this module rebuilds it.
-    pytest.mark.xdist_group("real_hst"),
+    # the group every worker that draws an item from this module rebuilds it. One
+    # group PER module, so the production-size modules still run in parallel with
+    # each other instead of trailing the suite as one serial chain.
+    pytest.mark.xdist_group("real_hst_agentdojo"),
 ]
 
 

--- a/tests/unit/test_benchmark_agentdojo_live.py
+++ b/tests/unit/test_benchmark_agentdojo_live.py
@@ -27,11 +27,12 @@ from tests.benchmarks.suites.agentdojo import AgentDojoAdapter  # noqa: E402
 pytestmark = [
     pytest.mark.real_hst,
     pytest.mark.timeout(1200),
-    # One xdist worker builds the module fixture once (--dist loadgroup); without
-    # the group every worker that draws an item from this module rebuilds it. One
-    # group PER module, so the production-size modules still run in parallel with
-    # each other instead of trailing the suite as one serial chain.
-    pytest.mark.xdist_group("real_hst_agentdojo"),
+    # ONE shared xdist group for every production-size module (--dist loadgroup):
+    # the module fixture is built once, and the four heavy builds run serially on
+    # one worker. A group per module (tried 2026-09-01) pegged every vCPU of the
+    # 4-core Windows runner at once and stalled the leg past its cap three times;
+    # the shared group ran green in 19.8 min on the same pool.
+    pytest.mark.xdist_group("real_hst"),
 ]
 
 

--- a/tests/unit/test_benchmark_subjective.py
+++ b/tests/unit/test_benchmark_subjective.py
@@ -21,8 +21,10 @@ pytestmark = [
     pytest.mark.real_hst,
     pytest.mark.timeout(1200),
     # One xdist worker builds the module fixture once (--dist loadgroup); without
-    # the group every worker that draws an item from this module rebuilds it.
-    pytest.mark.xdist_group("real_hst"),
+    # the group every worker that draws an item from this module rebuilds it. One
+    # group PER module, so the production-size modules still run in parallel with
+    # each other instead of trailing the suite as one serial chain.
+    pytest.mark.xdist_group("real_hst_bench_subjective"),
 ]
 
 # --- fixture ------------------------------------------------------------

--- a/tests/unit/test_benchmark_subjective.py
+++ b/tests/unit/test_benchmark_subjective.py
@@ -20,11 +20,12 @@ from tests.benchmarks.subjective_runner import HOLDOUT_EVERY, _prepared, run_sub
 pytestmark = [
     pytest.mark.real_hst,
     pytest.mark.timeout(1200),
-    # One xdist worker builds the module fixture once (--dist loadgroup); without
-    # the group every worker that draws an item from this module rebuilds it. One
-    # group PER module, so the production-size modules still run in parallel with
-    # each other instead of trailing the suite as one serial chain.
-    pytest.mark.xdist_group("real_hst_bench_subjective"),
+    # ONE shared xdist group for every production-size module (--dist loadgroup):
+    # the module fixture is built once, and the four heavy builds run serially on
+    # one worker. A group per module (tried 2026-09-01) pegged every vCPU of the
+    # 4-core Windows runner at once and stalled the leg past its cap three times;
+    # the shared group ran green in 19.8 min on the same pool.
+    pytest.mark.xdist_group("real_hst"),
 ]
 
 # --- fixture ------------------------------------------------------------

--- a/tests/unit/test_hosthook_spine.py
+++ b/tests/unit/test_hosthook_spine.py
@@ -6,6 +6,7 @@ translation + output shape.
 """
 
 import asyncio
+from pathlib import Path
 
 from doberman.engine.decision_engine import PASS_STUB, decide
 from doberman.engine.objective import ObjectiveGuardrail
@@ -149,6 +150,6 @@ def test_correlator_does_not_fire_without_a_session_id(tmp_path):
 def test_spine_never_imports_heavy_modules():
     import doberman.hosthooks.spine as mod
 
-    src = open(mod.__file__, encoding="utf-8").read()
+    src = Path(mod.__file__).read_text(encoding="utf-8")  # closed: -W error flags a leaked FileIO
     for heavy in ("proxy.executor", "numpy", "scipy", "river"):
         assert heavy not in src, f"spine must not import {heavy} (hot path)"


### PR DESCRIPTION
Follow-up to #518. The hand-dispatched first run of the nightly deep workflow (33571134304) did its job: macOS passed 3337 tests in random order, and it surfaced two real problems.

1. **The Starlette `httpx` → `httpx2` test-client deprecation went red on 21 dash modules.** A `-W "ignore:<regex>"` on the pytest command line is escaped literally (`parse_warning_filter(..., escape=True)`), so the pattern never matched under `-W error`.
2. **`test_spine_never_imports_heavy_modules` leaked a `FileIO`** on `spine.py` (`open(...).read()` with no close); strict warnings turn that into a `PytestUnraisableExceptionWarning` failure.

**Change:** `filterwarnings = ["error", "<tracked Starlette ignore>"]` in `pyproject.toml`. Later entries win, ini filters are pytest-scoped (a plugin's import-time deprecation cannot crash startup the way `PYTHONWARNINGS=error` does), and PR CI's only warning today is that one Starlette line (4 occurrences on both Linux and Windows legs of run 33569587018). So warnings are now errors on **every** leg, PR CI and local runs included; the nightly drops its `-W error` because a command-line `-W` outranks the ini and would re-raise every ignored warning. The spine test reads the file with `Path.read_text`.

**Verification:** locally, the dash, spine, telemetry, and surprise modules pass under the new ini with `pytest-randomly`; this PR's own CI is the first full-suite run with warnings-as-errors on Linux and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6w2pfW6ZdjJCrup7dDkth

**Third finding (nightly Windows 3.11 + Python 3.14 legs):** finalizer-time `PytestUnraisableExceptionWarning`s — an unclosed asyncio `StreamWriter` (blamed on `test_egress_proxy::test_enforcement_status_proven_via_a_running_proxy`), a `sqlite3.Connection` (blamed on `test_policy_catalogue::test_role_enable_default_links_its_observation_to_the_ledger`), a tempfile (blamed on `test_webhook_audit_sink::test_http_error_is_swallowed`). Real leaks, but which test gets blamed is decided by garbage-collection timing, so as errors they are a flake, not a gate. Second commit keeps them as visible warnings (`default::pytest.PytestUnraisableExceptionWarning`); the three leaks are follow-ups.

**Fourth and fifth commits (from this PR's own runs):** the Windows leg was cancelled by the new 30-minute job cap at 99% (20 minutes to 99%, then 8+ minutes of tail on a slow runner — the same variance as 2026-08-29). `timeout-minutes` is now per-OS (Windows 45, Linux 20); the per-test `--timeout` remains the hang guard. And the four production-size modules had shared one `xdist_group`, which made them a single serial chain that trailed the suite on one worker; they now have one group each, keeping the build-once property while running in parallel with each other.

**Sixth commit — the Windows stall, bisected on CI.** Three consecutive Windows legs of this PR hit the job cap after reaching 97–99% (the last one: 98% at a normal pace, then 21 minutes of no progress), while main's own Windows job re-ran green in 19.6 minutes on the same runner pool and a fresh local Python 3.13 venv ran the exact CI line in 3:40. Two throwaway branches dispatched with `workflow_dispatch`: one shared xdist group with warnings-as-errors kept → **green in 19.8 min**; per-module groups without warnings-as-errors → also green, in 21.3 min. Neither factor alone stalls; the full combination (per-module groups + warnings-as-errors) stalled 3/3, so the safe shape is the one main already runs and bisect B proved: the single shared group, with warnings-as-errors kept.