### PR TITLE
test(examples): isolate plugin discovery allowlists

### DIFF
--- a/examples/plugin-audit-sink/tests/test_example_sink.py
+++ b/examples/plugin-audit-sink/tests/test_example_sink.py
@@ -49,13 +49,37 @@ def sink_file(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathli
     return path
 
 
+@pytest.fixture
+def enable_plugin(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Enable the example in a test-local, process-snapshotted allowlist."""
+    from doberman.engine import plugin_config
+
+    monkeypatch.setenv(plugin_config.PLUGINS_FILE_ENV, str(tmp_path / "plugins.json"))
+    plugin_config.enable("example_sink")
+    plugin_config.reset_snapshot()
+    yield
+    plugin_config.reset_snapshot()
+
+
 # ---------------------------------------------------------------------------
 # A: Discovery
 # ---------------------------------------------------------------------------
 
 
-def test_entry_point_is_discoverable_after_install():
-    """``pip install -e`` registers the entry point; discover_audit_sinks finds it."""
+def test_entry_point_is_not_discoverable_without_enable(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Installing an example alone must not load it without explicit opt-in."""
+    from doberman.engine import plugin_config
+
+    monkeypatch.setenv(plugin_config.PLUGINS_FILE_ENV, str(tmp_path / "plugins.json"))
+    plugin_config.reset_snapshot()
+    assert not any(isinstance(sink, ExampleAuditSink) for sink in discover_audit_sinks())
+    plugin_config.reset_snapshot()
+
+
+def test_entry_point_is_discoverable_after_install(enable_plugin):
+    """``pip install -e`` plus explicit opt-in makes discover_audit_sinks find the example."""
     sinks = discover_audit_sinks()
     assert any(isinstance(s, ExampleAuditSink) for s in sinks), (
         f"ExampleAuditSink not discovered via {AUDIT_SINK_GROUP!r}; "

--- a/examples/plugin-guardrail/tests/test_example_rule.py
+++ b/examples/plugin-guardrail/tests/test_example_rule.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.engine.registry import RULE_GROUP, discover_rules
 from doberman.models import (
@@ -41,8 +42,30 @@ def _ctx(path: str, *, root: str = ".") -> EvalContext:
     return EvalContext(metadata={"repo_root": root, "raw_arguments": {"path": path}})
 
 
-def test_entry_point_is_discoverable_after_install():
-    """``pip install -e`` registers the entry point; discover_rules finds it."""
+@pytest.fixture
+def enable_plugin(tmp_path, monkeypatch):
+    """Enable the example in a test-local, process-snapshotted allowlist."""
+    from doberman.engine import plugin_config
+
+    monkeypatch.setenv(plugin_config.PLUGINS_FILE_ENV, str(tmp_path / "plugins.json"))
+    plugin_config.enable("example_rule")
+    plugin_config.reset_snapshot()
+    yield
+    plugin_config.reset_snapshot()
+
+
+def test_entry_point_is_not_discoverable_without_enable(tmp_path, monkeypatch):
+    """Installing an example alone must not load it without explicit opt-in."""
+    from doberman.engine import plugin_config
+
+    monkeypatch.setenv(plugin_config.PLUGINS_FILE_ENV, str(tmp_path / "plugins.json"))
+    plugin_config.reset_snapshot()
+    assert not any(isinstance(rule, ExampleRule) for rule in discover_rules())
+    plugin_config.reset_snapshot()
+
+
+def test_entry_point_is_discoverable_after_install(enable_plugin):
+    """``pip install -e`` plus explicit opt-in makes discover_rules find the example."""
     rules = discover_rules()
     assert any(isinstance(rule, ExampleRule) for rule in rules), (
         f"ExampleRule not discovered via {RULE_GROUP!r}; "
@@ -109,7 +132,7 @@ def test_explanation_never_echoes_path_or_payload():
     assert "private" not in result.explanation
 
 
-def test_plugin_fires_inside_objective_guardrail():
+def test_plugin_fires_inside_objective_guardrail(enable_plugin):
     """With the package installed, ObjectiveGuardrail discovers and runs it."""
     guardrail = ObjectiveGuardrail()  # load_plugins=True (default)
     # Benign-looking path for built-ins; only the tutorial plugin steps up.


### PR DESCRIPTION
## Slice
- Repo: doberman-core
- Feature / Slice: #581 — Isolate legacy plugin example discovery tests
- Plan reference: GitHub issue #581

## What this PR does
- Gives the guardrail and audit-sink example suites a temporary, opt-in plugin allowlist matching the detector example.
- Adds negative coverage that installed plugins remain undiscovered until explicitly enabled, and ensures the guardrail integration test enables its example first.

## Tests added (run in CI)
- `examples/plugin-guardrail/tests/test_example_rule.py` — explicit opt-in and disabled-by-default discovery coverage.
- `examples/plugin-audit-sink/tests/test_example_sink.py` — explicit opt-in and disabled-by-default discovery coverage.

## Changelog
- [x] This test-only change is invisible to users; no fragment needed.

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Installed-but-disabled plugins stay absent from discovery; each enabled example uses a per-test configuration path and resets only the test snapshot.
- No production behavior changed. AI assistance was used for this contribution.

Closes #581
