### PR TITLE
fix(rules): treat a single & as a command separator

### DIFF
--- a/changelog.d/524.md
+++ b/changelog.d/524.md
@@ -1,0 +1,2 @@
+- **A single `&` now separates commands.** The destructive-command rule and the egress walker scan
+  both sides of `a & b`, as `cmd.exe` and POSIX shells run both (#524)

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -2,8 +2,8 @@
 
 Blocks catastrophic shell/git commands and steps up authentication on
 risky-but-recoverable ones. Command parsing is treated as **adversarial**: a
-single command string may chain many commands with ``;``, ``&&``, ``||``, or
-pipes, hide work in ``$(...)``/backtick substitutions, or carry an opaque
+single command string may chain many commands with ``;``, ``&``, ``&&``, ``||``,
+or pipes, hide work in ``$(...)``/backtick substitutions, or carry an opaque
 payload (``bash -c "<base64>"``). We therefore:
 
 * split the command line into segments on the shell operators, and recurse into
@@ -202,7 +202,9 @@ def _split_segments(command: str) -> list[str]:
             continue
 
         operator_width = 2 if command[index : index + 2] in {"&&", "||"} else 0
-        if operator_width or char in {"|", ";", "\n"}:
+        # A single ``&`` separates commands too: cmd.exe runs both sides
+        # unconditionally and POSIX shells background the left and run the right.
+        if operator_width or char in {"|", ";", "&", "\n"}:
             segment = "".join(current).strip()
             if segment:
                 segments.append(segment)

--- a/tests/unit/test_rule_commands.py
+++ b/tests/unit/test_rule_commands.py
@@ -72,6 +72,17 @@ def test_chained_destructive_segment_blocks():
     # A benign first command followed by a catastrophic one must still BLOCK.
     assert _cmd("echo hi && rm -rf /").verdict is Verdict.BLOCK
     assert _cmd("ls; rm -rf ~").verdict is Verdict.BLOCK
+    # A single ``&`` separates commands too (cmd.exe unconditionally, POSIX as a
+    # background job) — it must never hide the right-hand side.
+    assert _cmd("echo hi & rm -rf /").verdict is Verdict.BLOCK
+    assert _cmd("echo hi &rm -rf /").verdict is Verdict.BLOCK
+    assert _cmd("echo hi & rm -rf ~ & echo done").verdict is Verdict.BLOCK
+
+
+def test_ampersand_in_redirection_or_quotes_is_not_a_chain():
+    assert _cmd("ls 2>&1").verdict is Verdict.PASS
+    assert _cmd("ls &> out.txt").verdict is Verdict.PASS
+    assert _cmd('echo "a & b"').verdict is Verdict.PASS
 
 
 def test_destructive_inside_command_substitution_blocks():


### PR DESCRIPTION
## What

The command tokenizer split a line on `;`, `&&`, `||`, `|` and newlines, but not on a single `&`. `cmd.exe` runs both sides of `a & b` unconditionally and POSIX shells background `a` and run `b`, so the right-hand side was never scanned as its own segment. `_split_segments` now treats `&` as a separator; `&&` is still matched first. The tokenizer is shared with the proxy's egress walker, so command egress extraction gets the same fix.

`&` inside quotes stays part of the token. `&` in redirections (`2>&1`, `&>`) produces harmless extra segments; raise-only, and covered by a regression test.

## Tests

`tests/unit/test_rule_commands.py`: three chained forms block; redirection and quoted forms still pass.

Found during the fresh-context adversarial review of the v2 redesign RFC (2026-09-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JMUDjz7a6xFiHDoQCuY1B