### PR TITLE
test(tui): never match an empty footer in the wait helpers

### DIFF
--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -94,8 +94,16 @@ async def _wait_for_footer_text(pilot, app, predicate, *, timeout: float = _WAIT
     gating) via `refresh_bindings()` -> a signal -> `call_after_refresh` -
     genuinely eventually-consistent, so a single `pilot.pause()` can
     legitimately race it under load. Returns the last-seen text either way,
-    so a real failure still shows a useful diff."""
-    return await _wait_for(pilot, lambda: _visible_footer_text(app), predicate, timeout=timeout)
+    so a real failure still shows a useful diff. An empty footer is the
+    not-yet-composed state, never a match: a negative-only predicate
+    (`"copy id" not in t`) would otherwise return on the first tick with `''`
+    (Windows CI, 2026-09-04, `assert 'reload' in ''` after #591)."""
+    return await _wait_for(
+        pilot,
+        lambda: _visible_footer_text(app),
+        lambda t: bool(t) and predicate(t),
+        timeout=timeout,
+    )
 
 
 async def _wait_for(pilot, get_value, predicate, *, timeout: float = _WAIT_TIMEOUT):
@@ -2006,8 +2014,9 @@ async def test_footer_at_80_columns_fits_and_esc_clear_shows_while_filter_focuse
 
         def _all_keys_fit() -> bool:
             footer = app.query_one("Footer")
-            return all(
-                key.region.x + key.region.width <= footer.size.width for key in app.query(FooterKey)
+            keys = list(app.query(FooterKey))  # no keys yet = not composed, not "fits"
+            return bool(keys) and all(
+                key.region.x + key.region.width <= footer.size.width for key in keys
             )
 
         assert await _wait_for(pilot, _all_keys_fit, lambda ok: ok)


### PR DESCRIPTION
## Summary

The Windows leg of #592 (a changelog-only PR) failed with `assert 'reload' in ''` in `test_footer_at_80_columns_fits_and_esc_clear_shows_while_filter_focused`. #591 raised the footer wait to a 10 s deadline, but the deadline never engages here: the wait's predicate is negative-only (`"prev BLOCK" not in t and "copy id" not in t`), and an unrendered Footer reads as `''`, which satisfies it on the first tick. The test then asserts `"reload"` against the blank string. Two other waits (lines 861 and 2214) have the same shape and were passing vacuously.

`_wait_for_footer_text` now treats an empty footer as the not-yet-composed state and never a match, so every caller waits for a real render. `_all_keys_fit` in the same test was `all()` over zero FooterKeys (True) and now requires at least one key.

Test-only, no fragment.

## Test plan
- [x] `ruff check`, `ruff format --check` clean.
- [x] `tests/unit/test_tui.py` under the CI flags (`-n 4 --dist loadgroup --max-worker-restart=0 --timeout=300`): 108 passed.
- [ ] CI green, Windows leg included.
