### PR TITLE
fix(ci): stop Windows CI stalls — no worker restarts, no per-open migration

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -57,6 +57,7 @@ jobs:
             echo "FAIL: enterprise package found in core environment"
             exit 1
           fi
+      # --max-worker-restart=0: see ci.yml (a replaced worker deadlocks loadgroup).
       # -p randomly prints its seed at the top of the log; reproduce an order
       # failure locally with `pytest -p randomly -p "randomly_seed=<seed>"`.
       # Warnings are errors on every leg via pyproject's `filterwarnings` (with the
@@ -66,7 +67,7 @@ jobs:
         env:
           DOBERMAN_TEST_REAL_HST: "1"
         run: >
-          pytest -n auto --dist loadgroup -p randomly --timeout=900 --durations=40 --durations-min=5.0
+          pytest -n auto --dist loadgroup --max-worker-restart=0 -p randomly --timeout=900 --durations=40 --durations-min=5.0
 
   dependency-audit:
     name: Dependency vulnerability audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,18 @@ jobs:
             exit 1
           fi
           echo "ok: core has no enterprise dependency"
-      # --timeout: a single stuck test dies in 5 min with a traceback naming it,
-      # instead of taking the whole leg to the job timeout with no diagnosis. The
-      # production-size gate modules carry their own `timeout` marker (see their
-      # `pytestmark`) because their module-scoped eval fixture lands on one item.
+      # --timeout: a single stuck test dies in 5 min instead of taking the whole
+      # leg to the job timeout. The production-size gate modules carry their own
+      # `timeout` marker (see their `pytestmark`) because their module-scoped eval
+      # fixture lands on one item. On Windows the only method is `thread`, which
+      # os._exit()s the xdist worker, and the worker's traceback goes to a stdout
+      # that execnet points at NUL - the controller only sees "node down".
+      # --max-worker-restart=0: a dead worker ends the run at once, reported as
+      # "worker crashed while running <test>". Left at the default, xdist 3.8
+      # replaces the worker and `--dist loadgroup` re-queues the dead worker's
+      # already-completed scopes as empty units (pytest-xdist#1378): the session
+      # then either deadlocks at ~99% until the job cap (ten Windows runs,
+      # 2026-09-03/04) or dies with `KeyError: <WorkerController gwN>`.
       # --durations: every run reports its slowest tests, so a creeping suite is
       # visible in the log before it becomes a timeout.
       # The GUI auth dialog is real Tk widgets; without a display its tests skip
@@ -109,7 +117,7 @@ jobs:
           DOBERMAN_TEST_FAST_HST_GATES: ${{ matrix.fast_gates && '1' || '' }}
         run: >
           ${{ runner.os == 'Linux' && 'xvfb-run -a -s "-screen 0 1280x800x24"' || '' }}
-          pytest -n auto --dist loadgroup --timeout=300 --durations=25 --durations-min=2.0
+          pytest -n auto --dist loadgroup --max-worker-restart=0 --timeout=300 --durations=25 --durations-min=2.0
           ${{ matrix.coverage && '--cov=doberman --cov-report=term-missing --cov-fail-under=90' || '' }}
   package-smoke-test:
     name: package-smoke-test (${{ matrix.os }})

