### PR TITLE
chore(release): re-cut v0.18.6 on main to include #590 and #591

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Closes detection bypasses and rebuilds setup, the dashboard, and the TUI.
 - Deny is now the dashboard's primary action and needs the same two-step confirm as Approve; lowering the security mode needs the same confirm gesture (#533)
 - `doberman setup` now ends honestly: `-- Setup complete/pending/incomplete --` with exit codes 0/1/3, and its output wraps and colors like `doberman status`/`doctor` (#535)
 - The subjective-layer benchmark diagnostic reports a held-out-benign false-positive rate next to the AUC and gains a seeded `--suite devsession` corpus that engages the full ensemble (#542)
+- Tk auth dialogs show one decision per screen: subtitle, reassurance, and keyboard note fold into "What is this?"; the severity word prints once (#590)
 
 ### Fixed
 - The auth dialog now shows a keyboard hint (`Tab/Arrows: switch - Enter: confirm - Esc: deny`) and grows to fit it instead of clipping (#507, thanks @thesageak)
@@ -71,6 +72,7 @@ Closes detection bypasses and rebuilds setup, the dashboard, and the TUI.
 - `doberman hook cursor` now reads stdin as raw UTF-8 bytes, so the BOM Windows `cursor-agent` emits no longer turns every hook into a deny (#571)
 - `doberman hook pre` now answers Cursor-shaped payloads instead of failing closed, which had denied every Cursor shell command on machines with global hooks installed (#576)
 - The test suite no longer touches your real Claude settings: every test gets a throwaway home and a guard fails the run if it changes (#577)
+- The store skips its schema migration when already current, about 11 fewer fsyncs per decided action (#591)
 
 ### Docs
 - Added `docs/AUTHORITY_TIERS.md`, documenting which layer of a decision may `BLOCK` versus only step up to `AUTH` (#544)

--- a/changelog.d/590.changed.md
+++ b/changelog.d/590.changed.md
@@ -1,1 +1,0 @@
-- Tk auth dialogs show one decision per screen: subtitle, reassurance, and keyboard note fold into "What is this?"; the severity word prints once (#590)

--- a/changelog.d/591.fixed.md
+++ b/changelog.d/591.fixed.md
@@ -1,1 +1,0 @@
-- The store skips its schema migration when already current, about 11 fewer fsyncs per decided action; Windows CI fails fast instead of stalling (#591)


### PR DESCRIPTION
## Summary
Re-cuts v0.18.6 on top of main so the tag carries #590 (Tk auth dialogs distilled to one decision per screen) and #591 (lazy schema migration, Windows CI fix). The version was already `0.18.6` (#585); this only folds the two post-release fragments into the compiled v0.18.6 section (their bullets under `### Changed` / `### Fixed`) and empties `changelog.d/` again. The heading date stays 2026-09-04, the local release day.

The tag `v0.18.6` targets this PR's squash commit instead of 0b2bd64.

## Changelog
- [x] Release re-cut; no new fragment (the two existing ones are compiled in).

## Test plan
- [x] `scripts/compile_changelog.py --check`: 0 fragments, ok.
- [ ] CI green, then tag + publish.
