### PR TITLE
land #586: test(examples): isolate plugin discovery allowlists

### DIFF
--- a/examples/plugin-audit-sink/tests/test_example_sink.py
+++ b/examples/plugin-audit-sink/tests/test_example_sink.py
@@ -49,13 +49,37 @@ def sink_file(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathli
     return path
 
 
+@pytest.fixture
+def enable_plugin(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Enable the example in a test-local, process-snapshotted allowlist."""
+    from doberman.engine import plugin_config
+
+    monkeypatch.setenv(plugin_config.PLUGINS_FILE_ENV, str(tmp_path / "plugins.json"))
+    plugin_config.enable("example_sink")
+    plugin_config.reset_snapshot()
+    yield
+    plugin_config.reset_snapshot()
+
+
 # ---------------------------------------------------------------------------
 # A: Discovery
 # ---------------------------------------------------------------------------
 
 
-def test_entry_point_is_discoverable_after_install():
-    """``pip install -e`` registers the entry point; discover_audit_sinks finds it."""
+def test_entry_point_is_not_discoverable_without_enable(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Installing an example alone must not load it without explicit opt-in."""
+    from doberman.engine import plugin_config
+
+    monkeypatch.setenv(plugin_config.PLUGINS_FILE_ENV, str(tmp_path / "plugins.json"))
+    plugin_config.reset_snapshot()
+    assert not any(isinstance(sink, ExampleAuditSink) for sink in discover_audit_sinks())
+    plugin_config.reset_snapshot()
+
+
+def test_entry_point_is_discoverable_after_install(enable_plugin):
+    """``pip install -e`` plus explicit opt-in makes discover_audit_sinks find the example."""
     sinks = discover_audit_sinks()
     assert any(isinstance(s, ExampleAuditSink) for s in sinks), (
         f"ExampleAuditSink not discovered via {AUDIT_SINK_GROUP!r}; "

--- a/examples/plugin-guardrail/tests/test_example_rule.py
+++ b/examples/plugin-guardrail/tests/test_example_rule.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
 from doberman.engine.objective import ObjectiveGuardrail
 from doberman.engine.registry import RULE_GROUP, discover_rules
 from doberman.models import (
@@ -41,8 +42,30 @@ def _ctx(path: str, *, root: str = ".") -> EvalContext:
     return EvalContext(metadata={"repo_root": root, "raw_arguments": {"path": path}})
 
 
-def test_entry_point_is_discoverable_after_install():
-    """``pip install -e`` registers the entry point; discover_rules finds it."""
+@pytest.fixture
+def enable_plugin(tmp_path, monkeypatch):
+    """Enable the example in a test-local, process-snapshotted allowlist."""
+    from doberman.engine import plugin_config
+
+    monkeypatch.setenv(plugin_config.PLUGINS_FILE_ENV, str(tmp_path / "plugins.json"))
+    plugin_config.enable("example_rule")
+    plugin_config.reset_snapshot()
+    yield
+    plugin_config.reset_snapshot()
+
+
+def test_entry_point_is_not_discoverable_without_enable(tmp_path, monkeypatch):
+    """Installing an example alone must not load it without explicit opt-in."""
+    from doberman.engine import plugin_config
+
+    monkeypatch.setenv(plugin_config.PLUGINS_FILE_ENV, str(tmp_path / "plugins.json"))
+    plugin_config.reset_snapshot()
+    assert not any(isinstance(rule, ExampleRule) for rule in discover_rules())
+    plugin_config.reset_snapshot()
+
+
+def test_entry_point_is_discoverable_after_install(enable_plugin):
+    """``pip install -e`` plus explicit opt-in makes discover_rules find the example."""
     rules = discover_rules()
     assert any(isinstance(rule, ExampleRule) for rule in rules), (
         f"ExampleRule not discovered via {RULE_GROUP!r}; "
@@ -109,7 +132,7 @@ def test_explanation_never_echoes_path_or_payload():
     assert "private" not in result.explanation
 
 
-def test_plugin_fires_inside_objective_guardrail():
+def test_plugin_fires_inside_objective_guardrail(enable_plugin):
     """With the package installed, ObjectiveGuardrail discovers and runs it."""
     guardrail = ObjectiveGuardrail()  # load_plugins=True (default)
     # Benign-looking path for built-ins; only the tutorial plugin steps up.


### PR DESCRIPTION
Lands #586 by @mgalore (closes #581) on the current `main`. The branch fell behind `main` after #590 and #591 merged; nothing conflicted, this is their commit rebased with authorship intact. No changes to the contributor's fork.

Original review: the two example-plugin suites now reset the plugin snapshot right after `enable()` and again in teardown, so no later test inherits an earlier allowlist. Both guards were verified locally by breaking them (CI does not run `examples/` suites; follow-up issue filed separately).

Closes #581.
