### PR TITLE
feat(hosthooks): install-hooks --host cursor, session heartbeat and doctor checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ After installing, run `doberman --install-completion` to enable shell tab comple
 | **Codex CLI** | Native PreToolUse hook *(experimental)* | `doberman install-hooks --host codex` |
 | **Claude Desktop / Cursor** | MCP proxy: wraps your tool server | `doberman serve -- <your-server>` → [guide](docs/SETUP.md) |
 | **OpenClaw** | Native plugin adapter | [guide](docs/SETUP.md) · [adapter](adapters/openclaw/README.md) |
-| **Cursor** | Native hooks adapter *(experimental)* | [adapter](adapters/cursor/README.md) |
+| **Cursor** | Native hooks adapter *(experimental)* | `doberman install-hooks --host cursor` · [adapter](adapters/cursor/README.md) |
 | **Any MCP-compatible agent** | MCP proxy | [guide](docs/SETUP.md) |
 
 **Fastest path (Claude Code):**

--- a/adapters/cursor/README.md
+++ b/adapters/cursor/README.md
@@ -7,24 +7,30 @@ gating event. Each tool call reaches Doberman **before** it runs and is answered
 [`docs/CONNECTOR_MEMO_CURSOR.md`](../../docs/CONNECTOR_MEMO_CURSOR.md).
 
 > **Status: experimental.** The adapter is built from Cursor's documentation and two staff-confirmed
-> forum details, not from a live capture; `doberman install-hooks --host cursor`, the manifest
-> scope, the `sessionStart` heartbeat and the `doctor` checks arrive in the next slice. Until then
-> the registration below is manual.
+> forum details, not from a live capture.
 
-## Register the hook
+## Install
 
-Create `.cursor/hooks.json` at the project root (or `~/.cursor/hooks.json` for every project) with
-`"failClosed": true` on every entry — Cursor's own default is **fail-open** on a hook crash or
-timeout, and this flag is what turns that into a deny:
+```bash
+doberman install-hooks --host cursor              # project .cursor/hooks.json
+doberman install-hooks --host cursor --global      # ~/.cursor/hooks.json (every project)
+```
+
+Then restart your Cursor session so it reloads `hooks.json` — Cursor loads hooks at startup only.
+`doberman uninstall-hooks --host cursor` reverses it; the install manifest also records the write,
+so a plain `doberman uninstall` cleans up the project scope too.
+
+What it writes — every gating event carries `"failClosed": true` (Cursor's own default is
+**fail-open** on a hook crash or timeout, and this flag is what turns that into a deny):
 
 ```json
 {
   "version": 1,
   "hooks": {
-    "preToolUse":          [{ "command": "doberman hook cursor", "timeout": 60, "failClosed": true }],
-    "beforeShellExecution": [{ "command": "doberman hook cursor", "timeout": 60, "failClosed": true }],
-    "beforeMCPExecution":  [{ "command": "doberman hook cursor", "timeout": 60, "failClosed": true }],
-    "beforeReadFile":      [{ "command": "doberman hook cursor", "timeout": 60, "failClosed": true }],
+    "preToolUse":          [{ "command": "doberman hook cursor", "timeout": 120, "failClosed": true }],
+    "beforeShellExecution": [{ "command": "doberman hook cursor", "timeout": 120, "failClosed": true }],
+    "beforeMCPExecution":  [{ "command": "doberman hook cursor", "timeout": 120, "failClosed": true }],
+    "beforeReadFile":      [{ "command": "doberman hook cursor", "timeout": 120, "failClosed": true }],
     "sessionStart":        [{ "command": "doberman hook cursor", "timeout": 10, "failClosed": false }]
   }
 }
@@ -32,10 +38,18 @@ timeout, and this flag is what turns that into a deny:
 
 `timeout` is in seconds and must cover Doberman's own approval dialog: an `AUTH` verdict pops the
 GUI/TTY challenge **inside** the hook, so a value shorter than the human's reaction time turns every
-approval into a deny. Sixty seconds matches the approval deadline; raise it if you set a longer one.
-`doberman` must be on the `PATH` Cursor launches hooks with (a `pipx` install is).
+approval into a deny. 120s comfortably outlasts the 90s approval window; `sessionStart` is a cosmetic
+liveness heartbeat (`failClosed: false` — a failed write never aborts a session), so its timeout is
+short. `doberman` must be on the `PATH` Cursor launches hooks with (a `pipx` install is).
 
-Restart Cursor after editing the file. Cursor loads hooks at startup only.
+## Self-check
+
+`doberman doctor`'s **"Cursor hooks"** line reports the live registration, not just "is something
+installed": a weak registration (a missing gating event, or `failClosed` not `true`) is a **FAIL**;
+wired but no session has called `sessionStart` back yet is a **WARN** ("open this project in Cursor
+and re-run doctor"); a low timeout is a non-critical WARN. The install-integrity manifest also covers
+`.cursor/hooks.json` (including `failClosed` and `timeout`, not just presence), so a hand-weakened
+file is reported the next time a surviving hook runs, and by `doctor`'s "Hook integrity" check.
 
 ## Verify it is wired
 
@@ -62,7 +76,7 @@ echo "exit $?"   # -> {"permission": "deny", ...} and exit 2
 | `beforeShellExecution` | `bash` | `command` + `cwd` |
 | `beforeMCPExecution` | `<tool_name>` | `tool_input` is a JSON string; unparseable → deny |
 | `beforeReadFile` | `file_read`, then an **output scan** of `content` | a credential in the file never reaches the model; the session is tainted and the value fingerprinted, so a later egress of it is a confirmed exfil |
-| `sessionStart` | acknowledged with `{}` | heartbeat lands with the installer slice |
+| `sessionStart` | acknowledged with `{}` | best-effort liveness heartbeat written to `.doberman/`, read by `doberman doctor` |
 
 Verdicts: `PASS` → `{"permission": "allow"}` (explicit, exit 0). `BLOCK` → `deny` **and** exit code 2
 (Cursor treats either as a block, so a lost document still blocks). `AUTH` → Doberman's own
@@ -93,9 +107,7 @@ config) requires approval.
   adapter does not know is **denied**, never waved through — report it and it will be added.
 - **`beforeReadFile` attachments are not gated.** Cursor sends `attachments` alongside the file;
   v1 scans `content` only.
-- **`sessionStart` is acknowledged, not recorded** until the installer slice adds the heartbeat.
-- **No self-check yet.** `doberman doctor` does not inspect `.cursor/hooks.json` until the installer
-  slice; verify the wiring by hand (above) after every Cursor update.
+- **`doberman setup` does not offer Cursor yet** — use `install-hooks --host cursor` directly.
 - **Enterprise / Team hooks win.** Cursor merges hooks Enterprise > Team > Project > User; an
   organisation policy can remove the registration. Re-verify after a policy change.
 - **Trust model.** As with every hook-based host, Cursor itself is trusted: a Cursor release that

--- a/changelog.d/571.md
+++ b/changelog.d/571.md
@@ -1,0 +1,11 @@
+- **Cursor native-hooks adapter, slice 2 (experimental).** `doberman install-hooks --host cursor` writes or
+  merges `.cursor/hooks.json` (project; `--global` for `~/.cursor/hooks.json`) with every gating event at
+  `failClosed: true` and a timeout that outlasts Doberman's approval dialog, plus a `sessionStart` liveness
+  heartbeat (`failClosed: false`, never a gate) recorded to `.doberman/cursor_session`; `uninstall-hooks
+  --host cursor`, `doberman uninstall` and `uninstall --global` reverse it. The install-integrity manifest
+  gains `cursor/project` and `cursor/user` scopes whose fingerprints cover `timeout` and `failClosed`, and
+  Cursor's four gating events are critical, so a hand-weakened file is a FAIL. New `doberman doctor` check
+  "Cursor hooks": a missing gating event or `failClosed` not true is a critical FAIL, a short timeout or no
+  session callback yet is a WARN, otherwise OK with the last session start; `status` and "Host hooks" list
+  `cursor:<scope>`. Also (#569): `doberman hook cursor` reads stdin as raw UTF-8 bytes, so the BOM
+  `cursor-agent` emits on Windows no longer turns every hook into a deny under a cp1252 console. Refs #202.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -77,8 +77,8 @@ Wiring commands plus the low-level per-host handlers they install.
 
 | Command | Purpose | Key flags |
 |---------|---------|-----------|
-| `doberman install-hooks` | Wire Doberman's hooks into a host so every tool call is gated before it runs. Idempotent. | `--global`/`-g`, `--local`, `--host`, `--path`/`-p`, `--dry-run` |
-| `doberman uninstall-hooks` | Remove Doberman's hooks from a host. Every other setting is left untouched. | `--global`/`-g`, `--local`, `--host`, `--path`/`-p`, `--dry-run` |
+| `doberman install-hooks` | Wire Doberman's hooks into a host so every tool call is gated before it runs. Idempotent. `--host claude\|codex\|cursor`. | `--global`/`-g`, `--local`, `--host`, `--path`/`-p`, `--dry-run` |
+| `doberman uninstall-hooks` | Remove Doberman's hooks from a host. Every other setting is left untouched. `--host claude\|codex\|cursor`. | `--global`/`-g`, `--local`, `--host`, `--path`/`-p`, `--dry-run` |
 | `doberman hook pre` | Claude Code PreToolUse hook: gate one tool call (allow/ask/deny). Reads the hook payload as JSON on stdin. | none |
 | `doberman hook post` | Claude Code PostToolUse hook: scan tool output for secrets and record history. | none |
 | `doberman hook openclaw` | OpenClaw `before_tool_call` plugin hook: gate one tool call. Always writes exactly one JSON verdict, unlike the Claude Code hooks above. | none |

--- a/src/doberman/cli/doctor.py
+++ b/src/doberman/cli/doctor.py
@@ -88,7 +88,8 @@ def _check_hooks(path: str) -> CheckResult:
     return CheckResult(
         "Host hooks",
         CheckStatus.FAIL,
-        "not installed in any scope - run `doberman install-hooks` (add `--host codex` for Codex)",
+        "not installed in any scope - run `doberman install-hooks` (add `--host codex` for "
+        "Codex, `--host cursor` for Cursor)",
         critical=True,
     )
 
@@ -155,6 +156,7 @@ def _check_hook_integrity(path: str) -> CheckResult:
     """#239: has Doberman's own hook registration changed since install-hooks?"""
     from doberman.hosthooks.install import hook_install_states
     from doberman.hosthooks.install_codex import codex_hook_install_states
+    from doberman.hosthooks.install_cursor import cursor_hook_install_states
     from doberman.hosthooks.integrity import check_all
 
     name = "Hook integrity"
@@ -177,8 +179,10 @@ def _check_hook_integrity(path: str) -> CheckResult:
         if seen:
             detail += f" - a divergence was seen at {max(seen)}; re-run install-hooks to clear"
         return CheckResult(name, CheckStatus.OK, detail)
-    installed = any(ok for _s, _p, ok in hook_install_states(path)) or any(
-        ok for s, _p, ok in codex_hook_install_states(path) if s != "plugin"
+    installed = (
+        any(ok for _s, _p, ok in hook_install_states(path))
+        or any(ok for s, _p, ok in codex_hook_install_states(path) if s != "plugin")
+        or any(ok for _s, _p, ok in cursor_hook_install_states(path))
     )
     if installed:
         return CheckResult(
@@ -188,6 +192,72 @@ def _check_hook_integrity(path: str) -> CheckResult:
             "to record a manifest",
         )
     return CheckResult(name, CheckStatus.OK, "nothing to verify (no hooks installed)")
+
+
+def _check_cursor_hooks(path: str) -> CheckResult:
+    """Weak-registration + liveness self-check for the Cursor adapter (slice 2).
+
+    Unlike Claude/Codex, Cursor's own hook contract can fail OPEN (a crash or
+    timeout runs the tool) unless every gating entry carries ``failClosed:
+    true`` and a timeout that outlasts Doberman's approval dialog - so this
+    check inspects the LIVE hooks.json content, not just "is something
+    installed". A weak registration is a critical FAIL (Doberman may not
+    actually be gating); a missing sessionStart callback is only a WARN (it
+    means "unverified", not "unprotected" - `doctor` cannot always tell them
+    apart from the file alone).
+    """
+    from doberman.hosthooks.install import load_settings
+    from doberman.hosthooks.install_cursor import (
+        cursor_hook_install_states,
+        last_session_start,
+        registration_issues,
+    )
+
+    name = "Cursor hooks"
+    states = cursor_hook_install_states(path)
+    installed_scopes = [scope for scope, _p, ok in states if ok]
+    if not installed_scopes:
+        return CheckResult(name, CheckStatus.OK, "not installed (only needed for `--host cursor`)")
+
+    criticals: list[str] = []
+    warnings: list[str] = []
+    for scope, hooks_path, ok in states:
+        if not ok:
+            continue
+        try:
+            settings = load_settings(Path(hooks_path))
+        except ValueError:
+            criticals.append(f"{scope}: hooks.json unreadable")
+            continue
+        for message, critical in registration_issues(settings):
+            (criticals if critical else warnings).append(f"{scope} {message}")
+
+    if criticals:
+        return CheckResult(
+            name,
+            CheckStatus.FAIL,
+            f"weak registration ({'; '.join(criticals)}) - run `doberman install-hooks "
+            "--host cursor` to restore",
+            critical=True,
+        )
+    if warnings:
+        return CheckResult(name, CheckStatus.WARN, "; ".join(warnings))
+
+    seen = last_session_start(path)
+    if seen:
+        return CheckResult(
+            name,
+            CheckStatus.OK,
+            f"wired ({', '.join(installed_scopes)}); failClosed on every gating event; "
+            f"last session start {seen}",
+        )
+    return CheckResult(
+        name,
+        CheckStatus.WARN,
+        f"wired ({', '.join(installed_scopes)}) but no Cursor session has called back yet - "
+        "open this project in Cursor and re-run doctor (Cursor hooks are known to "
+        "intermittently not fire)",
+    )
 
 
 def _check_codex_version() -> CheckResult:
