### PR TITLE
fix(tui): guard sibling widget queries against the mount-timing race (deflakes test_tui)

### DIFF
--- a/changelog.d/546.md
+++ b/changelog.d/546.md
@@ -1,0 +1,1 @@
+- Fixed a TUI mount-timing race where the first row highlight could query `#explanation-scroll` (and its sibling widgets) before they were mounted, crashing the app; the queries now no-op until the widgets exist (deflakes `test_tui.py` in CI).

--- a/src/doberman/tui.py
+++ b/src/doberman/tui.py
@@ -1536,11 +1536,17 @@ class DecisionExplainerApp(App[None]):
     def _why_panel(self) -> _WhyPanel | None:
         """Best-effort `#explanation-scroll` accessor: `None` instead of
         raising `NoMatches` when the panel isn't (yet, or any longer)
-        mounted. `on_mount` itself may assume the panel exists (compose
-        already put it there by then), but every OTHER call site races a
-        filter edit's `_rebuild_table`/`_show_empty_message` swap under CI
-        load and must no-op via this instead of crashing the app - the CI
-        flake this guards against (`NoMatches` on `#explanation-scroll`)."""
+        mounted. Root cause (the CI flake this guards against, reproduced
+        locally): a mount-timing race, not a filter-driven swap - the very
+        first `DataTable.RowHighlighted`, posted by the initial load's own
+        `table.move_cursor()`, can be pumped through
+        `on_data_table_row_highlighted` -> `_show_explanation` before every
+        sibling widget composed alongside this one is queryable yet.
+        `on_mount` itself is exempt (compose has already placed the panel by
+        then); every other call site must no-op via this instead of
+        crashing the app. `_update_date_bar`/`_update_next_line` guard the
+        same race on their own sibling widgets (`#date-bar`/`#next-line`)
+        the same way."""
         try:
             return self.query_one("#explanation-scroll", _WhyPanel)
         except NoMatches:
@@ -1598,8 +1604,14 @@ class DecisionExplainerApp(App[None]):
         layout, not "no data". The why panel itself goes blank (nothing to
         explain) and loses its time-line border title.
         """
-        self.query_one("#decisions", _DecisionTable).display = False
-        empty = self.query_one("#empty-message", Static)
+        # Same mount-timing race as `_why_panel`/`_update_gutter`: this can
+        # run inside the initial load, before `#decisions`/`#empty-message`
+        # are queryable yet - no-op the swap rather than crash the app.
+        try:
+            self.query_one("#decisions", _DecisionTable).display = False
+            empty = self.query_one("#empty-message", Static)
+        except NoMatches:
+            return
         empty.update(message)
         empty.display = True
         why_panel = self._why_panel()
@@ -1616,7 +1628,14 @@ class DecisionExplainerApp(App[None]):
         # applies here too (round 5 design critique item 9): the glyphs
         # aren't worth explaining for a browser with zero rows in it.
         text = _date_bar_text(row) if self._rows else ""
-        self.query_one("#date-bar", Static).update(text)
+        try:
+            # Same mount-timing race as `_why_panel`: the initial
+            # `move_cursor`'s `RowHighlighted` can be pumped through
+            # `on_data_table_row_highlighted` before this sibling widget is
+            # queryable - no-op rather than crash the app.
+            self.query_one("#date-bar", Static).update(text)
+        except NoMatches:
+            pass
 
     def _update_next_line(self, row: dict | None) -> None:
         # Docked separately from the panel body (round 3 design critique item
@@ -1625,7 +1644,10 @@ class DecisionExplainerApp(App[None]):
         # detail" affordance; the full-screen why (`full_why_text`) is the
         # detail itself and must not repeat it (round 5 design critique item 1).
         next_line = render.next_step_line(row.get("final_verdict")) if row is not None else None
-        widget = self.query_one("#next-line", Static)
+        try:
+            widget = self.query_one("#next-line", Static)  # same race, see `_update_date_bar`
+        except NoMatches:
+            return
         widget.update(_next_line_text(next_line) if next_line else "")
 
     def _update_gutter(self, index: int) -> None:
@@ -1633,7 +1655,14 @@ class DecisionExplainerApp(App[None]):
         # previous mark (if any) and mark the new cursor row with ">" - kept
         # independent of Textual's own cursor-row background, which measured
         # too low-contrast on its own to read as "selected".
-        table = self.query_one("#decisions", _DecisionTable)
+        try:
+            # Same mount-timing race as `_why_panel`/`_update_date_bar`: this
+            # fires from `on_data_table_row_highlighted`, a fresh query for
+            # `#decisions` posted by that same table's own cursor move - it
+            # can still lose the race before the table is queryable again.
+            table = self.query_one("#decisions", _DecisionTable)
+        except NoMatches:
+            return
         if self._gutter_row is not None and self._gutter_row != index:
             try:
                 table.update_cell_at(Coordinate(self._gutter_row, 0), Text(""), update_width=False)

