### PR TITLE
fix(rules): reconstruct the command line from command + args with token boundaries kept

### DIFF
--- a/changelog.d/527.md
+++ b/changelog.d/527.md
@@ -1,0 +1,3 @@
+- **A tool call's command line is rebuilt from `command` plus `args` with token boundaries kept.**
+  `{"command": "rm", "args": ["-rf", "/"]}` and a `bash -c` payload passed as a list are now scanned
+  as the line they run; a bare apostrophe in an argument no longer triggers a spurious prompt (#527)

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -829,16 +829,41 @@ def _auth(reason: ReasonCode, explanation: str) -> GuardrailResult:
     )
 
 
+def command_line_from_arguments(arguments: dict) -> str | None:
+    """Reconstruct the command line a tool will run from its raw arguments.
+
+    A string ``command``/``cmd``/``script`` is the line. A list-valued ``args``
+    is an argv: joined with ``shlex.join`` so every token keeps its boundary
+    (never plain-space-joined then re-split — that loses the token boundary of
+    e.g. ``bash -c "rm -rf /"`` and mis-splits values with a bare apostrophe),
+    and appended to a string ``command``/``cmd`` when both are present (the
+    common ``{"command": "rm", "args": ["-rf", "/"]}`` shape). Never raises.
+    """
+    head: str | None = None
+    for key in ("command", "cmd", "script"):
+        value = arguments.get(key)
+        if isinstance(value, str) and value.strip():
+            head = value
+            break
+        if isinstance(value, (list, tuple)) and value:
+            head = shlex.join(str(v) for v in value)
+            break
+
+    args_value = arguments.get("args")
+    args_line: str | None = None
+    if isinstance(args_value, (list, tuple)) and args_value:
+        args_line = shlex.join(str(v) for v in args_value)
+
+    if head is not None and args_line is not None:
+        return f"{head} {args_line}"
+    return head if head is not None else args_line
+
+
 def _raw_command_payload(ctx: EvalContext) -> str | None:
     """Extract a command-shaped string from the un-redacted raw arguments, if any."""
     raw_arguments = ctx.metadata.get("raw_arguments") if isinstance(ctx.metadata, dict) else None
     if isinstance(raw_arguments, dict):
-        for key in ("command", "cmd", "script", "args"):
-            value = raw_arguments.get(key)
-            if isinstance(value, str) and value.strip():
-                return value
-            if isinstance(value, (list, tuple)) and value:
-                return " ".join(str(v) for v in value)
+        return command_line_from_arguments(raw_arguments)
     return None
 
 

--- a/src/doberman/proxy/normalize.py
+++ b/src/doberman/proxy/normalize.py
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from doberman.canonical import canonicalize
-from doberman.engine.rules.commands import walk_command
+from doberman.engine.rules.commands import command_line_from_arguments, walk_command
 from doberman.engine.rules.destinations import _parse_host
 from doberman.engine.rules.secrets import candidate_secret_fingerprints, contains_strong_secret
 from doberman.models import ActionType, ReasonCode, Risk, SecurityObject, SourceContext
@@ -241,13 +241,7 @@ def _redact_args(arguments: dict[str, Any]) -> dict[str, Any]:
 
 
 def _command_text(arguments: dict[str, Any]) -> str | None:
-    for key in ("command", "cmd", "script", "args"):
-        value = arguments.get(key)
-        if isinstance(value, str) and value.strip():
-            return value
-        if isinstance(value, (list, tuple)) and value:
-            return " ".join(str(part) for part in value)
-    return None
+    return command_line_from_arguments(arguments)
 
 
 def _command_name(token: str) -> str:

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -54,6 +54,20 @@ def test_shell_with_no_args():
     assert obj.action_type is ActionType.shell_exec
 
 
+def test_shell_command_plus_args_composes_full_command_line(tmp_path):
+    # {"command": "rm", "args": ["-rf", "/"]} must be reconstructed into the
+    # SAME command line as an equivalent single string — the action
+    # fingerprint (HMAC'd over the un-redacted command line, see
+    # _action_fingerprint) is the only place normalize() surfaces this, since
+    # obj.target is built from the redacted args' "command" key alone. Before
+    # the fix, the "args" tail was invisible: fingerprints would NOT match.
+    root = str(tmp_path)
+    split = normalize("shell_exec", {"command": "rm", "args": ["-rf", "/"]}, {"repo_root": root})
+    combined = normalize("shell_exec", {"command": "rm -rf /"}, {"repo_root": root})
+    assert split.action_fingerprint is not None
+    assert split.action_fingerprint == combined.action_fingerprint
+
+
 def test_path_array_uses_representative_target_plus_count():
     obj = normalize("fs_delete", {"path": ["a.txt", "b.txt", "c.txt"]})
     assert obj.target == "a.txt"

