### PR TITLE
fix(tests): isolate HOME/USERPROFILE for every test and guard the real user-level settings file

### DIFF
--- a/changelog.d/577.md
+++ b/changelog.d/577.md
@@ -1,0 +1,1 @@
+- Tests: every test now runs with `HOME`/`USERPROFILE` pointed at a throwaway dir, and a session-scoped guard fails the run if the real user-level Claude settings file changes — a full suite run on a developer machine had rewritten it and removed the live hooks (#577).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ need to exercise key generation/rotation override this with their own
 import json as _json
 import logging
 import os
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -22,6 +23,44 @@ from doberman.hosthooks.integrity import MANIFEST_ENV
 from doberman.storage import fingerprint as _fingerprint_module
 from doberman.storage.device_metrics import HOME_ENV
 from doberman.storage.fingerprint import KEY_FILE_ENV
+
+# Captured at import time, before any fixture runs, so real_user_settings_untouched
+# below has a pre-test baseline to compare against.
+_REAL_USER_SETTINGS = Path.home() / ".claude" / "settings.json"
+_REAL_USER_SETTINGS_BEFORE = (
+    _REAL_USER_SETTINGS.read_bytes() if _REAL_USER_SETTINGS.exists() else None
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_user_home(tmp_path, monkeypatch):
+    """Point ``Path.home()``/``expanduser`` at a throwaway dir for every test.
+
+    A prior suite run reached the real ``~/.claude/settings.json`` through a CLI
+    path (install-hooks/uninstall/doctor) and overwrote it, wiping live hooks.
+    Nothing here isolated the user home, so this fixture now does.
+    """
+    user_home = tmp_path / "user-home"
+    monkeypatch.setenv("HOME", str(user_home))
+    monkeypatch.setenv("USERPROFILE", str(user_home))
+    monkeypatch.delenv("HOMEDRIVE", raising=False)
+    monkeypatch.delenv("HOMEPATH", raising=False)
+    return user_home
+
+
+@pytest.fixture(scope="session", autouse=True)
+def real_user_settings_untouched():
+    """Fail the run if any test wrote to the real user-level Claude settings file.
+
+    ``isolated_user_home`` above should make this unreachable; this is the backstop
+    that proves it — a per-test fixture can't itself assert after every other test's
+    teardown has already run.
+    """
+    yield
+    after = _REAL_USER_SETTINGS.read_bytes() if _REAL_USER_SETTINGS.exists() else None
+    assert after == _REAL_USER_SETTINGS_BEFORE, (
+        "the test suite modified the real user-level Claude settings file — a test reached Path.home()"
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Repo
`doberman-core` (public). Tests only — no runtime change.

## What
The unit suite never isolated `Path.home()`: `tests/conftest.py` pointed `DOBERMAN_HOME` at a temp dir but left `HOME`/`USERPROFILE` alone, so any CLI test that reaches the global settings path (`setup`, `install-hooks`, `uninstall-hooks`, `uninstall`, `doctor`) without its own `Path.home` monkeypatch read and wrote the developer's real `~/.claude/settings.json`. On CI the runner home is empty, so nothing ever noticed; on a developer box a full run rewrote the real file and removed the live Doberman hooks (2026-09-04).

- `isolated_user_home` (autouse, per test): `HOME` and `USERPROFILE` point at a throwaway dir; `HOMEDRIVE`/`HOMEPATH` cleared so the Windows fallback cannot leak either.
- `real_user_settings_untouched` (autouse, session): snapshots the real user-level settings file's bytes at conftest import time and fails the run if they changed — the backstop that proves the first fixture holds. Never prints the contents.

## Why now
Found tonight by a `doberman doctor` on a box whose hooks had vanished mid-suite; diffing against the day-old backup showed exactly the three Doberman hook entries missing.

## Test plan
- [x] Guard proven RED: a throwaway test that restored the real `Path.home` and wrote one byte made the session teardown fail with the fixture's message; throwaway removed, file restored byte- and mtime-exact.
- [x] `test_install_hooks*.py`, `test_cli_uninstall.py`, `test_install_integrity.py`, `test_cli_doctor.py`, `test_cli_encode_safe.py`, `test_cli_lowering_gate.py`: 204 passed / 0 failed / 2 skipped (was 200 / 4 / 2 — the four were the Windows-local `encode_safe` / `lowering_gate` failures caused by the real home leaking in).
- [x] `ruff check`, `ruff format --check`, `lint-imports`, corpus `--check` clean.
- [ ] CI green on all three OSes.

## Public-release safety
- [x] Nothing from the not-allowed list; no secrets, no paths from a real machine in the tests.
