### PR TITLE
fix(auth): finalize the Tk auth dialog on its own thread so a hook's exit code survives

### DIFF
--- a/changelog.d/575.md
+++ b/changelog.d/575.md
@@ -1,0 +1,6 @@
+- **A Tk approval dialog no longer changes the hook's exit code.** After a GUI-mediated decision the hook process
+  could abort during interpreter teardown (`Tcl_AsyncDelete: async handler deleted by the wrong thread`) and exit 3
+  instead of the code it raised. Claude Code treats a non-0/2 hook exit as a non-blocking error and runs the tool,
+  so a denied or expired AUTH action executed anyway; Cursor's `failClosed` turned an exit-3 allow into a deny. Every
+  Tk object a dialog creates is now finalized on the worker thread that created it and pending countdown timers are
+  cancelled before the window is destroyed; a subprocess regression test pins exit code 2 with a clean stderr.

--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -2121,6 +2121,29 @@ def _finalize_dialog(root: Any) -> None:
     root.destroy()
 
 
+def _run_then_collect(run: Any) -> Any:
+    """Call ``run()`` and ``gc.collect()`` on THIS thread afterwards.
+
+    A propagating exception has its traceback dropped first: the traceback pins
+    every frame below it (and the Tk widgets those frames hold), so without
+    this the collection could not free the dialog's reference cycle here and
+    Python would finalize it later on whichever thread allocates next -- the
+    main thread at interpreter exit, which aborts the process
+    (``Tcl_AsyncDelete``) and corrupts the hook's exit code. The exception
+    itself still propagates unchanged; only its traceback is lost.
+    """
+    try:
+        return run()
+    except BaseException as exc:
+        logger.debug(
+            "auth dialog raised %s (traceback dropped before Tk cleanup)", type(exc).__name__
+        )
+        exc.__traceback__ = None
+        raise
+    finally:
+        gc.collect()
+
+
 def _show_outcome_window(
     text: str, outcome: str = "denied", *, max_wait_ms: int | None = None
 ) -> None:
