### PR TITLE
fix(hosthooks): read the Cursor hook's stdin as UTF-8 bytes

### DIFF
--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1490,7 +1490,10 @@ def hook_cursor() -> None:
     _configure_stderr_logging()
     from doberman.hosthooks.cursor import run_cursor
 
-    text, code = run_cursor(sys.stdin.read())
+    # Raw bytes: the adapter decodes UTF-8 itself (a cp1252 console would turn
+    # cursor-agent's Windows BOM into mojibake and fail every hook closed).
+    stream = getattr(sys.stdin, "buffer", None)
+    text, code = run_cursor(stream.read() if stream is not None else sys.stdin.read())
     sys.stdout.write(text + "\n")
     raise typer.Exit(code)
 

--- a/src/doberman/hosthooks/cursor.py
+++ b/src/doberman/hosthooks/cursor.py
@@ -106,10 +106,15 @@ _MCP_PREFIX = "MCP:"
 AUTH_PROMPTER: Prompter | None = None
 
 
-def strip_bom(text: str) -> str:
-    """Drop a leading UTF-8 BOM. ``cursor-agent`` on Windows prefixes hook stdin
-    with one, which otherwise turns every hook into a JSON parse failure that
-    Cursor fails OPEN on (forum #168407, staff-confirmed, no fix ETA)."""
+def strip_bom(text: str | bytes) -> str:
+    """Decode hook stdin as UTF-8 and drop a leading BOM. ``cursor-agent`` on
+    Windows prefixes hook stdin with one, which otherwise turns every hook into a
+    JSON parse failure that Cursor fails OPEN on (forum #168407, staff-confirmed,
+    no fix ETA). Bytes are decoded here, not by the console: under Windows'
+    default cp1252 stdin the BOM arrives as three mojibake characters and a
+    non-ASCII path or command is mangled, so the CLI hands over raw bytes."""
+    if isinstance(text, bytes):
+        return text.decode("utf-8-sig", errors="replace")
     return text.lstrip("\ufeff")
 
 
@@ -376,9 +381,9 @@ def _scan_after_replay(payload: dict[str, Any]) -> dict[str, Any]:
         return deny()
 
 
-def run_cursor(stdin_text: str) -> tuple[str, int]:
-    """Parse the hook stdin (BOM-tolerant), evaluate, and return
-    ``(json_document, exit_code)`` for the CLI to emit."""
+def run_cursor(stdin_text: str | bytes) -> tuple[str, int]:
+    """Parse the hook stdin (raw UTF-8 bytes preferred; BOM-tolerant), evaluate,
+    and return ``(json_document, exit_code)`` for the CLI to emit."""
     try:
         payload = json.loads(strip_bom(stdin_text))
     except Exception:  # noqa: BLE001 — unparseable input denies the unknown call

--- a/tests/unit/test_hosthook_cursor.py
+++ b/tests/unit/test_hosthook_cursor.py
@@ -163,6 +163,33 @@ def test_malformed_stdin_fails_closed(bad):
     assert code == cursor.DENY_EXIT_CODE
 
 
+def test_raw_utf8_bytes_with_bom_are_decoded(tmp_path):
+    # The CLI hands over stdin BYTES. Under a cp1252 console (Windows default) a
+    # text read would turn the BOM into three mojibake characters and mangle any
+    # non-ASCII path; decoding here keeps both intact.
+    benign = _shell(tmp_path, "echo caf\u00e9")
+    raw = b"\xef\xbb\xbf" + json.dumps(benign, ensure_ascii=False).encode("utf-8")
+    text, code = cursor.run_cursor(raw)
+    assert json.loads(text) == {"permission": "allow"} and code == 0
+    dangerous = b"\xef\xbb\xbf" + json.dumps(_shell(tmp_path, "rm -rf /")).encode("utf-8")
+    text, code = cursor.run_cursor(dangerous)
+    assert json.loads(text)["permission"] == "deny" and code == 2
+    assert "BLOCK" in json.loads(text)["user_message"]  # evaluated, not the parse failsafe
+    assert (
+        cursor.strip_bom(b"\xff\xfe{") == "\ufffd\ufffd{"
+    )  # undecodable -> replaced, never raises
+
+
+def test_cli_reads_stdin_bytes_with_bom(tmp_path):
+    from doberman.cli.main import app
+
+    raw = b"\xef\xbb\xbf" + json.dumps(_shell(tmp_path, "rm -rf /")).encode("utf-8")
+    result = CliRunner().invoke(app, ["hook", "cursor"], input=raw)
+    assert result.exit_code == 2
+    doc = json.loads(result.stdout.strip().splitlines()[-1])
+    assert doc["permission"] == "deny" and "BLOCK" in doc["user_message"]
+
+
 def test_bom_prefixed_payload_is_parsed_not_denied(tmp_path):
     # cursor-agent on Windows prefixes stdin with a UTF-8 BOM (forum #168407).
     # Without the strip, every hook is a parse failure that Cursor fails OPEN on.


### PR DESCRIPTION
## What this PR does
A live probe of the installed binary through `cmd.exe` (the way Cursor launches hooks on Windows) showed a BOM-prefixed payload coming back as the parse failsafe instead of the verdict. `sys.stdin.read()` under the default cp1252 console decodes the BOM into three mojibake characters, so the strip never matched and every `cursor-agent` hook on Windows would deny (and any non-ASCII path or command was mangled).

`doberman hook cursor` now hands the adapter raw stdin bytes and `strip_bom` decodes them as `utf-8-sig`; undecodable bytes are replaced, never raised, so the fail-closed contract is unchanged.

## Tests added (run in CI)
- `test_raw_utf8_bytes_with_bom_are_decoded` — bytes with a BOM and a non-ASCII command are evaluated (allow / BLOCK), not fail-closed; undecodable bytes are replaced.
- `test_cli_reads_stdin_bytes_with_bom` — the Typer command end to end with BOM-prefixed bytes on stdin.

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Raise-only
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

Follow-up to #568. The other four hook commands still use `sys.stdin.read()`; their hosts do not send a BOM, but non-ASCII payloads on a cp1252 console deserve the same treatment (separate issue).