@@ -427,6 +497,7 @@ def run_checks(path: str = ".") -> list[CheckResult]:
         _safe_check("Host hooks", True, lambda: _check_hooks(path)),
         _safe_check("Hook command", True, lambda: _check_hook_command(path)),
         _safe_check("Hook integrity", True, lambda: _check_hook_integrity(path)),
+        _safe_check("Cursor hooks", True, lambda: _check_cursor_hooks(path)),
         _safe_check("Config", True, lambda: _check_config(path)),
         _safe_check("Decision DB", True, lambda: _check_db(path)),
         _safe_check("Enforcement", False, lambda: _check_enforcement(path)),

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1486,6 +1486,8 @@ def hook_cursor() -> None:
     only the fast deterministic objective floor and fails closed on any
     malformed input or engine error. Register it in ``.cursor/hooks.json`` with
     ``"failClosed": true`` (see adapters/cursor/README.md).
+
+    Wire it in with ``doberman install-hooks --host cursor``.
     """
     _configure_stderr_logging()
     from doberman.hosthooks.cursor import run_cursor
@@ -2604,7 +2606,9 @@ def install_hooks(
     local: bool = typer.Option(
         False, "--local", help="Install into .claude/settings.local.json (Claude only)."
     ),
-    host: str = typer.Option("claude", "--host", help="Which host to wire: claude | codex."),
+    host: str = typer.Option(
+        "claude", "--host", help="Which host to wire: claude | codex | cursor."
+    ),
     path: str = typer.Option(".", "--path", "-p", help="Project root (default: current dir)."),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print what would change; write nothing."
@@ -2616,19 +2620,27 @@ def install_hooks(
     PostToolUse + SessionStart into a `settings.json` (`--global` user-wide,
     `--local` project-local, else project `.claude/settings.json`). Codex CLI
     (`--host codex`): a PreToolUse hook into a `hooks.json` (`--global` ->
-    `~/.codex/hooks.json`, else `<repo>/.codex/hooks.json`).
+    `~/.codex/hooks.json`, else `<repo>/.codex/hooks.json`). Cursor
+    (`--host cursor`): the five Cursor events into `.cursor/hooks.json`
+    (`--global` -> `~/.cursor/hooks.json`, else `<repo>/.cursor/hooks.json`)
+    with `failClosed: true` on every gating event.
 
-    `--host` here is claude or codex only - mcp and openclaw don't write a hook
-    file, so there's nothing for this command to wire; `doberman setup --host
-    mcp`/`--host openclaw` prints the pointer for those instead.
+    `--host` here is claude, codex, or cursor only - mcp and openclaw don't write
+    a hook file, so there's nothing for this command to wire; `doberman setup
+    --host mcp`/`--host openclaw` prints the pointer for those instead.
 
     New here? `doberman setup` runs this for you and asks which hosts to guard.
     """
     if host == "codex":
         _install_codex(global_=global_, local=local, path=path, dry_run=dry_run)
         return
+    if host == "cursor":
+        _install_cursor(global_=global_, local=local, path=path, dry_run=dry_run)
+        return
     if host != "claude":
-        typer.echo(f"error: unknown --host {host!r}; expected 'claude' or 'codex'.", err=True)
+        typer.echo(
+            f"error: unknown --host {host!r}; expected 'claude', 'codex', or 'cursor'.", err=True
+        )
         raise typer.Exit(2)
 
     from doberman.hosthooks.install import (
@@ -2794,6 +2806,132 @@ def _uninstall_codex(*, global_: bool, local: bool, path: str, dry_run: bool) ->
     )
 
 