--- a/changelog.d/591.fixed.md
+++ b/changelog.d/591.fixed.md
@@ -1,0 +1,1 @@
+- The store skips its schema migration when already current, about 11 fewer fsyncs per decided action; Windows CI fails fast instead of stalling (#591)

--- a/src/doberman/storage/db.py
+++ b/src/doberman/storage/db.py
@@ -27,6 +27,7 @@ SECURITY / resilience:
 """
 
 import os
+import sqlite3
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
@@ -404,18 +405,36 @@ async def _ensure_schema(conn: aiosqlite.Connection) -> None:
     await conn.commit()
 
 
+async def _schema_is_current(conn: aiosqlite.Connection) -> bool:
+    """True when the DB already records ``SCHEMA_VERSION`` — the only state
+    ``_ensure_schema`` would leave untouched. A missing table or any other
+    version says "migrate"; the migration itself decides what that means."""
+    try:
+        async with conn.execute("SELECT version FROM schema_version") as cur:
+            rows = await cur.fetchall()
+    except sqlite3.OperationalError:  # fresh file, or a pre-versioned DB
+        return False
+    return [row[0] for row in rows] == [SCHEMA_VERSION]
+
+
 @asynccontextmanager
 async def open_db(repo_root: str = ".") -> AsyncIterator[aiosqlite.Connection]:
     """Open (creating if needed) the repo DB with the schema ensured.
 
     Creates ``.doberman/`` ``0700`` and the DB file ``0600`` on first use.
+    The migration runs only when the version row is not current: one decided
+    action opens the DB ~11 times, and re-running the legacy probes, the full
+    CREATE script and a committed version rewrite on each of them was the
+    dominant cost of every multi-action test (~1,100 opens for a 100-action
+    warm-up; 180-200 s per test on the Windows CI leg).
     """
     path = db_path(repo_root)
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     conn = await aiosqlite.connect(str(path))
     try:
         await conn.execute("PRAGMA busy_timeout = 3000")
-        await _ensure_schema(conn)
+        if not await _schema_is_current(conn):
+            await _ensure_schema(conn)
         _restrict_permissions(path)
         yield conn
     finally:

--- a/tests/unit/test_db_schema.py
+++ b/tests/unit/test_db_schema.py
@@ -185,3 +185,35 @@ def test_db_file_is_owner_only(tmp_path):
     assert path.exists()
     if os.name != "nt":
         assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+async def test_reopen_at_current_version_skips_the_migration(tmp_path, monkeypatch):
+    # Every open used to re-run the whole migration (legacy probes, the full
+    # CREATE script, a committed version rewrite) — ~11 opens per decided
+    # action, each paying an fsync; on the Windows CI leg that made three
+    # integration tests take 180-200 s. A DB already at SCHEMA_VERSION needs
+    # none of it; anything else (fresh, older, no version table) still does.
+    from doberman.storage import db as db_module
+
+    calls: list[int] = []
+    real = db_module._migrate_legacy
+
+    async def counting(conn):
+        calls.append(1)
+        await real(conn)
+
+    monkeypatch.setattr(db_module, "_migrate_legacy", counting)
+    async with open_db(str(tmp_path)):
+        pass
+    assert calls == [1]  # fresh DB: migrated once
+    async with open_db(str(tmp_path)) as conn:
+        async with conn.execute("SELECT version FROM schema_version") as cur:
+            assert [r[0] for r in await cur.fetchall()] == [SCHEMA_VERSION]
+    assert calls == [1]  # current DB: nothing to migrate
+
+    async with aiosqlite.connect(str(db_path(str(tmp_path)))) as conn:
+        await conn.execute("UPDATE schema_version SET version = ?", (SCHEMA_VERSION - 1,))
+        await conn.commit()
+    async with open_db(str(tmp_path)):
+        pass
+    assert calls == [1, 1]  # older DB: migrated again

--- a/tests/unit/test_db_schema.py
+++ b/tests/unit/test_db_schema.py
@@ -217,3 +217,16 @@ async def test_reopen_at_current_version_skips_the_migration(tmp_path, monkeypat
     async with open_db(str(tmp_path)):
         pass
     assert calls == [1, 1]  # older DB: migrated again
+
+
+def test_schema_text_change_requires_a_version_bump():
+    # open_db() migrates only when the version row is stale, so a DB already
+    # at SCHEMA_VERSION never sees a new table added to _SCHEMA unless the
+    # version moves too. Editing _SCHEMA: bump SCHEMA_VERSION, then update both
+    # literals here.
+    import hashlib
+
+    from doberman.storage.db import _SCHEMA
+
+    assert SCHEMA_VERSION == 14
+    assert hashlib.sha256(_SCHEMA.encode()).hexdigest()[:16] == "8168371109d84a8b"

--- a/tests/unit/test_destination_key_redaction.py
+++ b/tests/unit/test_destination_key_redaction.py
@@ -86,6 +86,9 @@ async def test_v12_migration_purges_legacy_raw_destination_rows(tmp_path):
                 "VALUES (?, ?, 'frontend', 3, ?, ?, ?)",
                 (eid, key, stamp, stamp, stamp),
             )
+        # A DB below SCHEMA_VERSION migrates on its next open (a current one
+        # is left alone); the v11 stamp is what makes the reopen run the purge.
+        await conn.execute("UPDATE schema_version SET version = 11")
         await conn.commit()
 
     # Reopening runs _ensure_schema → the idempotent v12 purge.

--- a/tests/unit/test_rule_dependency_admission.py
+++ b/tests/unit/test_rule_dependency_admission.py
@@ -18,7 +18,6 @@ import os
 import pathlib
 import random
 import socket
-import time
 from datetime import datetime, timezone
 
 import pytest
@@ -537,10 +536,9 @@ def test_bounded_on_a_one_megabyte_command():
     # payload that this rule does not fix (out of this slice's scope) —
     # measured ~25s locally for a 1 MB command. This only proves
     # `DependencyAdmissionRule.evaluate()` completes rather than hangs.
+    # The hang guard is CI's per-test `--timeout`, not a wall-clock bound here:
+    # a 90 s bound failed at 97 s on a slow Windows runner (#588).
     rule = DependencyAdmissionRule()
     huge_command = "pip install " + ("a" * (1024 * 1024))
-    start = time.monotonic()
     result = rule.evaluate(_action(), _ctx(huge_command))
-    elapsed = time.monotonic() - start
     assert result.verdict is Verdict.PASS
-    assert elapsed < 90, f"took {elapsed:.1f}s"  # generous bound; not a speed claim

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -13,6 +13,7 @@ installed.
 
 import json
 import re
+import time
 from datetime import datetime, timezone
 
 import pytest
@@ -79,35 +80,35 @@ def _visible_footer_text(app) -> str:
     return "  ".join(parts)
 
 
-async def _wait_for_footer_text(pilot, app, predicate, *, tries: int = 20, delay: float = 0.02):
+# Poll budget for eventually-consistent widget state. A passing check returns
+# on the first 20 ms tick that holds, so this only bounds a real failure; the
+# 0.4 s / 2 s budgets it replaces lost a Footer recompose under xdist load on
+# the Windows CI leg (`assert 'reload' in ''`, 2026-09-03).
+_WAIT_TIMEOUT = 10.0
+
+
+async def _wait_for_footer_text(pilot, app, predicate, *, timeout: float = _WAIT_TIMEOUT):
     """Poll `_visible_footer_text(app)` through `predicate` until it holds, or
-    `tries` attempts pass. Textual's Footer only recomposes after a dynamic
+    `timeout` seconds pass. Textual's Footer only recomposes after a dynamic
     `check_action` change (round 4 design critique item 3's row-action
     gating) via `refresh_bindings()` -> a signal -> `call_after_refresh` -
     genuinely eventually-consistent, so a single `pilot.pause()` can
     legitimately race it under load. Returns the last-seen text either way,
     so a real failure still shows a useful diff."""
-    text = _visible_footer_text(app)
-    for _ in range(tries):
-        if predicate(text):
-            return text
-        await pilot.pause(delay)
-        text = _visible_footer_text(app)
-    return text
+    return await _wait_for(pilot, lambda: _visible_footer_text(app), predicate, timeout=timeout)
 
 
-async def _wait_for(pilot, get_value, predicate, *, tries: int = 100, delay: float = 0.02):
+async def _wait_for(pilot, get_value, predicate, *, timeout: float = _WAIT_TIMEOUT):
     """General-purpose sibling of `_wait_for_footer_text` (round 5 design
-    critique item 11): poll `get_value()` through `predicate` until it holds,
-    or `tries * delay` (~2s by default) elapses. A widget's own update can
+    critique item 11): poll `get_value()` through `predicate` every 20 ms until
+    it holds, or `timeout` seconds elapse. A widget's own update can
     legitimately land a tick after the change that triggers it - reading it
     right after a single `pilot.pause()` can race that under load. Returns the
     last-seen value either way, so a real failure still shows a useful diff."""
+    deadline = time.monotonic() + timeout
     value = get_value()
-    for _ in range(tries):
-        if predicate(value):
-            return value
-        await pilot.pause(delay)
+    while not predicate(value) and time.monotonic() < deadline:
+        await pilot.pause(0.02)
         value = get_value()
     return value
 


### PR DESCRIPTION
## Summary

Windows CI has been red or stuck on one run in five. Of the last 83 `test (windows-latest, 3.12)` jobs: 10 sat silent at 92–99% until the 45-minute cap, 6 failed outright (19.3%). Ubuntu legs: none. This PR fixes the two root causes and two bound-tuned tests.

**Root cause 1 — a killed worker deadlocks the run.** On Windows, pytest-timeout can only use its `thread` method, which `os._exit()`s the whole xdist worker; execnet routes the worker's stdout to `NUL`, so the traceback never reaches the log and the controller prints only `[gwN] node down: Not properly terminated`. xdist 3.8 then spawns a replacement, and `--dist loadgroup`'s `remove_node` re-queues the dead worker's already-completed scopes as empty work units ([pytest-xdist#1378](https://github.com/pytest-dev/pytest-xdist/issues/1378)). Depending on timing the session either idles forever at the tail (every one of the 10 stalled logs has a `node down` line mid-run and no output after ~98%) or crashes with `INTERNALERROR KeyError: <WorkerController gw6>`. Reproduced locally with an 84-test file whose last test hard-exits: default flags hang until killed; `--max-worker-restart=0` ends in 11 s with `worker 'gw0' crashed while running 'test_crash.py::test_zz_crash'`. Both workflows now pass that flag.

**Root cause 2 — the tests being killed.** The Windows durations list on a green run shows three integration tests at 181–201 s under the 300 s ceiling; a runner 1.5× slower kills them. cProfile: each makes ~1,100 `aiosqlite.connect()` calls (about 11 per decided action, from `executor.py` calling `surprise_blended`/`budget_allows_step_up`/`observe`/`total_observations` on separate connections), and `open_db()` re-ran `_ensure_schema` on every open — the legacy-migration probes, the full CREATE script, and a committed rewrite of the version row (an fsync per open). `open_db()` now skips the migration when the version row already reads `SCHEMA_VERSION`; a fresh, older, or version-less DB still migrates. Locally the three tests drop from 18.8/19.6/19.4 s to 8.2/8.2/8.3 s; the devsession benchmark (#560, same open pattern) should follow.

**Two bound-tuned tests.** `test_tui`'s wait helpers polled for a fixed 0.4 s / 2 s and lost a Footer recompose under load (`assert 'reload' in ''`); they now poll to a 10 s deadline (a passing check still returns on the first 20 ms tick). `test_bounded_on_a_one_megabyte_command` asserted `elapsed < 90` and hit 97 s; CI's per-test timeout is its hang guard, so the wall-clock assert is gone (#588).

Not touched: `test_focus_ring…` (#551, no occurrence in the 120-run window) and the connection-reuse question in `executor.py` (11 opens per action is a product-latency item; follow-up issue proposed separately).

## Changes
- `.github/workflows/ci.yml`, `ci-nightly.yml`: `--max-worker-restart=0`, comment with the mechanism.
- `src/doberman/storage/db.py`: `_schema_is_current()`; `open_db()` migrates only when the version row is stale.
- `tests/unit/test_db_schema.py`: new test — fresh DB migrates once, current DB is left alone, an older version row migrates again.
- `tests/unit/test_destination_key_redaction.py`: the v12 purge test stamps the DB v11 before the reopen that must migrate it.
- `tests/unit/test_tui.py`: deadline-based `_wait_for` / `_wait_for_footer_text`.
- `tests/unit/test_rule_dependency_admission.py`: no wall-clock assert.

## Test plan
- [x] `ruff check`, `ruff format --check`, `lint-imports` clean.
- [x] New schema test fails before the `open_db` change, passes after.
- [x] Schema-touching modules, TUI suite, the five profiled tests, and `tests/integration` + storage/subjective unit modules green locally under the CI flags.
- [x] Windows leg green on 5b18019 (run 33940469814): 5242 passed in 1018 s (last green `main` run: 1346 s). The three heavy tests: 200.7/182.7/181.6 s → 66.4/63.6/59.6 s; poisoning-gate setup 70 → 42 s.

Closes #588. Refs #560.