@@ -2198,10 +2221,7 @@ def _show_outcome_window(
         finally:
             _finalize_dialog(root)
 
-    try:
-        _run()
-    finally:
-        gc.collect()
+    _run_then_collect(_run)
 
 
 def _run_dialog(
@@ -2260,10 +2280,7 @@ def _run_dialog(
         finally:
             _finalize_dialog(root)
 
-    try:
-        return _run()
-    finally:
-        gc.collect()
+    return _run_then_collect(_run)
 
 
 def _confirm_dialog(

--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -2095,31 +2095,30 @@ def _cancel_pending_after(root: Any) -> None:
 
 
 def _finalize_dialog(root: Any) -> None:
-    """Cancel pending timers, destroy ``root``, then force the cyclic GC to
-    run NOW, on this (worker) thread (SECURITY #399 follow-up).
+    """Cancel pending timers, then destroy ``root`` (SECURITY #399 follow-up).
 
-    Every real dialog runs on a background daemon thread (see
-    :func:`_open_root`'s docstring). A button's ``command=``/``bind()``
-    closure routinely closes over the very widget it is attached to (e.g.
-    :func:`_wire_keyboard`'s handlers close over ``root``), and a
-    ``PhotoImage`` kept alive via ``root._icon_ref``/``row._logo_ref`` sits
-    in the same widget tree -- reference CYCLES that plain refcounting
-    cannot collect. Left alone, they are only reclaimed whenever the cyclic
-    GC next runs, which is not guaranteed to be this thread: Python
-    guarantees a final collection at interpreter shutdown, which happens on
-    the MAIN thread. ``Image.__del__`` then calls back into a Tcl
-    interpreter that thread never entered, and Tcl aborts the whole process
-    ("main thread is not in main loop") instead of letting it exit with
-    whatever code the caller actually raised. Calling ``gc.collect()``
-    HERE -- still on the thread that created these objects, before this
-    function (and so the dialog's worker thread) returns -- finalizes them
-    on the right thread instead.
+    Deliberately does NOT call ``gc.collect()`` itself: while this runs,
+    ``root`` is still reachable from the caller's own local variable, so any
+    reference CYCLE rooted here (a button's ``command=``/``bind()`` closure
+    routinely closes over the very widget it is attached to -- e.g.
+    :func:`_wire_keyboard`'s handlers close over ``root`` -- and a
+    ``PhotoImage`` kept alive via ``root._icon_ref``/``row._logo_ref`` sits in
+    the same widget tree) is not yet garbage; a collection here could not
+    reclaim it. Every real caller runs on a background daemon thread (see
+    :func:`_open_root`'s docstring), so a cycle left alive past this call is
+    only reclaimed whenever the cyclic GC next runs -- not guaranteed to be
+    this thread: Python guarantees a final collection at interpreter
+    shutdown, on the MAIN thread, where ``Image.__del__`` calls back into a
+    Tcl interpreter that thread never entered and Tcl aborts the whole
+    process ("main thread is not in main loop") instead of letting it exit
+    with whatever code the caller actually raised. :func:`_show_outcome_window`
+    and :func:`_run_dialog` each call this from an inner closure and force
+    ``gc.collect()`` themselves ONLY after that closure -- and so ``root`` --
+    has gone out of scope, so the collection runs once the cycle is truly
+    unreachable, still on this (worker) thread.
     """
     _cancel_pending_after(root)
-    try:
-        root.destroy()
-    finally:
-        gc.collect()
+    root.destroy()
 
 
 def _show_outcome_window(
@@ -2156,38 +2155,53 @@ def _show_outcome_window(
     pin a background thread's Tk mainloop open forever. ``max_wait_ms``
     overrides that ceiling — tests pass a small value so nothing in the
     suite can wait minutes for what is only ever a safety net.
+
+    SECURITY (#399 follow-up): the window's whole life -- ``root`` included
+    -- runs inside a nested closure so that name goes out of scope (and any
+    Tk reference cycle rooted at it becomes truly unreachable) the instant
+    that closure returns, BEFORE the ``gc.collect()`` below runs. See
+    :func:`_finalize_dialog`.
     """
-    try:
-        root = _open_root()
-    except PrompterUnavailableError:
-        return
-    try:
-        root.title(f"Doberman - {outcome}")
-        root.configure(bg=_BG)
-        root.resizable(False, False)
-        root.attributes("-topmost", True)
-        root.bind("<Escape>", lambda _e: root.quit())
-        root.bind("<Button-1>", lambda _e: root.quit())
-        _populate_outcome_notice(root, text, outcome)
-        root.update_idletasks()
-        # Item 10: the toast prefers the FOCUSED window's monitor over the
-        # mouse's -- falls back to the mouse-pointer monitor (this module's
-        # usual placement, still used by every real challenge dialog) when
-        # there's no foreground window to ask, and from there to the primary
-        # screen exactly as :func:`_center_on_screen` always has.
-        monitor = _monitor_rect_for(_hmonitor_for_foreground_window() or _hmonitor_under_cursor())
-        _center_on_screen(root, monitor=monitor)
-        if outcome in _PERSISTENT_OUTCOMES:
-            root.after(
-                _PERSISTENT_OUTCOME_MAX_MS if max_wait_ms is None else max_wait_ms, root.quit
+
+    def _run() -> None:
+        try:
+            root = _open_root()
+        except PrompterUnavailableError:
+            return
+        try:
+            root.title(f"Doberman - {outcome}")
+            root.configure(bg=_BG)
+            root.resizable(False, False)
+            root.attributes("-topmost", True)
+            root.bind("<Escape>", lambda _e: root.quit())
+            root.bind("<Button-1>", lambda _e: root.quit())
+            _populate_outcome_notice(root, text, outcome)
+            root.update_idletasks()
+            # Item 10: the toast prefers the FOCUSED window's monitor over the
+            # mouse's -- falls back to the mouse-pointer monitor (this module's
+            # usual placement, still used by every real challenge dialog) when
+            # there's no foreground window to ask, and from there to the primary
+            # screen exactly as :func:`_center_on_screen` always has.
+            monitor = _monitor_rect_for(
+                _hmonitor_for_foreground_window() or _hmonitor_under_cursor()
             )
-        else:
-            root.after(_OUTCOME_DISPLAY_MS, root.quit)
-        root.mainloop()
-    except Exception:  # noqa: S110 — cosmetic only, must never affect the decided outcome
-        pass
+            _center_on_screen(root, monitor=monitor)
+            if outcome in _PERSISTENT_OUTCOMES:
+                root.after(
+                    _PERSISTENT_OUTCOME_MAX_MS if max_wait_ms is None else max_wait_ms, root.quit
+                )
+            else:
+                root.after(_OUTCOME_DISPLAY_MS, root.quit)
+            root.mainloop()
+        except Exception:  # noqa: S110 — cosmetic only, must never affect the decided outcome
+            pass
+        finally:
+            _finalize_dialog(root)
+
+    try:
+        _run()
     finally:
-        _finalize_dialog(root)
+        gc.collect()
 
 
 def _run_dialog(
@@ -2218,24 +2232,38 @@ def _run_dialog(
     itself changing shape (every existing caller of the ``_confirm_dialog*``/
     ``_code_dialog*`` wrappers below, including tests that monkeypatch them,
     still gets back exactly the bare answer it always has).
+
+    SECURITY (#399 follow-up): the dialog's whole life -- ``root``, ``answer``,
+    and every closure ``populate`` creates -- runs inside a nested closure so
+    those names go out of scope (and any Tk reference cycle rooted at them
+    becomes truly unreachable) the instant that closure returns, BEFORE the
+    ``gc.collect()`` below runs. See :func:`_finalize_dialog`.
     """
-    root = _open_root()
+
+    def _run() -> Any:
+        root = _open_root()
+        try:
+            _configure_window(root)
+            answer: dict = {}
+            populate(root, answer, timeout_s)
+            root.protocol("WM_DELETE_WINDOW", root.quit)
+            _center_on_screen(root)
+            _flash_and_bell(root)
+            root.mainloop()
+            value = answer.get("value", None if want_code else False)
+            # window closed without ever resolving -> denied
+            reason = answer.get("reason", "denied")
+            logger.info("auth dialog outcome=%s action=%s", reason, action_id)
+            if reason_out is not None:
+                reason_out["reason"] = reason
+            return value
+        finally:
+            _finalize_dialog(root)
+
     try:
-        _configure_window(root)
-        answer: dict = {}
-        populate(root, answer, timeout_s)
-        root.protocol("WM_DELETE_WINDOW", root.quit)
-        _center_on_screen(root)
-        _flash_and_bell(root)
-        root.mainloop()
-        value = answer.get("value", None if want_code else False)
-        reason = answer.get("reason", "denied")  # window closed without ever resolving -> denied
-        logger.info("auth dialog outcome=%s action=%s", reason, action_id)
-        if reason_out is not None:
-            reason_out["reason"] = reason
-        return value
+        return _run()
     finally:
-        _finalize_dialog(root)
+        gc.collect()
 
 
 def _confirm_dialog(

--- a/src/doberman/auth/gui_prompter.py
+++ b/src/doberman/auth/gui_prompter.py
@@ -49,6 +49,7 @@ real main thread is a Cocoa-level hazard that :func:`_open_root` refuses before
 it ever happens — see that function for the full rationale.
 """
 
+import gc
 import importlib.resources as _ir
 import logging
 import math
@@ -2068,6 +2069,59 @@ def _populate_outcome_notice(root: Any, text: str, outcome: str = "denied") -> N
         tk.Frame(panel, bg=_PANEL, height=10).pack()  # symmetric bottom padding either way
 
 
+def _cancel_pending_after(root: Any) -> None:
+    """Cancel every ``after`` callback still queued on ``root``'s Tcl
+    interpreter (SECURITY #399 follow-up).
+
+    A countdown's ``_tick`` (:func:`_build_countdown`), the CRITICAL-approve
+    gate's 100ms tick (:func:`_gate_approve_for_critical`), or the outcome
+    window's auto-close can still be pending when the dialog closes early
+    (a button click ends ``mainloop()`` well before its own ``root.after``
+    would have fired next). ``root.destroy()`` does not cancel a still-queued
+    ``after`` callback -- Tcl fires it anyway during later event processing,
+    against widget/image names that no longer exist, raising ``invalid
+    command name "..."``. Querying the interpreter directly (``after info``)
+    catches every pending id in one place instead of threading each ``_tick``
+    call site's id through every populate function.
+    """
+    try:
+        for after_id in root.tk.call("after", "info"):
+            try:
+                root.after_cancel(after_id)
+            except Exception:  # noqa: S110 — best-effort cleanup only
+                pass
+    except Exception:  # noqa: S110 — root's interpreter may already be gone
+        pass
+
+
+def _finalize_dialog(root: Any) -> None:
+    """Cancel pending timers, destroy ``root``, then force the cyclic GC to
+    run NOW, on this (worker) thread (SECURITY #399 follow-up).
+
+    Every real dialog runs on a background daemon thread (see
+    :func:`_open_root`'s docstring). A button's ``command=``/``bind()``
+    closure routinely closes over the very widget it is attached to (e.g.
+    :func:`_wire_keyboard`'s handlers close over ``root``), and a
+    ``PhotoImage`` kept alive via ``root._icon_ref``/``row._logo_ref`` sits
+    in the same widget tree -- reference CYCLES that plain refcounting
+    cannot collect. Left alone, they are only reclaimed whenever the cyclic
+    GC next runs, which is not guaranteed to be this thread: Python
+    guarantees a final collection at interpreter shutdown, which happens on
+    the MAIN thread. ``Image.__del__`` then calls back into a Tcl
+    interpreter that thread never entered, and Tcl aborts the whole process
+    ("main thread is not in main loop") instead of letting it exit with
+    whatever code the caller actually raised. Calling ``gc.collect()``
+    HERE -- still on the thread that created these objects, before this
+    function (and so the dialog's worker thread) returns -- finalizes them
+    on the right thread instead.
+    """
+    _cancel_pending_after(root)
+    try:
+        root.destroy()
+    finally:
+        gc.collect()
+
+
 def _show_outcome_window(
     text: str, outcome: str = "denied", *, max_wait_ms: int | None = None
 ) -> None:
@@ -2133,7 +2187,7 @@ def _show_outcome_window(
     except Exception:  # noqa: S110 — cosmetic only, must never affect the decided outcome
         pass
     finally:
-        root.destroy()
+        _finalize_dialog(root)
 
 
 def _run_dialog(
@@ -2181,7 +2235,7 @@ def _run_dialog(
             reason_out["reason"] = reason
         return value
     finally:
-        root.destroy()
+        _finalize_dialog(root)
 
 
 def _confirm_dialog(

--- a/tests/unit/test_gui_prompter_exit_code.py
+++ b/tests/unit/test_gui_prompter_exit_code.py
@@ -1,0 +1,93 @@
+"""Regression test: a GUI auth dialog run on its production worker thread must
+never corrupt the HOST PROCESS's exit code.
+
+Every real host hook (``doberman hook pre``/``hook_post``/``hook_cursor``/...)
+writes its decision JSON to stdout and then ``raise typer.Exit(code)``. When
+the decision needs a human, the dialog opens through
+``challenge._run_with_deadline`` -- a daemon ``threading.Thread``, never the
+process's real main thread. If a Tk-backed Python object (a ``PhotoImage``, a
+button's bound closure) is still alive in a reference cycle when that worker
+thread's function returns, Python's cyclic GC only reclaims it later, on
+whichever thread happens to allocate next -- typically the MAIN thread during
+interpreter shutdown, which never entered that dialog's Tcl interpreter. Tcl
+then aborts the whole process (``Tcl_AsyncDelete: async handler deleted by the
+wrong thread``) instead of letting it exit with the code the hook actually
+raised: Claude Code treats any hook exit other than 0/2 as a *non-blocking*
+error and runs the tool anyway (fail-open), and Cursor's ``failClosed`` flips
+a corrupted-exit *allow* into a deny (approvals become impossible).
+
+A second, independent defect: an unresolved countdown's ``root.after(1000,
+_tick)`` (or the CRITICAL-approve gate's 100ms tick) can still be queued in
+Tcl's timer queue after the dialog closes early -- ``root.destroy()`` does not
+itself cancel a still-pending ``after`` callback -- and firing it against the
+now-destroyed widget names raises ``invalid command name "..."`` from
+inside Tcl's own event processing.
+
+This test reproduces the exact production shape (real dialog widgets, real
+button closures, real countdown, run via ``challenge._run_with_deadline`` on a
+daemon worker thread) and asserts the subprocess's exit code and stderr are
+untouched by either defect.
+"""
+
+import gc
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from doberman.auth import gui_prompter
+
+pytestmark = pytest.mark.timeout(120, method="thread")
+
+# The dialog closes itself via root.after(150, root.quit) -- well under a
+# second -- so this never waits on a human. sys.exit(2) at the end mirrors
+# a real hook's `raise typer.Exit(2)` after the decision JSON is written.
+_SUBPROCESS_CODE = textwrap.dedent(
+    """
+    import sys
+
+    from doberman.auth import challenge, gui_prompter
+
+
+    def _populate(root, answer, timeout_s):
+        gui_prompter._populate_confirm(root, "regression test dialog", answer, timeout_s)
+        root.after(150, root.quit)
+
+
+    def _run_challenge():
+        return gui_prompter._run_dialog(
+            _populate, want_code=False, timeout_s=5.0, action_id="test-exit-code"
+        )
+
+
+    challenge._run_with_deadline(
+        _run_challenge, timeout_s=10.0, on_timeout=lambda: None, label="test-exit-code"
+    )
+    sys.exit(2)
+    """
+)
+
+
+def test_a_worker_thread_dialog_leaves_the_hooks_exit_code_intact():
+    try:
+        probe = gui_prompter._open_root()
+    except gui_prompter.PrompterUnavailableError:
+        pytest.skip("no display available for a GUI auth dialog")
+    probe.destroy()
+    gc.collect()
+
+    proc = subprocess.run(  # noqa: S603 - fixed args, no shell, this is the test
+        [sys.executable, "-c", _SUBPROCESS_CODE],
+        capture_output=True,
+        timeout=60,
+    )
+
+    stderr_text = proc.stderr.decode("utf-8", "replace")
+    assert proc.returncode == 2, f"exit code {proc.returncode} (expected 2); stderr:\n{stderr_text}"
+    for needle in (
+        b"Tcl_AsyncDelete",
+        b"invalid command name",
+        b"main thread is not in main loop",
+    ):
+        assert needle not in proc.stderr, f"{needle!r} found in stderr:\n{stderr_text}"

--- a/tests/unit/test_gui_prompter_exit_code.py
+++ b/tests/unit/test_gui_prompter_exit_code.py
@@ -69,7 +69,44 @@ _SUBPROCESS_CODE = textwrap.dedent(
 )
 
 
-def test_a_worker_thread_dialog_leaves_the_hooks_exit_code_intact():
+# The exception path: ``populate`` builds real widgets and then raises. The
+# worker stores the exception (traceback and all) and re-raises it on the main
+# thread, where the caller fails closed. Without the traceback being dropped
+# before the worker-thread collection, those traceback frames carry the Tk
+# widgets across to the main thread and the abort comes back.
+_SUBPROCESS_CODE_RAISING = textwrap.dedent(
+    """
+    import sys
+
+    from doberman.auth import challenge, gui_prompter
+
+
+    def _populate(root, answer, timeout_s):
+        gui_prompter._populate_confirm(root, "regression test dialog", answer, timeout_s)
+        raise RuntimeError("populate failed after building widgets")
+
+
+    def _run_challenge():
+        return gui_prompter._run_dialog(
+            _populate, want_code=False, timeout_s=5.0, action_id="test-exit-code"
+        )
+
+
+    try:
+        challenge._run_with_deadline(
+            _run_challenge, timeout_s=10.0, on_timeout=lambda: None, label="test-exit-code"
+        )
+    except RuntimeError:
+        pass  # the caller fails closed; the process must still exit with ITS code
+    sys.exit(2)
+    """
+)
+
+
+@pytest.mark.parametrize(
+    "code", [_SUBPROCESS_CODE, _SUBPROCESS_CODE_RAISING], ids=["decided", "populate-raises"]
+)
+def test_a_worker_thread_dialog_leaves_the_hooks_exit_code_intact(code):
     try:
         probe = gui_prompter._open_root()
     except gui_prompter.PrompterUnavailableError:
@@ -78,7 +115,7 @@ def test_a_worker_thread_dialog_leaves_the_hooks_exit_code_intact():
     gc.collect()
 
     proc = subprocess.run(  # noqa: S603 - fixed args, no shell, this is the test
-        [sys.executable, "-c", _SUBPROCESS_CODE],
+        [sys.executable, "-c", code],
         capture_output=True,
         timeout=60,
     )


### PR DESCRIPTION
## Summary

A Tk approval dialog could change the exit code of the hook process that showed it. Reproduced on Windows for `doberman hook pre` and `doberman hook cursor`: after the dialog ran on the challenge worker thread and the deny JSON had been written, interpreter shutdown finalized leftover tkinter objects from the main thread (`Image.__del__` → "main thread is not in main loop", then `Tcl_AsyncDelete: async handler deleted by the wrong thread`) and the process exited **3** instead of 2.

Claude Code treats a hook exit other than 0/2 as a non-blocking error and runs the tool, so a GUI-denied or expired AUTH action executed anyway. Cursor (`failClosed: true`) turns an exit-3 *allow* into a deny, so approvals there were impossible. Separately, the countdown's `after` callback fired after the window was destroyed ("invalid command name …_tick") on every dialog.

## Fix

- Every Tk object a dialog creates is finalized on the worker thread that created it (references dropped and collected right after `root.destroy()`), so nothing Tcl-backed survives to interpreter exit.
- The pending countdown `after` id is cancelled before the root is destroyed.
- No `os._exit`: CliRunner-based tests share the process; the fix is at the root cause.

## Tests

- New subprocess regression test runs a real dialog on a worker thread the way production does, then exits 2, and asserts the exit code is 2 with none of the three stderr strings above. It was red (exit 3) before the fix on a real display and is green after; it skips where no display exists.
- Manual re-probe on Windows after the fix: the same AUTH payloads through `hook pre` and `hook cursor` end with exit 2 and a clean stderr (details in the PR checklist below).

## Repo-boundary / security

- Public-release safe, no new dependency.
- Restores fail-closed behaviour on the Claude Code path for every GUI-mediated decision; no decision logic changed.

Found during the Cursor live test (refs #202).
