### PR TITLE
ci: the Windows PR leg runs the gate modules at fast size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
           # (The nightly deep workflow adds Windows 3.11/3.13 and macOS.)
           - os: "windows-latest"
             python-version: "3.12"
+            # The gate modules run at production size on every Linux leg and on
+            # every nightly leg; on the Windows PR leg their DB-heavy eval stalled
+            # the job to its cap four times (tests/conftest.py explains).
+            fast_gates: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -93,6 +97,8 @@ jobs:
       # --durations: every run reports its slowest tests, so a creeping suite is
       # visible in the log before it becomes a timeout.
       - name: Test suite
+        env:
+          DOBERMAN_TEST_FAST_HST_GATES: ${{ matrix.fast_gates && '1' || '' }}
         run: >
           pytest -n auto --dist loadgroup --timeout=300 --durations=25 --durations-min=2.0
           ${{ matrix.coverage && '--cov=doberman --cov-report=term-missing --cov-fail-under=90' || '' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,8 @@ python -m tools.parity.generate_parity --check
 
 CI runs exactly these: the lint, boundary, link, and parity checks once on Linux; the
 test suite on Linux 3.11–3.13 and Windows 3.12 (coverage is measured on the Linux 3.12 leg;
-every test has a 5-minute timeout); a wheel smoke test on Linux and Windows; and a
+every test has a 5-minute timeout; the Windows leg runs the benchmark/gate modules with the fast
+test-size half-space trees, the Linux legs and the nightly at production size); a wheel smoke test on Linux and Windows; and a
 full-history secret scan. A nightly deep run adds Windows 3.11/3.13, macOS, Python 3.14,
 random test order, warnings-as-errors, production-size half-space trees, and a dependency
 vulnerability audit — a red nightly is a bug in the suite or a dependency, not a rerun. The optional extras `explain` (Anthropic SDK) and `winhello`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,7 +253,8 @@ def _isolated_doberman_logger_state(monkeypatch):
 # (10 x height 8: ~30 ms). Where the model's shape is the thing under test - the
 # benchmark and gate modules - ``pytestmark = pytest.mark.real_hst`` keeps the
 # production size; the nightly deep workflow sets ``DOBERMAN_TEST_REAL_HST=1`` to
-# run the whole suite at production size and guard this shortcut.
+# run the whole suite at production size and guard this shortcut, and the Windows
+# PR leg sets ``DOBERMAN_TEST_FAST_HST_GATES=1`` to run even the gates fast.
 #
 # Done as a setup HOOK, not a fixture: module-scoped fixtures (the poisoning
 # eval, the subjective benchmark) are built before any function-scoped fixture
@@ -278,9 +279,17 @@ def _apply_hst_size(trees: int, height: int) -> None:
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item: pytest.Item) -> None:
-    real = item.get_closest_marker("real_hst") is not None or bool(
-        os.environ.get("DOBERMAN_TEST_REAL_HST")
-    )
+    if os.environ.get("DOBERMAN_TEST_REAL_HST"):
+        real = True  # the nightly: the whole suite at production size
+    elif os.environ.get("DOBERMAN_TEST_FAST_HST_GATES"):
+        # The Windows PR leg: even the gate modules run fast. Their production-size
+        # eval is DB-heavy (minutes on Windows, ~100x faster on Linux) and, under
+        # its 20-minute marker, a slow Windows runner let it stall the leg to the
+        # job cap four times on 2026-09-01/02. Production size still runs on every
+        # Linux PR leg and on every nightly leg (Windows included, 60-minute caps).
+        real = False
+    else:
+        real = item.get_closest_marker("real_hst") is not None
     _apply_hst_size(*(_HST_PRODUCTION if real else _HST_FAST))
 
 


### PR DESCRIPTION
Follow-up to #518/#523. main's own post-merge Windows leg (run 33583355564, commit 2f5a872 — the shared-group config that #523 and #529 had just run green) reproduced the intermittent stall: 99% at 26 minutes, then 19.5 minutes with no progress until the 45-minute cap cancelled it.

**Why it stalls:** the only work allowed to run that long on Windows is the production-size gate group under its `pytest.mark.timeout(1200)`. Its eval is DB-heavy — minutes on Windows, ~100x faster on Linux (BUILD-LOG 2026-08) — so on a slow Windows runner a build can exceed 20 minutes; pytest-timeout's thread method then kills the worker with `os._exit`, `--dist loadgroup` rebuilds the eval on another worker, and the job cap lands first. Four Windows legs died this way on 2026-09-01/02; every Linux leg was fine.

**Change:** the Windows PR leg sets `DOBERMAN_TEST_FAST_HST_GATES=1` (a `fast_gates` matrix key), and `tests/conftest.py` runs even the `real_hst` modules with the fast trees when it is set (`DOBERMAN_TEST_REAL_HST` still wins). Locally the poisoning gate's module fixture drops from minutes to 4 seconds. Production-size coverage of the gates is unchanged where it is deterministic: every Linux PR leg, and every nightly leg including Windows 3.11/3.13 (green at 30.0 and 20.6 minutes under 60-minute caps in run 33583357964). CONTRIBUTING says so.

**Verification:** ruff clean; `test_poisoning_gate.py` passes locally under the env var in 4 s; this PR's Windows leg is the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6w2pfW6ZdjJCrup7dDkth