--- a/src/doberman/tui.py
+++ b/src/doberman/tui.py
@@ -45,6 +45,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical, VerticalScroll
 from textual.coordinate import Coordinate
+from textual.css.query import NoMatches
 from textual.screen import ModalScreen
 from textual.widget import Widget
 from textual.widgets import DataTable, Footer, Header, Input, LoadingIndicator, Static
@@ -1532,6 +1533,19 @@ class DecisionExplainerApp(App[None]):
 
     # --- selection / why panel ------------------------------------------------
 
+    def _why_panel(self) -> _WhyPanel | None:
+        """Best-effort `#explanation-scroll` accessor: `None` instead of
+        raising `NoMatches` when the panel isn't (yet, or any longer)
+        mounted. `on_mount` itself may assume the panel exists (compose
+        already put it there by then), but every OTHER call site races a
+        filter edit's `_rebuild_table`/`_show_empty_message` swap under CI
+        load and must no-op via this instead of crashing the app - the CI
+        flake this guards against (`NoMatches` on `#explanation-scroll`)."""
+        try:
+            return self.query_one("#explanation-scroll", _WhyPanel)
+        except NoMatches:
+            return None
+
     def _set_panel(self, text: str | Text) -> None:
         self._panel_base = text
         self._refresh_why_panel_scroll_cue()
@@ -1557,10 +1571,12 @@ class DecisionExplainerApp(App[None]):
         up as a stuck stale cue under load once content had already gone
         back to something short.
         """
+        scroll = self._why_panel()
+        if scroll is None:
+            return
         try:
-            scroll = self.query_one("#explanation-scroll", _WhyPanel)
             static = self.query_one("#explanation", Static)
-        except Exception:  # noqa: BLE001 — defensive: not mounted yet
+        except NoMatches:  # defensive: not mounted yet
             return
         base = self._panel_base
         static.update(base)
@@ -1586,7 +1602,9 @@ class DecisionExplainerApp(App[None]):
         empty = self.query_one("#empty-message", Static)
         empty.update(message)
         empty.display = True
-        self.query_one("#explanation-scroll", _WhyPanel).set_time_line("")
+        why_panel = self._why_panel()
+        if why_panel is not None:
+            why_panel.set_time_line("")
         self._set_panel("")
 
     def _hide_empty_message(self) -> None:
@@ -1644,7 +1662,9 @@ class DecisionExplainerApp(App[None]):
         # design critique item 1: this now goes to the panel's border_title
         # (via `set_time_line`), not the panel body - see `_panel_text`.
         time_line = _abs_utc_and_age(row)
-        self.query_one("#explanation-scroll", _WhyPanel).set_time_line(time_line)
+        why_panel = self._why_panel()
+        if why_panel is not None:
+            why_panel.set_time_line(time_line)
         self._update_date_bar(row)
         self._update_next_line(row)
         self._update_gutter(index)

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -475,13 +475,23 @@ async def test_filtered_to_zero_matches_is_distinct_from_no_data(tmp_path):
 
 async def test_why_panel_missing_is_a_no_op_not_a_crash(tmp_path):
     """Regression for the CI-only flake: `textual.css.query.NoMatches` on
