### PR TITLE
fix(auth): show the command in the auth prompt instead of <redacted>

### DIFF
--- a/changelog.d/599.fixed.md
+++ b/changelog.d/599.fixed.md
@@ -1,0 +1,1 @@
+- The auth prompt shows the command the agent asked to run, with credential-shaped tokens masked and long paths kept, instead of a wholesale `<redacted>` target (#599)

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -140,6 +140,8 @@ engineering view? `doberman message-tone technical` switches to the terse `[RISK
 …` block, and `doberman message-tone human` switches back. It changes wording only: cosmetic, not
 possession-factor gated, and it never touches the decision, the reason codes, or what lands in the
 decision log.
+The command line shown is rendered from the raw arguments with credential-shaped tokens masked and
+cut at 300 characters; the decision log keeps only its redacted copy.
 
 ## Recovery actions
 

--- a/src/doberman/auth/provider.py
+++ b/src/doberman/auth/provider.py
@@ -164,7 +164,12 @@ def challenge_parts(
     AUTH's ``decision.effects`` — every prompter renders this exact string,
     so the channels cannot drift. ``None`` for every non-delete-class AUTH.
     """
-    target = action.target or "(no target)"
+    # The challenge copy of the action carries a prompt-only rendering of the
+    # raw arguments when the caller could build one (proxy.normalize
+    # .display_target), so the human reads the command rather than the log's
+    # wholesale "<redacted>" target.
+    shown = action.metadata.get("display_target")
+    target = shown if isinstance(shown, str) and shown else (action.target or "(no target)")
     notice = action.metadata.get("approval_memory_notice")
     notice = notice if isinstance(notice, str) and notice else None
     risk_word = decision.final_risk.value

--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -224,7 +224,7 @@ def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
             # Run Doberman's own action-bound challenge so the human can actually
             # approve in-session (issues #65/#67) — not just be told to.
             hook_result, auth_method = _resolve_auth(
-                result.decision, result.action, result.repo_root, result.session_id
+                result.decision, result.challenge_action, result.repo_root, result.session_id
             )
         else:
             hook_result = _decision_payload(result.decision)  # BLOCK -> deny

--- a/src/doberman/hosthooks/codex.py
+++ b/src/doberman/hosthooks/codex.py
@@ -164,7 +164,7 @@ def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
         if result.acted is Verdict.AUTH:
             hook_result, auth_method = hookio.resolve_auth_result(
                 result.decision,
-                result.action,
+                result.challenge_action,
                 event=_EVENT,
                 prompter=AUTH_PROMPTER,
                 message_tone=load_message_tone(result.repo_root),

--- a/src/doberman/hosthooks/cursor.py
+++ b/src/doberman/hosthooks/cursor.py
@@ -317,7 +317,7 @@ def evaluate(payload: dict[str, Any]) -> dict[str, Any]:
             if result.acted is Verdict.AUTH:
                 host_out, auth_method = hookio.resolve_auth_result(
                     result.decision,
-                    result.action,
+                    result.challenge_action,
                     event=_EVENT_LABEL,
                     prompter=AUTH_PROMPTER,
                     message_tone=load_message_tone(result.repo_root),

--- a/src/doberman/hosthooks/spine.py
+++ b/src/doberman/hosthooks/spine.py
@@ -31,7 +31,7 @@ from doberman.models import Decision, EvalContext, SecurityObject, Verdict
 from doberman.policy.drift import acted_verdict
 from doberman.policy.modes import DEFAULT_MODE
 from doberman.policy.sources import effective_policy
-from doberman.proxy.normalize import normalize
+from doberman.proxy.normalize import challenge_copy, normalize
 
 
 @dataclass(frozen=True)
@@ -44,6 +44,10 @@ class SpineResult:
     enforcement: str
     repo_root: str
     session_id: str | None
+    #: The action to hand to an AUTH challenge: ``action`` plus the prompt-only
+    #: rendering of the raw arguments (``proxy.normalize.challenge_copy``).
+    #: Never recorded — history and the dashboard row derive from ``action``.
+    challenge_action: SecurityObject
 
 
 def resolve_root_and_mode(cwd: object) -> tuple[str, str]:
@@ -133,7 +137,15 @@ def evaluate_action(
         # `off` softens the same way but is the silent, non-recording state; a
         # genuine PASS is never recorded (hot path — a DB write per pass floods).
         record_history(decision, action, repo_root, session_id, auth_result="executed")
-    return SpineResult(decision, action, acted, enforcement, repo_root, session_id)
+    return SpineResult(
+        decision,
+        action,
+        acted,
+        enforcement,
+        repo_root,
+        session_id,
+        challenge_copy(action, args),
+    )
 
 
 def record_history(

--- a/src/doberman/proxy/executor.py
+++ b/src/doberman/proxy/executor.py
@@ -71,7 +71,7 @@ from doberman.models import (
 from doberman.policy.drift import acted_verdict, effective_enforcement
 from doberman.policy.sources import effective_policy
 from doberman.proxy.interception_log import log_action
-from doberman.proxy.normalize import normalize
+from doberman.proxy.normalize import challenge_copy, normalize
 from doberman.storage import tool_pins
 from doberman.storage.db import active_elevations, claim_single_use, grant_elevation
 from doberman.storage.log import recent_session_decisions, record_decision
@@ -777,12 +777,15 @@ async def _handle_auth(
     # Off the event loop: the challenge blocks for a human, and an elicitation
     # answer arrives over the very session this loop services — waiting in-loop
     # would deadlock it (and freeze the proxy during GUI/TTY prompts too).
+    # The challenge renders the raw command (credential tokens masked); logging
+    # and everything after the challenge keep using `action`.
+    challenge_action = challenge_copy(action, arguments or {})
     auth_result: AuthResult | None = None
     try:
         auth_result = await asyncio.to_thread(
             run_auth_challenge,
             decision,
-            action,
+            challenge_action,
             prompter=AUTH_PROMPTER,
             message_tone=load_message_tone(REPO_ROOT),
             repo_root=REPO_ROOT,

--- a/src/doberman/proxy/normalize.py
+++ b/src/doberman/proxy/normalize.py
@@ -43,16 +43,26 @@ MAX_VALUE_LENGTH = 256
 # Obvious secret shapes (original stopgap; kept as a floor — see
 # `contains_strong_secret` below for the canonical, more complete detector):
 # long unbroken token-ish strings, common key prefixes, key=value secrets.
-_SECRET_SHAPES = re.compile(
-    r"""
+_KEY_SHAPES_SRC = r"""
     (?:AKIA[0-9A-Z]{16})                              # AWS access key id
     | (?:sk-[A-Za-z0-9_\-]{16,})                      # api secret key prefix
     | (?:gh[pousr]_[A-Za-z0-9]{20,})                  # github tokens
     | (?:-----BEGIN[ A-Z]*PRIVATE\ KEY-----)          # PEM private key
+"""
+_SECRET_SHAPES = re.compile(
+    _KEY_SHAPES_SRC
+    + r"""
     | (?:\b[A-Za-z0-9+/_\-]{40,}\b)                   # long unbroken token
     """,
     re.VERBOSE,
 )
+# The known shapes alone, for the prompt-only `display_target`: the long-run
+# floor above is exactly what a human must read at an auth prompt (a path, a
+# URL, a git ref), so the display keeps those and masks only what looks like a key.
+_KNOWN_SECRET_SHAPES = re.compile(_KEY_SHAPES_SRC, re.VERBOSE)
+
+# `display_target` length bound: enough to read a real command, never a payload.
+DISPLAY_MAX_LENGTH = 300
 
 # Argument keys whose values are secret-ish regardless of shape.
 _SENSITIVE_KEYS = re.compile(
@@ -662,6 +672,67 @@ def _extract_target(action_type: ActionType, arguments: dict[str, Any]) -> tuple
                 metadata["target_count"] = len(value)
                 return first, metadata
     return None, metadata
+
+
+def _mask_secret_tokens(text: str) -> str:
+    """Mask the whitespace-delimited tokens that look like a credential."""
+
+    def _mask(match: re.Match[str]) -> str:
+        token = match.group(0)
+        name, sep, _value = token.partition("=")
+        if sep and _SENSITIVE_KEYS.search(name):
+            return f"{name}={REDACTED}"
+        if len(token) >= _MIN_SECRET_LENGTH and (
+            _KNOWN_SECRET_SHAPES.search(token) or contains_strong_secret(token)
+        ):
+            return REDACTED
+        return token
+
+    return re.sub(r"\S+", _mask, text)
+
+
+def display_target(action_type: ActionType, arguments: dict[str, Any]) -> str | None:
+    """What the agent asked for, rendered for the HUMAN at an auth prompt.
+
+    The logged ``target`` comes from the redacted arguments, where any value
+    over :data:`MAX_VALUE_LENGTH` or holding a 40+ char unbroken run (a long
+    path, a hash, a URL) is replaced wholesale — so for most real shell
+    commands it is the literal ``<redacted>``, and a prompt built from it gave
+    the human nothing to judge. This renders the RAW arguments instead, masks
+    only the tokens that look like a credential, and bounds the length.
+
+    Prompt-only by contract: it rides on the challenge copy of the action
+    (``metadata["display_target"]``, see :func:`challenge_copy`), is never
+    persisted, and the dashboard's pending row never carries it (that channel
+    withholds the command by design). ``None`` when there is nothing to show;
+    never raises.
+    """
+    try:
+        text = command_line_from_arguments(arguments)
+        if not text:
+            text, _ = _extract_target(action_type, arguments)
+        if not text:
+            return None
+        shown = _mask_secret_tokens(text)
+        if len(shown) > DISPLAY_MAX_LENGTH:
+            extra = len(shown) - DISPLAY_MAX_LENGTH
+            shown = f"{shown[:DISPLAY_MAX_LENGTH]}... ({extra} more chars)"
+        return shown
+    except Exception:  # noqa: BLE001 — a display failure must never break a challenge
+        return None
+
+
+def challenge_copy(action: SecurityObject, arguments: dict[str, Any]) -> SecurityObject:
+    """``action`` with the prompt-only display attached, for the AUTH challenge alone.
+
+    The copy is what the prompters render (``auth.provider.challenge_parts``
+    reads ``metadata["display_target"]``); the original stays what is logged.
+    Returns ``action`` itself when there is nothing to show.
+    """
+    shown = display_target(action.action_type, arguments)
+    if not shown:
+        return action
+    return action.model_copy(update={"metadata": {**action.metadata, "display_target": shown}})
 
 
 def _action_fingerprint(

--- a/tests/unit/test_auth_display_target.py
+++ b/tests/unit/test_auth_display_target.py
@@ -1,0 +1,211 @@
+"""The auth prompt shows the human what the agent asked for, never "<redacted>".
+
+The log-side redactor (``proxy.normalize``) replaces any argument value over
+256 chars, or holding a 40+ char unbroken run (a long path, a hash, a URL),
+wholesale — so ``action.target`` for most real shell commands is the literal
+``<redacted>``. Every prompter rendered that target, and the local dialog read
+"Your agent wants to run a command: <redacted>" — nothing to judge.
+
+Contracts under test:
+* ``display_target`` renders the RAW arguments with only secret-shaped tokens
+  masked, bounded in length; the logged target stays ``<redacted>``;
+* the challenge carries it prompt-only: the message shows it, the caller's
+  ``SecurityObject`` is untouched, and the dashboard's pending row never holds
+  it (that channel withholds the command by design);
+* the host spine and the host-hook auth wrapper hand it along.
+"""
+
+import asyncio
+import json
+from datetime import datetime, timezone
+
+from doberman.auth import dashboard_prompter
+from doberman.auth.challenge import AuthTier, run_auth_challenge
+from doberman.auth.dashboard_prompter import DashboardPrompter
+from doberman.auth.provider import challenge_parts
+from doberman.hosthooks import hookio, spine
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+from doberman.proxy.normalize import REDACTED, challenge_copy, display_target, normalize
+from doberman.storage import approvals
+from doberman.storage.heartbeat import touch_heartbeat
+
+_NOW = datetime(2026, 9, 5, tzinfo=timezone.utc)
+_LONG_PATH = (
+    "C:/Users/someone/Documents/GitHub/Doberman/Doberman-Core/src/doberman/auth/provider.py"
+)
+_COMMAND = f"git diff --stat main -- {_LONG_PATH}"
+
+
+class FakePrompter:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def confirm(self, message: str) -> bool:
+        self.messages.append(message)
+        return True
+
+    def read_code(self, message: str) -> str:
+        self.messages.append(message)
+        return ""
+
+
+def _action(target: str | None = REDACTED) -> SecurityObject:
+    return SecurityObject(
+        id="act-dt",
+        ts=_NOW,
+        agent_role="tester",
+        action_type=ActionType.shell_exec,
+        tool_name="shell",
+        target=target,
+        risk=Risk.low,
+    )
+
+
+def _auth_decision() -> Decision:
+    reasons = [ReasonCode.destructive_command]
+    objective = GuardrailResult(
+        verdict=Verdict.AUTH, risk=Risk.low, reason_codes=reasons, explanation="why"
+    )
+    return Decision(
+        action_id="act-dt",
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.low,
+        objective=objective,
+        reason_codes=reasons,
+        explanation="why",
+        decided_at=_NOW,
+    )
+
+
+# --- display_target ---------------------------------------------------------------
+
+
+def test_long_path_shown_in_full_while_logged_target_stays_redacted():
+    args = {"command": _COMMAND}
+    assert normalize("bash", args, {"repo_root": "."}).target == REDACTED  # log floor unchanged
+    assert display_target(ActionType.shell_exec, args) == _COMMAND
+
+
+def test_secret_shaped_token_is_masked_and_the_rest_kept():
+    token = "ghp_" + "x" * 36
+    args = {"command": f"curl -H 'Authorization: {token}' https://api.example.com/repos"}
+    shown = display_target(ActionType.shell_exec, args)
+    assert shown is not None
+    assert token not in shown
+    assert REDACTED in shown
+    assert "https://api.example.com/repos" in shown
+
+
+def test_sensitive_key_value_is_masked():
+    shown = display_target(
+        ActionType.shell_exec,
+        {"command": "mysql --user=app --password=hunter2hunter2 -e 'select 1'"},
+    )
+    assert shown is not None
+    assert "hunter2" not in shown
+    assert "--user=app" in shown
+
+
+def test_oversized_command_is_truncated_after_masking():
+    token = "ghp_" + "y" * 36
+    args = {"command": "echo " + "a " * 90 + token + " " + "b " * 150}
+    shown = display_target(ActionType.shell_exec, args)
+    assert shown is not None
+    assert shown.startswith("echo a a a")
+    assert token not in shown
+    assert REDACTED in shown
+    assert len(shown) < 400
+    assert "more" in shown
+
+
+def test_argv_shape_and_file_actions_render_too():
+    assert (
+        display_target(ActionType.shell_exec, {"command": "ls", "args": ["-la", _LONG_PATH]})
+        == f"ls -la {_LONG_PATH}"
+    )
+    assert display_target(ActionType.file_write, {"path": _LONG_PATH, "content": "x"}) == _LONG_PATH
+    assert display_target(ActionType.file_write, {}) is None
+
+
+# --- prompt-only plumbing ---------------------------------------------------------
+
+
+def test_challenge_parts_prefers_display_target_in_both_tones():
+    action = _action().model_copy(update={"metadata": {"display_target": _COMMAND}})
+    for tone in ("human", "technical"):
+        parts = challenge_parts(_auth_decision(), action, AuthTier.soft_confirm, tone=tone)
+        assert parts["target"] == _COMMAND
+    assert challenge_parts(_auth_decision(), _action(), AuthTier.soft_confirm)["target"] == REDACTED
+
+
+def test_challenge_copy_leaves_the_original_untouched_and_is_identity_when_empty():
+    action = _action()
+    shown = challenge_copy(action, {"command": _COMMAND})
+    assert shown.metadata["display_target"] == _COMMAND
+    assert shown.id == action.id and shown.target == action.target
+    assert "display_target" not in action.metadata
+    assert challenge_copy(action, {}) is action
+
+
+def test_challenge_message_shows_the_command():
+    prompter = FakePrompter()
+    result = run_auth_challenge(
+        _auth_decision(), challenge_copy(_action(), {"command": _COMMAND}), prompter=prompter
+    )
+    assert result.approved is True
+    assert any(_COMMAND in m for m in prompter.messages)
+
+
+def test_hookio_auth_wrapper_shows_the_command_and_binds_to_the_same_action_id():
+    prompter = FakePrompter()
+    hook_result, method = hookio.resolve_auth_result(
+        _auth_decision(),
+        challenge_copy(_action(), {"command": _COMMAND}),
+        event="PreToolUse",
+        prompter=prompter,
+    )
+    assert any(_COMMAND in m for m in prompter.messages)
+    assert hook_result["hookSpecificOutput"]["permissionDecision"] == "allow", method
+
+
+def test_dashboard_pending_row_never_carries_the_display_target(tmp_path, monkeypatch):
+    root = str(tmp_path)
+    touch_heartbeat(root)
+    seen: list[str] = []
+
+    def _resolver(seconds: float) -> None:  # noqa: ARG001 - resolves instead of waiting
+        if seen:
+            return
+        rows = asyncio.run(approvals.list_pending(repo_root=root))
+        seen.append(json.dumps(rows, default=str))
+        asyncio.run(
+            approvals.resolve(rows[0]["id"], decision="denied", totp_code=None, repo_root=root)
+        )
+
+    monkeypatch.setattr(dashboard_prompter, "_sleep", _resolver)
+    result = run_auth_challenge(
+        _auth_decision(),
+        challenge_copy(_action(), {"command": _COMMAND}),
+        prompter=DashboardPrompter(root),
+    )
+    assert result.approved is False
+    assert seen
+    assert _LONG_PATH not in seen[0]
+
+
+def test_spine_result_carries_a_challenge_copy_and_a_clean_action(tmp_path):
+    result = spine.evaluate_action(
+        "bash", {"command": _COMMAND}, cwd=str(tmp_path), raw_session_id=None
+    )
+    assert result.challenge_action.metadata["display_target"] == _COMMAND
+    assert result.challenge_action.id == result.action.id
+    assert result.action.target == REDACTED
+    assert "display_target" not in result.action.metadata


### PR DESCRIPTION
## Slice
- Fix: the auth prompt showed `<redacted>` in place of the command (seen while approving a git push from a Claude Code session on v0.18.6).

## What this PR does
The prompt rendered `action.target`, which `normalize` derives from the redacted arguments: any value over 256 chars or holding a 40+ char unbroken run (a long path, a hash, a URL) is replaced wholesale, so most real shell commands prompted as `<redacted>` and the human had nothing to judge.

- `proxy.normalize.display_target(action_type, arguments)` renders the raw arguments (the same reconstruction the rules scan), masks credential-shaped tokens (the AKIA / `sk-` / `gh*_` / PEM shapes, the shared strong-secret detector, and `--password=...`-style pairs), and cuts at 300 chars with a count.
- `proxy.normalize.challenge_copy(action, arguments)` attaches it to a challenge-only copy of the action (`metadata["display_target"]`); `auth.provider.challenge_parts` prefers it over the target in both tones.
- `SpineResult.challenge_action` carries the copy to the three host adapters; the proxy builds it in `_handle_auth`. `run_auth_challenge` and `hookio.resolve_auth_result` keep their signatures.
- `action` itself, the decision history, the approval binding (same action id), and the dashboard pending row are unchanged: the dash withholds the command by design and its row is built from the decision and the path class only.

## Tests added (run in CI)
- `tests/unit/test_auth_display_target.py` (11): a long path is shown while the logged target stays `<redacted>`; a `ghp_` token is masked with the URL kept; `--password=` is masked with `--user=` kept; masking happens before the 300-char cut; the argv shape and file actions render; `challenge_parts` prefers the display in both tones and falls back to the target; `challenge_copy` is identity when there is nothing to show and never touches the original; the message through `run_auth_challenge` and through `hookio.resolve_auth_result` shows the command and still allows on the same action id; the dashboard row never carries it; the spine result carries a clean action plus the copy.

## Security checklist
- [x] Fails closed on error / uncertainty: `display_target` never raises (`None`, and the prompt falls back to the target); the challenge path is otherwise untouched.
- [x] No secret, full file, or unredacted prompt logged or committed: the display lives only on the challenge copy; `normalize()` output is byte-identical.
- [x] Any guardrail/learning change is raise-only: no decision logic changed.
- [x] Every BLOCK/AUTH carries reason codes + a human explanation: unchanged.

## Edge cases covered / Deviations from plan / Risks introduced
- A credential the token masker misses would reach the prompt channels (TTY, GUI, elicitation), which already run on the machine holding the agent's arguments; the log-side redaction is unchanged. Defense in depth, not a new exposure surface.
- `docs/TUNING.md` already promised the command in its example prompt; one sentence now notes the masking and the cut.
