### PR TITLE
test(examples): cover audit sink fan-out

### DIFF
--- a/changelog.d/537.md
+++ b/changelog.d/537.md
@@ -1,0 +1,2 @@
+- **Tests:** exercise the tutorial audit sink through core's real fan-out path so wiring
+  regressions are caught (#537)

--- a/tests/unit/test_examples_plugin_audit_sink.py
+++ b/tests/unit/test_examples_plugin_audit_sink.py
@@ -9,6 +9,7 @@ They do prove:
 
 * the package layout and ``doberman.audit_sinks`` entry-point declaration are correct;
 * ``ExampleAuditSink`` satisfies the core ``AuditSink`` protocol;
+* core's real ``emit_to_sinks()`` fan-out reaches the example sink;
 * ``emit`` never raises, including on a malformed record;
 * the sink's output never echoes a raw secret placed in the record.
 
@@ -19,6 +20,7 @@ tests (``examples/plugin-audit-sink/tests/``) and documented in its README.
 from __future__ import annotations
 
 import importlib
+import json
 import pathlib
 import sys
 import tomllib
@@ -27,7 +29,7 @@ from pathlib import Path
 import pytest
 
 from doberman.engine.registry import discover_audit_sinks
-from doberman.storage.sinks import AuditSink
+from doberman.storage.sinks import AuditSink, emit_to_sinks
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _EXAMPLE_ROOT = _REPO_ROOT / "examples" / "plugin-audit-sink"
@@ -90,6 +92,21 @@ def test_example_pyproject_declares_doberman_audit_sinks_entry_point():
 
 def test_example_sink_satisfies_audit_sink_protocol(example_sink_cls):
     assert isinstance(example_sink_cls(), AuditSink)
+
+
+def test_example_sink_fires_through_emit_to_sinks(example_sink_cls, tmp_path, monkeypatch):
+    from example_audit_sink.sinks import SINK_FILE_ENV
+
+    sink_file = tmp_path / "audit.jsonl"
+    monkeypatch.setenv(SINK_FILE_ENV, str(sink_file))
+    sink = example_sink_cls()
+    monkeypatch.setattr("doberman.engine.registry.discover_audit_sinks", lambda: [sink])
+
+    emit_to_sinks(_SAMPLE_RECORD, repo_root=str(tmp_path))
+
+    lines = sink_file.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == _SAMPLE_RECORD
 
 
 def test_example_sink_emit_never_raises(example_sink_cls, tmp_path, monkeypatch):


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: #504 — audit-sink fan-out regression coverage
- Plan reference: GitHub issue #504

## What this PR does
- imports `ExampleAuditSink` from the checkout without installing the example package
- registers the sink through the same discovery seam used by core
- routes `_SAMPLE_RECORD` through the real `emit_to_sinks()` path
- asserts that exactly one unchanged JSON line reaches the sink file

Closes #504

## Tests added (run in CI)
- `tests/unit/test_examples_plugin_audit_sink.py` — verifies real fan-out wiring and exact JSON output
- `pytest tests/unit/test_examples_plugin_audit_sink.py -q` — 7 passed
- full suite — 3568 passed, 7 skipped, 92.00% coverage
- `ruff check .`, `ruff format --check .`, Markdown link check, import-linter, and parity check all pass

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (unchanged; test-only change)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (not applicable; no runtime behavior changed)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (not applicable; no verdict behavior changed)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- The example package remains uninstalled, preserving the core standalone guarantee.
- Built-in sinks remain inert under the temporary repository root.
- No deviations or runtime risks introduced.

## AI assistance
Codex helped identify the issue, implement the focused test, and run the verification commands. I reviewed the resulting diff and test evidence.