### PR TITLE
feat(setup): ask which hosts to guard — detect, multi-select, per-host wiring, doctor pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ After installing, run `doberman --install-completion` to enable shell tab comple
 **Fastest path (Claude Code):**
 
 ```bash
-doberman setup      # pick a strictness mode, tune guardrails, wire the hooks
+doberman setup      # asks which agents to guard, then picks a strictness mode, tunes guardrails, wires them
 ```
 
 Anonymous usage counts are on by default (command names and daily totals, never paths, prompts, or

--- a/changelog.d/528.md
+++ b/changelog.d/528.md
@@ -1,0 +1,4 @@
+- **`doberman setup` asks which hosts to guard.** Detected hosts (Claude Code, Codex CLI, MCP clients) are
+  preselected; pick several at once; Codex gets the full wizard; MCP hosts get their `doberman serve` config
+  printed; `--host` is repeatable for `--yes`. The wizard ends with a doctor pass and says Doberman activates
+  when you restart, with `doberman password set` as the next step (#528)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -33,7 +33,7 @@ Day-to-day posture, status, and review commands.
 | `doberman approvals status` | Show whether exact-action approval memory is enabled, its TTL, and the live-entry count. Never prints fingerprints. | `--path`/`-p` |
 | `doberman approvals clear` | Clear every approval-memory entry for this repo. This is an ungated strengthening. | `--path`/`-p` |
 | `doberman approvals ttl SECONDS` | Set approval-memory TTL in `0..900`; `0` disables it. Raising is possession-factor gated; lowering is ungated. | `--path`/`-p` |
-| `doberman setup` | First-run wizard: pick a security posture and wire Claude Code hooks. | `--yes`/`-y`, `--mode`/`-m`, `--global`/`-g`, `--path`/`-p` |
+| `doberman setup` | First-run wizard: pick which hosts to guard and a security posture, then wire each host. | `--yes`/`-y`, `--mode`/`-m`, `--global`/`-g`, `--host` (repeatable), `--path`/`-p` |
 | `doberman telemetry on` | Opt in to anonymous CLI usage counts. | none |
 | `doberman telemetry off` | Opt out after one final best-effort disabled event. | none |
 | `doberman telemetry status` | Show effective state, the random distinct id, and active kill switches. | none |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -47,8 +47,10 @@ command), see the [PATH appendix](#appendix-a-stale-doberman-on-path). Maintaine
 
 ## 2. Run `doberman setup`
 
-On Claude Code, one command does the whole job. An interactive wizard picks your alertness mode,
-tunes your guardrails, and wires the hooks:
+One command does the whole job on any host. An interactive wizard detects which agents you have
+installed (Claude Code, Codex CLI, an MCP client, OpenClaw), asks which ones to guard, then picks
+your alertness mode, tunes your guardrails, and wires each chosen host — finishing with a doctor
+pass:
 
 ```bash
 doberman setup
@@ -58,9 +60,11 @@ doberman setup
 doberman setup --yes
 ```
 
-`--yes` accepts the defaults (balanced mode) with no prompts, useful for CI or scripting. Either
-way, basic protection works immediately. When the wizard finishes, [set a possession
-factor](#4-set-a-password-and-2fa), then verify with [`doberman doctor`](#5-check-its-health).
+`--yes` accepts the defaults (detected hosts, or Claude Code if nothing is detected; balanced mode)
+with no prompts, useful for CI or scripting. Pass `--host` (repeatable) to pick hosts explicitly,
+e.g. `doberman setup --yes --host claude --host codex`. Either way, basic protection works
+immediately. When the wizard finishes, [set a possession factor](#4-set-a-password-and-2fa) — it's
+the first line of `doberman setup`'s own next steps.
 
 On a different host, or want to see exactly what gets wired? The next section covers each path by
 hand.
@@ -70,9 +74,9 @@ hand.
 | Your host | How Doberman attaches | Where |
 |---|---|---|
 | Claude Code | Hooks: gate every built-in and MCP tool call (recommended) | [`doberman setup`](#2-run-doberman-setup) or [Claude Code hooks](#claude-code-hooks) |
-| Codex CLI | Hooks | `doberman install-hooks --host codex`, see [Claude Code hooks](#claude-code-hooks) |
-| Claude Desktop, Cursor, any MCP client | MCP proxy: wrap your tool server | [MCP proxy](#mcp-proxy) |
-| OpenClaw | Native plugin adapter | [OpenClaw](#openclaw) |
+| Codex CLI | Hooks | `doberman setup --host codex` or `doberman install-hooks --host codex`, see [Claude Code hooks](#claude-code-hooks) |
+| Claude Desktop, Cursor, any MCP client | MCP proxy: wrap your tool server | `doberman setup` prints the config; see [MCP proxy](#mcp-proxy) |
+| OpenClaw | Native plugin adapter | `doberman setup` prints the pointer; see [OpenClaw](#openclaw) |
 
 ### Claude Code hooks
 

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -2992,15 +2992,14 @@ def setup(
         # them as failures; `doberman doctor` has the detail.
         warnings = [r for r in results if r.status is not CheckStatus.OK and r not in critical]
         passed = len(results) - len(critical) - len(warnings)
-        if not critical:
-            line = f"Doctor: {passed} checks passed"
-            if warnings:
-                line += f", {len(warnings)} warning(s) (`doberman doctor` shows them)"
-            typer.echo(line)
-        else:
-            typer.echo(f"Doctor: {len(critical)} critical check(s) need attention:")
-            for r in critical:
-                typer.echo(f"  - {r.name}")
+        line = f"Doctor: {passed} passed"
+        if warnings:
+            line += f", {len(warnings)} warning(s) (`doberman doctor` shows them)"
+        if critical:
+            line += f", {len(critical)} critical — needs attention:"
+        typer.echo(line)
+        for r in critical:
+            typer.echo(f"  - {r.name}")
     except Exception as exc:  # noqa: BLE001 — a diagnostic pass must never crash setup
         typer.echo(f"Doctor: could not run ({type(exc).__name__})")
 

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -2147,20 +2147,15 @@ def install_hooks(
         typer.echo("This project is no longer excluded from global hooks.")
 
 
-def _install_codex(*, global_: bool, local: bool, path: str, dry_run: bool) -> None:
-    """`install-hooks --host codex`: wire ``doberman hook codex-pre`` into a
-    Codex hooks.json. ``--global`` -> ``~/.codex/hooks.json`` (user), else
-    ``<repo>/.codex/hooks.json`` (repo). ``--local`` has no Codex equivalent."""
-    if local:
-        typer.echo(
-            "error: --local has no Codex equivalent; use --global (user) or the default (repo).",
-            err=True,
-        )
-        raise typer.Exit(2)
+def _write_codex_hook(scope: str, path: str) -> Path:
+    """Write Doberman's Codex hook for *scope* and print the TRUST notice.
+
+    Shared by ``install-hooks --host codex`` (:func:`_install_codex`) and the
+    ``setup`` wizard's per-host wiring, so the write + notice text lives once.
+    """
     from doberman.hosthooks.install import load_settings, write_settings
     from doberman.hosthooks.install_codex import merge_codex_hooks, resolve_codex_hooks_path
 
-    scope = "user" if global_ else "repo"
     hooks_path = resolve_codex_hooks_path(scope, path)
 
     try:
@@ -2170,13 +2165,6 @@ def _install_codex(*, global_: bool, local: bool, path: str, dry_run: bool) -> N
         raise typer.Exit(2) from exc
 
     merged = merge_codex_hooks(current)
-
-    if dry_run:
-        typer.echo(f"[dry-run] target: {hooks_path}")
-        typer.echo("[dry-run] would add:")
-        typer.echo("  PreToolUse -> doberman hook codex-pre")
-        return
-
     write_settings(hooks_path, merged)
     typer.echo(f"wrote {hooks_path}")
     typer.echo("Doberman will now gate Codex's tool calls in this scope.")
@@ -2187,6 +2175,32 @@ def _install_codex(*, global_: bool, local: bool, path: str, dry_run: bool) -> N
     typer.echo("  run a Codex command and approve the hook when prompted, or launch with")
     typer.echo("  --dangerously-bypass-hook-trust only if you already vet the hook source.")
     typer.echo("Verify it's live: ask Codex to `cat .env` and confirm it is blocked.")
+    return hooks_path
+
+
+def _install_codex(*, global_: bool, local: bool, path: str, dry_run: bool) -> None:
+    """`install-hooks --host codex`: wire ``doberman hook codex-pre`` into a
+    Codex hooks.json. ``--global`` -> ``~/.codex/hooks.json`` (user), else
+    ``<repo>/.codex/hooks.json`` (repo). ``--local`` has no Codex equivalent."""
+    if local:
+        typer.echo(
+            "error: --local has no Codex equivalent; use --global (user) or the default (repo).",
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    scope = "user" if global_ else "repo"
+
+    if dry_run:
+        from doberman.hosthooks.install_codex import resolve_codex_hooks_path
+
+        hooks_path = resolve_codex_hooks_path(scope, path)
+        typer.echo(f"[dry-run] target: {hooks_path}")
+        typer.echo("[dry-run] would add:")
+        typer.echo("  PreToolUse -> doberman hook codex-pre")
+        return
+
+    _write_codex_hook(scope, path)
 
 
 def _uninstall_codex(*, global_: bool, local: bool, path: str, dry_run: bool) -> None:
@@ -2716,15 +2730,26 @@ def setup(
     global_: bool = typer.Option(
         False, "--global", "-g", help="Install hooks into ~/.claude/settings.json."
     ),
+    hosts: list[str] = typer.Option(  # noqa: B008 — Typer's Option() factory, not a mutable default
+        None,
+        "--host",
+        help=(
+            "Host to wire (repeatable): claude | codex | mcp | openclaw. "
+            "Default: detected hosts, else claude."
+        ),
+    ),
     path: str = typer.Option(".", "--path", "-p", help="Project root (default: current dir)."),
 ) -> None:
-    """Friendly first-run wizard: choose your security posture and wire Claude Code hooks.
+    """Friendly first-run wizard: pick your hosts and security posture, then wire them.
 
-    Walks through alertness mode, preference tuning, and automatic hook installation.
+    Detects which agents you have installed (Claude Code, Codex CLI, an MCP client,
+    OpenClaw), asks which ones to guard, then walks through alertness mode,
+    preference tuning, and per-host wiring, finishing with a doctor pass.
     Later lowerings require a possession factor — a 2FA code if enrolled,
     otherwise your Doberman password (set via ``doberman password set``).
     Pass ``--yes`` for a fully non-interactive run (useful for CI or scripting).
     """
+    from doberman.hosthooks import setup as hosthooks_setup
     from doberman.hosthooks.install import (
         load_settings,
         merge_doberman_hooks,
@@ -2733,7 +2758,12 @@ def setup(
     )
     from doberman.hosthooks.setup import (
         DIMENSION_DESCRIPTIONS,
+        HOSTS,
+        default_hosts,
+        detect_hosts,
+        host_menu_lines,
         mode_menu_lines,
+        parse_host_choice,
         parse_mode_choice,
     )
     from doberman.policy.preferences import vector_for
@@ -2750,7 +2780,44 @@ def setup(
     typer.echo("")
 
     # ------------------------------------------------------------------
-    # b. Alertness / mode
+    # b. Hosts
+    # ------------------------------------------------------------------
+    valid_host_keys = [h.key for h in HOSTS]
+    detected = detect_hosts(path, hosthooks_setup._home())
+
+    if hosts:
+        invalid = sorted(set(hosts) - set(valid_host_keys))
+        if invalid:
+            typer.echo(
+                f"error: unknown host(s) {', '.join(invalid)}; valid: "
+                + ", ".join(valid_host_keys),
+                err=True,
+            )
+            raise typer.Exit(2)
+        chosen_hosts = [k for k in valid_host_keys if k in set(hosts)]
+    elif yes:
+        chosen_hosts = default_hosts(detected)
+    else:
+        typer.echo("-- Hosts -------------------------------------------------")
+        for line in host_menu_lines(detected):
+            typer.echo(line)
+        typer.echo("")
+        default_nums = ",".join(
+            str(i) for i, h in enumerate(HOSTS, start=1) if h.key in default_hosts(detected)
+        )
+        while True:
+            raw = typer.prompt(
+                "Which hosts should Doberman guard? (numbers or names, comma-separated)",
+                default=default_nums,
+            )
+            try:
+                chosen_hosts = parse_host_choice(raw, detected)
+                break
+            except ValueError as exc:
+                typer.echo(f"  {exc} - try again")
+
+    # ------------------------------------------------------------------
+    # c. Alertness / mode
     # ------------------------------------------------------------------
     if mode_name is not None:
         # Caller pre-selected a mode; validate it immediately.
@@ -2764,9 +2831,11 @@ def setup(
 
         chosen_mode = SecurityMode.balanced
     else:
+        typer.echo("")
         typer.echo("-- Security mode ---------------------------------------")
         for line in mode_menu_lines():
             typer.echo(line)
+        typer.echo("Not sure? `doberman demo --mode strict` shows what each mode blocks.")
         typer.echo("")
         while True:
             raw = typer.prompt("Choose a mode (name or number)", default="balanced")
@@ -2796,7 +2865,7 @@ def setup(
         raise typer.Exit(2) from exc
 
     # ------------------------------------------------------------------
-    # c. Guardrails / preferences
+    # d. Guardrails / preferences
     # ------------------------------------------------------------------
     preset_vector = vector_for(chosen_mode)
     tune_prefs = False
@@ -2827,39 +2896,110 @@ def setup(
         save_preferences(preset_vector, path)
 
     # ------------------------------------------------------------------
-    # d. Hook installation scope
+    # e. Per-host wiring
     # ------------------------------------------------------------------
-    if global_:
-        scope = "global"
-    elif yes:
-        scope = "project"
-    else:
+    wired: list[tuple[str, str | None]] = []
+    claude_scope = "none"
+
+    if "claude" in chosen_hosts:
+        if global_:
+            claude_scope = "global"
+        elif yes:
+            claude_scope = "project"
+        else:
+            typer.echo("")
+            typer.echo("-- Hook installation (Claude Code) ----------------------")
+            use_global = typer.confirm(
+                "Install hooks globally (~/.claude/settings.json)?",
+                default=False,
+            )
+            claude_scope = "global" if use_global else "project"
+
+        settings_path = resolve_settings_path(claude_scope, path)
+        try:
+            current = load_settings(settings_path)
+        except ValueError as exc:
+            typer.echo(f"error: could not read existing settings: {exc}", err=True)
+            raise typer.Exit(2) from exc
+        merged = merge_doberman_hooks(current)
+        try:
+            write_settings(settings_path, merged)
+        except OSError as exc:
+            typer.echo(f"error: could not write {settings_path}: {exc}", err=True)
+            raise typer.Exit(1) from exc
+        wired.append(("claude", str(settings_path)))
+
+    if "codex" in chosen_hosts:
+        if global_:
+            codex_scope = "user"
+        elif yes:
+            codex_scope = "repo"
+        else:
+            typer.echo("")
+            typer.echo("-- Hook installation (Codex CLI) -------------------------")
+            use_user = typer.confirm(
+                "Install the Codex hook user-wide (~/.codex/hooks.json)?",
+                default=False,
+            )
+            codex_scope = "user" if use_user else "repo"
+        codex_hooks_path = _write_codex_hook(codex_scope, path)
+        wired.append(("codex", str(codex_hooks_path)))
+
+    if "mcp" in chosen_hosts:
         typer.echo("")
-        typer.echo("-- Hook installation -----------------------------------")
-        use_global = typer.confirm(
-            "Install hooks globally (~/.claude/settings.json)?",
-            default=False,
+        typer.echo("-- MCP proxy (Cursor / Claude Desktop / other MCP client) ---")
+        typer.echo(
+            "Doberman can't edit this host's MCP config for you; paste this into it, "
+            "replacing <your-mcp-server-command> with your existing tool server command:"
         )
-        scope = "global" if use_global else "project"
+        typer.echo("")
+        typer.echo("  doberman serve -- <your-mcp-server-command>")
+        typer.echo("")
+        typer.echo("Or, in a Claude-Desktop-style mcpServers config file:")
+        typer.echo("{")
+        typer.echo('  "mcpServers": {')
+        typer.echo('    "doberman": {')
+        typer.echo('      "command": "doberman",')
+        typer.echo('      "args": ["serve", "--", "<your-mcp-server-command>"]')
+        typer.echo("    }")
+        typer.echo("  }")
+        typer.echo("}")
+        wired.append(("mcp", None))
 
-    settings_path = resolve_settings_path(scope, path)
-
-    try:
-        current = load_settings(settings_path)
-    except ValueError as exc:
-        typer.echo(f"error: could not read existing settings: {exc}", err=True)
-        raise typer.Exit(2) from exc
-
-    merged = merge_doberman_hooks(current)
-
-    try:
-        write_settings(settings_path, merged)
-    except OSError as exc:
-        typer.echo(f"error: could not write {settings_path}: {exc}", err=True)
-        raise typer.Exit(1) from exc
+    if "openclaw" in chosen_hosts:
+        typer.echo("")
+        typer.echo("-- OpenClaw -------------------------------------------------")
+        typer.echo(
+            "OpenClaw agents route through Doberman via a small local plugin, not a hook-pack."
+        )
+        typer.echo(
+            "See adapters/openclaw/README.md for install steps and the mandatory canary check."
+        )
+        wired.append(("openclaw", None))
 
     # ------------------------------------------------------------------
-    # e. Summary
+    # f. Doctor pass
+    # ------------------------------------------------------------------
+    typer.echo("")
+    typer.echo("-- Doctor -------------------------------------------------")
+    try:
+        from doberman.cli.doctor import CheckStatus, run_checks
+
+        results = run_checks(path)
+        failing = [r for r in results if r.status is not CheckStatus.OK]
+        if not failing:
+            typer.echo(f"Doctor: {len(results)} checks passed")
+        else:
+            typer.echo(
+                f"Doctor: {len(results) - len(failing)} passed, {len(failing)} need attention:"
+            )
+            for r in failing:
+                typer.echo(f"  - {r.name}")
+    except Exception as exc:  # noqa: BLE001 — a diagnostic pass must never crash setup
+        typer.echo(f"Doctor: could not run ({type(exc).__name__})")
+
+    # ------------------------------------------------------------------
+    # g. Summary
     # ------------------------------------------------------------------
     typer.echo("")
     typer.echo("-- Setup complete ------------------------------------------")
@@ -2867,15 +3007,33 @@ def setup(
     typer.echo(
         f"Prefs:      {'custom (tuned)' if tune_prefs else 'preset defaults for ' + chosen_mode.value}"
     )
-    typer.echo(f"Hooks:      written to {settings_path}")
+    typer.echo("Hosts:")
+    for host_key, target in wired:
+        if host_key == "claude":
+            typer.echo(f"  claude   hooks written to {target}")
+        elif host_key == "codex":
+            typer.echo(f"  codex    hook written to {target}")
+        elif host_key == "mcp":
+            typer.echo("  mcp      config printed above (paste into your client)")
+        elif host_key == "openclaw":
+            typer.echo("  openclaw instructions printed above")
     typer.echo("")
-    typer.echo("Doberman is now active.")
-    typer.echo("Restart your Claude Code session to pick up the hooks.")
-    telemetry_cmd.capture_setup_completed(chosen_mode.value, scope, yes)
-    typer.echo(
-        "Next steps: `doberman password set`  |  `doberman 2fa setup` (optional)  |  "
-        "`doberman status`  |  `doberman uninstall-hooks` (exit)"
+
+    hooks_kind_wired = [h for h in wired if next(x for x in HOSTS if x.key == h[0]).kind == "hooks"]
+    if hooks_kind_wired:
+        typer.echo("Hooks written. Doberman activates when you restart your session.")
+        for host_key, _ in hooks_kind_wired:
+            host = next(x for x in HOSTS if x.key == host_key)
+            typer.echo(host.restart_hint)
+
+    telemetry_cmd.capture_setup_completed(
+        chosen_mode.value, [h for h, _ in wired], claude_scope, yes
     )
+    typer.echo(
+        "Next step: `doberman password set` — later lowerings need a possession factor "
+        "(a 2FA code if enrolled, otherwise this password)."
+    )
+    typer.echo("Also: `doberman 2fa setup` (optional)  |  `doberman status`  |  `doberman doctor`")
 
 
 @app.command("session-summary")

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -2983,17 +2983,23 @@ def setup(
     typer.echo("")
     typer.echo("-- Doctor -------------------------------------------------")
     try:
-        from doberman.cli.doctor import CheckStatus, run_checks
+        from doberman.cli.doctor import CheckStatus, critical_failures, run_checks
 
         results = run_checks(path)
-        failing = [r for r in results if r.status is not CheckStatus.OK]
-        if not failing:
-            typer.echo(f"Doctor: {len(results)} checks passed")
+        critical = critical_failures(results)
+        # Non-critical warnings (no decision DB or fingerprint key yet, no TUI
+        # extra) are normal right after a fresh setup — count them, don't list
+        # them as failures; `doberman doctor` has the detail.
+        warnings = [r for r in results if r.status is not CheckStatus.OK and r not in critical]
+        passed = len(results) - len(critical) - len(warnings)
+        if not critical:
+            line = f"Doctor: {passed} checks passed"
+            if warnings:
+                line += f", {len(warnings)} warning(s) (`doberman doctor` shows them)"
+            typer.echo(line)
         else:
-            typer.echo(
-                f"Doctor: {len(results) - len(failing)} passed, {len(failing)} need attention:"
-            )
-            for r in failing:
+            typer.echo(f"Doctor: {len(critical)} critical check(s) need attention:")
+            for r in critical:
                 typer.echo(f"  - {r.name}")
     except Exception as exc:  # noqa: BLE001 — a diagnostic pass must never crash setup
         typer.echo(f"Doctor: could not run ({type(exc).__name__})")

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -2996,7 +2996,7 @@ def setup(
         if warnings:
             line += f", {len(warnings)} warning(s) (`doberman doctor` shows them)"
         if critical:
-            line += f", {len(critical)} critical — needs attention:"
+            line += f", {len(critical)} critical - needs attention:"
         typer.echo(line)
         for r in critical:
             typer.echo(f"  - {r.name}")
@@ -3035,7 +3035,7 @@ def setup(
         chosen_mode.value, [h for h, _ in wired], claude_scope, yes
     )
     typer.echo(
-        "Next step: `doberman password set` — later lowerings need a possession factor "
+        "Next step: `doberman password set` - later lowerings need a possession factor "
         "(a 2FA code if enrolled, otherwise this password)."
     )
     typer.echo("Also: `doberman 2fa setup` (optional)  |  `doberman status`  |  `doberman doctor`")

--- a/src/doberman/cli/telemetry_cmd.py
+++ b/src/doberman/cli/telemetry_cmd.py
@@ -66,17 +66,26 @@ def configure_setup_consent(non_interactive: bool) -> None:
         telemetry.disable()
 
 
-def capture_setup_completed(mode: str, scope: str, non_interactive: bool) -> None:
-    """Emit the allowlisted setup outcome after hooks are installed."""
+def capture_setup_completed(
+    mode: str, hosts: list[str], claude_scope: str, non_interactive: bool
+) -> None:
+    """Emit the allowlisted setup outcome after the chosen hosts are wired.
+
+    ``hosts`` is the ordered list of host keys the wizard wired (claude / codex /
+    mcp / openclaw). ``claude_scope`` is the Claude settings scope ("project" /
+    "global") when "claude" was one of them, else the literal string "none".
+    Reuses the existing allowlisted ``setup_completed`` properties (``host``,
+    ``global_install``) rather than adding new ones.
+    """
     from doberman import telemetry
 
     telemetry.capture(
         "setup_completed",
         {
             "mode": mode,
-            "host": "claude",
-            "hooks_installed": True,
-            "global_install": scope == "global",
+            "host": ",".join(hosts),
+            "hooks_installed": any(h in ("claude", "codex") for h in hosts),
+            "global_install": claude_scope == "global",
             "source": "yes" if non_interactive else "wizard",
         },
     )

--- a/src/doberman/hosthooks/setup.py
+++ b/src/doberman/hosthooks/setup.py
@@ -7,6 +7,10 @@ prompt, echo, or write files — the command layer does that.
 
 from __future__ import annotations
 
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
 from doberman.policy.modes import SecurityMode
 
 #: One-line description for each mode shown during the setup wizard.
@@ -30,6 +34,115 @@ DIMENSION_DESCRIPTIONS: dict[str, str] = {
     ),
     "blast_radius": "How strongly to step up for actions that affect many targets.",
 }
+
+
+@dataclass(frozen=True)
+class Host:
+    """One host `setup` can wire, in wizard menu/wiring order."""
+
+    key: str  # "claude" | "codex" | "mcp" | "openclaw"
+    label: str
+    kind: str  # "hooks" | "mcp" | "plugin"
+    restart_hint: str  # printed in the summary for "hooks"-kind hosts only
+
+
+#: Hosts the wizard offers, in menu/wiring order. ``restart_hint`` is only ever
+#: shown for "hooks"-kind hosts (claude, codex); mcp/openclaw print their own
+#: one-line pointers during per-host wiring instead.
+HOSTS: tuple[Host, ...] = (
+    Host("claude", "Claude Code (hooks)", "hooks", "Restart your Claude Code session."),
+    Host("codex", "Codex CLI (hooks)", "hooks", "Restart your Codex CLI session."),
+    Host(
+        "mcp",
+        "Cursor / Claude Desktop / other MCP agent (proxy: doberman serve)",
+        "mcp",
+        "",
+    ),
+    Host("openclaw", "OpenClaw (plugin hook)", "plugin", ""),
+)
+
+
+def _home() -> Path:
+    """The real user home directory. A seam: tests monkeypatch this function
+    (never the real home) so host detection never reads this machine's actual
+    ``~/.claude`` / ``~/.codex`` / Claude Desktop config."""
+    return Path.home()
+
+
+def _claude_desktop_config_path(home: Path) -> Path:
+    """Where Claude Desktop's MCP config lives, derived from *home* — never the
+    real OS env — so this is deterministic under test."""
+    if sys.platform == "darwin":
+        return home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    if sys.platform == "win32":
+        return home / "AppData" / "Roaming" / "Claude" / "claude_desktop_config.json"
+    return home / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+def detect_hosts(project_root: str, home: Path) -> set[str]:
+    """Best-effort detection of which hosts are already set up on this machine.
+
+    ``openclaw`` has no reliable marker, so it is never auto-detected — the
+    wizard always offers it, never preselects it.
+    """
+    root = Path(project_root)
+    detected: set[str] = set()
+    if (home / ".claude").exists() or (root / ".claude").exists():
+        detected.add("claude")
+    if (home / ".codex").exists() or (root / ".codex").exists():
+        detected.add("codex")
+    if (
+        (root / ".cursor").exists()
+        or (home / ".cursor").exists()
+        or _claude_desktop_config_path(home).exists()
+    ):
+        detected.add("mcp")
+    return detected
+
+
+def host_menu_lines(detected: set[str]) -> list[str]:
+    """Return formatted menu lines for the four hosts, marking detected ones."""
+    lines: list[str] = []
+    for i, host in enumerate(HOSTS, start=1):
+        tag = "   <- detected" if host.key in detected else ""
+        lines.append(f"  [{i}] {host.label}{tag}")
+    return lines
+
+
+def default_hosts(detected: set[str]) -> list[str]:
+    """Detected hosts in :data:`HOSTS` order, else just ``["claude"]``."""
+    ordered = [h.key for h in HOSTS if h.key in detected]
+    return ordered if ordered else ["claude"]
+
+
+def parse_host_choice(raw: str, detected: set[str]) -> list[str]:
+    """Parse a hosts choice: numbers, names, mixed, comma/space separated, or "all".
+
+    Blank input returns :func:`default_hosts`. Raises ``ValueError`` on any
+    unrecognized token so the wizard can re-prompt. Result preserves
+    :data:`HOSTS` order and de-duplicates.
+    """
+    stripped = raw.strip()
+    if not stripped:
+        return default_hosts(detected)
+    if stripped.lower() == "all":
+        return [h.key for h in HOSTS]
+
+    by_number = {str(i): h.key for i, h in enumerate(HOSTS, start=1)}
+    by_name = {h.key: h.key for h in HOSTS}
+    chosen: set[str] = set()
+    for token in stripped.replace(",", " ").split():
+        low = token.lower()
+        if token in by_number:
+            chosen.add(by_number[token])
+        elif low in by_name:
+            chosen.add(by_name[low])
+        else:
+            valid = ", ".join(h.key for h in HOSTS)
+            raise ValueError(
+                f"unknown host {token!r}; valid: {valid}, numbers 1-{len(HOSTS)}, or 'all'"
+            )
+    return [h.key for h in HOSTS if h.key in chosen]
 
 
 def mode_menu_lines() -> list[str]:

--- a/tests/unit/test_setup_helpers.py
+++ b/tests/unit/test_setup_helpers.py
@@ -1,0 +1,226 @@
+"""Unit tests for the pure host-selection helpers backing `doberman setup` (HK.5).
+
+Pure functions only — no CliRunner, no real ``~/.claude``/``~/.codex``. Every
+``home`` is an explicit ``tmp_path`` subdirectory, never the real machine's home.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from doberman.hosthooks.setup import (
+    HOSTS,
+    default_hosts,
+    detect_hosts,
+    host_menu_lines,
+    parse_host_choice,
+)
+
+# ---------------------------------------------------------------------------
+# detect_hosts
+# ---------------------------------------------------------------------------
+
+
+def test_detect_hosts_nothing_present(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    root = tmp_path / "root"
+    home.mkdir()
+    root.mkdir()
+    assert detect_hosts(str(root), home) == set()
+
+
+def test_detect_hosts_claude_in_home(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    root = tmp_path / "root"
+    root.mkdir()
+    assert detect_hosts(str(root), home) == {"claude"}
+
+
+def test_detect_hosts_claude_in_project_root(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    root = tmp_path / "root"
+    (root / ".claude").mkdir(parents=True)
+    assert detect_hosts(str(root), home) == {"claude"}
+
+
+def test_detect_hosts_codex_in_home(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".codex").mkdir(parents=True)
+    root = tmp_path / "root"
+    root.mkdir()
+    assert detect_hosts(str(root), home) == {"codex"}
+
+
+def test_detect_hosts_codex_in_project_root(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    root = tmp_path / "root"
+    (root / ".codex").mkdir(parents=True)
+    assert detect_hosts(str(root), home) == {"codex"}
+
+
+def test_detect_hosts_cursor_in_project_root(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    root = tmp_path / "root"
+    (root / ".cursor").mkdir(parents=True)
+    assert detect_hosts(str(root), home) == {"mcp"}
+
+
+def test_detect_hosts_cursor_in_home(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".cursor").mkdir(parents=True)
+    root = tmp_path / "root"
+    root.mkdir()
+    assert detect_hosts(str(root), home) == {"mcp"}
+
+
+def test_detect_hosts_claude_desktop_config_darwin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+    home = tmp_path / "home"
+    config = home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    config.parent.mkdir(parents=True)
+    config.write_text("{}", encoding="utf-8")
+    root = tmp_path / "root"
+    root.mkdir()
+    assert detect_hosts(str(root), home) == {"mcp"}
+
+
+def test_detect_hosts_claude_desktop_config_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    home = tmp_path / "home"
+    config = home / "AppData" / "Roaming" / "Claude" / "claude_desktop_config.json"
+    config.parent.mkdir(parents=True)
+    config.write_text("{}", encoding="utf-8")
+    root = tmp_path / "root"
+    root.mkdir()
+    assert detect_hosts(str(root), home) == {"mcp"}
+
+
+def test_detect_hosts_claude_desktop_config_linux(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    home = tmp_path / "home"
+    config = home / ".config" / "Claude" / "claude_desktop_config.json"
+    config.parent.mkdir(parents=True)
+    config.write_text("{}", encoding="utf-8")
+    root = tmp_path / "root"
+    root.mkdir()
+    assert detect_hosts(str(root), home) == {"mcp"}
+
+
+def test_detect_hosts_openclaw_never_auto_detected(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    root = tmp_path / "root"
+    (root / "openclaw").mkdir(parents=True)  # a plausible-looking marker, still ignored
+    assert "openclaw" not in detect_hosts(str(root), home)
+
+
+def test_detect_hosts_multiple(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    (home / ".codex").mkdir(parents=True)
+    root = tmp_path / "root"
+    root.mkdir()
+    assert detect_hosts(str(root), home) == {"claude", "codex"}
+
+
+# ---------------------------------------------------------------------------
+# default_hosts
+# ---------------------------------------------------------------------------
+
+
+def test_default_hosts_nothing_detected_falls_back_to_claude() -> None:
+    assert default_hosts(set()) == ["claude"]
+
+
+def test_default_hosts_preserves_hosts_order() -> None:
+    assert default_hosts({"codex", "claude"}) == ["claude", "codex"]
+
+
+def test_default_hosts_single_non_claude() -> None:
+    assert default_hosts({"mcp"}) == ["mcp"]
+
+
+# ---------------------------------------------------------------------------
+# host_menu_lines
+# ---------------------------------------------------------------------------
+
+
+def test_host_menu_lines_covers_all_hosts() -> None:
+    lines = host_menu_lines(set())
+    assert len(lines) == len(HOSTS)
+    for host in HOSTS:
+        assert any(host.label in line for line in lines)
+
+
+def test_host_menu_lines_marks_only_detected() -> None:
+    lines = host_menu_lines({"claude"})
+    claude_line = next(line for line in lines if "Claude Code" in line)
+    codex_line = next(line for line in lines if "Codex CLI" in line)
+    assert "detected" in claude_line
+    assert "detected" not in codex_line
+
+
+# ---------------------------------------------------------------------------
+# parse_host_choice
+# ---------------------------------------------------------------------------
+
+
+def test_parse_host_choice_by_number() -> None:
+    assert parse_host_choice("1", set()) == ["claude"]
+    assert parse_host_choice("2", set()) == ["codex"]
+
+
+def test_parse_host_choice_by_name() -> None:
+    assert parse_host_choice("claude", set()) == ["claude"]
+    assert parse_host_choice("CODEX", set()) == ["codex"]
+
+
+def test_parse_host_choice_multiple_comma_separated() -> None:
+    assert parse_host_choice("1,2", set()) == ["claude", "codex"]
+
+
+def test_parse_host_choice_multiple_space_separated() -> None:
+    assert parse_host_choice("1 2", set()) == ["claude", "codex"]
+
+
+def test_parse_host_choice_mixed_names_and_numbers() -> None:
+    assert parse_host_choice("claude, 2", set()) == ["claude", "codex"]
+
+
+def test_parse_host_choice_all() -> None:
+    assert parse_host_choice("all", set()) == [h.key for h in HOSTS]
+
+
+def test_parse_host_choice_blank_returns_detected() -> None:
+    assert parse_host_choice("", {"codex"}) == ["codex"]
+
+
+def test_parse_host_choice_blank_returns_default_when_nothing_detected() -> None:
+    assert parse_host_choice("   ", set()) == ["claude"]
+
+
+def test_parse_host_choice_preserves_hosts_order_and_dedupes() -> None:
+    assert parse_host_choice("2,1,2,1", set()) == ["claude", "codex"]
+
+
+def test_parse_host_choice_unknown_name_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_host_choice("cursor", set())
+
+
+def test_parse_host_choice_out_of_range_number_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_host_choice("9", set())

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -434,10 +434,13 @@ def test_output_contains_doctor_pass(tmp_path: Path) -> None:
     result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
     assert result.exit_code == 0, result.output
     assert "Doctor:" in result.output
-    # A fresh install has only first-run warnings (no decision DB / fingerprint
-    # key yet): the wizard counts them and never lists them as failures.
-    assert "need attention" not in result.output
-    assert "checks passed" in result.output
+    # First-run warnings (no decision DB / fingerprint key yet, no TUI extra)
+    # are counted, never listed as failures. (Whether a *critical* check such
+    # as "Hook command" warns depends on the test runner's PATH, so only the
+    # non-critical names are pinned here.)
+    for first_run_warning in ("Decision DB", "Fingerprint key", "TUI extra"):
+        assert f"  - {first_run_warning}" not in result.output
+    assert "warning(s)" in result.output
 
 
 def test_output_contains_restart_activation_hint(tmp_path: Path) -> None:

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -21,6 +21,22 @@ app = cli_module.app
 runner = CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def _isolated_host_detection_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point host detection at a throwaway home so this dev machine's real
+    ``~/.claude`` / ``~/.codex`` never leaks into a test's default host choice.
+
+    Nothing is detected unless a test creates a marker under the returned dir,
+    so every existing interactive input sequence below can accept the "Hosts"
+    prompt's default (``claude`` only) with a leading blank line.
+    """
+    from doberman.hosthooks import setup as setup_helpers
+
+    home = tmp_path / "home"
+    monkeypatch.setattr(setup_helpers, "_home", lambda: home)
+    return home
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -138,14 +154,16 @@ def test_interactive_balanced_project_scope(tmp_path: Path) -> None:
     """Interactive run: balanced mode, keep preset prefs, project scope.
 
     Input sequence (newlines terminate each prompt):
+    - hosts: "" (default: claude only, nothing detected)
     - mode choice: "balanced"
+    - telemetry consent: "n"
     - tune prefs: "n"
     - global install: "n"
     """
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="balanced\nn\nn\nn\n",
+        input="\nbalanced\nn\nn\nn\n",
     )
     assert result.exit_code == 0, result.output
     assert "Agent profile" not in result.output
@@ -162,7 +180,7 @@ def test_interactive_numeric_mode_choice(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="3\nn\nn\nn\n",
+        input="\n3\nn\nn\nn\n",
     )
     assert result.exit_code == 0, result.output
     assert load_mode(str(tmp_path)) == "strict"
@@ -175,7 +193,7 @@ def test_interactive_tune_prefs(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input=f"balanced\nn\ny\n{weight_inputs}\nn\n",
+        input=f"\nbalanced\nn\ny\n{weight_inputs}\nn\n",
     )
     assert result.exit_code == 0, result.output
     prefs = load_preferences(str(tmp_path))
@@ -187,7 +205,7 @@ def test_setup_reprompts_on_bad_mode(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="blanced\nbalanced\nn\nn\nn\n",
+        input="\nblanced\nbalanced\nn\nn\nn\n",
     )
 
     assert result.exit_code == 0, result.output
@@ -216,7 +234,7 @@ def test_setup_explains_each_tuned_dimension(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input=f"balanced\nn\ny\n{weight_inputs}\nn\n",
+        input=f"\nbalanced\nn\ny\n{weight_inputs}\nn\n",
     )
 
     assert result.exit_code == 0, result.output
@@ -267,7 +285,7 @@ def test_interactive_telemetry_yes_persists_and_emits_setup_event(
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="balanced\ny\nn\nn\n",
+        input="\nbalanced\ny\nn\nn\n",
     )
 
     assert result.exit_code == 0, result.output
@@ -293,7 +311,7 @@ def test_interactive_telemetry_default_yes_records_the_choice(tmp_path: Path) ->
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="balanced\n\nn\nn\n",
+        input="\nbalanced\n\nn\nn\n",
     )
     assert result.exit_code == 0, result.output
     state = telemetry.status()
@@ -307,7 +325,7 @@ def test_interactive_telemetry_no_persists_disabled(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="balanced\nn\nn\nn\n",
+        input="\nbalanced\nn\nn\nn\n",
     )
     assert result.exit_code == 0, result.output
     assert telemetry.status().enabled is False
@@ -322,6 +340,113 @@ def test_yes_does_not_prompt_and_keeps_the_default(tmp_path: Path) -> None:
     state = telemetry.status()
     assert state.enabled is True
     assert state.consent_at is None  # default kept, nothing recorded as a choice
+
+
+# ---------------------------------------------------------------------------
+# Host selection (HK.5)
+# ---------------------------------------------------------------------------
+
+
+def _codex_hooks(tmp: Path) -> dict:
+    p = tmp / ".codex" / "hooks.json"
+    assert p.exists(), f"hooks.json not found at {p}"
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def test_yes_host_codex_writes_hooks_and_no_claude_dir(tmp_path: Path) -> None:
+    """``--yes --host codex`` wires only the Codex hook — no ``.claude`` at all."""
+    result = runner.invoke(app, ["setup", "--yes", "--host", "codex", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    hooks = _codex_hooks(tmp_path)
+    commands = [h["command"] for g in hooks["hooks"]["PreToolUse"] for h in g["hooks"]]
+    assert "doberman hook codex-pre" in commands
+    assert not (tmp_path / ".claude").exists()
+
+
+def test_yes_host_claude_and_codex_writes_both(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["setup", "--yes", "--host", "claude", "--host", "codex", "--path", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    s = _settings(tmp_path)
+    assert PRE_COMMAND in _doberman_commands(s, "PreToolUse")
+    hooks = _codex_hooks(tmp_path)
+    commands = [h["command"] for g in hooks["hooks"]["PreToolUse"] for h in g["hooks"]]
+    assert "doberman hook codex-pre" in commands
+
+
+def test_yes_detects_codex_and_wires_codex_only(
+    tmp_path: Path, _isolated_host_detection_home: Path
+) -> None:
+    """No explicit ``--host``: a detected ``~/.codex`` (with no Claude marker) drives
+    the ``--yes`` default, so only Codex is wired."""
+    (_isolated_host_detection_home / ".codex").mkdir(parents=True)
+    result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert not (tmp_path / ".claude").exists()
+    hooks = _codex_hooks(tmp_path)
+    commands = [h["command"] for g in hooks["hooks"]["PreToolUse"] for h in g["hooks"]]
+    assert "doberman hook codex-pre" in commands
+
+
+def test_interactive_hosts_1_2_wires_both(tmp_path: Path) -> None:
+    """Choosing "1,2" at the hosts prompt wires both Claude and Codex."""
+    result = runner.invoke(
+        app,
+        ["setup", "--path", str(tmp_path)],
+        input="1,2\nbalanced\nn\nn\nn\nn\n",
+    )
+    assert result.exit_code == 0, result.output
+    s = _settings(tmp_path)
+    assert PRE_COMMAND in _doberman_commands(s, "PreToolUse")
+    hooks = _codex_hooks(tmp_path)
+    commands = [h["command"] for g in hooks["hooks"]["PreToolUse"] for h in g["hooks"]]
+    assert "doberman hook codex-pre" in commands
+
+
+def test_yes_host_mcp_prints_serve_block_and_writes_no_hook_file(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["setup", "--yes", "--host", "mcp", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "doberman serve --" in result.output
+    assert not (tmp_path / ".claude").exists()
+    assert not (tmp_path / ".codex").exists()
+
+
+def test_yes_host_openclaw_prints_pointer(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["setup", "--yes", "--host", "openclaw", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "adapters/openclaw/README.md" in result.output
+    assert not (tmp_path / ".claude").exists()
+    assert not (tmp_path / ".codex").exists()
+
+
+def test_invalid_host_exits_2_naming_valid_hosts(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["setup", "--yes", "--host", "cursor", "--path", str(tmp_path)])
+    assert result.exit_code == 2
+    assert "claude" in result.output
+    assert "codex" in result.output
+    assert "mcp" in result.output
+    assert "openclaw" in result.output
+
+
+def test_output_contains_doctor_pass(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "Doctor:" in result.output
+
+
+def test_output_contains_restart_activation_hint(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "activates when you restart" in result.output
+
+
+def test_password_set_is_the_first_next_step(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    idx = result.output.index("Next step:")
+    assert "password set" in result.output[idx : idx + 60]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -434,6 +434,10 @@ def test_output_contains_doctor_pass(tmp_path: Path) -> None:
     result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
     assert result.exit_code == 0, result.output
     assert "Doctor:" in result.output
+    # A fresh install has only first-run warnings (no decision DB / fingerprint
+    # key yet): the wizard counts them and never lists them as failures.
+    assert "need attention" not in result.output
+    assert "checks passed" in result.output
 
 
 def test_output_contains_restart_activation_hint(tmp_path: Path) -> None:


### PR DESCRIPTION
## Slice
- Setup/onboarding host selection — S1 + S2 of `doberman-vault/Plans/2026-09-01-setup-onboarding-host-selection.md`

## What this PR does

`doberman setup` used to write Claude Code hooks for every user and sign off with "Restart your Claude Code session", whether or not Claude Code was the agent. It now asks which hosts to guard:

- **Detect and preselect.** `~/.claude` / `<repo>/.claude`, `~/.codex` / `<repo>/.codex`, `.cursor` or a Claude Desktop config mark Claude Code, Codex CLI and MCP hosts as detected; OpenClaw is always offered, never preselected.
- **Multi-select, asked once.** Numbers, names, "all", or Enter for the detected set. Mode, telemetry consent and preferences are asked once; wiring fans out per host. `--host` is repeatable for `--yes` parity (`doberman setup --yes --host claude --host codex`); `--global` keeps its meaning per hooks host.
- **Per-host wiring.** Claude Code and Codex CLI write their hook files (the Codex path now gets the shared wizard steps, and shares one write-plus-trust-notice helper with `install-hooks --host codex`). MCP hosts get the exact `doberman serve` config block printed, with the wizard saying it cannot edit that config; OpenClaw gets the adapter pointer.
- **Doctor pass** at the end: one line with passed count, first-run warnings counted (a fresh install has no decision DB or fingerprint key yet), criticals listed.
- **Copy.** "Hooks written. Doberman activates when you restart your session." replaces the false "is now active"; the mode menu points at `doberman demo --mode strict`; `doberman password set` is the single highlighted next step and `uninstall-hooks` leaves the send-off.

Pure helpers (`Host`, `HOSTS`, `detect_hosts`, `parse_host_choice`, `default_hosts`) live in `hosthooks/setup.py`; the command stays IO-only. Telemetry keeps the existing allowlisted properties (`host` is now the comma-joined list).

## Tests added (run in CI)
- `tests/unit/test_setup_helpers.py` (new): detection matrix, Claude Desktop path per platform, choice parsing (numbers/names/mixed/all/blank/unknown), ordering and de-duplication.
- `tests/unit/test_setup_wizard.py`: home-dir detection isolated via a seam; `--host codex` alone creates no `.claude/`; both hosts; detection-driven `--yes` default; interactive `1,2`; MCP and OpenClaw print-only paths; invalid `--host` exits 2; doctor line; restart copy; password-set-first next step; all existing tests kept (their input sequences answer the new first prompt).

## Security checklist
- [x] Fails closed on error / uncertainty (doctor pass never raises; unknown host exits 2)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no guardrail changes)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (n/a)

## Edge cases covered / Deviations from plan / Risks introduced
- An MCP- or OpenClaw-only run writes no hooks and skips the "hooks written" banner.
- Deviation: none from the plan. "Hermes" is covered by the MCP row, as the plan says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JMUDjz7a6xFiHDoQCuY1B