### PR TITLE
docs: add @mgalore to CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@ In alphabetical order by handle (ordering is not a ranking):
 - [@jasperdingg](https://github.com/jasperdingg)
 - **Lee Sang Hoon** — [@leemeo3](https://github.com/leemeo3)
 - [@Maqbool61](https://github.com/Maqbool61)
+- [@mgalore](https://github.com/mgalore)
 - [@navaneethsankar07](https://github.com/navaneethsankar07)
 - [@QY-25123](https://github.com/QY-25123)
 - [@Shihasz](https://github.com/Shihasz)


### PR DESCRIPTION
Credits @mgalore for #586 (landed via #594): the example-plugin suites now isolate their discovery allowlists. Alphabetical insert, nothing else touched.