--- a/tests/unit/test_normalize_egress.py
+++ b/tests/unit/test_normalize_egress.py
@@ -52,6 +52,13 @@ def test_shell_exec_no_external_destination():
     assert obj.external_destination is None
 
 
+def test_shell_exec_command_plus_args_resolves_egress_destination():
+    # {"command": "curl", "args": ["https://evil.example/x"]} used to surface
+    # only "curl" (args wasn't composed in) and miss the destination entirely.
+    obj = normalize("shell_exec", {"command": "curl", "args": ["https://evil.example/x"]})
+    assert obj.external_destination == "evil.example"
+
+
 # ---------------------------------------------------------------------------
 # 3. Network request path is UNCHANGED (regression guard)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_rule_commands.py
+++ b/tests/unit/test_rule_commands.py
@@ -392,3 +392,54 @@ def test_normalized_package_install_command_blocks_end_to_end(tmp_path):
     result = RULE.evaluate(obj, ctx)
     assert result.verdict is Verdict.BLOCK
     assert ReasonCode.destructive_command in result.reason_codes
+
+
+# --- command + args composition (token boundaries kept) ---------------------
+# `command`/`cmd`/`script` and a list-valued `args` are reconstructed together
+# with shlex.join, not the first-key-wins + plain-space-join that used to drop
+# the `-rf /` argv entirely and re-split an opaque `-c` payload on the wrong
+# boundaries. See doberman.engine.rules.commands.command_line_from_arguments.
+
+
+def _cmd_args(raw_arguments, *, action_type=ActionType.shell_exec):
+    action = SecurityObject(
+        id="cmd-args-1",
+        ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=action_type,
+        tool_name="shell_exec",
+    )
+    ctx = EvalContext(metadata={"raw_arguments": raw_arguments})
+    return RULE.evaluate(action, ctx)
+
+
+def test_command_plus_args_list_is_reconstructed_and_blocks():
+    # {"command": "rm", "args": ["-rf", "/"]} used to surface only "rm" (the
+    # first non-empty key) and PASS — the destructive argv was invisible.
+    result = _cmd_args({"command": "rm", "args": ["-rf", "/"]})
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.destructive_command in result.reason_codes
+
+
+def test_args_only_bash_dash_c_payload_is_not_passed():
+    # {"args": ["bash", "-c", "rm -rf /"]} used to be space-joined then
+    # re-split by shlex, losing the -c payload's token boundary. It must
+    # never PASS, whether the rule lands on opaque_command (AUTH) or
+    # recognizes the destructive payload outright (BLOCK).
+    result = _cmd_args({"args": ["bash", "-c", "rm -rf /"]})
+    assert result.verdict is not Verdict.PASS
+
+
+def test_args_with_bare_apostrophe_does_not_false_positive():
+    # {"args": ["--grep", "it's"]} on a non-command action type used to make
+    # shlex choke on the bare apostrophe (after a plain-space join) and the
+    # rule spuriously stepped up to AUTH (opaque_command) even though this
+    # action type never carries a command line.
+    result = _cmd_args({"args": ["--grep", "it's"]}, action_type=ActionType.file_read)
+    assert result.verdict is Verdict.PASS
+
+
+def test_args_only_list_still_blocks():
+    result = _cmd_args({"args": ["rm", "-rf", "/"]})
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.destructive_command in result.reason_codes


### PR DESCRIPTION
## What

Both places that read a tool call's command line from its raw arguments (`DestructiveCommandRule` and the proxy's egress extractor) took the first non-empty key among `command`/`cmd`/`script`/`args` and joined a list with plain spaces. So `{"command": "rm", "args": ["-rf", "/"]}` was scanned as `rm`, `{"args": ["bash", "-c", "rm -rf /"]}` lost the `-c` payload's token boundary on re-split, and `{"args": ["--grep", "it's"]}` tripped a spurious `opaque_command` on the bare apostrophe.

One shared `command_line_from_arguments` now reconstructs the line: a string `command`/`cmd`/`script` is the head, a list-valued `args` is `shlex.join`ed and appended when a head exists, and lists anywhere keep their token boundaries. `normalize._command_text` delegates to it, so command egress extraction sees the same line the rule does. Key priority is unchanged.

Raise-only for real commands; the apostrophe case is a false positive removed.

Not changed: `_extract_target` still builds the logged shell target from the `command` key alone, so the redacted target for the split shape reads `rm` while the rule scans the full line. Follow-up.

## Tests

`tests/unit/test_rule_commands.py`: split shape blocks; `bash -c` list is BLOCK (asserted as not-PASS); apostrophe on a `file_read` passes; args-only list still blocks. `tests/unit/test_normalize.py` / `test_normalize_egress.py`: split and combined shapes fingerprint identically; `{"command": "curl", "args": [url]}` resolves the egress destination. `lint-imports` 4 kept.

Found during the fresh-context adversarial review of PRs #519–#522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JMUDjz7a6xFiHDoQCuY1B