### PR TITLE
feat(proxy): doberman serve --url fronts a remote Streamable HTTP / SSE MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ stays empty. That last assertion is the chokepoint property the whole project ha
 > The rest of the integration suite deliberately uses an in-process fake downstream
 > ([`tests/fixtures/fake_tool_server.py`](tests/fixtures/fake_tool_server.py)) that records every call
 > it executes, so the tests can prove a blocked action reached nothing. It's a test fixture, not the
-> runtime. `doberman serve` always spawns and talks to the real server you give it after `--`.
+> runtime. `doberman serve` always talks to the real server: the one it spawns from the command after
+> `--`, or the remote one you point it at with `--url`.
 
 Doberman's proxy speaks MCP as pinned in `pyproject.toml` (`mcp>=1.27,<2`). Its cross-call protections
 (taint ledger, read-vs-send fingerprints, decision log) key off repo-local identity, never the

--- a/changelog.d/574.md
+++ b/changelog.d/574.md
@@ -1,0 +1,7 @@
+- **`doberman serve --url` fronts a remote MCP server.** `doberman serve --url https://host/mcp` proxies a
+  Streamable HTTP endpoint (`--transport sse` for the legacy SSE transport; repeatable `--header/-H "Name:
+  value"` for a bearer token) through the same policy chokepoint as `doberman serve -- <cmd>`: every downstream
+  `tools/call` still goes through `decide_and_execute`, and a BLOCK reaches no tool. Validation errors (URL plus a
+  command, a non-http(s) URL, an unknown transport, `--header` without `--url`, a malformed header) exit 2 before
+  anything connects; a transport failure exits 1 with a one-line error. Header values and the URL's query string
+  are never logged. Refs #202.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -39,7 +39,7 @@ Day-to-day posture, status, and review commands.
 | `doberman telemetry off` | Opt out. Sends one final best-effort disabled event only if telemetry had already minted an id (nothing to send, and no id minted, if this is the very first choice made on a fresh install). | none |
 | `doberman telemetry status` | Show effective state, the random distinct id, and active kill switches; a disabled reading names `doberman telemetry on` to opt back in, symmetric with the default-on reading's own `doberman telemetry off` pointer. | none |
 | `doberman session-summary` | Print the device-global session-guard summary and exit. Always exits 0; never blocks a session. | none |
-| `doberman serve` | Run Doberman as an MCP proxy in front of a downstream MCP tool server. | `--path`/`-p` |
+| `doberman serve` | Run Doberman as an MCP proxy in front of a downstream MCP tool server (spawned over stdio) or a remote server. | `--path`/`-p`, `--url`, `--transport`, `--header`/`-H` |
 | `doberman version` | Print the installed Doberman version. `doberman --version` / `-V` does the same. | none |
 
 ## Auth enrollment

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -308,6 +308,34 @@ claude mcp add doberman -- doberman serve -- npx -y @modelcontextprotocol/server
 Cursor, Codex, or any MCP-compatible client uses the same `mcpServers` format in its own config
 file; substitute your own tool server command after `--`.
 
