### PR TITLE
ci(pytest): ignore anyio 4.15 BlockingPortal-alias deprecation raised by starlette.testclient

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,12 @@ filterwarnings = [
     # Starlette's test client prefers httpx2; moving the dev extra is a dependency
     # follow-up (#518), not a suite defect.
     "ignore:Using `httpx` with `starlette.testclient` is deprecated",
+    # anyio 4.15 deprecates the `anyio.abc.BlockingPortal` alias that the installed
+    # starlette test client still imports at module load; under `error` that
+    # import-time DeprecationWarning fails collection of every dash test and the
+    # parity generator (CI 2026-09-03). Upstream fix is a starlette bump; until the
+    # dash extra moves, keep it a visible warning, not a collection error.
+    "ignore:The anyio.abc.BlockingPortal alias is deprecated:DeprecationWarning",
 ]
 markers = [
     "guarantee(name, host): claims a parity-matrix cell; collected by tools/parity (docs/PARITY.md)",


### PR DESCRIPTION
## What
anyio 4.15.0 (installed fresh on the CI runners on 2026-09-03) deprecates the `anyio.abc.BlockingPortal` alias. The installed starlette test client still imports it at module load, so under this repo's `filterwarnings = ["error", ...]` every `tests/unit/test_dash_*.py` module fails collection, and `tools.parity.generate_parity` (which runs pytest collection) fails `test_parity_doc_is_current`. Main is red for any fresh run; every open PR shows the same four red legs.

This adds one targeted `ignore:` filter for exactly that message (same pattern as the existing httpx/starlette filter), so the deprecation stays a visible warning instead of a collection error. No test or invariant is weakened.

## Follow-up
Bump starlette (which already imports `anyio.from_thread.BlockingPortal` upstream) together with the pending httpx2 dev-extra move (#518); then drop this filter.

## Checks
- [x] Nothing from the not-allowed list; core-only change to test configuration
- [x] Fail-closed / raise-only / redaction untouched