### PR TITLE
fix(auth): count a password attempt before the KDF, deny unrecordable attempts, protect the lockout file

### DIFF
--- a/changelog.d/526.md
+++ b/changelog.d/526.md
@@ -1,0 +1,3 @@
+- **Password guesses are counted before the hash runs, and an attempt that cannot be recorded is
+  refused.** Parallel wrong guesses no longer overwrite each other's count; the lockout file beside
+  the password hash is now control-plane protected like the TOTP one (#526)

--- a/src/doberman/auth/lockout.py
+++ b/src/doberman/auth/lockout.py
@@ -65,8 +65,11 @@ def _load_lockout(path: Path, *, now: float) -> tuple[int, float]:
         return (_MAX_CONSECUTIVE_FAILURES, now)
 
 
-def _save_lockout(path: Path, failures: int, last_failure_time: float) -> None:
+def _save_lockout(path: Path, failures: int, last_failure_time: float) -> bool:
     """Atomically persist lockout state; never raises into a caller.
+
+    Returns ``True`` when the state is on disk. A caller that must record an
+    attempt before it proceeds treats ``False`` as a denial (fail closed).
 
     Same write-then-``os.replace`` pattern as the secret file: a crash or
     concurrent read never observes a half-written state file.
@@ -90,7 +93,8 @@ def _save_lockout(path: Path, failures: int, last_failure_time: float) -> None:
                 pass
             raise
     except OSError:
-        pass  # best-effort: an unwritable lockout file must never crash verify()
+        return False  # an unwritable lockout file must never crash verify(); it reports
+    return True
 
 
 def _clear_lockout(secret_path: Path) -> None:

--- a/src/doberman/auth/password.py
+++ b/src/doberman/auth/password.py
@@ -152,9 +152,10 @@ def verify(secret: str) -> bool:
     """Verify ``secret`` against the stored hash without ever raising.
 
     Fails closed: not enrolled, malformed input/storage, KDF errors, or a
-    rate-limit lockout all return ``False``. A successful verification clears
-    the persisted lockout state; each failed comparison or verification error
-    saves an incremented failure count (see :mod:`doberman.auth.lockout`).
+    rate-limit lockout all return ``False``. Every attempt is counted on disk
+    before the KDF runs and a successful verification clears the persisted
+    lockout state; an attempt that cannot be recorded is denied
+    (see :mod:`doberman.auth.lockout`).
 
     Lockout semantics mirror :func:`doberman.auth.totp.verify`: once
     ``_MAX_CONSECUTIVE_FAILURES`` consecutive failures accrue, further
@@ -180,6 +181,14 @@ def verify(secret: str) -> bool:
             return False  # still locked: deny without touching state or the KDF
         failures = 0  # cooldown elapsed: this attempt starts a fresh window
 
+    # Count the attempt BEFORE the (slow) KDF runs, so concurrent guesses cannot
+    # all read the same pre-attempt count and overwrite each other after it; an
+    # attempt that cannot be recorded is denied rather than run unaccounted.
+    # ponytail: read-modify-write, not a CAS — the window is now one file
+    # write instead of one KDF; an O_EXCL lock file is the upgrade path.
+    if not _save_lockout(lockout_path, failures + 1, now):
+        return False
+
     try:
         if not isinstance(secret, str):
             raise TypeError("password must be text")
@@ -196,6 +205,4 @@ def verify(secret: str) -> bool:
 
     if ok:
         _clear_lockout(secret_path)
-    else:
-        _save_lockout(lockout_path, failures + 1, now)
-    return ok
+    return ok  # a failure was already counted above

--- a/src/doberman/engine/registry.py
+++ b/src/doberman/engine/registry.py
@@ -217,8 +217,10 @@ def discover_auth_providers(allowed: Collection[str]) -> list[object]:
     Opt-in only: an entry point is loaded (imported and constructed) only if its
     ``.name`` is in ``allowed`` — a package merely being installed is never
     enough to make it an authenticator. Non-allowed entry points are skipped
-    before any import/construction happens, so an unlisted package's code never
-    runs. Allowed candidates are still loaded defensively like rules/sources: an
+    before any import/construction happens, so THIS seam never imports an
+    unlisted package (the other entry-point groups still auto-load theirs, so
+    an installed package can still run code in-process — the allowlist is a
+    seam-level control, not a sandbox). Allowed candidates are still loaded defensively like rules/sources: an
     import/constructor failure, or an object that is not auth-provider-shaped
     (no callable ``authenticate``), is logged and skipped. ``allowed`` empty
     returns ``[]`` without iterating entry points at all — the auth layer then

--- a/src/doberman/engine/rules/paths.py
+++ b/src/doberman/engine/rules/paths.py
@@ -90,6 +90,7 @@ CONTROL_PLANE_GLOBS: tuple[str, ...] = (
     "**/doberman/totp.secret",
     "**/doberman/totp.secret.*",
     "**/doberman/password.hash",
+    "**/doberman/password.hash.*",
     # ...and the containing state dir, so a recursive delete of the whole directory
     # is caught too. Deliberately NOT a bare ``**/doberman`` — that would match any
     # checkout of this project (the repo itself is named ``doberman``) and block

--- a/tests/unit/test_auth_password.py
+++ b/tests/unit/test_auth_password.py
@@ -214,3 +214,23 @@ def test_password_hash_file_is_owner_only(isolated_password_hash):
 
     if os.name != "nt":
         assert stat.S_IMODE(isolated_password_hash.stat().st_mode) == 0o600
+
+
+def test_attempt_is_counted_before_the_kdf_runs(isolated_password_hash, monkeypatch):
+    password.enroll("correct-horse")
+    lockout = password._lockout_path(isolated_password_hash)
+
+    def kdf_explodes(*args, **kwargs):
+        raise RuntimeError("kdf crashed mid-verify")
+
+    monkeypatch.setattr(password.hashlib, "pbkdf2_hmac", kdf_explodes)
+    assert password.verify("correct-horse") is False
+    # The attempt landed on disk even though the KDF never finished.
+    assert password._load_lockout(lockout, now=password._now())[0] == 1
+
+
+def test_unrecordable_attempt_is_denied(isolated_password_hash, monkeypatch):
+    password.enroll("correct-horse")
+    monkeypatch.setattr(password, "_save_lockout", lambda *a, **k: False)
+    # Even the right password is refused when the attempt cannot be counted.
+    assert password.verify("correct-horse") is False

--- a/tests/unit/test_control_plane_auth_state.py
+++ b/tests/unit/test_control_plane_auth_state.py
@@ -54,6 +54,8 @@ def _cmd(command, *, root="."):
         "rm ~/.config/doberman/totp.secret",
         "rm ~/.config/doberman/totp.secret.lockout",
         "rm ~/.config/doberman/password.hash",
+        "rm ~/.config/doberman/password.hash.lockout",
+        'rm "$LOCALAPPDATA/doberman/password.hash.lockout"',
         # Windows default location (%LOCALAPPDATA%)
         "rm ~/AppData/Local/doberman/totp.secret",
         "rm ~/AppData/Local/doberman/password.hash",
@@ -141,6 +143,7 @@ def test_explanation_does_not_echo_the_auth_state_path():
         "~/.config/doberman/totp.secret",
         "~/.config/doberman/totp.secret.lockout",
         "~/.config/doberman/password.hash",
+        "~/.config/doberman/password.hash.lockout",
         "C:/Users/dev/AppData/Local/doberman/totp.secret",
         "C:\\Users\\dev\\AppData\\Local\\doberman\\totp.secret",
         "%LOCALAPPDATA%\\doberman\\password.hash",


### PR DESCRIPTION
## What

Three follow-ups to #521 from the fresh-context adversarial review:

- **The attempt is counted before the KDF runs.** `password.verify` used to load the counter, run the 600k-iteration KDF, then save. Concurrent wrong guesses all read the same pre-attempt count and overwrote each other, so the lockout never accrued under parallel guessing. The count is now written first; a successful verify still clears it.
- **An attempt that cannot be recorded is denied.** `lockout._save_lockout` now reports whether the state reached disk (an open handle on Windows can make `os.replace` fail). `password.verify` treats that as a denial instead of running unaccounted. TOTP's call sites keep ignoring the return value for now.
- **`password.hash.*` joins the control-plane globs.** `totp.secret.*` was protected by name, the new `password.hash.lockout` was not, so an env-var-spelled path such as `"$LOCALAPPDATA/doberman/password.hash.lockout"` escaped the directory globs. Now blocked like its TOTP sibling.

Also corrects the `discover_auth_providers` docstring: the opt-in stops *this* seam from importing an unlisted package; the other entry-point groups still auto-load, so it is a seam-level control, not a sandbox.

## Tests

`tests/unit/test_auth_password.py`: the count lands on disk even when the KDF raises; an unrecordable attempt refuses the correct password. `tests/unit/test_control_plane_auth_state.py`: deleting `password.hash.lockout` by either spelling is blocked and the name is recognised as control plane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JMUDjz7a6xFiHDoQCuY1B