+**Remote servers.** A server reached over the network instead of spawned as a subprocess —
+Streamable HTTP (default) or legacy SSE — is fronted with `--url` instead of a command after `--`:
+
+```bash
+doberman serve --url https://mcp.example.com/mcp
+doberman serve --url https://mcp.example.com/sse --transport sse   # legacy SSE endpoint
+```
+
+A bearer token (or any credential) goes through `--header`/`-H` (repeatable, `"Name: value"`),
+expanded by your shell so it never lands in argv or shell/process history:
+
+```bash
+doberman serve --url https://mcp.example.com/mcp -H "Authorization: Bearer $MCP_TOKEN"
+```
+
+Agent config JSON points `args` at `--url` instead of a spawned command:
+
+```json
+{
+  "mcpServers": {
+    "doberman": {
+      "command": "doberman",
+      "args": ["serve", "--url", "https://mcp.example.com/mcp"]
+    }
+  }
+}
+```
+
 The proxy protects only the tools you route through it. To gate the agent's built-in tools too
 (`Bash`, `Edit`, `Write`, ...), use [Claude Code hooks](#claude-code-hooks) where your host
 supports them.

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -332,7 +332,7 @@ def serve(
     # imports run synchronously, before asyncio.run, so nothing loads in-loop.
     from mcp import StdioServerParameters
 
-    from doberman.proxy.serve import serve_http, serve_stdio
+    from doberman.proxy.serve import _redacted, serve_http, serve_stdio
 
     downstream_argv = list(ctx.args)
 
@@ -380,7 +380,16 @@ def serve(
         else:
             asyncio.run(serve_stdio(params, repo_root=path))
     except Exception as exc:  # noqa: BLE001 - surface a clean stderr error, never a raw traceback
-        typer.echo(f"error: doberman serve failed: {exc}", err=True)
+        if url is not None:
+            # Never echo `exc` here: transport errors embed the request URL (query
+            # string included) and can quote header values.
+            typer.echo(
+                f"error: doberman serve failed: could not serve {_redacted(url)} "
+                f"({type(exc).__name__})",
+                err=True,
+            )
+        else:
+            typer.echo(f"error: doberman serve failed: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
 

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -283,12 +283,42 @@ def serve(
     path: str = typer.Option(
         ".", "--path", "-p", help="Repo root whose .doberman/ policy governs decisions."
     ),
+    url: str | None = typer.Option(
+        None,
+        "--url",
+        help=(
+            "Front a remote MCP server at this http(s) URL instead of spawning a command "
+            "(Streamable HTTP by default)."
+        ),
+    ),
+    transport: str = typer.Option(
+        "http",
+        "--transport",
+        help="With --url: 'http' (Streamable HTTP, default) or 'sse' (legacy SSE).",
+    ),
+    header: list[str] = typer.Option(  # noqa: B008 — Typer's Option() factory, not a mutable default
+        [],
+        "--header",
+        "-H",
+        help=(
+            "With --url: extra request header, 'Name: value' (repeatable). Pass secrets via "
+            "your shell's env expansion; argv is visible to local processes."
+        ),
+    ),
 ) -> None:
     """Run Doberman as an MCP proxy in front of a downstream MCP server.
 
     Everything after `--` is the downstream server command, for example:
 
         doberman serve -- npx -y @modelcontextprotocol/server-filesystem /path/to/repo
+
+    Or front a remote MCP server directly (Streamable HTTP by default; `--transport sse` for
+    legacy endpoints):
+
+        doberman serve --url https://mcp.example.com/mcp
+
+    A bearer token goes through a header, expanded by your shell so it never lands in argv or
+    shell history: `doberman serve --url ... -H "Authorization: Bearer $MCP_TOKEN"`.
 
     Point your agent's MCP config at this instead of the real server. AUTH prompts appear on
     your terminal; with no terminal attached (headless) an AUTH action is denied (fail closed).
@@ -302,18 +332,53 @@ def serve(
     # imports run synchronously, before asyncio.run, so nothing loads in-loop.
     from mcp import StdioServerParameters
 
-    from doberman.proxy.serve import serve_stdio
+    from doberman.proxy.serve import serve_http, serve_stdio
 
     downstream_argv = list(ctx.args)
-    if not downstream_argv:
+
+    if url is not None and downstream_argv:
+        typer.echo("error: use --url or a downstream command after '--', not both", err=True)
+        raise typer.Exit(code=2)
+    if url is None and not downstream_argv:
         typer.echo("error: provide the downstream server command after `--`", err=True)
         raise typer.Exit(code=2)
-    params = StdioServerParameters(command=downstream_argv[0], args=downstream_argv[1:])
+
+    if url is not None and not (url.startswith("http://") or url.startswith("https://")):
+        typer.echo("error: --url must be an http(s) URL", err=True)
+        raise typer.Exit(code=2)
+    if transport not in ("http", "sse"):
+        typer.echo("error: --transport must be 'http' or 'sse'", err=True)
+        raise typer.Exit(code=2)
+
+    headers: dict[str, str] | None = None
+    if url is None:
+        # A downstream command was given (the checks above ruled out "neither").
+        if header:
+            typer.echo("error: --header only applies with --url", err=True)
+            raise typer.Exit(code=2)
+        if transport != "http":
+            typer.echo("error: --transport only applies with --url", err=True)
+            raise typer.Exit(code=2)
+        params = StdioServerParameters(command=downstream_argv[0], args=downstream_argv[1:])
+    else:
+        parsed_headers: dict[str, str] = {}
+        for entry in header:
+            name, _sep, value = entry.partition(":")
+            name, value = name.strip(), value.strip()
+            if not _sep or not name or not value:
+                typer.echo("error: --header expects 'Name: value'", err=True)
+                raise typer.Exit(code=2)
+            parsed_headers[name] = value
+        headers = parsed_headers or None
+
     _configure_stderr_logging()
     if _stderr_is_tty():  # a human ran it; a client-spawned process gets a pipe
         typer.echo(f"doberman: {_SERVE_WAITING_HINT}", err=True)
     try:
-        asyncio.run(serve_stdio(params, repo_root=path))
+        if url is not None:
+            asyncio.run(serve_http(url, repo_root=path, headers=headers, transport=transport))
+        else:
+            asyncio.run(serve_stdio(params, repo_root=path))
     except Exception as exc:  # noqa: BLE001 - surface a clean stderr error, never a raw traceback
         typer.echo(f"error: doberman serve failed: {exc}", err=True)
         raise typer.Exit(code=1) from exc

--- a/src/doberman/proxy/serve.py
+++ b/src/doberman/proxy/serve.py
@@ -1,10 +1,12 @@
-"""Run Doberman as a real MCP proxy over stdio in front of one downstream tool server.
+"""Run Doberman as a real MCP proxy over stdio in front of one downstream tool server —
+spawned over stdio, or reached over Streamable HTTP / SSE.
 
 Doberman is an MCP *server* to the agent (over this process's stdin/stdout) and an MCP
-*client* to the downstream server (which it spawns). Every ``tools/call`` flows through the
-single chokepoint (:func:`doberman.proxy.executor.decide_and_execute`) — there is no path
-around it. This is the deployable counterpart to :func:`doberman.proxy.mcp_proxy.build_proxy_server`,
-which builds the proxy object; this module gives it a transport.
+*client* to the downstream server (spawned, or a remote endpoint it connects to). Every
+``tools/call`` flows through the single chokepoint
+(:func:`doberman.proxy.executor.decide_and_execute`) — there is no path around it. This is
+the deployable counterpart to :func:`doberman.proxy.mcp_proxy.build_proxy_server`, which
+builds the proxy object; this module gives it a transport.
 
 SECURITY: nothing here writes this process's stdout (that is the agent's MCP channel). AUTH
 challenges try four channels in order: the **dashboard** first
@@ -23,6 +25,9 @@ available the challenge denies (fail closed). A prompt never touches the agent s
 
 import asyncio
 import logging
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from urllib.parse import urlsplit
 
 from mcp import ClientSession, StdioServerParameters, stdio_client
 from mcp.server.stdio import stdio_server
@@ -39,8 +44,21 @@ from doberman.proxy.mcp_proxy import build_proxy_server
 logger = logging.getLogger("doberman.proxy.serve")
 
 
-async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = ".") -> None:
-    """Spawn ``downstream``, then serve the Doberman proxy to the agent over stdio.
+def _redacted(url: str) -> str:
+    """Strip the query string and fragment before a URL is ever logged — the query string
+    may carry a bearer token or similar credential."""
+    return urlsplit(url)._replace(query="", fragment="").geturl()
+
+
+async def _serve(
+    open_downstream: Callable[[], AbstractAsyncContextManager[tuple]],
+    label: str,
+    *,
+    repo_root: str,
+) -> None:
+    """Shared body of ``serve_stdio``/``serve_http``: point the engine at ``repo_root``, open
+    one downstream MCP connection via ``open_downstream()`` (an async context manager
+    yielding ``(read, write, *rest)``), and proxy it to the agent over stdio.
 
     Points the engine at ``repo_root`` (its ``.doberman/`` holds the active role, policy,
     decision log, and elevation store) and installs the dashboard→elicitation→GUI→terminal
@@ -63,8 +81,9 @@ async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = "."
         rules=executor._default_objective_rules(velocity_thresholds=_velocity_thresholds)
     )
 
-    logger.info("starting downstream: %s", downstream.command)
-    async with stdio_client(downstream) as (downstream_read, downstream_write):
+    logger.info("starting downstream: %s", label)
+    async with open_downstream() as streams:
+        downstream_read, downstream_write = streams[0], streams[1]
         async with ClientSession(downstream_read, downstream_write) as session:
             await session.initialize()
             proxy = build_proxy_server(session)
@@ -83,3 +102,47 @@ async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = "."
                 # non-UTF-8 capture turns the em-dash into a replacement char in their log.
                 logger.info("ready - proxying tool calls to the agent over stdio")
                 await proxy.run(agent_read, agent_write, proxy.create_initialization_options())
+
+
+async def serve_stdio(downstream: StdioServerParameters, *, repo_root: str = ".") -> None:
+    """Spawn ``downstream``, then serve the Doberman proxy to the agent over stdio.
+
+    See :func:`_serve` for the shared behaviour (repo root, prompter chain, transport
+    failure semantics).
+    """
+    await _serve(lambda: stdio_client(downstream), downstream.command, repo_root=repo_root)
+
+
+async def serve_http(
+    url: str,
+    *,
+    repo_root: str = ".",
+    headers: dict[str, str] | None = None,
+    transport: str = "http",
+) -> None:
+    """Front a remote MCP server reached over HTTP, then serve the Doberman proxy to the
+    agent over stdio.
+
+    ``transport`` selects the downstream wire protocol: ``"http"`` (default) is Streamable
+    HTTP, ``"sse"`` is the legacy SSE transport. See :func:`_serve` for the shared behaviour.
+    Never logs a header value or the URL's query string (only :func:`_redacted` (url) is
+    logged).
+    """
+    # Imported lazily (they pull in httpx) and referenced through the module object so
+    # tests can monkeypatch `mcp.client.streamable_http.streamablehttp_client` /
+    # `mcp.client.sse.sse_client` directly.
+    import mcp.client.sse as _sse_mod
+    import mcp.client.streamable_http as _http_mod
+
+    if transport == "http":
+
+        def _opener() -> AbstractAsyncContextManager[tuple]:
+            return _http_mod.streamablehttp_client(url, headers=headers)
+    elif transport == "sse":
+
+        def _opener() -> AbstractAsyncContextManager[tuple]:
+            return _sse_mod.sse_client(url, headers=headers)
+    else:
+        raise ValueError(f"unknown transport {transport!r}; expected 'http' or 'sse'")
+
+    await _serve(_opener, _redacted(url), repo_root=repo_root)

--- a/tests/integration/test_serve_url_end_to_end.py
+++ b/tests/integration/test_serve_url_end_to_end.py
@@ -1,0 +1,167 @@
+"""End-to-end test of `doberman serve --url`: a real agent <-> doberman <-> remote-HTTP chain.
+
+The HTTP twin of :mod:`test_serve_end_to_end` — same real agent/proxy/downstream round trip
+and the same chokepoint assertions, but the downstream server is a `FastMCP` app served over
+Streamable HTTP by a real `uvicorn` server in a background thread instead of a spawned stdio
+subprocess. Proves `--url` wires the deployable proxy exactly like the stdio path: a PASS
+reaches the tool (a line in the call-log); a BLOCK does not.
+
+``uvicorn`` is a ``dev``-extra-only dependency (never a runtime one), hence the importorskip.
+"""
+
+import asyncio
+import json
+import os
+import socket
+import sys
+import threading
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession, StdioServerParameters, stdio_client
+
+uvicorn = pytest.importorskip("uvicorn")
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402 - after importorskip
+
+# Generous bound for a *real* two-process (proxy + uvicorn) MCP/HTTP round-trip: process
+# spawn + handshake is slow on Windows/CI and saturates under parallel load. This guards
+# against a genuine hang, not slowness — the behavioral assertions below are what the test
+# actually checks. Mirrors test_serve_end_to_end.py's stdio twin.
+_TIMEOUT_S = 90.0
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _build_downstream_app(call_log: Path) -> FastMCP:
+    """A FastMCP app mirroring tests/fixtures/stdio_tool_server.py's tool surface: every
+    executed call is appended as one JSON line ``[tool_name, arguments]`` to ``call_log``, so
+    the test can assert exactly what reached a tool (the chokepoint property)."""
+    app = FastMCP("http-downstream")
+
+    def _record(tool_name: str, arguments: dict) -> None:
+        with open(call_log, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps([tool_name, arguments]) + "\n")
+
+    @app.tool()
+    def fs_write(path: str, content: str) -> str:
+        """Write content to a file."""
+        _record("fs_write", {"path": path, "content": content})
+        return "ok: fs_write executed"
+
+    @app.tool()
+    def fs_delete(path: str) -> str:
+        """Delete a file."""
+        _record("fs_delete", {"path": path})
+        return "ok: fs_delete executed"
+
+    @app.tool()
+    def shell_exec(command: str) -> str:
+        """Run a shell command."""
+        _record("shell_exec", {"command": command})
+        return "ok: shell_exec executed"
+
+    @app.tool()
+    def net_get(url: str) -> str:
+        """HTTP GET a URL."""
+        _record("net_get", {"url": url})
+        return "ok: net_get executed"
+
+    return app
+
+
+@pytest.fixture
+def http_downstream(tmp_path):
+    """Serve a FastMCP app over Streamable HTTP in a background thread; yields
+    ``(url, call_log)``. Streamable HTTP is mounted at ``/mcp`` (FastMCP's
+    ``streamable_http_path`` default — verified against the installed SDK, not assumed)."""
+    call_log = tmp_path / "calls.log"
+    app = _build_downstream_app(call_log)
+    port = _free_port()
+    config = uvicorn.Config(
+        app.streamable_http_app(),
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        # Streamable HTTP/SSE run over plain HTTP, not websockets; skip loading uvicorn's
+        # "auto" websocket protocol (which imports the deprecated `websockets.legacy` and
+        # trips this repo's warnings-as-errors pytest config from the background thread).
+        ws="none",
+    )
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                break
+        except OSError:
+            time.sleep(0.05)
+    else:
+        raise RuntimeError("http_downstream fixture: uvicorn server did not start in time")
+    try:
+        yield f"http://127.0.0.1:{port}/mcp", call_log
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10.0)
+
+
+@asynccontextmanager
+async def _agent_through_doberman(repo_root: Path, url: str) -> AsyncIterator[ClientSession]:
+    """An MCP client connected to `doberman serve --url`, which fronts the FastMCP downstream."""
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "doberman.cli.main", "serve", "--path", str(repo_root), "--url", url],
+        # Full env so the child can import doberman (venv) and find the interpreter.
+        env={**os.environ},
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as agent:
+            await agent.initialize()
+            yield agent
+
+
+def _logged_tools(call_log: Path) -> list[str]:
+    if not call_log.exists():
+        return []
+    return [
+        json.loads(line)[0] for line in call_log.read_text(encoding="utf-8").splitlines() if line
+    ]
+
+
+async def test_downstream_tools_are_re_exposed_over_http(tmp_path, http_downstream):
+    url, _call_log = http_downstream
+    async with asyncio.timeout(_TIMEOUT_S):
+        async with _agent_through_doberman(tmp_path, url) as agent:
+            result = await agent.list_tools()
+    names = {tool.name for tool in result.tools}
+    assert {"fs_write", "fs_delete", "shell_exec", "net_get"} <= names
+
+
+async def test_pass_decision_reaches_the_http_tool(tmp_path, http_downstream):
+    url, call_log = http_downstream
+    async with asyncio.timeout(_TIMEOUT_S):
+        async with _agent_through_doberman(tmp_path, url) as agent:
+            # A fetch to a trusted host PASSes (mirrors test_proxy_passthrough.py).
+            result = await agent.call_tool("net_get", {"url": "https://github.com/owner/repo"})
+    assert not result.isError
+    assert "net_get" in _logged_tools(call_log)
+
+
+async def test_block_decision_reaches_no_http_tool(tmp_path, http_downstream):
+    url, call_log = http_downstream
+    async with asyncio.timeout(_TIMEOUT_S):
+        async with _agent_through_doberman(tmp_path, url) as agent:
+            # A catastrophic command is BLOCKed by the objective guardrail.
+            result = await agent.call_tool("shell_exec", {"command": "rm -rf /"})
+    assert result.isError
+    # The chokepoint property: the blocked call never reached the downstream tool.
+    assert "shell_exec" not in _logged_tools(call_log)

--- a/tests/unit/test_serve.py
+++ b/tests/unit/test_serve.py
@@ -10,6 +10,8 @@ import logging
 import sys
 from contextlib import asynccontextmanager
 
+import mcp.client.sse
+import mcp.client.streamable_http
 import pytest
 from mcp import StdioServerParameters
 from typer.testing import CliRunner
@@ -185,3 +187,261 @@ async def test_serve_stdio_sets_repo_root_and_elicitation_first_prompter(monkeyp
     assert ran["session_args"] == ("d_read", "d_write")  # downstream streams wired into the session
     assert ran["initialized"] is True
     assert ran["run"] == ("a_read", "a_write", "init-opts")
+
+
+# --- CLI parsing: --url ------------------------------------------------------------
+
+
+def test_url_calls_serve_http_with_defaults(monkeypatch, _no_logging_mutation):
+    """Bare `--url` fronts the remote server over Streamable HTTP with no extra headers."""
+    seen: dict = {}
+    stdio_called = False
+
+    async def _http_spy(url, *, repo_root, headers, transport):
+        seen.update(url=url, repo_root=repo_root, headers=headers, transport=transport)
+
+    async def _stdio_spy(*_a, **_k):
+        nonlocal stdio_called
+        stdio_called = True
+
+    monkeypatch.setattr(serve_mod, "serve_http", _http_spy)
+    monkeypatch.setattr(serve_mod, "serve_stdio", _stdio_spy)
+
+    result = runner.invoke(cli.app, ["serve", "--url", "https://h.example/mcp"])
+
+    assert result.exit_code == 0, result.output
+    assert not stdio_called
+    assert seen == {
+        "url": "https://h.example/mcp",
+        "repo_root": ".",
+        "headers": None,
+        "transport": "http",
+    }
+
+
+def test_url_with_sse_transport_and_headers(monkeypatch, _no_logging_mutation):
+    seen: dict = {}
+
+    async def _http_spy(url, *, repo_root, headers, transport):
+        seen.update(url=url, repo_root=repo_root, headers=headers, transport=transport)
+
+    monkeypatch.setattr(serve_mod, "serve_http", _http_spy)
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "serve",
+            "--url",
+            "https://h.example/mcp",
+            "--transport",
+            "sse",
+            "-H",
+            "Authorization: Bearer x",
+            "-H",
+            "X-A: b",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen["transport"] == "sse"
+    assert seen["headers"] == {"Authorization": "Bearer x", "X-A": "b"}
+
+
+def test_url_and_command_together_exit_2(monkeypatch, _no_logging_mutation):
+    called: list[str] = []
+    monkeypatch.setattr(serve_mod, "serve_http", lambda *a, **k: called.append("http"))
+    monkeypatch.setattr(serve_mod, "serve_stdio", lambda *a, **k: called.append("stdio"))
+
+    result = runner.invoke(cli.app, ["serve", "--url", "https://h/mcp", "--", "mytool"])
+
+    assert result.exit_code == 2
+    assert not called
+
+
+def test_bad_url_scheme_exits_2(monkeypatch, _no_logging_mutation):
+    called: list[str] = []
+    monkeypatch.setattr(serve_mod, "serve_http", lambda *a, **k: called.append("http"))
+
+    result = runner.invoke(cli.app, ["serve", "--url", "ftp://h/mcp"])
+
+    assert result.exit_code == 2
+    assert not called
+
+
+def test_bad_transport_exits_2(monkeypatch, _no_logging_mutation):
+    called: list[str] = []
+    monkeypatch.setattr(serve_mod, "serve_http", lambda *a, **k: called.append("http"))
+
+    result = runner.invoke(cli.app, ["serve", "--url", "https://h/mcp", "--transport", "bogus"])
+
+    assert result.exit_code == 2
+    assert not called
+
+
+def test_transport_without_url_exits_2(monkeypatch, _no_logging_mutation):
+    """`--transport` only means anything alongside `--url`."""
+    called: list[str] = []
+    monkeypatch.setattr(serve_mod, "serve_stdio", lambda *a, **k: called.append("stdio"))
+
+    result = runner.invoke(cli.app, ["serve", "--transport", "sse", "--", "mytool"])
+
+    assert result.exit_code == 2
+    assert not called
+
+
+def test_header_without_url_exits_2(monkeypatch, _no_logging_mutation):
+    called: list[str] = []
+    monkeypatch.setattr(serve_mod, "serve_stdio", lambda *a, **k: called.append("stdio"))
+
+    result = runner.invoke(cli.app, ["serve", "-H", "Authorization: Bearer x", "--", "mytool"])
+
+    assert result.exit_code == 2
+    assert not called
+
+
+def test_malformed_header_exits_2(monkeypatch, _no_logging_mutation):
+    called: list[str] = []
+    monkeypatch.setattr(serve_mod, "serve_http", lambda *a, **k: called.append("http"))
+
+    result = runner.invoke(cli.app, ["serve", "--url", "https://h/mcp", "-H", "NoColonHere"])
+
+    assert result.exit_code == 2
+    assert not called
+
+
+def test_url_failure_reports_cleanly(monkeypatch, _no_logging_mutation):
+    """A failure to connect/serve the remote server becomes a clean stderr error + exit 1."""
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("downstream boom")
+
+    monkeypatch.setattr(serve_mod, "serve_http", _boom)
+
+    result = runner.invoke(cli.app, ["serve", "--url", "https://h/mcp"])
+
+    assert result.exit_code == 1
+    assert "doberman serve failed" in result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+# --- serve_http wiring -------------------------------------------------------------
+
+
+async def test_serve_http_wires_streamable_http_client(monkeypatch):
+    """`transport="http"` opens `streamablehttp_client` with the url + headers and wires the
+    same repo-root / prompter-chain / stdio-to-the-agent behaviour as `serve_stdio`."""
+    ran: dict = {}
+
+    @asynccontextmanager
+    async def _fake_streamablehttp_client(url, headers=None):
+        ran["opened_with"] = (url, headers)
+        yield ("d_read", "d_write", lambda: "session-id")  # 3-tuple, per the real client
+
+    class _FakeSession:
+        def __init__(self, read, write):
+            ran["session_args"] = (read, write)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def initialize(self):
+            ran["initialized"] = True
+
+    @asynccontextmanager
+    async def _fake_stdio_server():
+        yield ("a_read", "a_write")
+
+    class _FakeProxy:
+        def create_initialization_options(self):
+            return "init-opts"
+
+        async def run(self, read, write, opts):
+            ran["run"] = (read, write, opts)
+
+    monkeypatch.setattr(
+        mcp.client.streamable_http, "streamablehttp_client", _fake_streamablehttp_client
+    )
+    monkeypatch.setattr(serve_mod, "ClientSession", _FakeSession)
+    monkeypatch.setattr(serve_mod, "stdio_server", _fake_stdio_server)
+    monkeypatch.setattr(serve_mod, "build_proxy_server", lambda _session: _FakeProxy())
+
+    await serve_mod.serve_http(
+        "https://h.example/mcp?token=x",
+        repo_root="/some/repo",
+        headers={"Authorization": "Bearer y"},
+        transport="http",
+    )
+
+    assert ran["opened_with"] == (
+        "https://h.example/mcp?token=x",
+        {"Authorization": "Bearer y"},
+    )
+    assert executor.REPO_ROOT == "/some/repo"
+    assert isinstance(executor.AUTH_PROMPTER, FallbackPrompter)
+    assert [type(p) for p in executor.AUTH_PROMPTER.prompters] == [
+        DashboardPrompter,
+        ElicitationPrompter,
+        GuiPrompter,
+        TtyPrompter,
+    ]
+    assert ran["session_args"] == ("d_read", "d_write")
+    assert ran["initialized"] is True
+    assert ran["run"] == ("a_read", "a_write", "init-opts")
+
+
+async def test_serve_http_wires_sse_client(monkeypatch):
+    """`transport="sse"` opens the legacy `sse_client` (a 2-tuple) instead."""
+    ran: dict = {}
+
+    @asynccontextmanager
+    async def _fake_sse_client(url, headers=None):
+        ran["opened_with"] = (url, headers)
+        yield ("d_read", "d_write")  # 2-tuple, per the real client
+
+    class _FakeSession:
+        def __init__(self, read, write):
+            ran["session_args"] = (read, write)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def initialize(self):
+            ran["initialized"] = True
+
+    @asynccontextmanager
+    async def _fake_stdio_server():
+        yield ("a_read", "a_write")
+
+    class _FakeProxy:
+        def create_initialization_options(self):
+            return "init-opts"
+
+        async def run(self, read, write, opts):
+            ran["run"] = (read, write, opts)
+
+    monkeypatch.setattr(mcp.client.sse, "sse_client", _fake_sse_client)
+    monkeypatch.setattr(serve_mod, "ClientSession", _FakeSession)
+    monkeypatch.setattr(serve_mod, "stdio_server", _fake_stdio_server)
+    monkeypatch.setattr(serve_mod, "build_proxy_server", lambda _session: _FakeProxy())
+
+    await serve_mod.serve_http(
+        "https://h.example/mcp", repo_root="/some/repo", headers=None, transport="sse"
+    )
+
+    assert ran["opened_with"] == ("https://h.example/mcp", None)
+    assert ran["run"] == ("a_read", "a_write", "init-opts")
+
+
+async def test_serve_http_rejects_unknown_transport():
+    with pytest.raises(ValueError, match="unknown transport"):
+        await serve_mod.serve_http("https://h/mcp", transport="bogus")
+
+
+def test_redacted_url_drops_query():
+    assert serve_mod._redacted("https://h/mcp?token=abc#f") == "https://h/mcp"

--- a/tests/unit/test_serve.py
+++ b/tests/unit/test_serve.py
@@ -324,6 +324,33 @@ def test_url_failure_reports_cleanly(monkeypatch, _no_logging_mutation):
     assert result.exception is None or isinstance(result.exception, SystemExit)
 
 
+def test_url_failure_never_prints_the_query_or_header_values(monkeypatch, _no_logging_mutation):
+    # A transport error quoting the request URL and a header must not leak either.
+    async def _boom(*_a, **_k):
+        raise RuntimeError(
+            "connect failed: https://mcp.example.com/mcp?token=SECRETQUERY "
+            "(authorization: Bearer SECRETHEADER)"
+        )
+
+    monkeypatch.setattr(serve_mod, "serve_http", _boom)
+    result = runner.invoke(
+        cli.app,
+        [
+            "serve",
+            "--url",
+            "https://mcp.example.com/mcp?token=SECRETQUERY",
+            "-H",
+            "Authorization: Bearer SECRETHEADER",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "SECRETQUERY" not in result.output
+    assert "SECRETHEADER" not in result.output
+    assert "https://mcp.example.com/mcp" in result.output
+    assert "RuntimeError" in result.output
+
+
 # --- serve_http wiring -------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

`doberman serve --url <http(s) URL>` fronts a **remote** MCP server (Streamable HTTP by default, `--transport sse` for the legacy SSE transport) with the same policy proxy `doberman serve -- <cmd>` already applies to a spawned stdio server. Every downstream `tools/call` still goes through the one chokepoint (`executor.decide_and_execute`); a BLOCK reaches no downstream tool.

This is the "generic MCP bridge" gap from the #202 connector memo (`docs/CONNECTOR_MEMO_202_HOSTS.md`): any host that can only talk to a remote MCP endpoint can now be guarded by pointing it at `doberman serve --url` instead.

## What changed

- `proxy/serve.py`: the body of `serve_stdio` moves into a shared `_serve(open_downstream, label, *, repo_root)`; `serve_stdio` is a thin wrapper. New `serve_http(url, *, repo_root, headers, transport)` lazily imports `mcp.client.streamable_http` / `mcp.client.sse` (both ship in the pinned `mcp` 1.27.2, no new dependency). `_redacted(url)` strips the query string and fragment before a URL is ever logged.
- `cli/main.py`: `serve` gains `--url`, `--transport http|sse`, and repeatable `--header/-H "Name: value"`. All validation exits 2 before any network activity: `--url` together with a command after `--`, neither, a non-http(s) URL, an unknown transport, `--header`/`--transport` without `--url`, a malformed header. A transport failure exits 1 with a one-line error, no traceback.
- Header values and the URL's query string are never logged or printed. The docs note that a `-H "Authorization: Bearer $TOKEN"` value is visible in the process's argv like any CLI flag.
- Docs: `docs/SETUP.md` "Remote servers" block, `docs/CLI.md` flag list.

## Tests

- `tests/unit/test_serve.py`: 13 new tests for the CLI validation matrix, header parsing, transport selection, redaction, and the exit-1 transport-failure path.
- `tests/integration/test_serve_url_end_to_end.py` (new): an in-process FastMCP app served by uvicorn in a thread, the proxy spawned as a subprocess with `--url`, driven by a real `ClientSession`. Tools are re-exposed; a PASS decision reaches the HTTP tool; a BLOCK decision reaches no tool (call log stays empty).

## Repo-boundary / security

- Public-release safe: no enterprise references, no secrets, no new runtime dependency.
- Fail closed on every validation and transport error; the policy path is byte-for-byte the stdio one.

Refs #202.
