### PR TITLE
fix(setup): honest summary, gated preferences, scoped doctor pass, a first catch; setup leads Getting started

### DIFF
--- a/changelog.d/530.md
+++ b/changelog.d/530.md
@@ -1,0 +1,5 @@
+- **`doberman setup` tells the truth and ends on a catch.** A `--yes` run can no longer lower the mode
+  or the preference weights past the possession-factor gate, and the summary shows the mode actually in
+  force; the doctor pass is scoped to the hosts you wired and prints each fix; the wizard offers to run
+  `doberman demo` so you see a real BLOCK before you leave; `setup` now leads `--help` and the
+  removal commands have their own panel (#530)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -48,9 +48,11 @@ command), see the [PATH appendix](#appendix-a-stale-doberman-on-path). Maintaine
 ## 2. Run `doberman setup`
 
 One command does the whole job on any host. An interactive wizard detects which agents you have
-installed (Claude Code, Codex CLI, an MCP client, OpenClaw), asks which ones to guard, then picks
-your alertness mode, tunes your guardrails, and wires each chosen host — finishing with a doctor
-pass:
+installed (Claude Code, Codex CLI, an MCP client, OpenClaw), asks which ones to guard, picks your
+alertness mode, asks whether to send anonymous usage stats, tunes your guardrails, and wires each
+chosen host — finishing with a doctor pass and, if you wired a hooks-based host (Claude Code or
+Codex), an offer to run a scripted attack through the real engine right there so you can watch it
+work:
 
 ```bash
 doberman setup
@@ -304,9 +306,9 @@ fingerprint key.
 doberman doctor
 ```
 
-It only diagnoses (it never changes state) and exits non-zero when a critical check (hooks,
-config, or the decision database) isn't healthy, so it's safe to gate a script on
-`doberman doctor && ...`.
+It only diagnoses (it never changes state) and exits non-zero when a critical check (hooks, the
+hook command being on PATH, config, or the decision database) isn't healthy, so it's safe to gate
+a script on `doberman doctor && ...`.
 
 Optionally, map what Doberman can see:
 

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -56,6 +56,8 @@ from doberman.hosthooks.install import DASHBOARD_COMMAND
 from doberman.models import ActionType
 from doberman.policy.checklist import recommend_policy
 from doberman.policy.drift import (
+    Classification,
+    _prefs_classify,
     _run_weaken_gate,
     _verify_possession_factor,
     apply_change,
@@ -69,7 +71,7 @@ from doberman.policy.drift import (
 from doberman.policy.friction import build_friction_report, generate_proposals
 from doberman.policy.modes import SecurityMode, resolve_mode
 from doberman.policy.preferences import DIMENSIONS, preset_name
-from doberman.render import verdict_label, verdict_label_str
+from doberman.render import style_text, verdict_label, verdict_label_str
 from doberman.storage.approval_memory import clear as clear_approval_memory
 from doberman.storage.approval_memory import count_live as count_live_approval_memory
 from doberman.storage.db import active_elevations, grant_elevation, revoke_elevation
@@ -389,6 +391,21 @@ def review(
         typer.echo(f"\nSaved policy to {path}/.doberman/policies.yaml")
     else:
         typer.echo("\n(read-only; re-run with --yes to save)")
+
+
+#: Mode -> (color, bold) for the setup wizard's summary line, via render.style_text.
+_MODE_STYLE: dict[str, tuple[str, bool]] = {
+    "light": ("green", False),
+    "balanced": ("green", False),
+    "strict": ("yellow", True),
+    "paranoid": ("bright_red", True),
+}
+
+
+def _section(title: str, width: int = 58) -> str:
+    """A fixed-width ``-- <title> ----...`` section rule for the setup wizard."""
+    prefix = f"-- {title} "
+    return prefix + "-" * max(0, width - len(prefix))
 
 
 def _apply_mode_change(
@@ -962,8 +979,8 @@ def doctor(
     Policy version check records the observed policy version into
     `.doberman/policies.db` (itself a diagnostic record; it never touches policy,
     decisions, or enforcement). Exits non-zero if any critical check
-    (hooks / config / DB) is not healthy, so it is script-friendly
-    (`doberman doctor && ...`).
+    (hooks / hook command on PATH / config / DB) is not healthy, so it is
+    script-friendly (`doberman doctor && ...`).
     """
     from doberman.cli.doctor import CheckStatus, critical_failures, run_checks
 
@@ -2798,7 +2815,7 @@ def setup(
     elif yes:
         chosen_hosts = default_hosts(detected)
     else:
-        typer.echo("-- Hosts -------------------------------------------------")
+        typer.echo(_section("Hosts"))
         for line in host_menu_lines(detected):
             typer.echo(line)
         typer.echo("")
@@ -2807,7 +2824,7 @@ def setup(
         )
         while True:
             raw = typer.prompt(
-                "Which hosts should Doberman guard? (numbers or names, comma-separated)",
+                "Which hosts should Doberman guard? (numbers or names, comma-separated, or 'all')",
                 default=default_nums,
             )
             try:
@@ -2827,12 +2844,10 @@ def setup(
             typer.echo(f"error: {exc}", err=True)
             raise typer.Exit(2) from exc
     elif yes:
-        from doberman.policy.modes import SecurityMode
-
         chosen_mode = SecurityMode.balanced
     else:
         typer.echo("")
-        typer.echo("-- Security mode ---------------------------------------")
+        typer.echo(_section("Security mode"))
         for line in mode_menu_lines():
             typer.echo(line)
         typer.echo("Not sure? `doberman demo --mode strict` shows what each mode blocks.")
@@ -2847,53 +2862,125 @@ def setup(
 
     telemetry_cmd.configure_setup_consent(yes)
 
+    # A genuinely fresh repo (no persisted policy yet) mirrors apply_mode_change's
+    # own establish_ok first-run bypass: choosing an initial mode/preference
+    # posture establishes it, it doesn't weaken one.
+    first_run = load_policy(path) is None
+
     # Save the chosen mode. First-run onboarding establishes the initial posture
     # freely (establish_ok); a re-run over an existing policy still gates a
     # lowering behind a possession factor, so setup can't bypass the mode gate.
-    try:
-        if (
-            _apply_mode_change(chosen_mode.value, path, "doberman setup wizard", establish_ok=True)
-            is None
-        ):
+    # Under --yes a lowering is refused up front rather than falling through to
+    # the gate, which would otherwise open a real confirmation prompt on stdin.
+    mode_order = list(SecurityMode)
+    mode_applied = True
+    if yes and not first_run:
+        current_mode = resolve_mode(load_mode(path))
+        if mode_order.index(chosen_mode) < mode_order.index(current_mode):
             typer.echo(
-                "note: mode not lowered (a lowering needs an enrolled possession factor); "
-                "keeping the current mode",
+                f"note: --yes cannot lower the mode from {current_mode.value} to "
+                f"{chosen_mode.value}: a lowering needs a possession factor. Run "
+                f"`doberman mode {chosen_mode.value}` interactively.",
                 err=True,
             )
-    except ValueError as exc:
-        typer.echo(f"error: {exc}", err=True)
-        raise typer.Exit(2) from exc
+            mode_applied = False
+
+    if mode_applied:
+        try:
+            if (
+                _apply_mode_change(
+                    chosen_mode.value, path, "doberman setup wizard", establish_ok=True
+                )
+                is None
+            ):
+                typer.echo(
+                    "note: mode not lowered (a lowering needs an enrolled possession factor); "
+                    "keeping the current mode",
+                    err=True,
+                )
+                mode_applied = False
+        except ValueError as exc:
+            typer.echo(f"error: {exc}", err=True)
+            raise typer.Exit(2) from exc
+
+    persisted_mode = resolve_mode(load_mode(path))
 
     # ------------------------------------------------------------------
     # d. Guardrails / preferences
     # ------------------------------------------------------------------
-    preset_vector = vector_for(chosen_mode)
-    tune_prefs = False
-
-    if not yes:
-        typer.echo("")
-        typer.echo("-- Preference tuning -----------------------------------")
-        typer.echo(
-            f"The {chosen_mode.value!r} preset applies these weights: "
-            + "  ".join(f"{n}={getattr(preset_vector, n):.2f}" for n in DIMENSIONS)
-        )
-        tune_prefs = typer.confirm("Tune individual weights? (advanced)", default=False)
-
-    if tune_prefs:
-        vector = preset_vector
-        typer.echo("Enter a weight in [0, 1] for each dimension (press Enter to keep current):")
-        for dim in DIMENSIONS:
-            current = getattr(vector, dim)
-            typer.echo(f"  {DIMENSION_DESCRIPTIONS[dim]}")
-            raw_w = typer.prompt(f"  {dim} [{current:.2f}]", default=str(current))
-            try:
-                vector = vector.with_weight(dim, float(raw_w))
-            except (KeyError, ValueError) as exc:
-                typer.echo(f"  warning: {exc} - keeping {current:.2f}")
-        save_preferences(vector, path)
+    if not mode_applied:
+        # The mode stayed put; writing a preset/tuned vector for the requested
+        # (unapplied) mode would silently overwrite the persisted preferences
+        # with no possession-factor check at all. Skip the write entirely.
+        prefs_source = "unchanged (the mode change was not applied)"
+        typer.echo("note: preferences unchanged (the mode change was not applied)", err=True)
     else:
-        # Persist the preset so load_preferences returns the mode's preset explicitly.
-        save_preferences(preset_vector, path)
+        preset_vector = vector_for(persisted_mode)
+        tune_prefs = False
+
+        if not yes:
+            typer.echo("")
+            typer.echo(_section("Preference tuning"))
+            typer.echo(
+                f"The {persisted_mode.value!r} preset applies these weights: "
+                + "  ".join(f"{n}={getattr(preset_vector, n):.2f}" for n in DIMENSIONS)
+            )
+            tune_prefs = typer.confirm("Tune individual weights? (advanced)", default=False)
+
+        if tune_prefs:
+            vector = preset_vector
+            typer.echo("Enter a weight in [0, 1] for each dimension (press Enter to keep current):")
+            for dim in DIMENSIONS:
+                current = getattr(vector, dim)
+                typer.echo(f"  {DIMENSION_DESCRIPTIONS[dim]}")
+                raw_w = typer.prompt(f"  {dim}", default=f"{current:.2f}")
+                try:
+                    vector = vector.with_weight(dim, float(raw_w))
+                except (KeyError, ValueError) as exc:
+                    typer.echo(f"  warning: {exc} - keeping {current:.2f}")
+            new_vector = vector
+            prefs_source = "custom (tuned)"
+        else:
+            new_vector = preset_vector
+            prefs_source = f"preset defaults for {persisted_mode.value}"
+
+        if first_run:
+            # Establishing the initial preference posture is free, same as the
+            # mode's own establish_ok bypass.
+            save_preferences(new_vector, path)
+        else:
+            # Route through the same gated, raise-only chokepoint `doberman
+            # prefs` uses: a lowering relative to the persisted vector needs a
+            # possession factor. Under --yes, refuse a lowering up front rather
+            # than let the gate open a real confirmation prompt on stdin.
+            current_vector = load_preferences(path)
+            classification = _prefs_classify(current_vector.to_mapping(), new_vector.to_mapping())
+            if classification is Classification.weaken and yes:
+                typer.echo(
+                    "note: --yes cannot lower preferences below the persisted vector: a "
+                    "lowering needs a possession factor. Run `doberman prefs <dimension> "
+                    "<value>` interactively.",
+                    err=True,
+                )
+                prefs_source = "unchanged (not lowered)"
+            else:
+                outcome = asyncio.run(
+                    apply_preferences_change(
+                        current_vector.to_mapping(),
+                        new_vector.to_mapping(),
+                        "doberman setup wizard",
+                        repo_root=path,
+                    )
+                )
+                if outcome.approved:
+                    save_preferences(new_vector, path, ledger_ts=outcome.ts)
+                else:
+                    typer.echo(
+                        "note: preferences not lowered (a lowering needs a possession "
+                        "factor); keeping the current preferences",
+                        err=True,
+                    )
+                    prefs_source = "unchanged (not lowered)"
 
     # ------------------------------------------------------------------
     # e. Per-host wiring
@@ -2908,7 +2995,7 @@ def setup(
             claude_scope = "project"
         else:
             typer.echo("")
-            typer.echo("-- Hook installation (Claude Code) ----------------------")
+            typer.echo(_section("Hook installation (Claude Code)"))
             use_global = typer.confirm(
                 "Install hooks globally (~/.claude/settings.json)?",
                 default=False,
@@ -2927,6 +3014,7 @@ def setup(
         except OSError as exc:
             typer.echo(f"error: could not write {settings_path}: {exc}", err=True)
             raise typer.Exit(1) from exc
+        typer.echo(f"wrote {settings_path}")
         wired.append(("claude", str(settings_path)))
 
     if "codex" in chosen_hosts:
@@ -2936,7 +3024,7 @@ def setup(
             codex_scope = "repo"
         else:
             typer.echo("")
-            typer.echo("-- Hook installation (Codex CLI) -------------------------")
+            typer.echo(_section("Hook installation (Codex CLI)"))
             use_user = typer.confirm(
                 "Install the Codex hook user-wide (~/.codex/hooks.json)?",
                 default=False,
@@ -2947,7 +3035,7 @@ def setup(
 
     if "mcp" in chosen_hosts:
         typer.echo("")
-        typer.echo("-- MCP proxy (Cursor / Claude Desktop / other MCP client) ---")
+        typer.echo(_section("MCP proxy (Cursor / Claude Desktop / other MCP client)"))
         typer.echo(
             "Doberman can't edit this host's MCP config for you; paste this into it, "
             "replacing <your-mcp-server-command> with your existing tool server command:"
@@ -2968,7 +3056,7 @@ def setup(
 
     if "openclaw" in chosen_hosts:
         typer.echo("")
-        typer.echo("-- OpenClaw -------------------------------------------------")
+        typer.echo(_section("OpenClaw"))
         typer.echo(
             "OpenClaw agents route through Doberman via a small local plugin, not a hook-pack."
         )
@@ -2977,16 +3065,24 @@ def setup(
         )
         wired.append(("openclaw", None))
 
+    hooks_kind_wired = [h for h in wired if next(x for x in HOSTS if x.key == h[0]).kind == "hooks"]
+
     # ------------------------------------------------------------------
     # f. Doctor pass
     # ------------------------------------------------------------------
     typer.echo("")
-    typer.echo("-- Doctor -------------------------------------------------")
+    typer.echo(_section("Doctor"))
     try:
         from doberman.cli.doctor import CheckStatus, critical_failures, run_checks
 
         results = run_checks(path)
         critical = critical_failures(results)
+        if not hooks_kind_wired:
+            # Nothing hooks-based was wired this run (mcp/openclaw only) — the
+            # hook checks have nothing to diagnose, so they'd only ever read as
+            # a false "not installed" critical. Scope them out and say so.
+            hooks_only = {"Host hooks", "Hook command"}
+            critical = [r for r in critical if r.name not in hooks_only]
         # Non-critical warnings (no decision DB or fingerprint key yet, no TUI
         # extra) are normal right after a fresh setup — count them, don't list
         # them as failures; `doberman doctor` has the detail.
@@ -2997,21 +3093,30 @@ def setup(
             line += f", {len(warnings)} warning(s) (`doberman doctor` shows them)"
         if critical:
             line += f", {len(critical)} critical - needs attention:"
-        typer.echo(line)
+        if not hooks_kind_wired:
+            line += " (hooks n/a for this host)"
+        if critical:
+            typer.echo(style_text(line, "bright_red", bold=True))
+        elif warnings:
+            typer.echo(style_text(line, "yellow", bold=True))
+        else:
+            typer.echo(style_text(line, "green"))
         for r in critical:
-            typer.echo(f"  - {r.name}")
-    except Exception as exc:  # noqa: BLE001 — a diagnostic pass must never crash setup
-        typer.echo(f"Doctor: could not run ({type(exc).__name__})")
+            typer.echo(f"  - {r.name}: {r.detail}")
+    except Exception:  # noqa: BLE001 — a diagnostic pass must never crash setup
+        typer.echo("Doctor: could not run here; verify with `doberman doctor`")
 
     # ------------------------------------------------------------------
     # g. Summary
     # ------------------------------------------------------------------
     typer.echo("")
-    typer.echo("-- Setup complete ------------------------------------------")
-    typer.echo(f"Mode:       {chosen_mode.value}")
-    typer.echo(
-        f"Prefs:      {'custom (tuned)' if tune_prefs else 'preset defaults for ' + chosen_mode.value}"
-    )
+    typer.echo(_section("Setup complete"))
+    fg, bold = _MODE_STYLE[persisted_mode.value]
+    mode_line = f"Mode:       {style_text(persisted_mode.value, fg, bold=bold)}"
+    if persisted_mode is not chosen_mode:
+        mode_line += f" (requested {chosen_mode.value}; not lowered)"
+    typer.echo(mode_line)
+    typer.echo(f"Prefs:      {prefs_source}")
     typer.echo("Hosts:")
     for host_key, target in wired:
         if host_key == "claude":
@@ -3019,12 +3124,12 @@ def setup(
         elif host_key == "codex":
             typer.echo(f"  codex    hook written to {target}")
         elif host_key == "mcp":
-            typer.echo("  mcp      config printed above (paste into your client)")
+            typer.echo("  mcp      paste the block above into your client, then restart it")
+            typer.echo("  Verify it's live: ask your agent to read .env and confirm it is blocked.")
         elif host_key == "openclaw":
-            typer.echo("  openclaw instructions printed above")
+            typer.echo("  openclaw follow adapters/openclaw/README.md, then run its canary check")
     typer.echo("")
 
-    hooks_kind_wired = [h for h in wired if next(x for x in HOSTS if x.key == h[0]).kind == "hooks"]
     if hooks_kind_wired:
         typer.echo("Hooks written. Doberman activates when you restart your session.")
         for host_key, _ in hooks_kind_wired:
@@ -3034,11 +3139,37 @@ def setup(
     telemetry_cmd.capture_setup_completed(
         chosen_mode.value, [h for h, _ in wired], claude_scope, yes
     )
-    typer.echo(
-        "Next step: `doberman password set` - later lowerings need a possession factor "
-        "(a 2FA code if enrolled, otherwise this password)."
-    )
-    typer.echo("Also: `doberman 2fa setup` (optional)  |  `doberman status`  |  `doberman doctor`")
+
+    if hooks_kind_wired:
+        if yes:
+            typer.echo("See it work: `doberman demo --fast`")
+        elif typer.confirm(
+            "See it work? Run a scripted attack through the real engine now "
+            "(`doberman demo --fast`)",
+            default=True,
+        ):
+            typer.echo("")
+            demo_outcomes = run_demo(
+                mode=persisted_mode.value,
+                repo_root=path,
+                fast=True,
+                on_scenario=lambda outcome: typer.echo(format_outcome_line(outcome)),
+            )
+            typer.echo("")
+            typer.echo(format_summary_table(demo_outcomes))
+
+    typer.echo("")
+    if not password.is_enrolled() and not totp.is_enrolled():
+        typer.echo(
+            "Next step: `doberman password set` - later lowerings need a possession factor "
+            "(a 2FA code if enrolled, otherwise this password)."
+        )
+    else:
+        factor = "2FA" if totp.is_enrolled() else "password"
+        typer.echo(f"Possession factor: set ({factor}).")
+    typer.echo("Check health:  doberman doctor")
+    if hooks_kind_wired:
+        typer.echo("Change your mind:  doberman uninstall-hooks")
 
 
 @app.command("session-summary")

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -836,7 +836,7 @@ def _render_status_text(payload: dict) -> None:
         # Matches the sentinel doberman.__version__ falls back to when the
         # package metadata can't be found (running straight from a source
         # checkout, no install) - "0.0.0+unknown" reads as a broken install.
-        typer.echo("Version:    unknown (source checkout)")
+        typer.echo("Version: unknown (source checkout)")
     else:
         typer.echo(f"Version: {doberman_version}")
     typer.echo("")

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -814,7 +814,14 @@ def _render_status_text(payload: dict) -> None:
     modes = ", ".join(m.value for m in SecurityMode)
     typer.echo("Doberman status")
     typer.echo("=" * 32)
-    typer.echo(f"Version: {payload['doberman_version']}")
+    doberman_version = payload["doberman_version"]
+    if doberman_version == "0.0.0+unknown":
+        # Matches the sentinel doberman.__version__ falls back to when the
+        # package metadata can't be found (running straight from a source
+        # checkout, no install) - "0.0.0+unknown" reads as a broken install.
+        typer.echo("Version:    unknown (source checkout)")
+    else:
+        typer.echo(f"Version: {doberman_version}")
     typer.echo("")
 
     role = payload["role"]
@@ -1711,7 +1718,7 @@ def dash(
     uvicorn.run(create_app(token, path), host=_DASH_HOST, port=port, access_log=False)
 
 
-@app.command(rich_help_panel="Daily")
+@app.command(rich_help_panel="Getting started")
 def demo(
     path: str = typer.Option(".", "--path", "-p", help="Repository root to log decisions against."),
     mode: str = typer.Option(
@@ -2105,6 +2112,8 @@ def install_hooks(
     ``--local`` project-local, else project ``.claude/settings.json``). Codex CLI
     (``--host codex``): a PreToolUse hook into a ``hooks.json`` (``--global`` ->
     ``~/.codex/hooks.json``, else ``<repo>/.codex/hooks.json``).
+
+    New here? `doberman setup` runs this for you and asks which hosts to guard.
     """
     if host == "codex":
         _install_codex(global_=global_, local=local, path=path, dry_run=dry_run)
@@ -2246,7 +2255,7 @@ def _uninstall_codex(*, global_: bool, local: bool, path: str, dry_run: bool) ->
     )
 
 
-@app.command("uninstall-hooks", rich_help_panel="Getting started")
+@app.command("uninstall-hooks", rich_help_panel="Leaving")
 def uninstall_hooks(
     global_: bool = typer.Option(
         False,
@@ -2564,7 +2573,7 @@ def _uninstall_global(path: str, yes: bool, dry_run: bool, keep_package: bool) -
     typer.echo("\nDoberman removed from this device.")
 
 
-@app.command(rich_help_panel="Getting started")
+@app.command(rich_help_panel="Leaving")
 def uninstall(
     path: str = typer.Option(".", "--path", "-p", help="Project root (default: current dir)."),
     yes: bool = typer.Option(
@@ -2728,7 +2737,10 @@ def setup(
         None, "--mode", "-m", help="Security mode (light/balanced/strict/paranoid)."
     ),
     global_: bool = typer.Option(
-        False, "--global", "-g", help="Install hooks into ~/.claude/settings.json."
+        False,
+        "--global",
+        "-g",
+        help="Install hooks user-wide (Claude: ~/.claude/settings.json; Codex: ~/.codex/hooks.json).",
     ),
     hosts: list[str] = typer.Option(  # noqa: B008 — Typer's Option() factory, not a mutable default
         None,
@@ -3073,6 +3085,23 @@ def dashboard() -> None:
 def version() -> None:
     """Print the installed Doberman version."""
     typer.echo(__version__)
+
+
+# Typer/Rich list commands within a help panel in `app.registered_commands`
+# order. `setup` (the guided path) should lead "Getting started", followed by
+# `demo` (the best onboarding asset), then the rest - reorder that list once
+# here (a stable sort, so every other command keeps its registration order)
+# instead of moving command definitions around this file.
+_GETTING_STARTED_LEAD = {"setup": 0, "demo": 1, "doctor": 2, "install-hooks": 3, "update": 4}
+
+
+def _command_name(command: typer.models.CommandInfo) -> str:
+    return command.name or command.callback.__name__.replace("_", "-")
+
+
+app.registered_commands.sort(
+    key=lambda c: _GETTING_STARTED_LEAD.get(_command_name(c), len(_GETTING_STARTED_LEAD))
+)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/doberman/hosthooks/setup.py
+++ b/src/doberman/hosthooks/setup.py
@@ -101,11 +101,16 @@ def detect_hosts(project_root: str, home: Path) -> set[str]:
 
 
 def host_menu_lines(detected: set[str]) -> list[str]:
-    """Return formatted menu lines for the four hosts, marking detected ones."""
+    """Return formatted menu lines for the four hosts, marking detected ones.
+
+    Labels are padded to the widest one so every ``<- detected`` tag lines up
+    in a column, regardless of which host it's marking.
+    """
+    width = max(len(host.label) for host in HOSTS)
     lines: list[str] = []
     for i, host in enumerate(HOSTS, start=1):
         tag = "   <- detected" if host.key in detected else ""
-        lines.append(f"  [{i}] {host.label}{tag}")
+        lines.append(f"  [{i}] {host.label:<{width}}{tag}")
     return lines
 
 

--- a/src/doberman/render.py
+++ b/src/doberman/render.py
@@ -59,6 +59,17 @@ def supports_color() -> bool:
     return sys.stdout.isatty()  # pragma: no cover - only if click lacks the helper
 
 
+def style_text(text: str, fg: str, *, bold: bool = False) -> str:
+    """Color ``text`` with ``fg`` (+ ``bold``) when the terminal supports it, else plain.
+
+    Generic sibling of :func:`verdict_label` for one-off status lines (e.g. the
+    setup wizard's mode/doctor lines) that aren't a :class:`Verdict`.
+    """
+    if not supports_color():
+        return text
+    return typer.style(text, fg=fg, bold=bold)
+
+
 def verdict_label(verdict: Verdict) -> str:
     """A fixed-width label for ``verdict`` — colored when the terminal supports it.
 

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -124,3 +124,39 @@ def test_dashboard_alias_is_hidden_from_root_help():
 
     assert root_command.commands["session-summary"].hidden is False
     assert root_command.commands["dashboard"].hidden is True
+
+
+def test_getting_started_panel_leads_with_setup_then_demo():
+    """`setup` (the guided path) leads "Getting started", `demo` (the best
+    onboarding asset) follows it - both ahead of doctor/install-hooks/update."""
+    root_output = _normalize_help_output(
+        runner.invoke(app, ["--help"], env={"FORCE_COLOR": "1"}).output
+    )
+    ordered_names = ["setup", "demo", "doctor", "install-hooks", "update"]
+    positions = [root_output.index(name) for name in ordered_names]
+
+    assert positions == sorted(positions)
+
+
+def test_demo_is_filed_under_getting_started():
+    demo_panel = next(
+        c.rich_help_panel for c in app.registered_commands if c.callback.__name__ == "demo"
+    )
+
+    assert demo_panel == "Getting started"
+
+
+def test_removal_commands_get_their_own_leaving_panel():
+    panels_by_name = {
+        (c.name or c.callback.__name__.replace("_", "-")): c.rich_help_panel
+        for c in app.registered_commands
+    }
+
+    assert panels_by_name["uninstall-hooks"] == "Leaving"
+    assert panels_by_name["uninstall"] == "Leaving"
+
+
+def test_install_hooks_help_points_back_to_setup():
+    result = runner.invoke(app, ["install-hooks", "--help"], env={"FORCE_COLOR": "1"})
+
+    assert "doberman setup" in _normalize_help_output(result.output)

--- a/tests/unit/test_cli_status.py
+++ b/tests/unit/test_cli_status.py
@@ -14,6 +14,7 @@ from typer.testing import CliRunner
 
 from doberman import __version__
 from doberman.auth import totp
+from doberman.cli import main as cli_main
 from doberman.cli.main import app
 from doberman.hosthooks.install import (
     merge_doberman_hooks,
@@ -71,7 +72,23 @@ def _seed_block(root: str) -> None:
 def test_status_shows_installed_version(tmp_path):
     result = runner.invoke(app, ["status", "--path", str(tmp_path)])
     assert result.exit_code == 0
-    assert f"Version: {__version__}" in result.stdout
+    if __version__ == "0.0.0+unknown":
+        # Running from a source checkout with no `doberman-core` install -
+        # see test_status_shows_unknown_version_as_source_checkout below.
+        assert "Version:    unknown (source checkout)" in result.stdout
+    else:
+        assert f"Version: {__version__}" in result.stdout
+
+
+def test_status_shows_unknown_version_as_source_checkout(tmp_path, monkeypatch):
+    # `doberman.__version__` falls back to this sentinel when the package
+    # metadata can't be found; `status` must not print it raw (it reads like
+    # a broken install) and instead explains why.
+    monkeypatch.setattr(cli_main, "__version__", "0.0.0+unknown")
+    result = runner.invoke(app, ["status", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "Version:    unknown (source checkout)" in result.stdout
+    assert "0.0.0+unknown" not in result.stdout
 
 
 def test_status_reports_hook_install_state_per_scope(tmp_path):

--- a/tests/unit/test_cli_status.py
+++ b/tests/unit/test_cli_status.py
@@ -75,7 +75,7 @@ def test_status_shows_installed_version(tmp_path):
     if __version__ == "0.0.0+unknown":
         # Running from a source checkout with no `doberman-core` install -
         # see test_status_shows_unknown_version_as_source_checkout below.
-        assert "Version:    unknown (source checkout)" in result.stdout
+        assert "Version: unknown (source checkout)" in result.stdout
     else:
         assert f"Version: {__version__}" in result.stdout
 
@@ -87,7 +87,7 @@ def test_status_shows_unknown_version_as_source_checkout(tmp_path, monkeypatch):
     monkeypatch.setattr(cli_main, "__version__", "0.0.0+unknown")
     result = runner.invoke(app, ["status", "--path", str(tmp_path)])
     assert result.exit_code == 0
-    assert "Version:    unknown (source checkout)" in result.stdout
+    assert "Version: unknown (source checkout)" in result.stdout
     assert "0.0.0+unknown" not in result.stdout
 
 

--- a/tests/unit/test_setup_helpers.py
+++ b/tests/unit/test_setup_helpers.py
@@ -173,6 +173,13 @@ def test_host_menu_lines_marks_only_detected() -> None:
     assert "detected" not in codex_line
 
 
+def test_host_menu_lines_detected_tags_align() -> None:
+    """Every ``<- detected`` tag starts at the same column, regardless of label length."""
+    lines = host_menu_lines({h.key for h in HOSTS})
+    columns = {line.index("<- detected") for line in lines}
+    assert len(columns) == 1, f"tags not aligned: {lines}"
+
+
 # ---------------------------------------------------------------------------
 # parse_host_choice
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -145,6 +145,34 @@ def test_yes_saves_preferences(tmp_path: Path) -> None:
     assert prefs.reversibility == pytest.approx(0.7)
 
 
+def test_yes_refuses_to_lower_mode_without_prompting(tmp_path: Path) -> None:
+    """``--yes`` then ``--yes --mode light`` never opens a prompt and refuses the lowering."""
+    first = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
+    assert first.exit_code == 0, first.output
+
+    result = runner.invoke(app, ["setup", "--yes", "--mode", "light", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "[y/N]" not in result.output
+    assert "Reason:" not in result.output
+    assert "not lowered" in result.output
+    assert "Mode:       balanced (requested light; not lowered)" in result.output
+    assert load_mode(str(tmp_path)) == "balanced"
+    prefs = load_preferences(str(tmp_path))
+    assert prefs.confidentiality == pytest.approx(0.5)
+
+
+def test_yes_raise_over_existing_policy_applies_free(tmp_path: Path) -> None:
+    """A raise (``--yes --mode strict`` over an existing balanced policy) applies with no gate."""
+    first = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
+    assert first.exit_code == 0, first.output
+
+    result = runner.invoke(app, ["setup", "--yes", "--mode", "strict", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert load_mode(str(tmp_path)) == "strict"
+    prefs = load_preferences(str(tmp_path))
+    assert prefs.confidentiality == pytest.approx(0.7)
+
+
 # ---------------------------------------------------------------------------
 # Interactive path (via CliRunner input=)
 # ---------------------------------------------------------------------------
@@ -159,11 +187,12 @@ def test_interactive_balanced_project_scope(tmp_path: Path) -> None:
     - telemetry consent: "n"
     - tune prefs: "n"
     - global install: "n"
+    - see it work? (demo offer): "n"
     """
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="\nbalanced\nn\nn\nn\n",
+        input="\nbalanced\nn\nn\nn\nn\n",
     )
     assert result.exit_code == 0, result.output
     assert "Agent profile" not in result.output
@@ -180,7 +209,7 @@ def test_interactive_numeric_mode_choice(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="\n3\nn\nn\nn\n",
+        input="\n3\nn\nn\nn\nn\n",
     )
     assert result.exit_code == 0, result.output
     assert load_mode(str(tmp_path)) == "strict"
@@ -193,7 +222,7 @@ def test_interactive_tune_prefs(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input=f"\nbalanced\nn\ny\n{weight_inputs}\nn\n",
+        input=f"\nbalanced\nn\ny\n{weight_inputs}\nn\nn\n",
     )
     assert result.exit_code == 0, result.output
     prefs = load_preferences(str(tmp_path))
@@ -205,12 +234,37 @@ def test_setup_reprompts_on_bad_mode(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="\nblanced\nbalanced\nn\nn\nn\n",
+        input="\nblanced\nbalanced\nn\nn\nn\nn\n",
     )
 
     assert result.exit_code == 0, result.output
     assert "unknown mode" in result.output
     assert "try again" in result.output
+
+
+def test_interactive_demo_offer_declined_by_default(tmp_path: Path) -> None:
+    """Answering 'n' to the closing demo offer runs nothing extra and still exits 0."""
+    result = runner.invoke(
+        app,
+        ["setup", "--path", str(tmp_path)],
+        input="\nbalanced\nn\nn\nn\nn\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert "See it work?" in result.output
+    assert "BLOCK" not in result.output
+
+
+def test_interactive_demo_offer_accepted_runs_real_engine(tmp_path: Path) -> None:
+    """Answering 'y' to the closing demo offer runs the real scripted attack reel
+    in-process and shows a real BLOCK verdict from it."""
+    result = runner.invoke(
+        app,
+        ["setup", "--path", str(tmp_path)],
+        input="\nbalanced\nn\nn\nn\ny\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert "See it work?" in result.output
+    assert "BLOCK" in result.output
 
 
 def test_setup_explains_each_tuned_dimension(tmp_path: Path) -> None:
@@ -234,7 +288,7 @@ def test_setup_explains_each_tuned_dimension(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input=f"\nbalanced\nn\ny\n{weight_inputs}\nn\n",
+        input=f"\nbalanced\nn\ny\n{weight_inputs}\nn\nn\n",
     )
 
     assert result.exit_code == 0, result.output
@@ -285,7 +339,7 @@ def test_interactive_telemetry_yes_persists_and_emits_setup_event(
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="\nbalanced\ny\nn\nn\n",
+        input="\nbalanced\ny\nn\nn\nn\n",
     )
 
     assert result.exit_code == 0, result.output
@@ -311,7 +365,7 @@ def test_interactive_telemetry_default_yes_records_the_choice(tmp_path: Path) ->
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="\nbalanced\n\nn\nn\n",
+        input="\nbalanced\n\nn\nn\nn\n",
     )
     assert result.exit_code == 0, result.output
     state = telemetry.status()
@@ -325,7 +379,7 @@ def test_interactive_telemetry_no_persists_disabled(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="\nbalanced\nn\nn\nn\n",
+        input="\nbalanced\nn\nn\nn\nn\n",
     )
     assert result.exit_code == 0, result.output
     assert telemetry.status().enabled is False
@@ -395,7 +449,7 @@ def test_interactive_hosts_1_2_wires_both(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
         ["setup", "--path", str(tmp_path)],
-        input="1,2\nbalanced\nn\nn\nn\nn\n",
+        input="1,2\nbalanced\nn\nn\nn\nn\nn\n",
     )
     assert result.exit_code == 0, result.output
     s = _settings(tmp_path)
@@ -419,6 +473,30 @@ def test_yes_host_openclaw_prints_pointer(tmp_path: Path) -> None:
     assert "adapters/openclaw/README.md" in result.output
     assert not (tmp_path / ".claude").exists()
     assert not (tmp_path / ".codex").exists()
+
+
+def test_yes_host_mcp_doctor_scoped_and_shows_canary(tmp_path: Path) -> None:
+    """MCP-only: the hooks-only doctor checks are scoped out, and the summary
+    gets its own end state + canary instead of the hooks restart banner."""
+    result = runner.invoke(app, ["setup", "--yes", "--host", "mcp", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "  - Host hooks" not in result.output
+    assert "  - Hook command" not in result.output
+    assert "hooks n/a" in result.output
+    assert (
+        "Verify it's live: ask your agent to read .env and confirm it is blocked." in result.output
+    )
+    assert "activates when you restart" not in result.output
+
+
+def test_yes_host_openclaw_doctor_scoped(tmp_path: Path) -> None:
+    """OpenClaw-only: same doctor scoping as MCP-only (no hooks-kind host wired)."""
+    result = runner.invoke(app, ["setup", "--yes", "--host", "openclaw", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "  - Host hooks" not in result.output
+    assert "  - Hook command" not in result.output
+    assert "hooks n/a" in result.output
+    assert "activates when you restart" not in result.output
 
 
 def test_invalid_host_exits_2_naming_valid_hosts(tmp_path: Path) -> None:
@@ -449,11 +527,57 @@ def test_output_contains_restart_activation_hint(tmp_path: Path) -> None:
     assert "activates when you restart" in result.output
 
 
+def test_doctor_remediation_detail_shown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A remaining critical is printed as '- <name>: <detail>' using doctor's own text."""
+    from doberman.cli import doctor as doctor_mod
+
+    def _fake_run_checks(path: str) -> list:
+        return [
+            doctor_mod.CheckResult(
+                "Config",
+                doctor_mod.CheckStatus.FAIL,
+                "no policy saved - run `doberman setup`",
+                critical=True,
+            )
+        ]
+
+    monkeypatch.setattr(doctor_mod, "run_checks", _fake_run_checks)
+    result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "  - Config: no policy saved - run `doberman setup`" in result.output
+
+
+def test_doctor_crash_falls_back_cleanly(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from doberman.cli import doctor as doctor_mod
+
+    def _boom(path: str) -> list:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(doctor_mod, "run_checks", _boom)
+    result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "Doctor: could not run here; verify with `doberman doctor`" in result.output
+
+
 def test_password_set_is_the_first_next_step(tmp_path: Path) -> None:
     result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
     assert result.exit_code == 0, result.output
     idx = result.output.index("Next step:")
     assert "password set" in result.output[idx : idx + 60]
+
+
+def test_enrolled_password_replaces_next_step_with_possession_factor(tmp_path: Path) -> None:
+    """With a possession factor already enrolled, the password nudge is gone and
+    the summary says so instead."""
+    from doberman.auth import password as password_mod
+
+    password_mod.enroll("correct horse battery staple")
+
+    result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "Next step:" not in result.output
+    assert "password set" not in result.output
+    assert "Possession factor: set (password)." in result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Slice
- Onboarding follow-ups from the impeccable critique + audit of `doberman setup` (2026-09-02, snapshot in the memory repo's `.impeccable/critique/`)

## What this PR does

**P0, pre-existing:** `setup --yes --mode light` over an existing balanced policy printed `Mode: light` after the weaken gate had refused, wrote light's preference weights with no possession factor, and opened a `[y/N]` under `--yes`. Now: a `--yes` lowering is refused up front with a clear note and no prompt; the preference write goes through the same raise-only gate the `prefs` command uses and is skipped entirely when the mode change was refused; the summary prints the persisted mode and flags divergence (`Mode: balanced (requested light; not lowered)`).

**Doctor pass:** scoped to the hosts wired this run (`hooks n/a for this host` for MCP/OpenClaw-only runs instead of a false `Host hooks` critical); each remaining critical prints `name: detail` using doctor's own remediation text; the fallback no longer prints a Python class name. `docs/SETUP.md` §5 and `doctor --help` now name four critical categories, matching the code.

**The ending:** an offer to run `doberman demo --fast` in-process (a real BLOCK through the real engine) when hooks were wired, printed as a command under `--yes`; state-aware next steps (`password set` only when no possession factor is enrolled); `Check health:` and `Change your mind: doberman uninstall-hooks` as separate lines; MCP and OpenClaw get their own end state and a `.env` canary.

**Hierarchy and consistency:** verdict-coloured mode and doctor lines through `render` helpers (NO_COLOR-safe, text identical), aligned `<- detected` tags, one section-rule width, the weight prompt shows one default, Claude wiring prints `wrote <path>` like Codex, the hosts prompt mentions `'all'`.

**Help surfaces:** `setup` leads "Getting started", `demo` joins it, `uninstall`/`uninstall-hooks` move to a "Leaving" panel (a stable sort of `app.registered_commands`, no function moves); `install-hooks --help` points back to `setup`; `--global` help names both hosts; `status` renders the unknown-version sentinel as `unknown (source checkout)`.

## Tests added (run in CI)
- `tests/unit/test_setup_wizard.py`: refused lowering keeps mode + prefs and prints no prompt; a raise applies; MCP/OpenClaw-only runs have no hooks critical and get the canary; doctor remediation and fallback; demo offer declined/accepted (a real BLOCK asserted); state-aware next steps; existing interactive inputs answer the new closing prompt.
- `tests/unit/test_setup_helpers.py`: menu alignment. `tests/unit/test_cli_help.py`: panel order and membership. `tests/unit/test_cli_status.py`: unknown-version rendering.

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (the ungated preference write is closed)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (n/a)

## Edge cases covered / Deviations from plan / Risks introduced
- A stray function-local `SecurityMode` import in `setup` shadowed the module import; removed.
- `docs/CLI.md` does not use the Typer panel names, so it needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JMUDjz7a6xFiHDoQCuY1B