### PR TITLE
feat(hosthooks): install-integrity guard for Doberman's own hook registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ After installing, run `doberman --install-completion` to enable shell tab comple
 > uninstall; `doberman doctor` flags any hook entry whose `doberman` is not on PATH. More recovery
 > steps: [Recover](docs/RECOVERY.md).
 
+- Install integrity: install-hooks records a keyed fingerprint of Doberman's own hook entries in
+  your per-user Doberman config dir (never in the repo). If those entries are later stripped or
+  altered, the next surviving hook invocation warns and doberman doctor reports which scope
+  diverged. Detection only; it never blocks. (#239)
+
 | Your agent | How Doberman plugs in | Get started |
 |---|---|---|
 | **Claude Code** | Hooks: gates every built-in and MCP tool call *(recommended)* | `doberman setup` → [guide](docs/SETUP.md) |

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -68,6 +68,13 @@ taint bump. The dedupe is a UX concern, never a gate: any doubt re-evaluates.
   version range (`doberman doctor` reports yours) and a scheduled canary catches
   upstream API churn — but a Codex release outside the tested range may need an
   adapter update.
+- **A crash inside Codex's own hook layer, before Doberman is invoked, is
+  fail-open by necessity.** The host proceeds and no Doberman decision is
+  recorded (seen live on 2026-08-09 as a tree-sitter allocation failure in the
+  Codex hook runner). Core cannot intercept a host that never calls it. What
+  Doberman does: `doberman doctor` verifies the hook registration is intact
+  (#239), and this section says so plainly. An automated live canary (a `codex
+  exec` that must be blocked) is tracked in #335.
 
 ## Learn more
 

--- a/changelog.d/239.md
+++ b/changelog.d/239.md
@@ -1,0 +1,6 @@
+- **Install-integrity guard for Doberman's own hook registration.** `install-hooks` records keyed
+  fingerprints of the installed hook groups in the per-user config dir, `uninstall-hooks` clears
+  them first, every hook invocation warns (Claude Code `systemMessage` / Codex stderr) when a
+  recorded registration was stripped or changed, and `doberman doctor` reports intact / diverged /
+  untracked. Warning-only: never changes a verdict or exit code (#239; documents the Codex
+  hook-layer crash limit from #335)

--- a/src/doberman/cli/doctor.py
+++ b/src/doberman/cli/doctor.py
@@ -151,6 +151,45 @@ def _check_hook_command(path: str) -> CheckResult:
     )
 
 
+def _check_hook_integrity(path: str) -> CheckResult:
+    """#239: has Doberman's own hook registration changed since install-hooks?"""
+    from doberman.hosthooks.install import hook_install_states
+    from doberman.hosthooks.install_codex import codex_hook_install_states
+    from doberman.hosthooks.integrity import check_all
+
+    name = "Hook integrity"
+    statuses = check_all(path)
+    diverged = [s for s in statuses if s.state == "diverged"]
+    intact = [s for s in statuses if s.state == "intact"]
+    if diverged:
+        where = ", ".join(f"{s.host} {s.scope}: {'/'.join(s.diverged_events)}" for s in diverged)
+        critical = any(s.critical for s in diverged)
+        return CheckResult(
+            name,
+            CheckStatus.FAIL if critical else CheckStatus.WARN,
+            f"diverged ({where}) - Doberman's hook registration changed since install; "
+            "run `doberman install-hooks` to restore",
+            critical=critical,
+        )
+    if intact:
+        detail = "intact (" + ", ".join(f"{s.host} {s.scope}" for s in intact) + ")"
+        seen = [s.divergence_seen for s in intact if s.divergence_seen]
+        if seen:
+            detail += f" - a divergence was seen at {max(seen)}; re-run install-hooks to clear"
+        return CheckResult(name, CheckStatus.OK, detail)
+    installed = any(ok for _s, _p, ok in hook_install_states(path)) or any(
+        ok for _s, _p, ok in codex_hook_install_states(path)
+    )
+    if installed:
+        return CheckResult(
+            name,
+            CheckStatus.WARN,
+            "untracked - installed before integrity tracking; re-run `doberman install-hooks` "
+            "to record a manifest",
+        )
+    return CheckResult(name, CheckStatus.OK, "nothing to verify (no hooks installed)")
+
+
 def _check_codex_version() -> CheckResult:
     """Report the installed Codex CLI version against the adapter's supported
     range. Always **non-critical** (WARN, never FAIL): a newer or absent Codex is
@@ -387,6 +426,7 @@ def run_checks(path: str = ".") -> list[CheckResult]:
     return [
         _safe_check("Host hooks", True, lambda: _check_hooks(path)),
         _safe_check("Hook command", True, lambda: _check_hook_command(path)),
+        _safe_check("Hook integrity", True, lambda: _check_hook_integrity(path)),
         _safe_check("Config", True, lambda: _check_config(path)),
         _safe_check("Decision DB", True, lambda: _check_db(path)),
         _safe_check("Enforcement", False, lambda: _check_enforcement(path)),

--- a/src/doberman/cli/doctor.py
+++ b/src/doberman/cli/doctor.py
@@ -178,7 +178,7 @@ def _check_hook_integrity(path: str) -> CheckResult:
             detail += f" - a divergence was seen at {max(seen)}; re-run install-hooks to clear"
         return CheckResult(name, CheckStatus.OK, detail)
     installed = any(ok for _s, _p, ok in hook_install_states(path)) or any(
-        ok for _s, _p, ok in codex_hook_install_states(path)
+        ok for s, _p, ok in codex_hook_install_states(path) if s != "plugin"
     )
     if installed:
         return CheckResult(

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1331,6 +1331,7 @@ def doctor(
     section_for = {
         "Host hooks": "Hooks",
         "Hook command": "Hooks",
+        "Hook integrity": "Hooks",
         "Config": "Policy",
         "Enforcement": "Policy",
         "Policy version": "Policy",
@@ -3028,9 +3029,10 @@ def _uninstall_global(path: str, yes: bool, dry_run: bool, keep_package: bool) -
         if not claude_installed.get(scope):
             continue
         target = resolve_settings_path(scope, path)
-        _clear_manifest("claude", scope, target)
         try:
-            write_settings(target, remove_doberman_hooks(load_settings(target)))
+            current = load_settings(target)
+            _clear_manifest("claude", scope, target)
+            write_settings(target, remove_doberman_hooks(current))
         except (ValueError, OSError) as exc:
             errors.append(f"{target}: {exc}")
 
@@ -3043,9 +3045,10 @@ def _uninstall_global(path: str, yes: bool, dry_run: bool, keep_package: bool) -
         if not codex_installed.get(scope):
             continue
         target = resolve_codex_hooks_path(scope, path)
-        _clear_manifest("codex", scope, target)
         try:
-            write_settings(target, remove_codex_hooks(load_settings(target)))
+            current = load_settings(target)
+            _clear_manifest("codex", scope, target)
+            write_settings(target, remove_codex_hooks(current))
         except (ValueError, OSError) as exc:
             errors.append(f"{target}: {exc}")
 
@@ -3208,9 +3211,9 @@ def uninstall(
     for scope, settings_path, installed in _hook_install_states(path):
         if scope not in ("project", "local") or not installed:
             continue
-        _clear_manifest("claude", scope, resolve_settings_path(scope, path))
         try:
             current = load_settings(resolve_settings_path(scope, path))
+            _clear_manifest("claude", scope, resolve_settings_path(scope, path))
             write_settings(resolve_settings_path(scope, path), remove_doberman_hooks(current))
         except (ValueError, OSError) as exc:
             errors.append(f"{settings_path}: {exc}")
@@ -3218,9 +3221,9 @@ def uninstall(
     for scope, hooks_path, installed in codex_hook_install_states(path):
         if scope != "repo" or not installed:
             continue
-        _clear_manifest("codex", scope, resolve_codex_hooks_path(scope, path))
         try:
             current = load_settings(resolve_codex_hooks_path(scope, path))
+            _clear_manifest("codex", scope, resolve_codex_hooks_path(scope, path))
             write_settings(resolve_codex_hooks_path(scope, path), remove_codex_hooks(current))
         except (ValueError, OSError) as exc:
             errors.append(f"{hooks_path}: {exc}")

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -2540,6 +2540,34 @@ def decision_log_prune(
     typer.echo(f"Decision log pruned: {deleted} row(s).")
 
 
+def _record_manifest(host: str, scope: str, settings_path: Path, groups: dict) -> None:
+    """Record the install manifest entry; a failure is reported, never fatal."""
+    from doberman.hosthooks.integrity import record_install
+
+    try:
+        record_install(host, scope, settings_path, groups)
+    except Exception as exc:  # noqa: BLE001 - tracking must never break an install
+        typer.echo(
+            f"warning: could not record the hook install manifest ({type(exc).__name__}); "
+            "`doberman doctor` will report the hook integrity as untracked.",
+            err=True,
+        )
+
+
+def _clear_manifest(host: str, scope: str, settings_path: Path) -> None:
+    """Forget the manifest entry BEFORE removing hooks; a failure is reported, never fatal."""
+    from doberman.hosthooks.integrity import clear_install
+
+    try:
+        clear_install(host, scope, settings_path)
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(
+            f"warning: could not clear the hook install manifest ({type(exc).__name__}); "
+            "`doberman doctor` may report a divergence until you re-run install-hooks.",
+            err=True,
+        )
+
+
 @app.command("install-hooks", rich_help_panel="Getting started")
 def install_hooks(
     global_: bool = typer.Option(
@@ -2579,6 +2607,7 @@ def install_hooks(
         raise typer.Exit(2)
 
     from doberman.hosthooks.install import (
+        doberman_groups,
         load_settings,
         merge_doberman_hooks,
         resolve_settings_path,
@@ -2609,6 +2638,7 @@ def install_hooks(
     else:
         write_settings(settings_path, merged)
         typer.echo(f"wrote {settings_path}")
+    _record_manifest("claude", scope, settings_path, doberman_groups(merged))
     typer.echo("Doberman will now gate every tool call in this project.")
     typer.echo("The session dashboard will print at the start of every session.")
     if remove_exclusion(path):
@@ -2631,7 +2661,11 @@ def _write_codex_hook(scope: str, path: str, *, show_verify: bool = True) -> tup
     "cat .env" text otherwise duplicated it.
     """
     from doberman.hosthooks.install import load_settings, write_settings
-    from doberman.hosthooks.install_codex import merge_codex_hooks, resolve_codex_hooks_path
+    from doberman.hosthooks.install_codex import (
+        codex_doberman_groups,
+        merge_codex_hooks,
+        resolve_codex_hooks_path,
+    )
 
     hooks_path = resolve_codex_hooks_path(scope, path)
 
@@ -2648,6 +2682,7 @@ def _write_codex_hook(scope: str, path: str, *, show_verify: bool = True) -> tup
     else:
         write_settings(hooks_path, merged)
         typer.echo(style_text(f"wrote {hooks_path}", bold=True))
+    _record_manifest("codex", scope, hooks_path, codex_doberman_groups(merged))
     if remove_exclusion(path):
         typer.echo("This project is no longer excluded from global hooks.")
     typer.echo("")
@@ -2724,6 +2759,7 @@ def _uninstall_codex(*, global_: bool, local: bool, path: str, dry_run: bool) ->
         typer.echo("[dry-run] would remove:  PreToolUse -> doberman hook codex-pre")
         return
 
+    _clear_manifest("codex", scope, hooks_path)
     write_settings(hooks_path, cleaned)
     typer.echo(f"wrote {hooks_path}")
     typer.echo("Doberman Codex hooks removed.")
@@ -2803,6 +2839,7 @@ def uninstall_hooks(
         typer.echo(f"  SessionStart -> {DASHBOARD_COMMAND}")
         return
 
+    _clear_manifest("claude", scope, settings_path)
     write_settings(settings_path, cleaned)
     typer.echo(f"wrote {settings_path}")
     typer.echo("Doberman hooks removed.")
@@ -2991,6 +3028,7 @@ def _uninstall_global(path: str, yes: bool, dry_run: bool, keep_package: bool) -
         if not claude_installed.get(scope):
             continue
         target = resolve_settings_path(scope, path)
+        _clear_manifest("claude", scope, target)
         try:
             write_settings(target, remove_doberman_hooks(load_settings(target)))
         except (ValueError, OSError) as exc:
@@ -3005,6 +3043,7 @@ def _uninstall_global(path: str, yes: bool, dry_run: bool, keep_package: bool) -
         if not codex_installed.get(scope):
             continue
         target = resolve_codex_hooks_path(scope, path)
+        _clear_manifest("codex", scope, target)
         try:
             write_settings(target, remove_codex_hooks(load_settings(target)))
         except (ValueError, OSError) as exc:
@@ -3169,6 +3208,7 @@ def uninstall(
     for scope, settings_path, installed in _hook_install_states(path):
         if scope not in ("project", "local") or not installed:
             continue
+        _clear_manifest("claude", scope, resolve_settings_path(scope, path))
         try:
             current = load_settings(resolve_settings_path(scope, path))
             write_settings(resolve_settings_path(scope, path), remove_doberman_hooks(current))
@@ -3178,6 +3218,7 @@ def uninstall(
     for scope, hooks_path, installed in codex_hook_install_states(path):
         if scope != "repo" or not installed:
             continue
+        _clear_manifest("codex", scope, resolve_codex_hooks_path(scope, path))
         try:
             current = load_settings(resolve_codex_hooks_path(scope, path))
             write_settings(resolve_codex_hooks_path(scope, path), remove_codex_hooks(current))
@@ -3259,6 +3300,7 @@ def setup(
     """
     from doberman.hosthooks import setup as hosthooks_setup
     from doberman.hosthooks.install import (
+        doberman_groups,
         load_settings,
         merge_doberman_hooks,
         resolve_settings_path,
@@ -3822,6 +3864,7 @@ def setup(
                 raise typer.Exit(1) from exc
             typer.echo(style_text(f"wrote {settings_path}", bold=True))
             wired_state["claude"] = "wrote"
+        _record_manifest("claude", claude_scope, settings_path, doberman_groups(merged))
         wired.append(("claude", str(settings_path)))
         _mark_content()  # item 11: no header under --yes/flags, but real content just printed
 

--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -266,6 +266,30 @@ def _record_pre_history(
         pass
 
 
+def _attach_integrity_warning(
+    out: dict[str, Any] | None, payload: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Add a ``systemMessage`` when Doberman's own registration diverged (#239).
+
+    Warning-only: never changes ``hookSpecificOutput``; an excluded project is a
+    true no-op; any failure returns *out* unchanged.
+    """
+    try:
+        cwd = payload.get("cwd")
+        if spine.is_excluded(cwd):
+            return out
+        from doberman.hosthooks.integrity import hook_warning
+
+        warning = hook_warning(spine.resolve_root_and_mode(cwd)[0])
+    except Exception:  # noqa: BLE001 — the guard must never alter a decision
+        return out
+    if warning is None:
+        return out
+    merged = dict(out or {})
+    merged["systemMessage"] = warning
+    return merged
+
+
 def run_pre_hook(stdin_text: str) -> str | None:
     """Parse the hook stdin, evaluate, and return the JSON string to print to
     stdout — or ``None`` to abstain (print nothing).
@@ -279,7 +303,7 @@ def run_pre_hook(stdin_text: str) -> str | None:
         return json.dumps(_deny())
     if not isinstance(payload, dict):
         return json.dumps(_deny())
-    out = evaluate_pre(payload)
+    out = _attach_integrity_warning(evaluate_pre(payload), payload)
     return json.dumps(out) if out is not None else None
 
 
@@ -641,5 +665,5 @@ def run_post_hook(stdin_text: str) -> str | None:
         return json.dumps(_post_block(_POST_FAILSAFE_REASON))
     if not isinstance(payload, dict):
         return json.dumps(_post_block(_POST_FAILSAFE_REASON))
-    out = evaluate_post(payload)
+    out = _attach_integrity_warning(evaluate_post(payload), payload)
     return json.dumps(out) if out is not None else None

--- a/src/doberman/hosthooks/codex.py
+++ b/src/doberman/hosthooks/codex.py
@@ -226,12 +226,11 @@ def run_codex_pre(stdin_text: str) -> str | None:
     singleflight.record(key, text)
 
     try:  # #239: warn on stderr when Doberman's own registration diverged.
-        from doberman.hosthooks import spine as _spine
         from doberman.hosthooks.integrity import hook_warning
 
         cwd = payload.get("cwd")
-        if not _spine.is_excluded(cwd):
-            warning = hook_warning(_spine.resolve_root_and_mode(cwd)[0])
+        if not spine.is_excluded(cwd):
+            warning = hook_warning(spine.resolve_root_and_mode(cwd)[0])
             if warning:
                 print(warning, file=sys.stderr)
     except Exception:  # noqa: BLE001,S110 — warning-only

--- a/src/doberman/hosthooks/codex.py
+++ b/src/doberman/hosthooks/codex.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from typing import TYPE_CHECKING, Any
 
 from doberman.config import load_message_tone
@@ -223,4 +224,17 @@ def run_codex_pre(stdin_text: str) -> str | None:
     out = evaluate_pre(payload)
     text = json.dumps(out) if out is not None else None
     singleflight.record(key, text)
+
+    try:  # #239: warn on stderr when Doberman's own registration diverged.
+        from doberman.hosthooks import spine as _spine
+        from doberman.hosthooks.integrity import hook_warning
+
+        cwd = payload.get("cwd")
+        if not _spine.is_excluded(cwd):
+            warning = hook_warning(_spine.resolve_root_and_mode(cwd)[0])
+            if warning:
+                print(warning, file=sys.stderr)
+    except Exception:  # noqa: BLE001,S110 — warning-only
+        pass
+
     return text

--- a/src/doberman/hosthooks/install.py
+++ b/src/doberman/hosthooks/install.py
@@ -72,6 +72,23 @@ def _is_doberman_group(group: dict[str, Any]) -> bool:
     return False
 
 
+def doberman_groups(settings: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Doberman-owned hook groups per event key (for the install manifest).
+
+    Only groups :func:`_is_doberman_group` recognises are returned, so a foreign
+    hook's command never reaches the manifest even as a fingerprint input.
+    """
+    hooks_section = settings.get("hooks") or {}
+    out: dict[str, list[dict[str, Any]]] = {}
+    for event_key, groups in hooks_section.items():
+        if not isinstance(groups, list):
+            continue
+        ours = [g for g in groups if isinstance(g, dict) and _is_doberman_group(g)]
+        if ours:
+            out[event_key] = ours
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Pure merge / remove functions
 # ---------------------------------------------------------------------------

--- a/src/doberman/hosthooks/install_codex.py
+++ b/src/doberman/hosthooks/install_codex.py
@@ -89,6 +89,24 @@ def remove_codex_hooks(settings: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def codex_doberman_groups(settings: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Doberman-owned hook groups per event key, Codex-shaped (for the install manifest).
+
+    Same shape as :func:`doberman.hosthooks.install.doberman_groups`; reuses this
+    module's own ``_is_doberman_group`` import (the shared marker also matches
+    ``codex-pre``) so a foreign group's command never reaches the manifest.
+    """
+    hooks_section = settings.get("hooks") or {}
+    out: dict[str, list[dict[str, Any]]] = {}
+    for event_key, groups in hooks_section.items():
+        if not isinstance(groups, list):
+            continue
+        ours = [g for g in groups if isinstance(g, dict) and _is_doberman_group(g)]
+        if ours:
+            out[event_key] = ours
+    return out
+
+
 def resolve_codex_hooks_path(scope: str, project_root: str) -> Path:
     """Resolve the target ``hooks.json`` path for *scope*.
 

--- a/src/doberman/hosthooks/install_codex.py
+++ b/src/doberman/hosthooks/install_codex.py
@@ -27,7 +27,7 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-from doberman.hosthooks.install import _is_doberman_group, load_settings
+from doberman.hosthooks.install import _is_doberman_group, doberman_groups, load_settings
 
 #: Codex PreToolUse group Doberman registers — matches every tool. The
 #: ``doberman hook `` marker (shared with the Claude Code installer) identifies it
@@ -92,19 +92,12 @@ def remove_codex_hooks(settings: dict[str, Any]) -> dict[str, Any]:
 def codex_doberman_groups(settings: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
     """Doberman-owned hook groups per event key, Codex-shaped (for the install manifest).
 
-    Same shape as :func:`doberman.hosthooks.install.doberman_groups`; reuses this
-    module's own ``_is_doberman_group`` import (the shared marker also matches
-    ``codex-pre``) so a foreign group's command never reaches the manifest.
+    Codex's groups are byte-identical Claude-Code-shaped dicts (the shared
+    ``_is_doberman_group`` marker matches ``codex-pre`` too), so this is a thin
+    wrapper around :func:`doberman.hosthooks.install.doberman_groups` kept
+    under this name for the Codex-specific import sites.
     """
-    hooks_section = settings.get("hooks") or {}
-    out: dict[str, list[dict[str, Any]]] = {}
-    for event_key, groups in hooks_section.items():
-        if not isinstance(groups, list):
-            continue
-        ours = [g for g in groups if isinstance(g, dict) and _is_doberman_group(g)]
-        if ours:
-            out[event_key] = ours
-    return out
+    return doberman_groups(settings)
 
 
 def resolve_codex_hooks_path(scope: str, project_root: str) -> Path:

--- a/src/doberman/hosthooks/integrity.py
+++ b/src/doberman/hosthooks/integrity.py
@@ -1,0 +1,243 @@
+"""Install-integrity manifest for Doberman's own hook registration (issue #239).
+
+A host hook is registered by editing the agent's settings file. Nothing used to
+record what was installed, so an agent (or anything else) that strips those
+entries silently removed Doberman from its own execution path. This module keeps
+a per-user manifest of keyed fingerprints of the installed Doberman hook groups
+and lets every surviving hook invocation, and ``doberman doctor``, notice when a
+recorded registration changed.
+
+Design rules:
+
+* The manifest lives in the per-user config dir next to the fingerprint key,
+  never inside a repository. A repo-local manifest could be deleted by the same
+  actor that strips the hooks, turning "absent means intentional" into a bypass.
+* Warning-only. :func:`verify_install` and :func:`note_divergence` never raise;
+  callers on the hook path degrade to "no warning". The check never changes a
+  hook's verdict, envelope, or exit code.
+* Redaction: the manifest holds host, scope, a keyed fingerprint of the settings
+  path, keyed fingerprints of the Doberman groups per event, timestamps, and a
+  divergence record. Never a raw path or command.
+* Speed: stdlib only at module scope; the fingerprint helper is imported lazily.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+#: Env override for the manifest file (tests, unusual layouts).
+MANIFEST_ENV = "DOBERMAN_INSTALL_MANIFEST"
+MANIFEST_VERSION = 1
+#: Events whose Doberman group is the gate itself. Losing one means Doberman is
+#: no longer gating calls on that host; anything else (SessionStart) is cosmetic.
+CRITICAL_EVENTS = frozenset({"PreToolUse", "PostToolUse"})
+
+
+@dataclass(frozen=True)
+class IntegrityStatus:
+    """The verdict for one recorded (host, scope) registration."""
+
+    host: str
+    scope: str
+    #: ``"intact"`` | ``"diverged"`` | ``"absent"`` (no manifest entry, or unreadable).
+    state: str
+    diverged_events: tuple[str, ...] = ()
+    critical: bool = False
+    #: ISO timestamp of the last divergence noted for this entry, if any.
+    divergence_seen: str | None = None
+
+
+def manifest_path() -> Path:
+    override = os.environ.get(MANIFEST_ENV)
+    if override:
+        return Path(override)
+    from doberman.storage.fingerprint import user_config_dir
+
+    return user_config_dir() / "install-manifest.json"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _fp(value: str) -> str:
+    from doberman.storage.fingerprint import fingerprint
+
+    return fingerprint(value)
+
+
+def _path_fp(settings_path: Path) -> str:
+    return _fp(str(Path(settings_path).expanduser().resolve(strict=False)))
+
+
+def _group_fps(groups_by_event: dict[str, list[dict[str, Any]]]) -> dict[str, str]:
+    """One keyed fingerprint per event that has at least one Doberman group.
+
+    Canonical JSON (sorted keys, no whitespace) so formatting never counts as a
+    change. Events with no Doberman group are omitted rather than fingerprinted
+    as ``[]`` so a foreign addition elsewhere in the file is not a divergence.
+    """
+    out: dict[str, str] = {}
+    for event, groups in groups_by_event.items():
+        if groups:
+            out[event] = _fp(json.dumps(groups, sort_keys=True, separators=(",", ":")))
+    return out
+
+
+def _load() -> dict[str, Any]:
+    path = manifest_path()
+    if not path.exists():
+        return {"version": MANIFEST_VERSION, "entries": []}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("entries"), list):
+        raise ValueError("install manifest is not a manifest object")
+    return data
+
+
+def _save(data: dict[str, Any]) -> None:
+    path = manifest_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _find(data: dict[str, Any], host: str, scope: str, path_fp: str) -> dict[str, Any] | None:
+    for entry in data["entries"]:
+        if (
+            isinstance(entry, dict)
+            and entry.get("host") == host
+            and entry.get("scope") == scope
+            and entry.get("path_fp") == path_fp
+        ):
+            return entry
+    return None
+
+
+def record_install(
+    host: str,
+    scope: str,
+    settings_path: Path,
+    groups_by_event: dict[str, list[dict[str, Any]]],
+) -> None:
+    """Record (or replace) the fingerprints for one installed registration.
+
+    Replaces any previous entry for the same (host, scope, path) and clears a
+    prior divergence record: a re-install is the human saying "this is the
+    intended state". Raises on I/O or key failure; the CLI reports it.
+    """
+    data = _load()
+    path_fp = _path_fp(settings_path)
+    entry = {
+        "host": host,
+        "scope": scope,
+        "path_fp": path_fp,
+        "groups": _group_fps(groups_by_event),
+        "recorded_at": _now(),
+    }
+    data["entries"] = [
+        e
+        for e in data["entries"]
+        if not (
+            isinstance(e, dict)
+            and e.get("host") == host
+            and e.get("scope") == scope
+            and e.get("path_fp") == path_fp
+        )
+    ]
+    data["entries"].append(entry)
+    _save(data)
+
+
+def clear_install(host: str, scope: str, settings_path: Path) -> None:
+    """Forget one registration. Absent manifest or entry is a no-op.
+
+    Called BEFORE the hooks are removed so a legitimate uninstall never trips
+    the guard. Raises on I/O failure; the CLI reports it.
+    """
+    path = manifest_path()
+    if not path.exists():
+        return
+    data = _load()
+    path_fp = _path_fp(settings_path)
+    before = len(data["entries"])
+    data["entries"] = [
+        e
+        for e in data["entries"]
+        if not (
+            isinstance(e, dict)
+            and e.get("host") == host
+            and e.get("scope") == scope
+            and e.get("path_fp") == path_fp
+        )
+    ]
+    if len(data["entries"]) != before:
+        _save(data)
+
+
+def verify_install(
+    host: str,
+    scope: str,
+    settings_path: Path,
+    groups_by_event: dict[str, list[dict[str, Any]]],
+) -> IntegrityStatus:
+    """Compare the live Doberman groups against the recorded entry. Never raises.
+
+    ``absent`` when there is no entry or anything cannot be read/fingerprinted
+    (no alarm: the guard must never crash or block a hook). ``diverged`` names
+    every recorded event whose group is missing or changed; events recorded
+    with no Doberman group are not tracked, so additions never diverge.
+    """
+    try:
+        data = _load()
+        entry = _find(data, host, scope, _path_fp(settings_path))
+        if entry is None or not isinstance(entry.get("groups"), dict):
+            return IntegrityStatus(host, scope, "absent")
+        live = _group_fps(groups_by_event)
+        diverged: list[str] = []
+        for event, recorded_fp in entry["groups"].items():
+            current = live.get(event)
+            if current is None or not hmac.compare_digest(str(recorded_fp), current):
+                diverged.append(event)
+        seen = None
+        div = entry.get("diverged")
+        if isinstance(div, dict) and isinstance(div.get("last_seen"), str):
+            seen = div["last_seen"]
+        if diverged:
+            return IntegrityStatus(
+                host,
+                scope,
+                "diverged",
+                tuple(sorted(diverged)),
+                critical=any(e in CRITICAL_EVENTS for e in diverged),
+                divergence_seen=seen,
+            )
+        return IntegrityStatus(host, scope, "intact", divergence_seen=seen)
+    except Exception:  # noqa: BLE001 - the guard degrades to "no alarm", never crashes a hook
+        return IntegrityStatus(host, scope, "absent")
+
+
+def note_divergence(host: str, scope: str, settings_path: Path, events: tuple[str, ...]) -> None:
+    """Best-effort tamper record on the entry (first/last seen, count). Never raises."""
+    try:
+        data = _load()
+        entry = _find(data, host, scope, _path_fp(settings_path))
+        if entry is None:
+            return
+        now = _now()
+        div = entry.get("diverged")
+        if not isinstance(div, dict):
+            div = {"events": [], "first_seen": now, "last_seen": now, "count": 0}
+        div["events"] = sorted(set(div.get("events") or []) | set(events))
+        div["last_seen"] = now
+        div["count"] = int(div.get("count") or 0) + 1
+        entry["diverged"] = div
+        _save(data)
+    except Exception:  # noqa: BLE001,S110 - a record-keeping failure must never reach a hook
+        pass

--- a/src/doberman/hosthooks/integrity.py
+++ b/src/doberman/hosthooks/integrity.py
@@ -224,3 +224,78 @@ def note_divergence(host: str, scope: str, settings_path: Path, events: tuple[st
         _save(data)
     except Exception:  # noqa: BLE001,S110 - a record-keeping failure must never reach a hook
         pass
+
+
+#: Every tracked (host, scope) registration. Codex's scopes are "repo" (the
+#: project-settings analog) and "user" (the global-settings analog) -- see
+#: doberman.hosthooks.install_codex.resolve_codex_hooks_path.
+_SCOPES: tuple[tuple[str, str], ...] = (
+    ("claude", "project"),
+    ("claude", "global"),
+    ("claude", "local"),
+    ("codex", "repo"),
+    ("codex", "user"),
+)
+
+
+def _live_groups(
+    host: str, scope: str, project_root: str
+) -> tuple[Path, dict[str, list[dict[str, Any]]]]:
+    """Resolve a scope's settings file and its live Doberman groups. May raise."""
+    from doberman.hosthooks.install import load_settings
+
+    if host == "claude":
+        from doberman.hosthooks.install import doberman_groups, resolve_settings_path
+
+        path = resolve_settings_path(scope, project_root)
+        return path, doberman_groups(load_settings(path))
+    from doberman.hosthooks.install_codex import codex_doberman_groups, resolve_codex_hooks_path
+
+    path = resolve_codex_hooks_path(scope, project_root)
+    return path, codex_doberman_groups(load_settings(path))
+
+
+def check_all(project_root: str) -> list[IntegrityStatus]:
+    """Verify every tracked scope for *project_root*. Never raises.
+
+    One status per ``(host, scope)`` in :data:`_SCOPES`; a scope whose settings
+    file is unreadable yields ``absent`` rather than raising.
+    """
+    out: list[IntegrityStatus] = []
+    for host, scope in _SCOPES:
+        try:
+            path, groups = _live_groups(host, scope, project_root)
+            out.append(verify_install(host, scope, path, groups))
+        except Exception:  # noqa: BLE001 - an unreadable settings file is "absent", never a crash
+            out.append(IntegrityStatus(host, scope, "absent"))
+    return out
+
+
+def hook_warning(project_root: str) -> str | None:
+    """The one-line warning a hook attaches when a recorded registration diverged.
+
+    Cheap when there is nothing to check (no manifest file: return without
+    reading any settings file). Never raises; any failure is "no warning".
+    """
+    try:
+        if not manifest_path().exists():
+            return None
+        diverged = [s for s in check_all(project_root) if s.state == "diverged"]
+        if not diverged:
+            return None
+        for s in diverged:
+            try:
+                path, _ = _live_groups(s.host, s.scope, project_root)
+                note_divergence(s.host, s.scope, path, s.diverged_events)
+            except Exception:  # noqa: BLE001,S110
+                pass
+        from doberman.branding import DOG
+
+        where = ", ".join(f"{s.host} {s.scope}: {'/'.join(s.diverged_events)}" for s in diverged)
+        return (
+            f"{DOG} Doberman: hook registration changed since install ({where}). "
+            "Doberman may not be gating every call here. Run `doberman doctor`, "
+            "then `doberman install-hooks` to restore."
+        )
+    except Exception:  # noqa: BLE001 - warning-only; never reaches the hook's decision
+        return None

--- a/src/doberman/hosthooks/integrity.py
+++ b/src/doberman/hosthooks/integrity.py
@@ -108,16 +108,17 @@ def _save(data: dict[str, Any]) -> None:
     os.replace(tmp, path)
 
 
+def _matches(entry: Any, host: str, scope: str, path_fp: str) -> bool:
+    return (
+        isinstance(entry, dict)
+        and entry.get("host") == host
+        and entry.get("scope") == scope
+        and entry.get("path_fp") == path_fp
+    )
+
+
 def _find(data: dict[str, Any], host: str, scope: str, path_fp: str) -> dict[str, Any] | None:
-    for entry in data["entries"]:
-        if (
-            isinstance(entry, dict)
-            and entry.get("host") == host
-            and entry.get("scope") == scope
-            and entry.get("path_fp") == path_fp
-        ):
-            return entry
-    return None
+    return next((e for e in data["entries"] if _matches(e, host, scope, path_fp)), None)
 
 
 def record_install(
@@ -141,16 +142,7 @@ def record_install(
         "groups": _group_fps(groups_by_event),
         "recorded_at": _now(),
     }
-    data["entries"] = [
-        e
-        for e in data["entries"]
-        if not (
-            isinstance(e, dict)
-            and e.get("host") == host
-            and e.get("scope") == scope
-            and e.get("path_fp") == path_fp
-        )
-    ]
+    data["entries"] = [e for e in data["entries"] if not _matches(e, host, scope, path_fp)]
     data["entries"].append(entry)
     _save(data)
 
@@ -167,16 +159,7 @@ def clear_install(host: str, scope: str, settings_path: Path) -> None:
     data = _load()
     path_fp = _path_fp(settings_path)
     before = len(data["entries"])
-    data["entries"] = [
-        e
-        for e in data["entries"]
-        if not (
-            isinstance(e, dict)
-            and e.get("host") == host
-            and e.get("scope") == scope
-            and e.get("path_fp") == path_fp
-        )
-    ]
+    data["entries"] = [e for e in data["entries"] if not _matches(e, host, scope, path_fp)]
     if len(data["entries"]) != before:
         _save(data)
 

--- a/src/doberman/storage/fingerprint.py
+++ b/src/doberman/storage/fingerprint.py
@@ -51,15 +51,23 @@ _MAX_INPUT_CHARS = 8192
 _PREFIX = "hmac:"
 
 
-def _default_key_path() -> Path:
-    """Per-user key path OUTSIDE any repository (never committed)."""
+def user_config_dir() -> Path:
+    """Per-user Doberman config directory OUTSIDE any repository (never committed).
+
+    Holds the fingerprint key and the hook install manifest.
+    """
     if os.name == "nt":
         base = os.environ.get("LOCALAPPDATA") or os.path.join(
             os.path.expanduser("~"), "AppData", "Local"
         )
     else:
         base = os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
-    return Path(base) / "doberman" / "fingerprint.key"
+    return Path(base) / "doberman"
+
+
+def _default_key_path() -> Path:
+    """Per-user key path OUTSIDE any repository (never committed)."""
+    return user_config_dir() / "fingerprint.key"
 
 
 def _key_path() -> Path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from typer.testing import Result
 
 from doberman.auth.password import PASSWORD_FILE_ENV
 from doberman.auth.totp import TOTP_FILE_ENV
+from doberman.hosthooks.integrity import MANIFEST_ENV
 from doberman.storage import fingerprint as _fingerprint_module
 from doberman.storage.device_metrics import HOME_ENV
 from doberman.storage.fingerprint import KEY_FILE_ENV
@@ -44,6 +45,15 @@ def isolated_fingerprint_key(tmp_path, monkeypatch):
     monkeypatch.setenv(KEY_FILE_ENV, str(key_path))
     _fingerprint_module._load_or_create_key.cache_clear()
     return key_path
+
+
+@pytest.fixture(autouse=True)
+def isolated_install_manifest(tmp_path, monkeypatch):
+    """Point the hook install manifest (#239) at a per-test temp file so CLI
+    tests that run install-hooks never write to the real per-user manifest."""
+    manifest_path = tmp_path / "doberman-install-manifest.json"
+    monkeypatch.setenv(MANIFEST_ENV, str(manifest_path))
+    return manifest_path
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -632,3 +632,20 @@ def test_doctor_integrity_untracked_install_warns(integrity_env: Path, tmp_path:
 def test_doctor_integrity_nothing_installed_is_ok(integrity_env: Path) -> None:
     r = _integrity(run_checks(str(integrity_env)))
     assert r.status is CheckStatus.OK
+
+
+def test_doctor_integrity_plugin_only_codex_is_ok(
+    integrity_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plugin-only Codex install has no writable hooks.json to manifest -
+    doctor must not permanently WARN "untracked" for it (round follow-up on #239)."""
+    import doberman.hosthooks.install_codex as install_codex_mod
+
+    monkeypatch.setattr(
+        install_codex_mod,
+        "codex_hook_install_states",
+        lambda path: [("plugin", str(Path(path) / "plugin-hooks.json"), True)],
+    )
+    r = _integrity(run_checks(str(integrity_env)))
+    assert r.status is CheckStatus.OK
+    assert r.detail == "nothing to verify (no hooks installed)"

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -13,6 +13,7 @@ test ever touches real per-user state.
 """
 
 import asyncio
+import json as _json
 import os
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,6 +25,7 @@ from doberman.cli import doctor as doctor_mod
 from doberman.cli.doctor import CheckStatus, run_checks
 from doberman.cli.main import app
 from doberman.config import save_policy
+from doberman.hosthooks import integrity
 from doberman.hosthooks.install import (
     merge_doberman_hooks,
     resolve_settings_path,
@@ -566,3 +568,67 @@ def test_doctor_wraps_with_a_hanging_indent_at_columns_60(tmp_path: Path) -> Non
     continuation = lines[idx + 1]
     assert continuation.startswith("       ")  # 7-space hang, never column 0
     assert continuation.strip()  # sanity: this line actually has wrapped text
+
+
+# ---------------------------------------------------------------------------
+# Hook integrity (#239): doctor reports intact / diverged / untracked
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def integrity_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("DOBERMAN_KEY_FILE", str(tmp_path / "fp.key"))
+    monkeypatch.setenv(integrity.MANIFEST_ENV, str(tmp_path / "manifest.json"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)  # isolated_executor_repo_root already creates this dir
+    return repo
+
+
+def _integrity(results: list[doctor_mod.CheckResult]) -> doctor_mod.CheckResult:
+    return next(r for r in results if r.name == "Hook integrity")
+
+
+def test_doctor_integrity_intact(integrity_env: Path) -> None:
+    assert CliRunner().invoke(app, ["install-hooks", "--path", str(integrity_env)]).exit_code == 0
+    r = _integrity(run_checks(str(integrity_env)))
+    assert r.status is CheckStatus.OK
+    assert "claude project" in r.detail
+
+
+def test_doctor_integrity_critical_divergence(integrity_env: Path) -> None:
+    assert CliRunner().invoke(app, ["install-hooks", "--path", str(integrity_env)]).exit_code == 0
+    settings_path = resolve_settings_path("project", str(integrity_env))
+    data = _json.loads(settings_path.read_text(encoding="utf-8"))
+    data["hooks"].pop("PreToolUse")
+    settings_path.write_text(_json.dumps(data), encoding="utf-8")
+    r = _integrity(run_checks(str(integrity_env)))
+    assert r.status is CheckStatus.FAIL
+    assert r.critical is True
+    assert "PreToolUse" in r.detail
+    assert str(integrity_env) not in r.detail
+
+
+def test_doctor_integrity_sessionstart_only_warns(integrity_env: Path) -> None:
+    assert CliRunner().invoke(app, ["install-hooks", "--path", str(integrity_env)]).exit_code == 0
+    settings_path = resolve_settings_path("project", str(integrity_env))
+    data = _json.loads(settings_path.read_text(encoding="utf-8"))
+    data["hooks"].pop("SessionStart")
+    settings_path.write_text(_json.dumps(data), encoding="utf-8")
+    r = _integrity(run_checks(str(integrity_env)))
+    assert r.status is CheckStatus.WARN
+    assert r.critical is False
+
+
+def test_doctor_integrity_untracked_install_warns(integrity_env: Path, tmp_path: Path) -> None:
+    assert CliRunner().invoke(app, ["install-hooks", "--path", str(integrity_env)]).exit_code == 0
+    (tmp_path / "manifest.json").unlink()
+    r = _integrity(run_checks(str(integrity_env)))
+    assert r.status is CheckStatus.WARN
+    assert "untracked" in r.detail
+
+
+def test_doctor_integrity_nothing_installed_is_ok(integrity_env: Path) -> None:
+    r = _integrity(run_checks(str(integrity_env)))
+    assert r.status is CheckStatus.OK

--- a/tests/unit/test_install_integrity.py
+++ b/tests/unit/test_install_integrity.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from doberman.hosthooks import integrity
+
+
+@pytest.fixture
+def manifest_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    key = tmp_path / "fp.key"
+    manifest = tmp_path / "manifest.json"
+    monkeypatch.setenv("DOBERMAN_KEY_FILE", str(key))
+    monkeypatch.setenv(integrity.MANIFEST_ENV, str(manifest))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    return manifest
+
+
+PRE = {"matcher": "Bash", "hooks": [{"type": "command", "command": "doberman hook pre"}]}
+POST = {"matcher": "Bash", "hooks": [{"type": "command", "command": "doberman hook post"}]}
+START = {"hooks": [{"type": "command", "command": "doberman session-summary"}]}
+GROUPS = {"PreToolUse": [PRE], "PostToolUse": [POST], "SessionStart": [START]}
+
+
+def test_record_then_verify_is_intact(manifest_env: Path, tmp_path: Path) -> None:
+    settings = tmp_path / "repo" / ".claude" / "settings.json"
+    integrity.record_install("claude", "project", settings, GROUPS)
+    status = integrity.verify_install("claude", "project", settings, GROUPS)
+    assert status.state == "intact"
+    assert status.diverged_events == ()
+    assert status.critical is False
+
+
+def test_missing_pretooluse_is_critical_divergence(manifest_env: Path, tmp_path: Path) -> None:
+    settings = tmp_path / "repo" / ".claude" / "settings.json"
+    integrity.record_install("claude", "project", settings, GROUPS)
+    stripped = {"PostToolUse": [POST], "SessionStart": [START]}
+    status = integrity.verify_install("claude", "project", settings, stripped)
+    assert status.state == "diverged"
+    assert status.diverged_events == ("PreToolUse",)
+    assert status.critical is True
+
+
+def test_changed_sessionstart_is_non_critical_divergence(
+    manifest_env: Path, tmp_path: Path
+) -> None:
+    settings = tmp_path / "repo" / ".claude" / "settings.json"
+    integrity.record_install("claude", "project", settings, GROUPS)
+    changed = dict(
+        GROUPS,
+        SessionStart=[
+            {"hooks": [{"type": "command", "command": "doberman session-summary --quiet"}]}
+        ],
+    )
+    status = integrity.verify_install("claude", "project", settings, changed)
+    assert status.state == "diverged"
+    assert status.diverged_events == ("SessionStart",)
+    assert status.critical is False
+
+
+def test_addition_of_foreign_group_is_not_divergence(manifest_env: Path, tmp_path: Path) -> None:
+    settings = tmp_path / "repo" / ".claude" / "settings.json"
+    integrity.record_install("claude", "project", settings, GROUPS)
+    # The caller only passes Doberman-owned groups; a new event key with no
+    # Doberman group is simply ignored.
+    status = integrity.verify_install("claude", "project", settings, dict(GROUPS, Stop=[]))
+    assert status.state == "intact"
+
+
+def test_no_entry_is_absent(manifest_env: Path, tmp_path: Path) -> None:
+    settings = tmp_path / "repo" / ".claude" / "settings.json"
+    status = integrity.verify_install("claude", "project", settings, GROUPS)
+    assert status.state == "absent"
+    assert status.critical is False
+
+
+def test_clear_removes_only_that_entry(manifest_env: Path, tmp_path: Path) -> None:
+    a = tmp_path / "a" / ".claude" / "settings.json"
+    b = tmp_path / "b" / ".claude" / "settings.json"
+    integrity.record_install("claude", "project", a, GROUPS)
+    integrity.record_install("claude", "project", b, GROUPS)
+    integrity.clear_install("claude", "project", a)
+    assert integrity.verify_install("claude", "project", a, {}).state == "absent"
+    assert integrity.verify_install("claude", "project", b, GROUPS).state == "intact"
+    integrity.clear_install("claude", "project", a)  # idempotent, no raise
+
+
+def test_manifest_holds_no_paths_or_commands(manifest_env: Path, tmp_path: Path) -> None:
+    settings = tmp_path / "repo" / ".claude" / "settings.json"
+    secret_group = {
+        "hooks": [{"type": "command", "command": "doberman hook pre --token SECRET-XYZ-123"}]
+    }
+    integrity.record_install("claude", "project", settings, {"PreToolUse": [secret_group]})
+    raw = manifest_env.read_text(encoding="utf-8")
+    assert str(tmp_path) not in raw
+    assert "repo" not in raw
+    assert "SECRET-XYZ-123" not in raw
+    assert "doberman hook pre" not in raw
+    data = json.loads(raw)
+    entry = data["entries"][0]
+    assert entry["path_fp"].startswith("hmac:")
+    assert entry["groups"]["PreToolUse"].startswith("hmac:")
+
+
+def test_corrupt_manifest_reads_as_absent(manifest_env: Path, tmp_path: Path) -> None:
+    manifest_env.write_text("{not json", encoding="utf-8")
+    settings = tmp_path / "repo" / ".claude" / "settings.json"
+    status = integrity.verify_install("claude", "project", settings, GROUPS)
+    assert status.state == "absent"
+
+
+def test_missing_key_never_raises_from_verify(
+    manifest_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = tmp_path / "repo" / ".claude" / "settings.json"
+    integrity.record_install("claude", "project", settings, GROUPS)
+    monkeypatch.setenv(
+        "DOBERMAN_KEY_FILE",
+        str(tmp_path / "missing" / "dir" / "that" / "cannot" / "be" / "made" / "\0bad"),
+    )
+    status = integrity.verify_install("claude", "project", settings, GROUPS)
+    assert status.state == "absent"
+
+
+def test_note_divergence_records_first_and_last_seen(manifest_env: Path, tmp_path: Path) -> None:
+    settings = tmp_path / "repo" / ".claude" / "settings.json"
+    integrity.record_install("claude", "project", settings, GROUPS)
+    integrity.note_divergence("claude", "project", settings, ("PreToolUse",))
+    integrity.note_divergence("claude", "project", settings, ("PreToolUse",))
+    data = json.loads(manifest_env.read_text(encoding="utf-8"))
+    div = data["entries"][0]["diverged"]
+    assert div["events"] == ["PreToolUse"]
+    assert div["count"] == 2
+    assert div["first_seen"] <= div["last_seen"]
+    status = integrity.verify_install("claude", "project", settings, GROUPS)
+    assert status.state == "intact"
+    assert status.divergence_seen == div["last_seen"]
+
+
+def test_record_install_clears_old_divergence(manifest_env: Path, tmp_path: Path) -> None:
+    settings = tmp_path / "repo" / ".claude" / "settings.json"
+    integrity.record_install("claude", "project", settings, GROUPS)
+    integrity.note_divergence("claude", "project", settings, ("PreToolUse",))
+    integrity.record_install("claude", "project", settings, GROUPS)
+    assert integrity.verify_install("claude", "project", settings, GROUPS).divergence_seen is None
+
+
+def test_user_config_dir_backs_the_key_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from doberman.storage import fingerprint as fp
+
+    monkeypatch.delenv("DOBERMAN_KEY_FILE", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert fp._default_key_path() == fp.user_config_dir() / "fingerprint.key"

--- a/tests/unit/test_install_integrity.py
+++ b/tests/unit/test_install_integrity.py
@@ -7,7 +7,7 @@ import pytest
 from typer.testing import CliRunner
 
 from doberman.cli.main import app
-from doberman.hosthooks import integrity
+from doberman.hosthooks import claude_code, integrity
 from doberman.hosthooks.install import (
     doberman_groups,
     load_settings,
@@ -251,3 +251,145 @@ def test_codex_install_records_and_uninstall_clears(manifest_env: Path, tmp_path
         == 0
     )
     assert integrity.verify_install("codex", "repo", hooks_path, groups).state == "absent"
+
+
+# ---------------------------------------------------------------------------
+# check_all / hook_warning — verify at every surviving hook invocation (#239)
+# ---------------------------------------------------------------------------
+
+
+def _install(repo: Path) -> Path:
+    assert CliRunner().invoke(app, ["install-hooks", "--path", str(repo)]).exit_code == 0
+    return resolve_settings_path("project", str(repo))
+
+
+def _strip(settings_path: Path, event: str) -> None:
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    data["hooks"].pop(event)
+    settings_path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _pass_payload(repo: Path) -> str:
+    return json.dumps(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": str(repo / "README.md")},
+            "cwd": str(repo),
+            "session_id": "s1",
+        }
+    )
+
+
+def test_pre_hook_warns_when_post_group_stripped(manifest_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    settings_path = _install(repo)
+    _strip(settings_path, "PostToolUse")
+    out = claude_code.run_pre_hook(_pass_payload(repo))
+    assert out is not None
+    data = json.loads(out)
+    assert "hookSpecificOutput" not in data  # the PASS envelope is unchanged: no deny added
+    assert "PostToolUse" in data["systemMessage"]
+    assert str(tmp_path) not in data["systemMessage"]
+
+
+def test_pre_hook_silent_when_intact(manifest_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    _install(repo)
+    assert claude_code.run_pre_hook(_pass_payload(repo)) is None
+
+
+def test_pre_hook_silent_when_uninstalled_legitimately(manifest_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    _install(repo)
+    assert CliRunner().invoke(app, ["uninstall-hooks", "--path", str(repo)]).exit_code == 0
+    assert claude_code.run_pre_hook(_pass_payload(repo)) is None
+
+
+def test_deny_envelope_keeps_its_decision_and_gains_warning(
+    manifest_env: Path, tmp_path: Path
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    settings_path = _install(repo)
+    _strip(settings_path, "PostToolUse")
+    out = claude_code.run_pre_hook("not json")
+    data = json.loads(out)
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_divergence_is_recorded_in_manifest(manifest_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    settings_path = _install(repo)
+    _strip(settings_path, "PreToolUse")
+    claude_code.run_pre_hook(_pass_payload(repo))
+    data = json.loads(manifest_env.read_text(encoding="utf-8"))
+    assert data["entries"][0]["diverged"]["events"] == ["PreToolUse"]
+
+
+def test_hook_warning_never_raises(
+    manifest_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    _install(repo)
+    monkeypatch.setattr(
+        integrity, "check_all", lambda root: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    assert integrity.hook_warning(str(repo)) is None
+    assert claude_code.run_pre_hook(_pass_payload(repo)) is None
+
+
+def test_no_manifest_file_means_no_settings_reads(
+    manifest_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(integrity, "check_all", lambda root: calls.append(root) or [])
+    assert integrity.hook_warning(str(tmp_path)) is None
+    assert calls == []
+
+
+def test_excluded_project_skips_the_check(
+    manifest_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    settings_path = _install(repo)
+    _strip(settings_path, "PreToolUse")
+    monkeypatch.setattr("doberman.hosthooks.spine.is_excluded", lambda cwd: True)
+    assert claude_code.run_pre_hook(_pass_payload(repo)) is None
+
+
+def test_codex_pre_hook_warns_on_stderr(
+    manifest_env: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from doberman.hosthooks import codex
+    from doberman.hosthooks.install_codex import resolve_codex_hooks_path
+
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    assert (
+        CliRunner().invoke(app, ["install-hooks", "--host", "codex", "--path", str(repo)]).exit_code
+        == 0
+    )
+    # Codex scopes in this codebase are "repo" (project-analog) and "user" (global-
+    # analog) — not "project"; see resolve_codex_hooks_path.
+    hooks_path = resolve_codex_hooks_path("repo", str(repo))
+    _strip(hooks_path, "PreToolUse")
+    # Benign Codex payload shape (mirrors tests/unit/test_hosthook_codex.py's pre_bash.json
+    # fixture usage): a Read tool, translated by codex.to_normalize_input via the shared
+    # Claude Code builtin map, PASSes (abstains) so the warning is the only signal.
+    payload = json.dumps(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": str(repo / "x")},
+            "cwd": str(repo),
+        }
+    )
+    codex.run_codex_pre(payload)
+    assert "hook registration changed" in capsys.readouterr().err

--- a/tests/unit/test_install_integrity.py
+++ b/tests/unit/test_install_integrity.py
@@ -130,6 +130,10 @@ def test_missing_key_never_raises_from_verify(
         "DOBERMAN_KEY_FILE",
         str(tmp_path / "missing" / "dir" / "that" / "cannot" / "be" / "made" / "\0bad"),
     )
+    # The key is process-cached; drop it so verify must reload from the bad path.
+    from doberman.storage.fingerprint import _load_or_create_key
+
+    _load_or_create_key.cache_clear()
     status = integrity.verify_install("claude", "project", settings, GROUPS)
     assert status.state == "absent"
 

--- a/tests/unit/test_install_integrity.py
+++ b/tests/unit/test_install_integrity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from pathlib import Path
 
 import pytest
@@ -362,6 +363,79 @@ def test_excluded_project_skips_the_check(
     _strip(settings_path, "PreToolUse")
     monkeypatch.setattr("doberman.hosthooks.spine.is_excluded", lambda cwd: True)
     assert claude_code.run_pre_hook(_pass_payload(repo)) is None
+
+
+def test_pre_hook_real_deny_keeps_hook_output_and_gains_warning(
+    manifest_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Unlike test_deny_envelope_keeps_its_decision_and_gains_warning (which feeds
+    # "not json" and never reaches evaluate_pre), this drives a REAL BLOCK decision
+    # through evaluate_pre so the merge is exercised against a real hookSpecificOutput,
+    # not just the parse-failure _deny() stub.
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    settings_path = _install(repo)
+    _strip(settings_path, "PostToolUse")
+
+    # The decision reason embeds a fresh action id (uuid4) on every call, so a
+    # second evaluation of the identical payload would otherwise differ only in
+    # that token. Freeze it so the "same hookSpecificOutput" comparison is exact.
+    from doberman.proxy import normalize as normalize_mod
+
+    monkeypatch.setattr(normalize_mod.uuid, "uuid4", lambda: uuid.UUID(int=0))
+
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "rm -rf /"},
+        "cwd": str(repo),
+    }
+    baseline = claude_code.evaluate_pre(dict(payload))
+    assert baseline is not None
+    assert baseline["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    out = claude_code.run_pre_hook(json.dumps(payload))
+    assert out is not None
+    data = json.loads(out)
+    assert data["hookSpecificOutput"] == baseline["hookSpecificOutput"]
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "hook registration changed since install" in data["systemMessage"]
+    assert str(tmp_path) not in data["systemMessage"]
+
+
+def test_post_hook_gains_warning_when_registration_diverged(
+    manifest_env: Path, tmp_path: Path
+) -> None:
+    # run_post_hook's _attach_integrity_warning wiring (mirrors the PreToolUse
+    # coverage above) had no test at all before this.
+    def _post_payload(repo: Path) -> str:
+        return json.dumps(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo hi"},
+                "tool_response": "build succeeded",
+                "cwd": str(repo),
+            }
+        )
+
+    intact = tmp_path / "intact"
+    intact.mkdir(exist_ok=True)
+    _install(intact)
+    baseline = claude_code.run_post_hook(_post_payload(intact))
+    assert baseline is None  # registration intact -> evaluate_post's abstain survives untouched
+
+    diverged = tmp_path / "diverged"
+    diverged.mkdir(exist_ok=True)
+    settings_path = _install(diverged)
+    _strip(settings_path, "PreToolUse")  # PostToolUse itself stays wired to report this
+    out = claude_code.run_post_hook(_post_payload(diverged))
+    assert out is not None
+    data = json.loads(out)
+    assert "hookSpecificOutput" not in data
+    assert "hook registration changed since install" in data["systemMessage"]
+    assert "PreToolUse" in data["systemMessage"]
+    assert str(tmp_path) not in data["systemMessage"]
 
 
 def test_codex_pre_hook_warns_on_stderr(

--- a/tests/unit/test_install_integrity.py
+++ b/tests/unit/test_install_integrity.py
@@ -254,6 +254,35 @@ def test_codex_install_records_and_uninstall_clears(manifest_env: Path, tmp_path
     assert integrity.verify_install("codex", "repo", hooks_path, groups).state == "absent"
 
 
+def test_setup_wizard_records_the_manifest(
+    manifest_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`setup --yes` wires Claude hooks through the same merge/write path as
+    `install-hooks` (main.py's per-host wiring step) and must also record the
+    integrity manifest - pins that against a regression."""
+    import shutil
+
+    real_which = shutil.which
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda name, *a, **k: (
+            "/venv/bin/doberman"
+            if name == "doberman"
+            else None
+            if name == "codex"
+            else real_which(name, *a, **k)
+        ),
+    )
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    result = CliRunner().invoke(app, ["setup", "--yes", "--host", "claude", "--path", str(repo)])
+    assert result.exit_code == 0, result.output
+    settings_path = resolve_settings_path("project", str(repo))
+    groups = doberman_groups(load_settings(settings_path))
+    assert integrity.verify_install("claude", "project", settings_path, groups).state == "intact"
+
+
 # ---------------------------------------------------------------------------
 # check_all / hook_warning — verify at every surviving hook invocation (#239)
 # ---------------------------------------------------------------------------
@@ -310,7 +339,7 @@ def test_pre_hook_silent_when_uninstalled_legitimately(manifest_env: Path, tmp_p
     assert claude_code.run_pre_hook(_pass_payload(repo)) is None
 
 
-def test_deny_envelope_keeps_its_decision_and_gains_warning(
+def test_unparseable_payload_deny_is_untouched_by_the_integrity_check(
     manifest_env: Path, tmp_path: Path
 ) -> None:
     repo = tmp_path / "repo"
@@ -320,6 +349,7 @@ def test_deny_envelope_keeps_its_decision_and_gains_warning(
     out = claude_code.run_pre_hook("not json")
     data = json.loads(out)
     assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "systemMessage" not in data
 
 
 def test_divergence_is_recorded_in_manifest(manifest_env: Path, tmp_path: Path) -> None:

--- a/tests/unit/test_install_integrity.py
+++ b/tests/unit/test_install_integrity.py
@@ -126,10 +126,11 @@ def test_missing_key_never_raises_from_verify(
 ) -> None:
     settings = tmp_path / "repo" / ".claude" / "settings.json"
     integrity.record_install("claude", "project", settings, GROUPS)
-    monkeypatch.setenv(
-        "DOBERMAN_KEY_FILE",
-        str(tmp_path / "missing" / "dir" / "that" / "cannot" / "be" / "made" / "\0bad"),
-    )
+    # A regular file where the key's parent directory should be: the key can be
+    # neither read nor created there, on every OS.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setenv("DOBERMAN_KEY_FILE", str(blocker / "fingerprint.key"))
     # The key is process-cached; drop it so verify must reload from the bad path.
     from doberman.storage.fingerprint import _load_or_create_key
 

--- a/tests/unit/test_install_integrity.py
+++ b/tests/unit/test_install_integrity.py
@@ -4,8 +4,16 @@ import json
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
+from doberman.cli.main import app
 from doberman.hosthooks import integrity
+from doberman.hosthooks.install import (
+    doberman_groups,
+    load_settings,
+    merge_doberman_hooks,
+    resolve_settings_path,
+)
 
 
 @pytest.fixture
@@ -157,3 +165,89 @@ def test_user_config_dir_backs_the_key_path(
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     assert fp._default_key_path() == fp.user_config_dir() / "fingerprint.key"
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring — install-hooks / uninstall-hooks record and clear the manifest
+# ---------------------------------------------------------------------------
+
+
+def test_doberman_groups_extracts_only_our_groups() -> None:
+    foreign = {"matcher": "Bash", "hooks": [{"type": "command", "command": "echo hi"}]}
+    merged = merge_doberman_hooks({"hooks": {"PreToolUse": [foreign]}})
+    groups = doberman_groups(merged)
+    assert set(groups) == {"PreToolUse", "PostToolUse", "SessionStart"}
+    assert foreign not in groups["PreToolUse"]
+    assert doberman_groups({}) == {}
+
+
+def test_install_hooks_records_manifest(manifest_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    result = CliRunner().invoke(app, ["install-hooks", "--path", str(repo)])
+    assert result.exit_code == 0, result.output
+    settings_path = resolve_settings_path("project", str(repo))
+    groups = doberman_groups(load_settings(settings_path))
+    assert integrity.verify_install("claude", "project", settings_path, groups).state == "intact"
+
+
+def test_install_hooks_already_wired_still_records(manifest_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    runner = CliRunner()
+    assert runner.invoke(app, ["install-hooks", "--path", str(repo)]).exit_code == 0
+    manifest_env.unlink()  # simulate a pre-manifest install
+    assert runner.invoke(app, ["install-hooks", "--path", str(repo)]).exit_code == 0
+    settings_path = resolve_settings_path("project", str(repo))
+    groups = doberman_groups(load_settings(settings_path))
+    assert integrity.verify_install("claude", "project", settings_path, groups).state == "intact"
+
+
+def test_install_hooks_dry_run_writes_no_manifest(manifest_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    result = CliRunner().invoke(app, ["install-hooks", "--path", str(repo), "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert not manifest_env.exists()
+
+
+def test_uninstall_hooks_clears_manifest_first(manifest_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    runner = CliRunner()
+    assert runner.invoke(app, ["install-hooks", "--path", str(repo)]).exit_code == 0
+    assert runner.invoke(app, ["uninstall-hooks", "--path", str(repo)]).exit_code == 0
+    settings_path = resolve_settings_path("project", str(repo))
+    assert integrity.verify_install("claude", "project", settings_path, {}).state == "absent"
+
+
+def test_manifest_write_failure_does_not_fail_install(
+    manifest_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    monkeypatch.setenv(integrity.MANIFEST_ENV, str(tmp_path))  # a directory: unwritable as a file
+    result = CliRunner().invoke(app, ["install-hooks", "--path", str(repo)])
+    assert result.exit_code == 0, result.output
+    assert "manifest" in result.output.lower()
+
+
+def test_codex_install_records_and_uninstall_clears(manifest_env: Path, tmp_path: Path) -> None:
+    from doberman.hosthooks.install_codex import codex_doberman_groups, resolve_codex_hooks_path
+
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    runner = CliRunner()
+    assert (
+        runner.invoke(app, ["install-hooks", "--host", "codex", "--path", str(repo)]).exit_code == 0
+    )
+    # No --global -> the Codex repo scope (the Claude "project" scope's analog).
+    hooks_path = resolve_codex_hooks_path("repo", str(repo))
+    groups = codex_doberman_groups(load_settings(hooks_path))
+    assert groups["PreToolUse"]
+    assert integrity.verify_install("codex", "repo", hooks_path, groups).state == "intact"
+    assert (
+        runner.invoke(app, ["uninstall-hooks", "--host", "codex", "--path", str(repo)]).exit_code
+        == 0
+    )
+    assert integrity.verify_install("codex", "repo", hooks_path, groups).state == "absent"


### PR DESCRIPTION
## Summary

Doberman now notices when its own hook registration has been changed behind its back.

- `install-hooks` (and the setup wizard) record a per-user manifest of the Doberman-owned hook groups they wrote: one HMAC fingerprint per event (`PreToolUse`, `PostToolUse`, and the Codex equivalents) over the canonical JSON of those groups, keyed by host, scope, and a fingerprint of the settings path. `uninstall-hooks` clears the entry.
- Every hook invocation (Claude Code pre/post, Codex pre) re-fingerprints the live settings and compares. On divergence it attaches a warning (`systemMessage` for Claude Code, stderr for Codex) naming only the host, scope, and event names, and records first-seen/last-seen in the manifest. The check is warning-only: it never changes a verdict, the hook envelope, or the exit code, and any error inside it yields no warning.
- `doberman doctor` gains a "Hook integrity" check: OK when every tracked registration is intact, WARN when hooks are installed but untracked (installed before this version), FAIL when a `PreToolUse`/`PostToolUse` group was stripped.

Closes #239. Documents the Codex hook-layer crash limit from #335 (adapters/codex/README.md, "Honest limits"); the live canary for #335 is deferred to its own slice.

## Deviations from the issue text

- The manifest lives in the per-user config dir (`user_config_dir()/install-manifest.json`, override `DOBERMAN_INSTALL_MANIFEST`), not repo-local `.doberman/`: a repo-local manifest is deletable by the same actor that strips the hooks, so it would detect nothing.
- Tampering by *addition* (a foreign group appended to the same event) is out of scope; the fingerprint covers the Doberman-owned groups only.

## Security checks

- Fail closed unchanged: the deny-on-unparseable-payload path is untouched, and a real BLOCK keeps its `hookSpecificOutput` when the warning is merged in (tested).
- Redaction: warning and doctor text carry host, scope, and event names only; a test asserts the repo path never appears.
- Fingerprints are keyed HMAC-SHA256 (`hmac:<hex>`), same key as the existing fingerprint helper.
- Hot path: `integrity.py` is stdlib-only at module scope; install/branding imports are lazy; with no manifest file the check returns before reading any settings.

## Tests

- `tests/unit/test_install_integrity.py` (new): manifest round-trip, divergence per event, critical vs non-critical, CLI record/clear across install/uninstall/setup/dry-run, hook warning attach/skip/never-raise/excluded-project/Codex-stderr, real-deny envelope preserved, post-hook wiring.
- `tests/unit/test_cli_doctor.py`: the doctor check's OK/WARN/FAIL/untracked verdicts and the no-manifest path.
- `tests/conftest.py`: autouse fixture isolating `DOBERMAN_INSTALL_MANIFEST` per test (the suite had been writing into the real per-user manifest).

## Review notes and follow-ups

A fresh-context whole-branch review (constraints evidenced with file:line, two mutation checks red/green) returned merge-ready after two one-line fixes, both applied here: the doctor check is listed under the Hooks section, and the "untracked" warning ignores the Codex `plugin` scope (which has no writable hooks.json). Follow-ups it accepted as documentation rather than fixes:

- `disableAllHooks: true` in any host settings file neutralizes hooks while the manifest still reads intact; the Host hooks doctor check should learn that key.
- Deleting the manifest degrades to a doctor "untracked" WARN and silent hooks; confirm the control-plane path classes (the globs that classify edits to `.claude/settings*.json` and `.codex/hooks.json` as control-plane writes) also cover `install-manifest.json`.
- Stale entries for relocated or renamed repos are never pruned; the new path shows as "untracked".
- A replaced or PATH-shadowed `doberman` binary is undetected; the Hook command check covers absence only.
- `check_all` re-loads the manifest once per scope (bounded at 5); load it once. `MANIFEST_VERSION` is written but not yet gated on in `_load`. The `doctor.py` module docstring still says "three checks".

## Checklist

- [x] Repo: `doberman-core`
- [x] Public-release safe: no enterprise concepts, no secrets, no customer data
- [x] Tests added and green locally; ruff + lint-imports green
- [x] Docs: README bullet, adapters/codex/README.md honest limits, `changelog.d/239.md`
