### PR TITLE
fix(proxy): classify host-namespaced MCP tools by their tool name

### DIFF
--- a/changelog.d/525.md
+++ b/changelog.d/525.md
@@ -1,0 +1,3 @@
+- **Host-namespaced MCP tools are classified by their tool name.** `mcp__<server>__write_file` now
+  normalizes to a file write instead of `other`, so the path and role rules apply to MCP tools on the
+  Claude Code hook path (#525)

--- a/src/doberman/proxy/normalize.py
+++ b/src/doberman/proxy/normalize.py
@@ -202,6 +202,13 @@ _SUSPECTED_EGRESS_VERB = re.compile(
 
 def _map_action_type(tool_name: str) -> ActionType:
     name = tool_name.lower()
+    # Host-namespaced MCP tools (``mcp__<server>__<tool>``, the shape Claude Code
+    # passes through verbatim) are classified by the tool part: the server
+    # prefix is routing, not a category, and must not hide a file/shell tool.
+    if name.startswith("mcp__"):
+        _server, _sep, tool_part = name[5:].partition("__")
+        if tool_part:
+            name = tool_part
     if "install" in name:
         return ActionType.package_install
     for prefixes, action_type in _TOOL_PREFIX_MAP:

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -19,6 +19,13 @@ from doberman.proxy.normalize import MAX_VALUE_LENGTH, REDACTED, normalize
         ("pip_install", ActionType.package_install),
         ("npm_install_package", ActionType.package_install),
         ("totally_unknown_tool", ActionType.other),
+        # Host-namespaced MCP tools classify by the tool part, not the server.
+        ("mcp__filesystem__write_file", ActionType.file_write),
+        ("mcp__my-shell__shell_exec", ActionType.shell_exec),
+        ("mcp__Fetch__http_get", ActionType.network_request),
+        ("mcp__pkg__npm_install", ActionType.package_install),
+        ("mcp__x__totally_unknown", ActionType.other),
+        ("mcp__noseparator", ActionType.other),
     ],
 )
 def test_tool_name_maps_to_action_type(tool_name, expected):


### PR DESCRIPTION
## What

Claude Code passes MCP tools through as `mcp__<server>__<tool>`, and `hosthooks` hands that name to `normalize` verbatim. `_map_action_type` matched the whole string against its prefix table, so `mcp__filesystem__write_file` normalized to `ActionType.other` and the path-typed rules (role boundary, policy-source protection) never ran for it. The mapper now strips the `mcp__<server>__` routing prefix and classifies by the tool part. Raise-only: more calls get a real action type, so more rules apply; nothing that was typed before changes type.

## Tests

`tests/unit/test_normalize.py`: six new parametrized cases (file, shell, network, install, unknown tool part, no separator). Existing host-hook and normalize tests pass unchanged.

Found during the fresh-context adversarial review of PRs #519–#522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JMUDjz7a6xFiHDoQCuY1B