### PR TITLE
land #514: fix(auth): add auth dialog window icon

### DIFF
--- a/changelog.d/514.md
+++ b/changelog.d/514.md
@@ -1,0 +1,1 @@
+- **Auth dialog:** the window now carries the Doberman mark as its title-bar and taskbar icon instead of Tk's default feather; icon loading is best-effort and never blocks the dialog (#514)

--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -439,6 +439,15 @@ def _configure_window(root: Any) -> None:
     root.attributes("-topmost", True)  # the dialog must pop OVER the agent's terminal
     _apply_dark_title_bar(root)
     try:
+        import tkinter as tk
+
+        with _ir.as_file(_ir.files("doberman.auth").joinpath("_assets/doberman-mark.png")) as p:
+            icon = tk.PhotoImage(file=str(p))
+            root.iconphoto(True, icon)
+            root._icon_ref = icon
+    except Exception:  # noqa: S110 — cosmetic only; icon failure must not block the dialog
+        pass
+    try:
         root.tk.call("tk", "scaling", _dpi_for_dialog_placement() / 72.0)
     except Exception:  # noqa: S110 — cosmetic only (and unavailable on a fake root in tests)
         pass

--- a/tests/unit/test_gui_prompter.py
+++ b/tests/unit/test_gui_prompter.py
@@ -921,6 +921,21 @@ def test_configure_window_sets_icon(monkeypatch):
     assert default is True
 
 
+def test_configure_window_continues_when_icon_load_fails(monkeypatch):
+    tkinter = pytest.importorskip("tkinter")
+
+    def _boom(*_a):
+        raise RuntimeError("Icon load failed")
+
+    monkeypatch.setattr(tkinter, "PhotoImage", _boom)
+
+    root = _FakeRoot()
+    gui_prompter._configure_window(root)
+
+    assert root.titles == [gui_prompter._TITLE]
+    assert root.iconphoto_calls == []
+
+
 def _fake_focus_tracking(root, *widgets):
     """Replace ``root.focus_get`` and each widget's ``focus_set`` with a small,
     self-consistent in-memory stand-in for Tk's real OS/window-manager-mediated

--- a/tests/unit/test_gui_prompter.py
+++ b/tests/unit/test_gui_prompter.py
@@ -566,6 +566,7 @@ class _FakeRoot:
         self.attrs: dict = {}
         self.config: dict = {}
         self.titles: list[str] = []
+        self.iconphoto_calls: list = []
         self.resizable_args: tuple | None = None
         self.protocols: dict = {}
         self.bindings: dict = {}
@@ -586,6 +587,9 @@ class _FakeRoot:
 
     def title(self, text):
         self.titles.append(text)
+
+    def iconphoto(self, default, image):
+        self.iconphoto_calls.append((default, image))
 
     def resizable(self, w, h):
         self.resizable_args = (w, h)
@@ -902,6 +906,19 @@ def real_root():
         pytest.skip("no display available")
     yield root
     root.destroy()
+
+
+def test_configure_window_sets_icon(monkeypatch):
+    tkimage = pytest.importorskip("tkinter")
+    monkeypatch.setattr(tkimage, "PhotoImage", lambda **_kw: _kw.get("file"))
+
+    root = _FakeRoot()
+    gui_prompter._configure_window(root)
+
+    assert len(root.iconphoto_calls) == 1
+
+    default, _ = root.iconphoto_calls[0]
+    assert default is True
 
 
 def _fake_focus_tracking(root, *widgets):


### PR DESCRIPTION
Landing branch for #514 by @thesageak (ADR 0080: never push to a contributor's fork). The repository no longer accepts merge commits, so this branch is a linear cherry-pick of their three commits onto main, each still authored by @thesageak, plus one maintainer commit adding the `changelog.d/514.md` fragment CONTRIBUTING asks for. It merges by rebase so their commits land on main under their name.

Conflict resolved inside their commits: main rebuilt the GUI dialog on real widgets (ec8fa6f), which moved `_configure_window` and rewrote `tests/unit/test_gui_prompter.py`. The icon block was re-inserted into the new `_configure_window` right after `_apply_dark_title_bar(root)`, and the two tests plus the `_FakeRoot.iconphoto` recorder were re-added to the new test file. No behaviour changed from the author's version.

Closes #432