-    `#explanation-scroll`, seen on the Ubuntu 3.11 CI leg (never locally) on
-    two unrelated PRs. Under load, a query for the docked why panel can lose
-    a race with the panel's own mount/rebuild and raise instead of finding
-    it. `_why_panel()` must return `None` rather than raise when the panel
-    isn't in the DOM, and every call site that uses it (`_show_empty_message`,
-    `_show_explanation`, `_refresh_why_panel_scroll_cue`) must no-op instead
-    of crashing the app.
+    `#explanation-scroll` (and siblings `#date-bar`/`#next-line`/`#decisions`/
+    `#empty-message`), seen on the Ubuntu 3.11 CI leg on two unrelated PRs,
+    and reproduced locally (~1 in 6-15 runs of
+    `test_filtered_to_zero_matches_is_distinct_from_no_data`) with the
+    identical traceback for each id. Root cause: a mount-timing race, not a
+    filter-driven swap - the very first `DataTable.RowHighlighted`, posted by
+    the initial load's own `table.move_cursor()`, can be pumped through
+    `on_data_table_row_highlighted` -> `_show_explanation` before a sibling
+    widget composed alongside the table is queryable yet - `#decisions`
+    itself included, since `_update_gutter` re-queries it fresh rather than
+    holding the event's own table reference. Each racy widget's
+    accessor/query (`_why_panel()` for `#explanation-scroll`; the guarded
+    queries in `_update_date_bar`, `_update_next_line`, `_update_gutter`,
+    `_show_empty_message` for `#date-bar`/`#next-line`/`#decisions`/
+    `#empty-message`) must no-op instead of raising, and every call site that
+    uses them (`_show_empty_message`, `_show_explanation`,
+    `_refresh_why_panel_scroll_cue`) must no-op instead of crashing the app.
     """
     root = str(tmp_path)
     await _seed_block(root)
@@ -489,15 +499,26 @@ async def test_why_panel_missing_is_a_no_op_not_a_crash(tmp_path):
     async with app.run_test() as pilot:
         await _wait_loaded(pilot, app)
         why_panel = app.query_one("#explanation-scroll")
+        date_bar = app.query_one("#date-bar")
+        next_line = app.query_one("#next-line")
+        decisions = app.query_one("#decisions")
+        empty_message = app.query_one("#empty-message")
         await why_panel.remove()
+        await date_bar.remove()
+        await next_line.remove()
+        await decisions.remove()
+        await empty_message.remove()
         await pilot.pause()
 
         assert app._why_panel() is None
 
-        # None of these may raise `NoMatches` now that the panel is gone -
+        # None of these may raise `NoMatches` now that the widgets are gone -
         # they must silently no-op instead of crashing the app, same as a
-        # query that loses the mount/rebuild race under CI load.
+        # query that loses the initial-load mount race under CI load.
         app._refresh_why_panel_scroll_cue()
+        app._update_date_bar(None)
+        app._update_next_line(None)
+        app._update_gutter(0)
         app._show_empty_message("(no rows match the filter - press esc to clear it)")
         app._show_explanation(0)
 

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -473,6 +473,35 @@ async def test_filtered_to_zero_matches_is_distinct_from_no_data(tmp_path):
         assert app.query_one("#empty-message").display is False
 
 
+async def test_why_panel_missing_is_a_no_op_not_a_crash(tmp_path):
+    """Regression for the CI-only flake: `textual.css.query.NoMatches` on
+    `#explanation-scroll`, seen on the Ubuntu 3.11 CI leg (never locally) on
+    two unrelated PRs. Under load, a query for the docked why panel can lose
+    a race with the panel's own mount/rebuild and raise instead of finding
+    it. `_why_panel()` must return `None` rather than raise when the panel
+    isn't in the DOM, and every call site that uses it (`_show_empty_message`,
+    `_show_explanation`, `_refresh_why_panel_scroll_cue`) must no-op instead
+    of crashing the app.
+    """
+    root = str(tmp_path)
+    await _seed_block(root)
+    app = DecisionExplainerApp(root)
+    async with app.run_test() as pilot:
+        await _wait_loaded(pilot, app)
+        why_panel = app.query_one("#explanation-scroll")
+        await why_panel.remove()
+        await pilot.pause()
+
+        assert app._why_panel() is None
+
+        # None of these may raise `NoMatches` now that the panel is gone -
+        # they must silently no-op instead of crashing the app, same as a
+        # query that loses the mount/rebuild race under CI load.
+        app._refresh_why_panel_scroll_cue()
+        app._show_empty_message("(no rows match the filter - press esc to clear it)")
+        app._show_explanation(0)
+
+
 # --- bounded load / subtitle --------------------------------------------------
 
 


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: chore/CI — deflake `test_tui.py::test_filtered_to_zero_matches_is_distinct_from_no_data`
- Plan reference: BUILD-LOG 2026-09-03 (the flake blocked #541 and #543 on the Ubuntu 3.11 leg)

## What this PR does
Fixes a mount-timing race in the TUI, reproduced locally with the exact CI signature (`NoMatches: No nodes match '#explanation-scroll'`, 1/10 pristine runs): the very first `DataTable.RowHighlighted`, posted by the initial load's own `table.move_cursor()`, can be pumped through `on_data_table_row_highlighted` → `_show_explanation` before the sibling widgets composed alongside the table are queryable. The exception escaped `app.run_test()` itself, so no test-side wait could fix it.
- Adds a `_why_panel()` accessor that returns `None` instead of raising, and routes the post-mount `#explanation-scroll` queries through it.
- Guards the sibling queries in the same race the same way (`#date-bar`, `#next-line`, `#decisions` via `_update_gutter`, `#empty-message`) — the first scoped fix still hit 5/30 on `#decisions`.
- Root cause documented once in the accessor's docstring; each guard comments back to it.
- After the fix: 0/30 `NoMatches` of any id on the target test (was 1/10 then 5/30). `on_mount`'s own query is intentionally left strict.

## Tests added (run in CI)
- `tests/unit/test_tui.py::test_why_panel_missing_is_a_no_op_not_a_crash` — removes all five racy widgets mid-run and calls every guarded method, asserting none raise (RED before the fix). Full `test_tui.py`: 108 passed.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (display-only code path; no decision logic touched)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only — N/A, no guardrail change
- [x] Every BLOCK/AUTH carries reason codes + a human explanation — unchanged
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Per-site `try/except NoMatches` rather than one gate at the top of `_show_explanation`, because `_update_date_bar`/`_update_next_line`/`_show_empty_message` have other callers (`_reset_to_empty`, `_rebuild_table`) that hit the same window.
- Risk: a guard that silently no-ops could mask a genuinely missing widget in future refactors; the regression test pins the current widget ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRi24XEAQGtWWFXuLfF1Ca
