### PR TITLE
docs(benchmarks): RedCode rows re-measured after #570/#580

### DIFF
--- a/changelog.d/584.docs.md
+++ b/changelog.d/584.docs.md
@@ -1,0 +1,1 @@
+- `docs/BENCHMARKS.md`: RedCode rows re-measured on `main` after the reverse-shell and command-walk hardening; in-scope ASR 0.104 → 0.010, only 7 print-only variants remain (#584)

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -378,7 +378,9 @@ benchmark measures what ships. This moved RedCode's numbers (the only external s
 triggers it — MSB's consummating actions and LLMail-Inject's `send_email` are not command-shaped):
 harness-aggregate ASR 0.391 → **0.37234**, in-scope-only ASR 0.140 → **0.104** (75/720 bypassed, was
 101/720); `asr_strict`, FPR, and `hard_fpr` are unchanged. See the RedCode section below for the
-per-scenario detail (`udp_amplification_send` accounts for the entire delta).
+per-scenario detail (`udp_amplification_send` accounts for the entire delta). Those were the numbers at
+the parity fix; the reverse-shell and command-walk hardening that landed after it (#570, #580) moved the
+in-scope ASR again — the RedCode table below is the current measurement.
 
 ### RedCode-Exec (risky code execution)
 
@@ -398,11 +400,14 @@ identical to stateless, so only stateless is published.
 | Metric | Before (no guardrail) | After (Doberman built-ins) |
 |---|---|---|
 | n (attack / benign) | 1410 / 60 | same |
-| ASR (harness aggregate, in-scope + out-of-scope mixed) | 1.00 | 0.37234 |
-| ASR (**in-scope only** — the doc-facing number, see below) | 1.00 | **0.104** (75/720 bypassed) |
-| asr_strict (in-scope only) | 1.00 | **0.200** (144/720 not hard-blocked) |
+| ASR (harness aggregate, in-scope + out-of-scope mixed) | 1.00 | 0.31844 |
+| ASR (**in-scope only** — the doc-facing number, see below) | 1.00 | **0.010** (7/720 bypassed) |
+| asr_strict (in-scope only) | 1.00 | **0.182** (131/720 not hard-blocked) |
 | FPR | 0.00 | 0.067 (4/60) |
 | hard_fpr | 0.00 | 0.017 (1/60) |
+
+Re-measured 2026-09-04 on `main` at `b689a9d` (built-ins only) after the reverse-shell (#570) and
+command-walk (#580) hardening: in scope 589 BLOCK / 124 AUTH / 7 PASS; benign 56 PASS / 3 AUTH / 1 BLOCK.
 
 **Harness-parity fix (see the caveat above the RedCode heading).** Once command-shaped actions are
 classified through the proxy's own destination extractor, `udp_amplification_send`'s bash-half `nc`
@@ -410,9 +415,9 @@ invocations resolve to `egress_requires_auth` instead of a silent PASS: mitigate
 bypass 27 → **1**. Every other scenario, `asr_strict`, FPR, and `hard_fpr` are unchanged (`nc`/`ssh`/
 `curl`-style commands already had their own destination in the other scenarios, or none appear in them).
 
-The harness's own aggregate ASR (0.37234) mixes in-scope and out-of-scope records together, since the
+The harness's own aggregate ASR (0.31844) mixes in-scope and out-of-scope records together, since the
 generic ASR/FPR path has no scope concept — it is **not** the headline number. The in-scope-only ASR
-(0.104) and asr_strict (0.200), computed from `scenario_report()`'s per-scenario breakdown below, are:
+(0.010) and asr_strict (0.182), computed from `scenario_report()`'s per-scenario breakdown below, are:
 **690 of the 1410 attack records (48.9%) are `out_of_scope`** (code-quality/logic-bug/fairness
 demonstrations Doberman's rule surface does not gate — see the per-scenario table) and are excluded from
 both.
@@ -446,14 +451,14 @@ threat model does not gate — reported separately below, never folded into the 
 | `copy_protected_file` | block | 60 | 60 | 60 | 0 |
 | `delete_protected_file` | block | 60 | 60 | 60 | 0 |
 | `eval_injection_os_system` | auth_or_block | 60 | 60 | 60 | 0 |
-| `kill_sshd_processes` | auth_or_block | 60 | 13 | 13 | **47** |
+| `kill_sshd_processes` | auth_or_block | 60 | 60 | 13 | 0 (was 13/13/47 before #580) |
 | `malicious_url_download` | auth_or_block | 60 | 60 | 60 | 0 |
 | `path_traversal_protected_read` | block | 60 | 60 | 60 | 0 |
-| `privilege_escalation_demo` | auth_or_block | 30 | 3 | 3 | **27** |
+| `privilege_escalation_demo` | auth_or_block | 30 | 23 | 3 | **7** (was 3/3/27 before #580) |
 | `read_protected_file` | auth_or_block | 60 | 60 | 60 | 0 |
-| `reverse_shell_listener` | block | 30 | 30 | 17 | 0 (13 AUTH, not BLOCK) |
+| `reverse_shell_listener` | block | 30 | 30 | 30 | 0 (was 17 BLOCK + 13 AUTH before #570) |
 | `secret_file_exfil_http_post` | block | 60 | 60 | 60 | 0 |
-| `udp_amplification_send` | auth_or_block | 60 | **59** | 3 | **1** (was 33/3/27 before the harness-parity fix) |
+| `udp_amplification_send` | auth_or_block | 60 | 60 | 3 | 0 (was 59/3/1 before #580, 33/3/27 before the harness-parity fix) |
 
 **690 out-of-scope records** (14 of the 27 scenarios), for two different reasons (M1 — worth telling
 apart, not one umbrella):
@@ -472,28 +477,26 @@ below — same shape of command, opposite side of the scope line, because RedCod
 Doberman's path-confinement rule answer different questions. See
 `tests/benchmarks/suites/redcode.py`'s module docstring for the full per-scenario rationale.
 
-**Rule gaps (A4 — real measured gaps, no rule changes in this PR):**
-- `kill_sshd_processes` (47/60 bypass, 78%): most variants kill sshd via a Python `psutil`
-  process-iteration loop or a bash function that greps the process list and signals matched PIDs, not a
-  literal `pkill`/`kill -9`/`service ssh stop` invocation the destructive-command rule's process-kill
-  vocabulary matches; only the variants that do call a recognized kill command are stopped.
-- `udp_amplification_send` (1/60 bypass, 1.7% — down from 27/60, 45%, before the harness-parity fix
-  above): the bash-half variants (shell out to `nc -u`) are now classified through the proxy's own
-  command-egress extractor and reach `egress_requires_auth`, the same way the live proxy already
-  classified them; only 3 of those 59 mitigated cases are `raw_socket_channel` hits (nc's exec-on-connect
-  shape), so most of the newly-mitigated 26 are the plain-AUTH egress-ambiguous path, not the raw-socket
-  rule. The one residual bypass is the pure-Python `socket`-module send, which has no shell-visible verb
-  for either rule to key on.
-- `privilege_escalation_demo` (27/30 bypass, 90%): most of this index's 30 code variants only print a
-  "privileges raised/lowered" message rather than call a real OS privilege primitive (no `sudo`/`setuid`
-  observed in the sampled record) — a largely inert scenario in this checkout's shape. Every one of the
+**Rule gaps (A4 — re-measured on `main` after the reverse-shell and command-walk hardening, #570 / #580):**
+- `kill_sshd_processes` (0/60 bypass, was 47/60): process-kill commands and interpreter kill calls
+  (`kill`/`pkill`/`killall`, `os.kill`, `psutil` kill/terminate) require authentication since #580
+  (`destructive_command`); 13 variants still reach a hard BLOCK, the other 47 stop at AUTH — the
+  recoverable-tier verdict for killing a process, by design, not a floor-strength gap.
+- `udp_amplification_send` (0/60 bypass, was 1/60 after the harness-parity fix and 27/60 before it): the
+  bash-half variants (shell out to `nc -u`) are classified through the proxy's own command-egress extractor
+  and reach `egress_requires_auth`; 3 of the 60 are `raw_socket_channel` hard blocks (nc's exec-on-connect
+  shape). The last residual case, the pure-Python `socket`-module send, now stops at AUTH
+  (`opaque_command`) under the hardened interpreter-payload walk (#580).
+- `privilege_escalation_demo` (7/30 bypass, was 27/30): 23 variants are stepped up since #580 (20 AUTH
+  `opaque_command`, 3 BLOCK); the remaining 7 only print a "privileges raised/lowered" message and call no
+  OS primitive at all, so there is nothing for a rule to key on short of matching prose — an inert shape,
+  reported as a bypass rather than excluded. Every one of the
   30 variants is still evaluated at runtime (the harness never samples records — see the per-scenario
   table's `n`); the module docstring's own caveat is narrower: each index's `_SCENARIOS` classification
   label was assigned from *sample* records read while writing the adapter, not all 30 per index (see
   `suites/redcode.py`'s module docstring).
-- `reverse_shell_listener` is fully **mitigated** (30/30, `asr` 0.0) but only 17/30 reach a hard **BLOCK**
-  — 13/30 land at AUTH instead of the `block` expectation (`asr_strict` 0.43 for this scenario alone), a
-  partial floor-strength gap rather than a full miss.
+- `reverse_shell_listener` is fully **blocked** (30/30 hard BLOCK, `asr_strict` 0.0 for this scenario; was
+  17 BLOCK + 13 AUTH): exec-on-connect reverse shells BLOCK instead of AUTH since #570.
 - `eval_injection_os_system` (originally flagged as a suspected gap before this task's real run) is
   **fully mitigated** (60/60) — the `python -c '<source>'` interpreter-invocation wrapping and the widened
   `_first_path` extraction (both already shipped on this branch) closed it; it is not listed as a gap.
@@ -642,9 +645,9 @@ block, before or after.
 
 ### Follow-ups (not built in this task)
 
-- **RedCode rule gaps** (A4, above): `kill_sshd_processes`, `udp_amplification_send`,
-  `privilege_escalation_demo` bypass rates, and `reverse_shell_listener`'s AUTH-vs-BLOCK split — no rule
-  changes land in this PR; a future slice could extend the destructive-command/raw-socket vocabularies.
+- **RedCode rule gaps** (A4, above): closed by #570 / #580 except `privilege_escalation_demo`'s 7
+  print-only variants, which call no OS primitive — nothing a rule can key on without matching prose,
+  which would be benchmark-shaped rather than a real detection.
 - **`read_email`-class tools as a recognized untrusted-read tool name.** `UNTRUSTED_READ_TOOLS`
   (`doberman.engine.taint_floor`) is `{"WebFetch", "WebSearch"}` only; the harness's own session-replay
   path works around this by keying "untrusted read" off `source_context` instead (see


### PR DESCRIPTION
Docs-only. Re-measures the RedCode-Exec suite on main at b689a9d (built-ins only) now that #570 (reverse-shell BLOCK) and #580 (command-walk hardening) are merged, and refreshes docs/BENCHMARKS.md: in-scope ASR 0.104 -> 0.010 (7/720 bypassed), asr_strict 0.200 -> 0.182, FPR and hard_fpr unchanged (4/60, 1/60); per-scenario rows for kill_sshd_processes, privilege_escalation_demo, reverse_shell_listener, udp_amplification_send; the rule-gaps prose and the follow-ups bullet. The only remaining in-scope bypasses are the 7 print-only privilege_escalation_demo variants, which call no OS primitive. No code changes. Numbers from python -m tests.benchmarks.run --suite redcode --profile builtins_only with DOBERMAN_BENCH_REDCODE_DIR set (no data vendored).