+def _write_cursor_hook(scope: str, path: str, *, show_verify: bool = True) -> tuple[Path, bool]:
+    """Write Doberman's Cursor hooks for *scope* and print the notice.
+
+    Shared by ``install-hooks --host cursor`` (:func:`_install_cursor`) and, in
+    future, a ``setup`` wizard cursor step. Mirrors :func:`_write_codex_hook`'s
+    already-wired/wrote/manifest/exclusion shape. Returns ``(hooks_path,
+    already_wired)``.
+    """
+    from doberman.hosthooks.install import load_settings, write_settings
+    from doberman.hosthooks.install_cursor import (
+        cursor_doberman_groups,
+        merge_cursor_hooks,
+        resolve_cursor_hooks_path,
+    )
+
+    hooks_path = resolve_cursor_hooks_path(scope, path)
+
+    try:
+        current = load_settings(hooks_path)
+    except ValueError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    merged = merge_cursor_hooks(current)
+    already_wired = merged == current
+    if already_wired:
+        typer.echo(style_text(f"already wired: {hooks_path}", bold=True))
+    else:
+        write_settings(hooks_path, merged)
+        typer.echo(style_text(f"wrote {hooks_path}", bold=True))
+    _record_manifest("cursor", scope, hooks_path, cursor_doberman_groups(merged))
+    if remove_exclusion(path):
+        typer.echo("This project is no longer excluded from global hooks.")
+    typer.echo("")
+    typer.echo("Restart your Cursor session so it reloads hooks.json.")
+    typer.echo(
+        "Doberman now gates Cursor's built-in tools, shell commands, MCP calls and file reads "
+        "in this scope (failClosed: a hook crash or timeout denies)."
+    )
+    if show_verify:
+        typer.echo("Verify it's live: ask Cursor to `cat .env` and confirm it is blocked.")
+    return hooks_path, already_wired
+
+
+def _install_cursor(*, global_: bool, local: bool, path: str, dry_run: bool) -> None:
+    """`install-hooks --host cursor`: wire ``doberman hook cursor`` into a
+    Cursor hooks.json. ``--global`` -> ``~/.cursor/hooks.json`` (user), else
+    ``<repo>/.cursor/hooks.json`` (project). ``--local`` has no Cursor equivalent."""
+    if local:
+        typer.echo(
+            "error: --local has no Cursor equivalent; use --global (user) or the default "
+            "(project).",
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    scope = "user" if global_ else "project"
+
+    if dry_run:
+        from doberman.hosthooks.cursor import EVENT_SESSION_START
+        from doberman.hosthooks.install_cursor import (
+            GATE_EVENTS,
+            GATE_TIMEOUT_S,
+            SESSION_START_TIMEOUT_S,
+            resolve_cursor_hooks_path,
+        )
+
+        hooks_path = resolve_cursor_hooks_path(scope, path)
+        typer.echo(f"[dry-run] target: {hooks_path}")
+        typer.echo("[dry-run] would add:")
+        for event in (*GATE_EVENTS, EVENT_SESSION_START):
+            timeout = SESSION_START_TIMEOUT_S if event == EVENT_SESSION_START else GATE_TIMEOUT_S
+            typer.echo(f"  {event} -> doberman hook cursor (failClosed, {timeout}s)")
+        return
+
+    _write_cursor_hook(scope, path)  # returns (path, already_wired); install-hooks needs neither
+
+
+def _uninstall_cursor(*, global_: bool, local: bool, path: str, dry_run: bool) -> None:
+    """`uninstall-hooks --host cursor`: remove Doberman's Cursor hook entries."""
+    if local:
+        typer.echo("error: --local has no Cursor equivalent.", err=True)
+        raise typer.Exit(2)
+    from doberman.hosthooks.cursor import EVENT_SESSION_START
+    from doberman.hosthooks.install import load_settings, write_settings
+    from doberman.hosthooks.install_cursor import (
+        GATE_EVENTS,
+        _is_doberman_entry,
+        remove_cursor_hooks,
+        resolve_cursor_hooks_path,
+    )
+
+    scope = "user" if global_ else "project"
+    hooks_path = resolve_cursor_hooks_path(scope, path)
+
+    try:
+        current = load_settings(hooks_path)
+    except ValueError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+    hooks_section = current.get("hooks") or {}
+    had_doberman = any(
+        _is_doberman_entry(entry)
+        for entries in hooks_section.values()
+        if isinstance(entries, list)
+        for entry in entries
+    )
+    if not had_doberman:
+        typer.echo("No Doberman Cursor hooks found - nothing to remove.")
+        return
+
+    cleaned = remove_cursor_hooks(current)
+    if dry_run:
+        typer.echo(f"[dry-run] target: {hooks_path}")
+        typer.echo("[dry-run] would remove:")
+        for event in (*GATE_EVENTS, EVENT_SESSION_START):
+            typer.echo(f"  {event} -> doberman hook cursor")
+        return
+
+    _clear_manifest("cursor", scope, hooks_path)
+    write_settings(hooks_path, cleaned)
+    typer.echo(f"wrote {hooks_path}")
+    typer.echo("Doberman Cursor hooks removed.")
+
+
 @app.command("uninstall-hooks", rich_help_panel="Leaving")
 def uninstall_hooks(
     global_: bool = typer.Option(
@@ -2805,7 +2943,9 @@ def uninstall_hooks(
     local: bool = typer.Option(
         False, "--local", help="Remove from .claude/settings.local.json (Claude only)."
     ),
-    host: str = typer.Option("claude", "--host", help="Which host to unwire: claude | codex."),
+    host: str = typer.Option(
+        "claude", "--host", help="Which host to unwire: claude | codex | cursor."
+    ),
     path: str = typer.Option(".", "--path", "-p", help="Project root (default: current dir)."),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print what would change; write nothing."
@@ -2815,13 +2955,19 @@ def uninstall_hooks(
 
     Idempotent - safe to run even when hooks are not present.  Non-Doberman hooks
     and every other setting are left untouched. ``--host codex`` removes the Codex
-    hook group instead of the Claude Code hooks.
+    hook group instead of the Claude Code hooks; ``--host cursor`` removes the
+    Cursor hook entries.
     """
     if host == "codex":
         _uninstall_codex(global_=global_, local=local, path=path, dry_run=dry_run)
         return
+    if host == "cursor":
+        _uninstall_cursor(global_=global_, local=local, path=path, dry_run=dry_run)
+        return
     if host != "claude":
-        typer.echo(f"error: unknown --host {host!r}; expected 'claude' or 'codex'.", err=True)
+        typer.echo(
+            f"error: unknown --host {host!r}; expected 'claude', 'codex', or 'cursor'.", err=True
+        )
         raise typer.Exit(2)
 
     from doberman.hosthooks.install import (
@@ -2888,6 +3034,7 @@ def _project_uninstall_targets(path: str) -> list[tuple[str, str]]:
     project-scoped only.
     """
     from doberman.hosthooks.install_codex import codex_hook_install_states
+    from doberman.hosthooks.install_cursor import cursor_hook_install_states
 
     targets: list[tuple[str, str]] = []
     for scope, settings_path, installed in _hook_install_states(path):
@@ -2896,6 +3043,9 @@ def _project_uninstall_targets(path: str) -> list[tuple[str, str]]:
     for scope, hooks_path, installed in codex_hook_install_states(path):
         if scope == "repo" and installed:
             targets.append(("Codex CLI hooks (repo)", hooks_path))
+    for scope, hooks_path, installed in cursor_hook_install_states(path):
+        if scope == "project" and installed:
+            targets.append(("Cursor hooks (project)", hooks_path))
     doberman_dir = Path(path) / CONFIG_DIR
     if doberman_dir.exists():
         targets.append((".doberman/ (policy + decision database)", str(doberman_dir)))
@@ -2933,10 +3083,12 @@ def _format_command(argv: list[str]) -> str:
 def _global_uninstall_targets(path: str) -> tuple[list[tuple[str, str]], str, list[str]]:
     """Every global-uninstall plan entry, including absent and read-only targets."""
     from doberman.hosthooks.install_codex import codex_hook_install_states
+    from doberman.hosthooks.install_cursor import cursor_hook_install_states
     from doberman.storage import device_metrics, fingerprint
 
     claude_states = {scope: settings_path for scope, settings_path, _ in _hook_install_states(path)}
     codex_states = {scope: hooks_path for scope, hooks_path, _ in codex_hook_install_states(path)}
+    cursor_states = {scope: hooks_path for scope, hooks_path, _ in cursor_hook_install_states(path)}
     kind, argv = _package_remover()
     targets = [
         ("Claude Code hooks (global)", claude_states["global"]),
@@ -2945,6 +3097,8 @@ def _global_uninstall_targets(path: str) -> tuple[list[tuple[str, str]], str, li
         ("Codex CLI hooks (user)", codex_states["user"]),
         ("Codex CLI hooks (repo)", codex_states["repo"]),
         ("Codex CLI hooks (plugin scope; not writable)", codex_states["plugin"]),
+        ("Cursor hooks (user)", cursor_states["user"]),
+        ("Cursor hooks (project)", cursor_states["project"]),
         (".doberman/ (policy + decision database)", str(Path(path) / CONFIG_DIR)),
         ("TOTP enrollment", str(totp.resolve_path())),
         ("password enrollment", str(password.resolve_path())),
@@ -3003,6 +3157,11 @@ def _uninstall_global(path: str, yes: bool, dry_run: bool, keep_package: bool) -
         codex_hook_install_states,
         remove_codex_hooks,
         resolve_codex_hooks_path,
+    )
+    from doberman.hosthooks.install_cursor import (
+        cursor_hook_install_states,
+        remove_cursor_hooks,
+        resolve_cursor_hooks_path,
     )
     from doberman.storage import device_metrics, fingerprint
 
@@ -3073,6 +3232,20 @@ def _uninstall_global(path: str, yes: bool, dry_run: bool, keep_package: bool) -
             current = load_settings(target)
             _clear_manifest("codex", scope, target)
             write_settings(target, remove_codex_hooks(current))
+        except (ValueError, OSError) as exc:
+            errors.append(f"{target}: {exc}")
+
+    cursor_installed = {
+        scope: installed for scope, _hooks_path, installed in cursor_hook_install_states(path)
+    }
+    for scope in ("user", "project"):
+        if not cursor_installed.get(scope):
+            continue
+        target = resolve_cursor_hooks_path(scope, path)
+        try:
+            current = load_settings(target)
+            _clear_manifest("cursor", scope, target)
+            write_settings(target, remove_cursor_hooks(current))
         except (ValueError, OSError) as exc:
             errors.append(f"{target}: {exc}")
 
@@ -3162,6 +3335,11 @@ def uninstall(
         remove_codex_hooks,
         resolve_codex_hooks_path,
     )
+    from doberman.hosthooks.install_cursor import (
+        cursor_hook_install_states,
+        remove_cursor_hooks,
+        resolve_cursor_hooks_path,
+    )
 
     targets = _project_uninstall_targets(path)
     if not targets:
@@ -3249,6 +3427,16 @@ def uninstall(
             current = load_settings(resolve_codex_hooks_path(scope, path))
             _clear_manifest("codex", scope, resolve_codex_hooks_path(scope, path))
             write_settings(resolve_codex_hooks_path(scope, path), remove_codex_hooks(current))
+        except (ValueError, OSError) as exc:
+            errors.append(f"{hooks_path}: {exc}")
+
+    for scope, hooks_path, installed in cursor_hook_install_states(path):
+        if scope != "project" or not installed:
+            continue
+        try:
+            current = load_settings(resolve_cursor_hooks_path(scope, path))
+            _clear_manifest("cursor", scope, resolve_cursor_hooks_path(scope, path))
+            write_settings(resolve_cursor_hooks_path(scope, path), remove_cursor_hooks(current))
         except (ValueError, OSError) as exc:
             errors.append(f"{hooks_path}: {exc}")
 

--- a/src/doberman/hosthooks/cursor.py
+++ b/src/doberman/hosthooks/cursor.py
@@ -17,8 +17,9 @@ payload's ``hook_event_name``:
   Claude Code's ``PostToolUse`` output scan — a credential in the file never
   reaches the model, and the session is tainted + fingerprinted so a later
   egress of that value is a confirmed exfil.
-* ``sessionStart`` — acknowledged with ``{}`` (the heartbeat lands with the
-  installer slice).
+* ``sessionStart`` — acknowledged with ``{}`` and a best-effort liveness
+  heartbeat written to ``.doberman/`` (see :func:`record_session_start`), so
+  ``doberman doctor`` can tell whether Cursor is actually calling the hook.
 
 Verdict mapping: ``PASS`` -> ``{"permission": "allow"}`` and exit 0. ``BLOCK`` ->
 ``{"permission": "deny", "user_message": ..., "agent_message": ...}`` AND exit
@@ -62,6 +63,11 @@ from doberman.models import Verdict
 
 if TYPE_CHECKING:  # annotations only — keeps the hot path free of the auth stack
     from doberman.auth.challenge import Prompter
+
+#: File under `.doberman/` the sessionStart heartbeat writes into (install_cursor
+#: imports THIS name to build the doctor-facing path; defined here, not there, so
+#: this module never has to import install_cursor).
+SESSION_MARKER = "cursor_session"
 
 EVENT_PRE_TOOL = "preToolUse"
 EVENT_SHELL = "beforeShellExecution"
@@ -218,6 +224,23 @@ def repo_root_of(payload: dict[str, Any]) -> str | None:
     return cwd if isinstance(cwd, str) and cwd else None
 
 
+def record_session_start(project_root: str) -> None:
+    """Best-effort liveness record for `doberman doctor`: write the UTC ISO time into
+    <root>/.doberman/cursor_session (dir created 0o700). Any OSError is swallowed - a
+    heartbeat may never fail a session start."""
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    from doberman.storage.db import CONFIG_DIR
+
+    try:
+        marker = Path(project_root) / CONFIG_DIR / SESSION_MARKER
+        marker.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+        marker.write_text(datetime.now(timezone.utc).isoformat(), encoding="utf-8")
+    except OSError:
+        pass
+
+
 def _from_host_output(host_out: dict[str, Any]) -> dict[str, Any]:
     """Map the shared ``hookSpecificOutput`` shape onto Cursor's document."""
     hso = host_out.get("hookSpecificOutput") or {}
@@ -262,6 +285,9 @@ def evaluate(payload: dict[str, Any]) -> dict[str, Any]:
     try:
         event = payload.get("hook_event_name")
         if event == EVENT_SESSION_START:
+            cwd = repo_root_of(payload)
+            if cwd and not spine.is_excluded(cwd):
+                record_session_start(cwd)
             return {}
         if event not in GATED_EVENTS:
             return deny()  # no identifiable action -> refuse

--- a/src/doberman/hosthooks/install_codex.py
+++ b/src/doberman/hosthooks/install_codex.py
@@ -192,16 +192,22 @@ def protection_state(project_root: str) -> tuple[bool, str, list[tuple[str, str,
       ``"not_on_path"`` (wired somewhere, but this shell can't resolve
       ``doberman``).
     * ``hooks`` — the combined ``(scope, path, installed)`` list: Claude's
-      three scopes first, then Codex's two, prefixed ``"codex:"`` so a caller
-      can tell them apart, same as `doctor`'s "Host hooks" check already does.
+      three scopes first, then Codex's two, then Cursor's two, prefixed
+      ``"codex:"`` / ``"cursor:"`` so a caller can tell them apart, same as
+      `doctor`'s "Host hooks" check already does.
     """
     from doberman.hosthooks.install import hook_install_states
+    from doberman.hosthooks.install_cursor import cursor_hook_install_states
 
-    hooks = list(hook_install_states(project_root)) + [
-        (f"codex:{scope}", p, ok)
-        for scope, p, ok in codex_hook_install_states(project_root)
-        if scope != "plugin"
-    ]
+    hooks = (
+        list(hook_install_states(project_root))
+        + [
+            (f"codex:{scope}", p, ok)
+            for scope, p, ok in codex_hook_install_states(project_root)
+            if scope != "plugin"
+        ]
+        + [(f"cursor:{scope}", p, ok) for scope, p, ok in cursor_hook_install_states(project_root)]
+    )
     if not any(ok for _scope, _p, ok in hooks):
         return False, "no_hooks", hooks
     if shutil.which("doberman") is None:

--- a/src/doberman/hosthooks/install_cursor.py
+++ b/src/doberman/hosthooks/install_cursor.py
@@ -32,15 +32,19 @@ from pathlib import Path
 from typing import Any
 
 from doberman.auth.approval import DEFAULT_APPROVAL_TIMEOUT_S
-from doberman.hosthooks.cursor import (
-    EVENT_MCP,
-    EVENT_PRE_TOOL,
-    EVENT_READ,
-    EVENT_SESSION_START,
-    EVENT_SHELL,
-    SESSION_MARKER,
-)
 from doberman.hosthooks.install import load_settings
+
+# Event names and the marker filename are LITERALS, not imports from
+# doberman.hosthooks.cursor: that module pulls the whole adapter stack (config,
+# policy, egress - ~400 ms), and this one is imported on EVERY host's hook hot
+# path by the install-integrity check once a manifest exists.
+# tests/unit/test_install_hooks_cursor.py pins them to the adapter's constants.
+EVENT_PRE_TOOL = "preToolUse"
+EVENT_SHELL = "beforeShellExecution"
+EVENT_MCP = "beforeMCPExecution"
+EVENT_READ = "beforeReadFile"
+EVENT_SESSION_START = "sessionStart"
+SESSION_MARKER = "cursor_session"
 
 #: The command every Cursor hook entry runs.
 HOOK_COMMAND = "doberman hook cursor"
@@ -231,7 +235,7 @@ def registration_issues(settings: dict[str, Any]) -> list[tuple[str, bool]]:
         if not is_number or timeout < DEFAULT_APPROVAL_TIMEOUT_S:
             issues.append(
                 (
-                    f"{event}: timeout {timeout}s is below the "
+                    f"{event}: timeout {f'{timeout}s' if is_number else 'missing'} is below the "
                     f"{int(DEFAULT_APPROVAL_TIMEOUT_S)}s approval window "
                     "(an unanswered approval is denied early)",
                     False,

--- a/src/doberman/hosthooks/install_cursor.py
+++ b/src/doberman/hosthooks/install_cursor.py
@@ -1,0 +1,272 @@
+"""Idempotent install/uninstall of Doberman's Cursor hook into a hooks.json.
+
+Cursor's ``hooks.json`` is FLAT (from the adapter README, ``docs/CONNECTOR_MEMO_CURSOR.md``):
+``{"version": 1, "hooks": {"<event>": [{"command": "...", "timeout": <seconds>,
+"failClosed": <bool>}]}}`` — one entry per list, no nested ``hooks`` list, no
+``matcher``. That shape means the Claude/Codex ``_is_doberman_group`` sentinel
+(which looks for a ``hooks`` sub-list) never matches a Cursor entry, so this
+module carries its own entry predicate (:func:`_is_doberman_entry`) rather than
+reusing :mod:`doberman.hosthooks.install`'s.
+
+Doberman registers ONE command, ``doberman hook cursor``, for every gating event
+(:data:`GATE_EVENTS`) plus ``sessionStart`` (a liveness heartbeat, not a gate —
+see :mod:`doberman.hosthooks.cursor`). Every gating entry carries
+``"failClosed": true``: Cursor's own default is fail-OPEN on a hook crash or
+timeout, and this flag is what turns that into a deny. The gate timeout is set
+comfortably above Doberman's own approval dialog (:data:`GATE_TIMEOUT_S`) so an
+unanswered AUTH is denied by the human, not by Cursor's clock.
+
+This mirrors :mod:`doberman.hosthooks.install_codex` in shape (pure merge/remove
+functions never mutate their inputs, so they are trivially unit-testable) and
+reuses its format-agnostic JSON I/O (:func:`~doberman.hosthooks.install.load_settings`).
+
+Scopes: ``user`` -> ``~/.cursor/hooks.json`` (every project), ``project`` ->
+``<project_root>/.cursor/hooks.json``. There is no Cursor equivalent of Claude
+Code's ``settings.local.json`` "local" scope.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+from doberman.auth.approval import DEFAULT_APPROVAL_TIMEOUT_S
+from doberman.hosthooks.cursor import (
+    EVENT_MCP,
+    EVENT_PRE_TOOL,
+    EVENT_READ,
+    EVENT_SESSION_START,
+    EVENT_SHELL,
+    SESSION_MARKER,
+)
+from doberman.hosthooks.install import load_settings
+
+#: The command every Cursor hook entry runs.
+HOOK_COMMAND = "doberman hook cursor"
+
+#: The four gating events, in registration order (matches the adapter README).
+GATE_EVENTS: tuple[str, ...] = (EVENT_PRE_TOOL, EVENT_SHELL, EVENT_MCP, EVENT_READ)
+
+#: Cursor's per-hook timeout (seconds) must outlast Doberman's in-hook approval dialog, or an
+#: unanswered AUTH is denied by the timeout instead of the human.
+GATE_TIMEOUT_S = int(DEFAULT_APPROVAL_TIMEOUT_S) + 30  # 120
+
+#: sessionStart is a cosmetic heartbeat, not a gate — a short timeout is fine, and
+#: `failClosed: false` (see session_start_entry) means it can never abort a session.
+SESSION_START_TIMEOUT_S = 10
+
+#: Sentinel substring used to detect Doberman-owned entries (same marker family as
+#: doberman.hosthooks.install / install_codex's "doberman hook " sentinel).
+_DOBERMAN_MARKER = "doberman hook "
+
+
+def gate_entry() -> dict[str, Any]:
+    """One Doberman entry for a gating event."""
+    return {"command": HOOK_COMMAND, "timeout": GATE_TIMEOUT_S, "failClosed": True}
+
+
+def session_start_entry() -> dict[str, Any]:
+    """Doberman's sessionStart entry.
+
+    ``failClosed`` is False ON PURPOSE: a failed heartbeat must never abort a
+    session; it is a liveness record, not a gate.
+    """
+    return {"command": HOOK_COMMAND, "timeout": SESSION_START_TIMEOUT_S, "failClosed": False}
+
+
+def _is_doberman_entry(entry: Any) -> bool:
+    """True if *entry* is a dict whose ``command`` names a Doberman hook."""
+    if not isinstance(entry, dict):
+        return False
+    cmd = entry.get("command")
+    return isinstance(cmd, str) and _DOBERMAN_MARKER in cmd
+
+
+def merge_cursor_hooks(settings: dict[str, Any]) -> dict[str, Any]:
+    """Return a *new* hooks.json dict with Doberman's entries added/replaced.
+
+    Existing non-Doberman entries, foreign events, and every other top-level key
+    are preserved. ``version`` defaults to ``1`` when absent; an existing value
+    is kept. **Idempotent:** a pre-existing Doberman entry for an event is
+    replaced (never duplicated) — calling this twice yields the same result as
+    calling it once. Never mutates *settings*.
+    """
+    result: dict[str, Any] = copy.deepcopy(settings)
+    result.setdefault("version", 1)
+    hooks: dict[str, Any] = copy.deepcopy(result.get("hooks") or {})
+
+    for event in (*GATE_EVENTS, EVENT_SESSION_START):
+        existing: list[Any] = list(hooks.get(event) or [])
+        non_doberman = [e for e in existing if not _is_doberman_entry(e)]
+        entry = gate_entry() if event in GATE_EVENTS else session_start_entry()
+        hooks[event] = [*non_doberman, entry]
+
+    result["hooks"] = hooks
+    return result
+
+
+def remove_cursor_hooks(settings: dict[str, Any]) -> dict[str, Any]:
+    """Return a *new* hooks.json dict with Doberman's entries removed.
+
+    Non-Doberman entries and every other key (including ``version``) are
+    preserved. Empty event lists are dropped; if ``hooks`` becomes empty it is
+    removed too. A no-op when ``hooks`` is absent.
+    """
+    result: dict[str, Any] = copy.deepcopy(settings)
+    if "hooks" not in result:
+        return result
+
+    hooks: dict[str, Any] = copy.deepcopy(result["hooks"])
+    cleaned: dict[str, Any] = {}
+    for event, entries in hooks.items():
+        if not isinstance(entries, list):
+            cleaned[event] = entries
+            continue
+        kept = [e for e in entries if not _is_doberman_entry(e)]
+        if kept:
+            cleaned[event] = kept
+
+    if cleaned:
+        result["hooks"] = cleaned
+    else:
+        del result["hooks"]
+    return result
+
+
+def cursor_doberman_groups(settings: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Doberman-owned entries per event, for the install manifest.
+
+    Only list-valued events are considered, and the fingerprint input is the
+    WHOLE entry (command, timeout, failClosed), so weakening ``failClosed`` or
+    lowering ``timeout`` counts as a divergence.
+    """
+    hooks_section = settings.get("hooks") or {}
+    out: dict[str, list[dict[str, Any]]] = {}
+    for event, entries in hooks_section.items():
+        if not isinstance(entries, list):
+            continue
+        ours = [e for e in entries if isinstance(e, dict) and _is_doberman_entry(e)]
+        if ours:
+            out[event] = ours
+    return out
+
+
+def resolve_cursor_hooks_path(scope: str, project_root: str) -> Path:
+    """Resolve the target ``hooks.json`` path for *scope*.
+
+    ``user`` -> ``~/.cursor/hooks.json`` · ``project`` -> ``<project_root>/.cursor/hooks.json``.
+
+    Raises:
+        ValueError: if *scope* is not ``"user"`` or ``"project"``.
+    """
+    match scope:
+        case "user":
+            return Path.home() / ".cursor" / "hooks.json"
+        case "project":
+            return Path(project_root) / ".cursor" / "hooks.json"
+        case _:
+            raise ValueError(f"Unknown Cursor scope {scope!r}; expected 'user' or 'project'.")
+
+
+def cursor_hook_install_states(project_root: str) -> list[tuple[str, str, bool]]:
+    """Report, per Cursor scope, whether Doberman's hooks are wired in.
+
+    Returns ``(scope, path, installed)`` for ``user`` then ``project``.
+    **Never raises:** an unreadable or unparseable hooks.json is reported as
+    *not installed* rather than crashing ``status`` / ``doctor``.
+    """
+    states: list[tuple[str, str, bool]] = []
+    for scope in ("user", "project"):
+        path = resolve_cursor_hooks_path(scope, project_root)
+        installed = False
+        try:
+            settings = load_settings(path)
+            hooks_section = settings.get("hooks") or {}
+            installed = any(
+                _is_doberman_entry(entry)
+                for entries in hooks_section.values()
+                if isinstance(entries, list)
+                for entry in entries
+            )
+        except Exception:  # noqa: BLE001,S110 — a bad hooks.json must not crash the caller
+            pass
+        states.append((scope, str(path), installed))
+    return states
+
+
+def registration_issues(settings: dict[str, Any]) -> list[tuple[str, bool]]:
+    """Weaknesses in the live registration, as ``(message, critical)`` pairs.
+
+    Checked in this order, per gate event (:data:`GATE_EVENTS`): not registered
+    at all (critical) · registered but ``failClosed`` is not ``True`` (critical,
+    since Cursor fails OPEN otherwise) · a timeout below the approval window
+    (non-critical: late, not silently open). Then, once: ``sessionStart`` not
+    registered (non-critical — cosmetic, but doctor loses its liveness signal).
+    """
+    hooks_section = settings.get("hooks") or {}
+
+    def _doberman_entries(event: str) -> list[dict[str, Any]]:
+        entries = hooks_section.get(event)
+        if not isinstance(entries, list):
+            return []
+        return [e for e in entries if isinstance(e, dict) and _is_doberman_entry(e)]
+
+    issues: list[tuple[str, bool]] = []
+    for event in GATE_EVENTS:
+        entries = _doberman_entries(event)
+        if not entries:
+            issues.append((f"{event}: not registered", True))
+            continue
+        entry = entries[-1]
+        if entry.get("failClosed") is not True:
+            issues.append(
+                (
+                    f"{event}: failClosed is not true (Cursor fails OPEN on a hook crash or timeout)",
+                    True,
+                )
+            )
+        timeout = entry.get("timeout")
+        is_number = isinstance(timeout, (int, float)) and not isinstance(timeout, bool)
+        if not is_number or timeout < DEFAULT_APPROVAL_TIMEOUT_S:
+            issues.append(
+                (
+                    f"{event}: timeout {timeout}s is below the "
+                    f"{int(DEFAULT_APPROVAL_TIMEOUT_S)}s approval window "
+                    "(an unanswered approval is denied early)",
+                    False,
+                )
+            )
+
+    if not _doberman_entries(EVENT_SESSION_START):
+        issues.append(
+            (
+                "sessionStart: not registered (no session heartbeat; doctor cannot tell "
+                "whether hooks fire)",
+                False,
+            )
+        )
+    return issues
+
+
+def session_marker_path(project_root: str) -> Path:
+    """Where :func:`doberman.hosthooks.cursor.record_session_start` writes its heartbeat."""
+    from doberman.storage.db import CONFIG_DIR
+
+    return Path(project_root) / CONFIG_DIR / SESSION_MARKER
+
+
+def last_session_start(project_root: str) -> str | None:
+    """The marker's ISO timestamp text, or ``None`` if absent/unreadable/unparseable.
+
+    Never raises: a missing or corrupt marker just means "no session seen yet",
+    not a doctor crash.
+    """
+    from datetime import datetime
+
+    try:
+        text = session_marker_path(project_root).read_text(encoding="utf-8").strip()
+        datetime.fromisoformat(text)
+    except Exception:  # noqa: BLE001 — an unreadable/unparseable marker is "no session yet"
+        return None
+    return text

--- a/src/doberman/hosthooks/integrity.py
+++ b/src/doberman/hosthooks/integrity.py
@@ -36,7 +36,20 @@ MANIFEST_ENV = "DOBERMAN_INSTALL_MANIFEST"
 MANIFEST_VERSION = 1
 #: Events whose Doberman group is the gate itself. Losing one means Doberman is
 #: no longer gating calls on that host; anything else (SessionStart) is cosmetic.
-CRITICAL_EVENTS = frozenset({"PreToolUse", "PostToolUse"})
+#: Cursor's four gating events (see doberman.hosthooks.cursor) are the gate
+#: itself; its `sessionStart` is cosmetic, same as Claude/Codex's. Literal set,
+#: not an import of doberman.hosthooks.cursor's constants — this module runs on
+#: the hook hot path.
+CRITICAL_EVENTS = frozenset(
+    {
+        "PreToolUse",
+        "PostToolUse",
+        "preToolUse",
+        "beforeShellExecution",
+        "beforeMCPExecution",
+        "beforeReadFile",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -228,13 +241,16 @@ def note_divergence(host: str, scope: str, settings_path: Path, events: tuple[st
 
 #: Every tracked (host, scope) registration. Codex's scopes are "repo" (the
 #: project-settings analog) and "user" (the global-settings analog) -- see
-#: doberman.hosthooks.install_codex.resolve_codex_hooks_path.
+#: doberman.hosthooks.install_codex.resolve_codex_hooks_path. Cursor's scopes are
+#: "project" and "user" -- see doberman.hosthooks.install_cursor.resolve_cursor_hooks_path.
 _SCOPES: tuple[tuple[str, str], ...] = (
     ("claude", "project"),
     ("claude", "global"),
     ("claude", "local"),
     ("codex", "repo"),
     ("codex", "user"),
+    ("cursor", "project"),
+    ("cursor", "user"),
 )
 
 
@@ -249,6 +265,14 @@ def _live_groups(
 
         path = resolve_settings_path(scope, project_root)
         return path, doberman_groups(load_settings(path))
+    if host == "cursor":
+        from doberman.hosthooks.install_cursor import (
+            cursor_doberman_groups,
+            resolve_cursor_hooks_path,
+        )
+
+        path = resolve_cursor_hooks_path(scope, project_root)
+        return path, cursor_doberman_groups(load_settings(path))
     from doberman.hosthooks.install_codex import codex_doberman_groups, resolve_codex_hooks_path
 
     path = resolve_codex_hooks_path(scope, project_root)

--- a/tests/unit/test_hosthook_cursor.py
+++ b/tests/unit/test_hosthook_cursor.py
@@ -219,6 +219,40 @@ def test_session_start_is_acknowledged(tmp_path):
     assert _run(payload) == ({}, 0)
 
 
+def test_session_start_writes_a_parseable_utc_marker(tmp_path):
+    from datetime import datetime
+
+    payload = _load("pre_shell.json", tmp_path)
+    payload["hook_event_name"] = cursor.EVENT_SESSION_START
+    assert _run(payload) == ({}, 0)
+
+    marker = tmp_path / ".doberman" / cursor.SESSION_MARKER
+    assert marker.exists()
+    datetime.fromisoformat(marker.read_text(encoding="utf-8"))  # never raises
+
+
+def test_session_start_skips_the_marker_for_an_excluded_project(tmp_path, monkeypatch):
+    monkeypatch.setattr(spine_module, "is_excluded", lambda cwd: True)
+    payload = _load("pre_shell.json", tmp_path)
+    payload["hook_event_name"] = cursor.EVENT_SESSION_START
+    assert _run(payload) == ({}, 0)
+    assert not (tmp_path / ".doberman" / cursor.SESSION_MARKER).exists()
+
+
+def test_session_start_swallows_a_write_failure(tmp_path, monkeypatch):
+    real_write_text = Path.write_text
+
+    def _flaky_write_text(self, *args, **kwargs):
+        if self.name == cursor.SESSION_MARKER:
+            raise OSError("disk full")
+        return real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", _flaky_write_text)
+    payload = _load("pre_shell.json", tmp_path)
+    payload["hook_event_name"] = cursor.EVENT_SESSION_START
+    assert _run(payload) == ({}, 0)  # a failed heartbeat must never fail a session start
+
+
 def test_missing_tool_name_fails_closed(tmp_path):
     payload = _shell(tmp_path, "echo hi")
     del payload["tool_name"]

--- a/tests/unit/test_install_hooks_cursor.py
+++ b/tests/unit/test_install_hooks_cursor.py
@@ -492,3 +492,28 @@ def test_gate_passed_uninstall_removes_cursor_project_hooks(tmp_path, monkeypatc
 
     assert result.exit_code == 0, result.output
     assert "doberman hook cursor" not in hooks_path.read_text(encoding="utf-8")
+
+
+def test_event_and_marker_constants_match_the_adapter():
+    # Literals here (see the module comment) must never drift from the adapter.
+    from doberman.hosthooks import cursor, install_cursor
+
+    assert set(install_cursor.GATE_EVENTS) == cursor.GATED_EVENTS
+    assert install_cursor.EVENT_SESSION_START == cursor.EVENT_SESSION_START
+    assert install_cursor.SESSION_MARKER == cursor.SESSION_MARKER
+
+
+def test_installer_import_does_not_load_the_adapter_stack():
+    # The install-integrity check imports this module on every host's hook hot
+    # path; importing the adapter (config, policy, egress) there costs ~400 ms.
+    import subprocess
+    import sys
+
+    code = (
+        "import sys, doberman.hosthooks.install_cursor; "
+        "print('doberman.hosthooks.cursor' in sys.modules)"
+    )
+    out = subprocess.run(  # noqa: S603 - fixed argv, our own interpreter
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert out == "False"

--- a/tests/unit/test_install_hooks_cursor.py
+++ b/tests/unit/test_install_hooks_cursor.py
@@ -1,0 +1,494 @@
+"""Install/uninstall Doberman's Cursor hook into a hooks.json (Cursor adapter slice 2).
+
+Mirrors ``test_install_hooks_codex.py`` for Cursor's FLAT hooks.json shape
+(``{"version": 1, "hooks": {"<event>": [{"command", "timeout", "failClosed"}]}}``):
+idempotent merge, foreign-entry preservation, no-op remove, scope path resolution,
+weak-registration diagnosis, install-manifest integrity, doctor's "Cursor hooks"
+check, and the CLI wiring (``install-hooks``/``uninstall-hooks --host cursor``).
+
+The per-test isolation fixtures in ``tests/conftest.py`` (``isolated_install_manifest``,
+``isolated_fingerprint_key``, ``isolated_password_hash``, ...) are ``autouse`` — no
+local fixture is needed to keep these tests off the real per-user manifest/key/state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from doberman.cli.main import app
+from doberman.hosthooks import integrity
+from doberman.hosthooks.cursor import (
+    EVENT_MCP,
+    EVENT_PRE_TOOL,
+    EVENT_READ,
+    EVENT_SESSION_START,
+    EVENT_SHELL,
+)
+from doberman.hosthooks.install import load_settings, write_settings
+from doberman.hosthooks.install_cursor import (
+    DEFAULT_APPROVAL_TIMEOUT_S,
+    GATE_EVENTS,
+    cursor_doberman_groups,
+    cursor_hook_install_states,
+    merge_cursor_hooks,
+    registration_issues,
+    remove_cursor_hooks,
+    resolve_cursor_hooks_path,
+)
+
+runner = CliRunner()
+
+_ALL_EVENTS = (*GATE_EVENTS, EVENT_SESSION_START)
+
+
+# ---------------------------------------------------------------------------
+# merge_cursor_hooks
+# ---------------------------------------------------------------------------
+
+
+def test_merge_registers_all_five_events():
+    merged = merge_cursor_hooks({})
+    for event in _ALL_EVENTS:
+        assert event in merged["hooks"]
+        assert merged["hooks"][event][0]["command"] == "doberman hook cursor"
+
+
+def test_merge_gate_entries_are_failclosed_with_a_long_enough_timeout():
+    merged = merge_cursor_hooks({})
+    for event in GATE_EVENTS:
+        entry = merged["hooks"][event][0]
+        assert entry["failClosed"] is True
+        assert entry["timeout"] >= DEFAULT_APPROVAL_TIMEOUT_S
+
+
+def test_merge_session_start_entry_is_not_failclosed():
+    merged = merge_cursor_hooks({})
+    entry = merged["hooks"][EVENT_SESSION_START][0]
+    assert entry["failClosed"] is False
+
+
+def test_merge_adds_version_when_absent():
+    merged = merge_cursor_hooks({})
+    assert merged["version"] == 1
+
+
+def test_merge_keeps_an_existing_version():
+    merged = merge_cursor_hooks({"version": 2})
+    assert merged["version"] == 2
+
+
+def test_merge_is_idempotent():
+    once = merge_cursor_hooks({})
+    twice = merge_cursor_hooks(once)
+    for event in _ALL_EVENTS:
+        doberman_entries = [
+            e for e in twice["hooks"][event] if "doberman hook " in e.get("command", "")
+        ]
+        assert len(doberman_entries) == 1  # replaced, never duplicated
+
+
+def test_merge_preserves_foreign_entries_and_events_and_other_keys():
+    existing = {
+        "hooks": {
+            EVENT_PRE_TOOL: [{"command": "some-other-tool", "timeout": 5, "failClosed": True}],
+            "afterFileEdit": [{"command": "formatter.sh", "timeout": 5}],
+        },
+        "other_key": 42,
+    }
+    merged = merge_cursor_hooks(existing)
+    commands = [e["command"] for e in merged["hooks"][EVENT_PRE_TOOL]]
+    assert "some-other-tool" in commands  # foreign entry in the same event kept
+    assert "doberman hook cursor" in commands
+    assert merged["hooks"]["afterFileEdit"][0]["command"] == "formatter.sh"  # foreign event kept
+    assert merged["other_key"] == 42
+
+
+def test_merge_does_not_mutate_input():
+    original = {"hooks": {EVENT_PRE_TOOL: []}}
+    merge_cursor_hooks(original)
+    assert original == {"hooks": {EVENT_PRE_TOOL: []}}
+
+
+# ---------------------------------------------------------------------------
+# remove_cursor_hooks
+# ---------------------------------------------------------------------------
+
+
+def test_remove_is_noop_when_absent():
+    settings = {"version": 1, "hooks": {EVENT_PRE_TOOL: [{"command": "not-doberman"}]}}
+    assert remove_cursor_hooks(settings) == settings
+
+
+def test_remove_strips_doberman_and_keeps_foreign():
+    merged = merge_cursor_hooks(
+        {"hooks": {EVENT_PRE_TOOL: [{"command": "keep-me", "timeout": 5, "failClosed": True}]}}
+    )
+    cleaned = remove_cursor_hooks(merged)
+    commands = [e["command"] for e in cleaned["hooks"][EVENT_PRE_TOOL]]
+    assert commands == ["keep-me"]
+
+
+def test_remove_drops_empty_hooks_key():
+    merged = merge_cursor_hooks({})
+    cleaned = remove_cursor_hooks(merged)
+    assert "hooks" not in cleaned  # only Doberman was present -> hooks removed entirely
+
+
+def test_remove_keeps_version():
+    merged = merge_cursor_hooks({"version": 1})
+    cleaned = remove_cursor_hooks(merged)
+    assert cleaned["version"] == 1
+
+
+def test_round_trip_stays_valid_json_and_bak_is_written(tmp_path):
+    target = tmp_path / ".cursor" / "hooks.json"
+    target.parent.mkdir(parents=True)
+    target.write_text('{"version": 1, "hooks": {}}', encoding="utf-8")
+    write_settings(target, merge_cursor_hooks(load_settings(target)))
+    assert target.with_suffix(".json.bak").exists()
+    assert "doberman hook cursor" in target.read_text(encoding="utf-8")
+
+    write_settings(target, remove_cursor_hooks(load_settings(target)))
+    json.loads(target.read_text(encoding="utf-8"))  # still valid JSON
+    assert "doberman hook cursor" not in target.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# resolve_cursor_hooks_path / cursor_hook_install_states
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_paths():
+    assert resolve_cursor_hooks_path("user", "/repo") == Path.home() / ".cursor" / "hooks.json"
+    assert resolve_cursor_hooks_path("project", "/repo") == Path("/repo") / ".cursor" / "hooks.json"
+
+
+@pytest.mark.parametrize("scope", ["repo", "local"])
+def test_resolve_rejects_unknown_scope(scope):
+    with pytest.raises(ValueError):
+        resolve_cursor_hooks_path(scope, "/repo")
+
+
+def test_install_states_scope_order_and_project_detection(tmp_path):
+    (tmp_path / ".cursor").mkdir()
+    write_settings(tmp_path / ".cursor" / "hooks.json", merge_cursor_hooks({}))
+    states = cursor_hook_install_states(str(tmp_path))
+    assert [s for s, _p, _ok in states] == ["user", "project"]
+    project = next(s for s in states if s[0] == "project")
+    assert project[2] is True
+
+
+def test_install_states_never_raises_on_bad_json(tmp_path):
+    (tmp_path / ".cursor").mkdir()
+    (tmp_path / ".cursor" / "hooks.json").write_text("NOT JSON", encoding="utf-8")
+    states = cursor_hook_install_states(str(tmp_path))
+    assert [s for s, _p, _ok in states] == ["user", "project"]
+    project = next(s for s in states if s[0] == "project")
+    assert project[2] is False
+
+
+# ---------------------------------------------------------------------------
+# registration_issues
+# ---------------------------------------------------------------------------
+
+
+def _complete_settings() -> dict:
+    return merge_cursor_hooks({})
+
+
+def test_registration_issues_empty_for_a_complete_registration():
+    assert registration_issues(_complete_settings()) == []
+
+
+def test_missing_gate_event_is_critical():
+    settings = _complete_settings()
+    del settings["hooks"][EVENT_SHELL]
+    issues = registration_issues(settings)
+    assert (f"{EVENT_SHELL}: not registered", True) in issues
+
+
+def test_failclosed_false_is_critical():
+    settings = _complete_settings()
+    settings["hooks"][EVENT_MCP][0]["failClosed"] = False
+    issues = registration_issues(settings)
+    assert any(msg.startswith(f"{EVENT_MCP}: failClosed is not true") and c for msg, c in issues)
+
+
+def test_low_timeout_is_non_critical():
+    settings = _complete_settings()
+    settings["hooks"][EVENT_READ][0]["timeout"] = 30
+    issues = registration_issues(settings)
+    assert any(
+        msg.startswith(f"{EVENT_READ}: timeout 30s is below") and c is False for msg, c in issues
+    )
+
+
+def test_missing_session_start_is_non_critical():
+    settings = _complete_settings()
+    del settings["hooks"][EVENT_SESSION_START]
+    issues = registration_issues(settings)
+    assert (
+        "sessionStart: not registered (no session heartbeat; doctor cannot tell "
+        "whether hooks fire)",
+        False,
+    ) in issues
+
+
+def test_foreign_only_entry_counts_as_not_registered():
+    settings = {"hooks": {EVENT_PRE_TOOL: [{"command": "someone-elses-tool", "timeout": 999}]}}
+    issues = registration_issues(settings)
+    assert (f"{EVENT_PRE_TOOL}: not registered", True) in issues
+
+
+# ---------------------------------------------------------------------------
+# CLI: install-hooks / uninstall-hooks --host cursor
+# ---------------------------------------------------------------------------
+
+
+def test_cli_install_writes_hooks_json_and_records_manifest(tmp_path):
+    repo = tmp_path / "project"
+    repo.mkdir()
+    result = runner.invoke(app, ["install-hooks", "--host", "cursor", "--path", str(repo)])
+    assert result.exit_code == 0, result.output
+    assert "wrote" in result.output
+
+    hooks_path = resolve_cursor_hooks_path("project", str(repo))
+    assert hooks_path.exists()
+    groups = cursor_doberman_groups(load_settings(hooks_path))
+    assert integrity.verify_install("cursor", "project", hooks_path, groups).state == "intact"
+
+
+def test_cli_install_second_run_says_already_wired(tmp_path):
+    repo = tmp_path / "project"
+    repo.mkdir()
+    runner.invoke(app, ["install-hooks", "--host", "cursor", "--path", str(repo)])
+    result = runner.invoke(app, ["install-hooks", "--host", "cursor", "--path", str(repo)])
+    assert result.exit_code == 0, result.output
+    assert "already wired" in result.output
+
+
+def test_cli_install_dry_run_writes_nothing_and_names_the_five_events(tmp_path):
+    repo = tmp_path / "project"
+    repo.mkdir()
+    result = runner.invoke(
+        app, ["install-hooks", "--host", "cursor", "--path", str(repo), "--dry-run"]
+    )
+    assert result.exit_code == 0, result.output
+    assert not (repo / ".cursor" / "hooks.json").exists()
+    for event in _ALL_EVENTS:
+        assert event in result.output
+
+
+def test_cli_install_local_exits_2(tmp_path):
+    repo = tmp_path / "project"
+    repo.mkdir()
+    result = runner.invoke(
+        app, ["install-hooks", "--host", "cursor", "--local", "--path", str(repo)]
+    )
+    assert result.exit_code == 2
+
+
+def test_cli_install_global_writes_under_home(tmp_path, monkeypatch):
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    repo = tmp_path / "project"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app, ["install-hooks", "--host", "cursor", "--global", "--path", str(repo)]
+    )
+    assert result.exit_code == 0, result.output
+    assert (fake_home / ".cursor" / "hooks.json").exists()
+
+
+def test_cli_uninstall_removes_entries_and_clears_manifest_then_repeat_says_none_found(tmp_path):
+    repo = tmp_path / "project"
+    repo.mkdir()
+    runner.invoke(app, ["install-hooks", "--host", "cursor", "--path", str(repo)])
+    hooks_path = resolve_cursor_hooks_path("project", str(repo))
+
+    result = runner.invoke(app, ["uninstall-hooks", "--host", "cursor", "--path", str(repo)])
+    assert result.exit_code == 0, result.output
+    assert "doberman hook cursor" not in hooks_path.read_text(encoding="utf-8")
+    assert integrity.verify_install("cursor", "project", hooks_path, {}).state == "absent"
+
+    repeat = runner.invoke(app, ["uninstall-hooks", "--host", "cursor", "--path", str(repo)])
+    assert "No Doberman Cursor hooks found" in repeat.output
+
+
+def test_unknown_host_error_names_cursor(tmp_path):
+    result = runner.invoke(app, ["install-hooks", "--host", "bogus", "--path", str(tmp_path)])
+    assert result.exit_code == 2
+    assert "cursor" in result.output.lower()
+
+    result = runner.invoke(app, ["uninstall-hooks", "--host", "bogus", "--path", str(tmp_path)])
+    assert result.exit_code == 2
+    assert "cursor" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Install-integrity manifest
+# ---------------------------------------------------------------------------
+
+
+def test_integrity_intact_after_install_then_diverges_when_failclosed_flips(tmp_path):
+    repo = tmp_path / "project"
+    repo.mkdir()
+    runner.invoke(app, ["install-hooks", "--host", "cursor", "--path", str(repo)])
+    hooks_path = resolve_cursor_hooks_path("project", str(repo))
+
+    statuses = integrity.check_all(str(repo))
+    cursor_status = next(s for s in statuses if s.host == "cursor" and s.scope == "project")
+    assert cursor_status.state == "intact"
+
+    data = json.loads(hooks_path.read_text(encoding="utf-8"))
+    data["hooks"][EVENT_PRE_TOOL][0]["failClosed"] = False
+    hooks_path.write_text(json.dumps(data), encoding="utf-8")
+
+    statuses = integrity.check_all(str(repo))
+    cursor_status = next(s for s in statuses if s.host == "cursor" and s.scope == "project")
+    assert cursor_status.state == "diverged"
+    assert cursor_status.critical is True
+    assert EVENT_PRE_TOOL in cursor_status.diverged_events
+
+    warning = integrity.hook_warning(str(repo))
+    assert warning is not None
+    assert "cursor project" in warning
+
+
+# ---------------------------------------------------------------------------
+# doctor's "Cursor hooks" check
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_not_installed_is_ok_and_mentions_host_cursor(tmp_path):
+    from doberman.cli.doctor import CheckStatus, run_checks
+
+    check = next(r for r in run_checks(str(tmp_path)) if r.name == "Cursor hooks")
+    assert check.status is CheckStatus.OK
+    assert "--host cursor" in check.detail
+
+
+def test_doctor_installed_no_marker_warns(tmp_path):
+    from doberman.cli.doctor import CheckStatus, run_checks
+
+    repo = tmp_path / "project"
+    repo.mkdir()
+    runner.invoke(app, ["install-hooks", "--host", "cursor", "--path", str(repo)])
+
+    check = next(r for r in run_checks(str(repo)) if r.name == "Cursor hooks")
+    assert check.status is CheckStatus.WARN
+    assert "no Cursor session has called back yet" in check.detail
+
+
+def test_doctor_installed_with_marker_is_ok_with_timestamp(tmp_path):
+    from doberman.cli.doctor import CheckStatus, run_checks
+    from doberman.hosthooks.cursor import record_session_start
+
+    repo = tmp_path / "project"
+    repo.mkdir()
+    runner.invoke(app, ["install-hooks", "--host", "cursor", "--path", str(repo)])
+    record_session_start(str(repo))
+
+    check = next(r for r in run_checks(str(repo)) if r.name == "Cursor hooks")
+    assert check.status is CheckStatus.OK
+    assert "last session start" in check.detail
+
+
+def test_doctor_failclosed_false_is_critical_fail(tmp_path):
+    from doberman.cli.doctor import CheckStatus, run_checks
+
+    repo = tmp_path / "project"
+    repo.mkdir()
+    runner.invoke(app, ["install-hooks", "--host", "cursor", "--path", str(repo)])
+    hooks_path = resolve_cursor_hooks_path("project", str(repo))
+    data = json.loads(hooks_path.read_text(encoding="utf-8"))
+    data["hooks"][EVENT_SHELL][0]["failClosed"] = False
+    hooks_path.write_text(json.dumps(data), encoding="utf-8")
+
+    check = next(r for r in run_checks(str(repo)) if r.name == "Cursor hooks")
+    assert check.status is CheckStatus.FAIL
+    assert check.critical is True
+
+
+def test_doctor_low_timeout_warns(tmp_path):
+    from doberman.cli.doctor import CheckStatus, run_checks
+
+    repo = tmp_path / "project"
+    repo.mkdir()
+    runner.invoke(app, ["install-hooks", "--host", "cursor", "--path", str(repo)])
+    hooks_path = resolve_cursor_hooks_path("project", str(repo))
+    data = json.loads(hooks_path.read_text(encoding="utf-8"))
+    data["hooks"][EVENT_READ][0]["timeout"] = 30
+    hooks_path.write_text(json.dumps(data), encoding="utf-8")
+
+    check = next(r for r in run_checks(str(repo)) if r.name == "Cursor hooks")
+    assert check.status is CheckStatus.WARN
+
+
+def test_doctor_host_hooks_check_lists_cursor_project(tmp_path):
+    from doberman.cli.doctor import run_checks
+
+    repo = tmp_path / "project"
+    repo.mkdir()
+    runner.invoke(app, ["install-hooks", "--host", "cursor", "--path", str(repo)])
+
+    check = next(r for r in run_checks(str(repo)) if r.name == "Host hooks")
+    assert "cursor:project" in check.detail
+
+
+def test_run_checks_order_has_cursor_hooks_right_after_hook_integrity(tmp_path):
+    from doberman.cli.doctor import run_checks
+
+    names = [r.name for r in run_checks(str(tmp_path))]
+    assert names.index("Cursor hooks") == names.index("Hook integrity") + 1
+
+
+# ---------------------------------------------------------------------------
+# doberman uninstall (project-scoped) also cleans up Cursor
+# ---------------------------------------------------------------------------
+
+
+def test_project_uninstall_targets_lists_cursor_when_installed(tmp_path):
+    from doberman.cli.main import _project_uninstall_targets
+
+    repo = tmp_path / "project"
+    repo.mkdir()
+    runner.invoke(app, ["install-hooks", "--host", "cursor", "--path", str(repo)])
+
+    targets = _project_uninstall_targets(str(repo))
+    assert any(desc == "Cursor hooks (project)" for desc, _p in targets)
+
+
+def test_gate_passed_uninstall_removes_cursor_project_hooks(tmp_path, monkeypatch):
+    from doberman.auth import password
+    from doberman.cli import main as cli_main
+    from doberman.config import save_policy
+    from doberman.policy.checklist import recommend_policy
+
+    class _Correct:
+        def confirm(self, message):
+            return True
+
+        def read_code(self, message):
+            return _password
+
+    _password = "correct horse battery staple"  # noqa: S105 — synthetic test credential
+    password.enroll(_password)
+    monkeypatch.setattr(cli_main, "CliPrompter", lambda: _Correct())
+
+    repo = tmp_path / "project"
+    repo.mkdir()
+    runner.invoke(app, ["install-hooks", "--host", "cursor", "--path", str(repo)])
+    hooks_path = resolve_cursor_hooks_path("project", str(repo))
+    save_policy(recommend_policy(), str(repo))
+
+    result = runner.invoke(app, ["uninstall", "--path", str(repo), "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "doberman hook cursor" not in hooks_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: Cursor native-hooks adapter, slice 2 of 2 (installer, manifest scope, session heartbeat, doctor). Refs #202 (the Cursor part of the umbrella issue). Follows #568 (the hook) and #569 (the stdin fix).
- Plan reference: `docs/CONNECTOR_MEMO_CURSOR.md` (#563); slice 1 = #568.

## What this PR does

**`doberman install-hooks --host cursor`** (`src/doberman/hosthooks/install_cursor.py`, new) writes or merges `.cursor/hooks.json` (project; `--global` → `~/.cursor/hooks.json`), mirroring the Codex installer against Cursor's flat entry shape (`{command, timeout, failClosed}` — no nested `hooks` list, no `matcher`, so the Claude/Codex group sentinel never matches it and the module carries its own `doberman hook ` entry predicate).

| Event | Entry written |
|---|---|
| `preToolUse` / `beforeShellExecution` / `beforeMCPExecution` / `beforeReadFile` | `doberman hook cursor`, **`failClosed: true`**, timeout 120 s (Doberman's approval window is 90 s; Cursor's timeout must outlast the in-hook dialog or an unanswered approval is denied by the clock instead of the human) |
| `sessionStart` | `doberman hook cursor`, `failClosed: false`, timeout 10 s — a liveness heartbeat, never a gate, so a failed heartbeat can never abort a session |

- Idempotent merge (replace in place, never duplicate); foreign entries, foreign events and every other key preserved; `version: 1` added only when absent. `uninstall-hooks --host cursor` reverses it; `doberman uninstall` (project scope) and `doberman uninstall --global` include the Cursor files in their plan and removal.
- **Install-integrity manifest** (#239): new `cursor/project` and `cursor/user` scopes. The fingerprint covers `timeout` and `failClosed`, so a hand-weakened file diverges; Cursor's four gating events join `CRITICAL_EVENTS`, so that divergence is critical (a FAIL in `doctor`, the stderr warning on the next surviving hook).
- **`sessionStart` heartbeat:** the hook writes the UTC time to `.doberman/cursor_session` (best-effort, exclusion respected, never raises, still answers `{}`).
- **`doctor` "Cursor hooks"** (right after "Hook integrity"): nothing installed → OK (opt-in host); a gating event missing or `failClosed` not true → **FAIL (critical)**; timeout under the approval window or `sessionStart` missing → WARN; wired but no session has called back yet → WARN (Cursor has no self-check and hooks are known to intermittently not fire); otherwise OK with the last session-start time. "Host hooks" and `status` now list `cursor:<scope>`; the shared `protection_state` predicate counts Cursor scopes.
- Docs: `adapters/cursor/README.md` (Install / Self-check / updated limits), root README hosts row, `docs/CLI.md` `--host` cells. Changelog fragment covers this PR and #569.

## Tests added (run in CI)
- `tests/unit/test_install_hooks_cursor.py` (new): merge registers all five events with the right `failClosed`/timeout, adds/keeps `version`, idempotent, preserves foreign entries and keys, never mutates input; remove is a no-op when absent, keeps foreign entries and `version`, drops an empty `hooks`, `.bak` written, file stays valid JSON; path resolution + unknown scope; install states never raise on `NOT JSON`; `registration_issues` for complete / missing event / `failClosed` false / low timeout / missing `sessionStart` / foreign-only entry; CLI install (`wrote` → `already wired`, manifest entry recorded, `--dry-run` writes nothing, `--local` exits 2, `--global` → user path) and uninstall (entries removed, manifest cleared, repeat says nothing to remove); integrity intact → `failClosed` flipped → diverged + critical, `hook_warning` names `cursor project`; doctor states (OK / WARN no-session / OK with timestamp / FAIL critical / WARN timeout, "Host hooks" lists `cursor:project`, check order); uninstall targets and the gate-passed `doberman uninstall` removing the Cursor file.
- `tests/unit/test_hosthook_cursor.py`: the heartbeat writes a parseable UTC marker; skipped for an excluded project; an `OSError` on write is swallowed and the response is still `{}` / exit 0.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty (an unreadable hooks.json is "not installed"/"unreadable", never an implied allow; `doctor`/`status` never raise; the heartbeat can only ever fail silent)
- [x] No secret, full file, or unredacted prompt logged or committed (the manifest stores keyed fingerprints of the entries, never the file)
- [x] Any guardrail/learning change is raise-only (the installer only adds `failClosed: true` registrations; critical-event set is additive)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged — this slice adds no decision path)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- `doberman setup` does not offer Cursor as a host yet (the wizard's host table still routes Cursor to the MCP proxy) — deliberately left out of this slice; a contributor-sized follow-up.
- The heartbeat only proves a session started; it cannot prove every later hook fired. `doctor` says so.
- `sessionStart` payload shape is documentation-derived like the rest of the fixtures; the heartbeat needs only `workspace_roots`/`cwd`.
