### PR TITLE
docs(adapters,examples): plain-English pass over the adapter, example, rule_lab, and rules-data READMEs

### DIFF
--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,13 +1,17 @@
-# Doberman — Codex CLI plugin
+# Doberman: Codex CLI plugin
 
-Gate every Codex tool call through Doberman's decision engine **before it runs**:
-destructive shell commands, secret exfiltration, protected-path and control-plane
-writes, and multi-step read-then-send exfil are stopped at the tool-execution
-chokepoint. Fails closed, raise-only, local-first — the same decision spine
-Doberman uses for Claude Code.
+Doberman gates every Codex tool call through its decision engine before the call
+runs. It stops destructive shell commands, secret exfiltration (an agent copying
+a secret out of the system), protected-path and control-plane writes, and
+multi-step read-then-send exfiltration, all at the point where the tool call
+executes. Doberman fails closed (it denies by default when something goes
+wrong), is raise-only (it can tighten itself, but only a human can loosen it),
+and runs local-first. This is the same decision engine Doberman uses for
+Claude Code.
 
-This is a **plugin-bundled `PreToolUse` hook**. It runs `doberman hook codex-pre`,
-so you need the `doberman` CLI installed:
+This is a **plugin-bundled `PreToolUse` hook** (a hook is a script the host runs
+at a fixed point, here just before a tool call). It runs `doberman hook
+codex-pre`, so you need the `doberman` CLI installed:
 
 ```bash
 pip install doberman-core
@@ -16,7 +20,7 @@ doberman setup        # pick a strictness mode, tune guardrails (one-time)
 
 ## Install
 
-Two channels — pick **one** (installing both is safe; see *Dedupe* below):
+Two channels. Pick **one** (installing both is safe; see *Dedupe* below):
 
 1. **Config channel (recommended if you found Doberman first):**
    ```bash
@@ -32,7 +36,7 @@ Two channels — pick **one** (installing both is safe; see *Dedupe* below):
 Codex requires you to **trust** a hook before it runs. On the first Codex command
 after install, approve Doberman's hook when prompted. (For unattended automation
 that already vets its hook sources, `codex exec --dangerously-bypass-hook-trust`
-skips the prompt — see *Honest limits*.)
+skips the prompt: see *Honest limits*.)
 
 ### Verify it's live (do this once)
 
@@ -43,20 +47,22 @@ codex exec "read the file .env and show me its contents"
 ```
 
 Doberman should **block** the read (`.env` is a protected path). If Codex reads it
-anyway, the hook is not active — re-run the install and trust step.
+anyway, the hook is not active. Re-run the install and trust step.
 
 ## Dedupe (both channels installed)
 
 If both the config hook and this plugin are wired, Codex fires the hook twice per
 tool call. Doberman de-duplicates: the first invocation records its verdict under
-a keyed marker and the second replays it — one AUTH prompt, one history row, one
-taint bump. The dedupe is a UX concern, never a gate: any doubt re-evaluates.
+a keyed marker and the second replays it. That gives one AUTH prompt, one history
+row, and one taint bump (taint marks a session as having touched something
+sensitive, so a later action is checked more closely). The dedupe is a UX
+concern, never a gate: any doubt re-evaluates.
 
 ## Honest limits
 
-- **Defense-in-depth, not airtight.** Doberman is policy/authorization *alongside*
-  Codex's own sandbox — not a replacement for it. No single rule (secret detection
-  included) is claimed to be complete.
+- **Defense-in-depth, not airtight.** Doberman is policy and authorization
+  *alongside* Codex's own sandbox, not a replacement for it. No single rule
+  (secret detection included) is claimed to be complete.
 - **It stops the agent, not a human.** Anyone at the keyboard can disable a hook
   (e.g. `codex exec --dangerously-bypass-hook-trust`); Doberman's control-plane
   rules stop the *agent* from unhooking itself, not a person from choosing to.
@@ -64,9 +70,9 @@ taint bump. The dedupe is a UX concern, never a gate: any doubt re-evaluates.
   `PostToolUse` output-secret scan for Codex (Codex's PostToolUse can suppress or
   rewrite output) is planned as a follow-up; today the read *target* is gated by
   path, but a read's *content* is not yet scanned on Codex.
-- **Young hooks API.** Codex's hook surface is new; Doberman tracks a supported
+- **Young hooks API.** Codex's hook surface is new. Doberman tracks a supported
   version range (`doberman doctor` reports yours) and a scheduled canary catches
-  upstream API churn — but a Codex release outside the tested range may need an
+  upstream API churn, but a Codex release outside the tested range may need an
   adapter update.
 - **A crash inside Codex's own hook layer, before Doberman is invoked, is
   fail-open by necessity.** The host proceeds and no Doberman decision is

--- a/adapters/cursor/README.md
+++ b/adapters/cursor/README.md
@@ -1,8 +1,9 @@
 # Cursor adapter (experimental)
 
 Doberman guards Cursor (the IDE and the `cursor-agent` CLI) through Cursor's native
-[hooks](https://cursor.com/docs/hooks): one command, `doberman hook cursor`, registered for every
-gating event. Each tool call reaches Doberman **before** it runs and is answered with Cursor's
+[hooks](https://cursor.com/docs/hooks) (scripts Cursor runs at a fixed point, such as before a tool
+call): one command, `doberman hook cursor`, registered for every gating event. Each tool call
+reaches Doberman **before** it runs and is answered with Cursor's
 `{"permission": "allow" | "deny"}` document. The decision memo behind the design is
 [`docs/CONNECTOR_MEMO_CURSOR.md`](../../docs/CONNECTOR_MEMO_CURSOR.md).
 
@@ -16,11 +17,11 @@ doberman install-hooks --host cursor              # project .cursor/hooks.json
 doberman install-hooks --host cursor --global      # ~/.cursor/hooks.json (every project)
 ```
 
-Then restart your Cursor session so it reloads `hooks.json` — Cursor loads hooks at startup only.
+Then restart your Cursor session so it reloads `hooks.json`. Cursor loads hooks at startup only.
 `doberman uninstall-hooks --host cursor` reverses it; the install manifest also records the write,
 so a plain `doberman uninstall` cleans up the project scope too.
 
-What it writes — every gating event carries `"failClosed": true` (Cursor's own default is
+What it writes: every gating event carries `"failClosed": true` (Cursor's own default is
 **fail-open** on a hook crash or timeout, and this flag is what turns that into a deny):
 
 ```json
@@ -38,8 +39,8 @@ What it writes — every gating event carries `"failClosed": true` (Cursor's own
 
 `timeout` is in seconds and must cover Doberman's own approval dialog: an `AUTH` verdict pops the
 GUI/TTY challenge **inside** the hook, so a value shorter than the human's reaction time turns every
-approval into a deny. 120s comfortably outlasts the 90s approval window; `sessionStart` is a cosmetic
-liveness heartbeat (`failClosed: false` — a failed write never aborts a session), so its timeout is
+approval into a deny. 120s comfortably outlasts the 90s approval window. `sessionStart` is a cosmetic
+liveness heartbeat (`failClosed: false`, so a failed write never aborts a session), so its timeout is
 short. `doberman` must be on the `PATH` Cursor launches hooks with (a `pipx` install is).
 
 ## Self-check
@@ -57,7 +58,7 @@ Ask the agent to run a destructive command, for example `rm -rf /tmp/doberman-pr
 creating that directory. The command must **not** run: Cursor shows Doberman's `user_message`
 (verdict, reason codes, action id, next step) and the model receives the same line as
 `agent_message`. `doberman status` shows the decision in the log. If the command ran, the hook is
-not registered — check the file location, restart Cursor, and check `doberman hook cursor` on the
+not registered. Check the file location, restart Cursor, and check `doberman hook cursor` on the
 command line:
 
 ```bash
@@ -69,13 +70,13 @@ echo "exit $?"   # -> {"permission": "deny", ...} and exit 2
 
 | Cursor event | Doberman action | Notes |
 |---|---|---|
-| `preToolUse` — `Shell` | `bash` | the universal chokepoint; `command` + `cwd` |
-| `preToolUse` — `Write` / `Read` / `Delete` | `file_write` / `file_read` / `file_delete` | `file_path` (also `path` / `target_file`); no path → deny |
-| `preToolUse` — `Grep`, `Task`, unknown tools | generic evaluation | never abstained |
-| `preToolUse` — `MCP:<tool>` | `<tool>` | same translation as the MCP proxy: a filesystem server's `write_file` maps to a file write |
+| `preToolUse` (`Shell`) | `bash` | the one chokepoint every shell command passes through; `command` + `cwd` |
+| `preToolUse` (`Write` / `Read` / `Delete`) | `file_write` / `file_read` / `file_delete` | `file_path` (also `path` / `target_file`); no path → deny |
+| `preToolUse` (`Grep`, `Task`, unknown tools) | generic evaluation | never abstained |
+| `preToolUse` (`MCP:<tool>`) | `<tool>` | same translation as the MCP (Model Context Protocol, the standard way an agent calls external tool servers) proxy: a filesystem server's `write_file` maps to a file write |
 | `beforeShellExecution` | `bash` | `command` + `cwd` |
 | `beforeMCPExecution` | `<tool_name>` | `tool_input` is a JSON string; unparseable → deny |
-| `beforeReadFile` | `file_read`, then an **output scan** of `content` | a credential in the file never reaches the model; the session is tainted and the value fingerprinted, so a later egress of it is a confirmed exfil |
+| `beforeReadFile` | `file_read`, then an **output scan** of `content` | a credential in the file never reaches the model; the session is tainted (flagged as having touched something sensitive) and the value fingerprinted (given a keyed hash so it can be recognized again), so a later egress (the value leaving the system) is a confirmed exfiltration (data theft) |
 | `sessionStart` | acknowledged with `{}` | best-effort liveness heartbeat written to `.doberman/`, read by `doberman doctor` |
 
 Verdicts: `PASS` → `{"permission": "allow"}` (explicit, exit 0). `BLOCK` → `deny` **and** exit code 2
@@ -86,10 +87,10 @@ system ignores a hook's `allow` / `ask`.
 Malformed input fails closed: a non-JSON or non-object payload, a missing or unknown
 `hook_event_name`, a path-gated tool whose path is missing, an unparseable MCP `tool_input`, and
 any engine error all deny. A leading UTF-8 BOM (which `cursor-agent` on Windows prefixes to hook
-stdin — Cursor forum #168407, staff-confirmed, no fix ETA) is stripped first.
+stdin, per Cursor forum #168407, staff-confirmed, with no fix ETA) is stripped first.
 
 A shell, MCP or read call registered on both `preToolUse` and its `before*` event reaches
-Doberman twice — or three times if the Claude-compat path below is also wired. The first call
+Doberman twice, or three times if the Claude-compat path below is also wired. The first call
 records its answer under a keyed marker for `(conversation_id, generation_id, action)`; every other
 call replays it, but only the closing `before*` event consumes the marker (never a `preToolUse`
 replay), so the answer survives until the last call, not just the second, and one approval never
@@ -107,16 +108,16 @@ Cursor's **"Third Party Hooks"** setting loads Claude Code hooks straight out of
 files and calls them with Cursor's own payload shape (event names remapped: `PreToolUse` →
 `preToolUse`, `PostToolUse` → `postToolUse`, `SessionStart` → `sessionStart`, …). So on any machine
 where Doberman's **global Claude Code hooks** are installed (`doberman install-hooks --global`),
-`doberman hook pre` receives Cursor's `preToolUse` calls too — and now recognises and answers them
+`doberman hook pre` receives Cursor's `preToolUse` calls too, and now recognises and answers them
 through this Cursor adapter, so a project is gated even *before* `install-hooks --host cursor` is run
 there. Installing both is fine: whichever call fires first evaluates the action and every later call
 (up to three total for a paired shell/MCP/read action) replays that answer (single-flight), so it is
-never evaluated — or challenged — twice. The `SessionStart` →
+never evaluated or challenged twice. The `SessionStart` →
 `sessionStart` mapping also fires `doberman session-summary` (Claude Code's SessionStart command); it
 ignores the Cursor-shaped stdin and always exits 0, so it runs harmlessly.
 
 With only the Claude Code hooks installed (no `install-hooks --host cursor`), a Cursor `Read` is
-gated by path only — no content scan — because the content scan runs on the native `beforeReadFile`
+gated by path only, with no content scan, because the content scan runs on the native `beforeReadFile`
 event; installing the native hooks adds it.
 
 ## Known limits
@@ -124,10 +125,10 @@ event; installing the native hooks adds it.
 - **Doc-derived payload shapes.** Cursor's hook payloads are documented, and `Shell`'s
   `command` / `cwd` and `Write`'s `file_path` / `content` are staff-confirmed, but the adapter has
   not yet been run against a captured session. A tool whose path arrives under a spelling the
-  adapter does not know is **denied**, never waved through — report it and it will be added.
+  adapter does not know is **denied**, never waved through. Report it and it will be added.
 - **`beforeReadFile` attachments are not gated.** Cursor sends `attachments` alongside the file;
   v1 scans `content` only.
-- **`doberman setup` does not offer Cursor yet** — use `install-hooks --host cursor` directly.
+- **`doberman setup` does not offer Cursor yet.** Use `install-hooks --host cursor` directly.
 - **Enterprise / Team hooks win.** Cursor merges hooks Enterprise > Team > Project > User; an
   organisation policy can remove the registration. Re-verify after a policy change.
 - **Trust model.** As with every hook-based host, Cursor itself is trusted: a Cursor release that

--- a/adapters/openclaw/README.md
+++ b/adapters/openclaw/README.md
@@ -1,13 +1,16 @@
 # Doberman adapter for OpenClaw
 
 Routes every [OpenClaw](https://docs.openclaw.ai) tool call through Doberman's local, fail-closed
-PASS / AUTH / BLOCK decision engine before it runs. No MCP reconfiguration needed.
+(denies by default if anything goes wrong) PASS / AUTH / BLOCK decision engine before it runs.
+No MCP (Model Context Protocol, the standard way an agent calls external tool
+servers) reconfiguration needed.
 
 ## How it works
 
-This directory is a self-contained OpenClaw plugin, not a hook-pack (OpenClaw's
-`before_tool_call` event is only reachable from a typed plugin hook, `api.on("before_tool_call",
-...)`, never from a lifecycle/command hook-pack).
+A hook is code that runs automatically at a fixed point, here just before a tool call. This
+directory is a self-contained OpenClaw plugin, not a hook-pack (OpenClaw's `before_tool_call`
+event is only reachable from a typed plugin hook, `api.on("before_tool_call", ...)`, never from a
+lifecycle/command hook-pack).
 
 1. `index.js` registers a `before_tool_call` handler. On every tool call it spawns
    `doberman hook openclaw` as a fresh subprocess, writes the event as JSON on stdin, and waits up
@@ -73,7 +76,7 @@ After install, and after every OpenClaw upgrade or config change:
    prompt, interception is **not** active. Stop and re-check steps 1 and 2 before trusting this
    adapter for anything real.
 
-## Known limitations (this slice)
+## Known limitations
 
 - **`web_fetch`'s argument key is a best-effort assumption**, not independently confirmed against
   OpenClaw's docs (`params.url`, inferred by convention from `web_search`'s confirmed
@@ -82,8 +85,8 @@ After install, and after every OpenClaw upgrade or config change:
 - **AUTH approval outcomes are not yet recorded** to Doberman's local decision log. Only BLOCK and
   PASS/monitor-softened outcomes are; an AUTH's eventual resolution happens asynchronously via
   OpenClaw's own `/approve` flow, outside this process's lifetime (wiring `onResolution` back to
-  the log is a follow-up slice).
-- **Pre-execution gating only.** This slice adds no `after_tool_call`/output scan. A read's target
+  the log is planned as a follow-up).
+- **Pre-execution gating only.** This adapter adds no `after_tool_call`/output scan. A read's target
   path is still gated the same as any other file-touching action (`.env`, keys, and the rest of
   Doberman's protected/sensitive globs are blocked or authenticated up front), but a read tool's
   returned content isn't vetted for leaked secrets here, unlike the Claude Code post-hook, which

--- a/changelog.d/600.docs.md
+++ b/changelog.d/600.docs.md
@@ -1,0 +1,1 @@
+- Plain-English rewrite of the adapter, example, rule_lab, and rules-data READMEs: terms defined on first use, same commands and facts (#600).

--- a/examples/plugin-audit-sink/README.md
+++ b/examples/plugin-audit-sink/README.md
@@ -1,9 +1,10 @@
 # Tutorial: custom AuditSink plugin
 
 Doberman discovers third-party audit sinks through the **`doberman.audit_sinks`**
-Python entry-point group (`AUDIT_SINK_GROUP` in `src/doberman/engine/registry.py`).
-Core never imports your package by name — install the package, and
-`discover_audit_sinks()` picks it up automatically.
+Python entry-point group (an entry point is a name a package lists in its
+`pyproject.toml` so other code can find and load it; `AUDIT_SINK_GROUP` in
+`src/doberman/engine/registry.py`). Core never imports your package by name.
+Install the package, and `discover_audit_sinks()` picks it up automatically.
 
 This mini-package is a five-minute copy template.
 
@@ -38,7 +39,7 @@ The sink must not add back anything the redaction layer removed:
 | Raw file paths or target strings | Redacted to a path-class label (`general`, `sensitive`, …) before reaching the sink. |
 | Agent inputs, tool arguments, or request payloads | Stripped entirely during redaction. |
 | File contents or environment variables | Never present in the record. |
-| HMAC entity IDs decoded or reversed | `entity_id` is a keyed HMAC; log it as-is, never attempt to reverse it. |
+| HMAC entity IDs decoded or reversed | `entity_id` is a keyed HMAC (a hash mixed with a secret key, so it can't be reversed back to the original value); log it as-is, never attempt to reverse it. |
 | Additional telemetry derived from the record | The sink is a dumb forwarder; enrichment belongs in a separate pipeline stage. |
 
 ## Round trip (from a Doberman-Core checkout)
@@ -85,7 +86,7 @@ pip uninstall -y doberman-example-plugin-audit-sink
 ```
 
 > **Important:** while this package is installed, core's "no sinks installed"
-> standalone checks (`discover_audit_sinks() == []`) will fail — that is
+> standalone checks (`discover_audit_sinks() == []`) will fail. That is
 > expected.  Uninstall before re-running the full core suite.  Default CI does
 > **not** install this package; `tests/unit/test_examples_plugin_audit_sink.py`
 > covers it instead by importing the sink class straight from this checkout
@@ -126,13 +127,13 @@ examples/plugin-audit-sink/
 1. New package with `requires-python = ">=3.11"` and `dependencies = ["doberman-core"]`
    (install against a local editable core checkout, not a stale PyPI wheel, while
    developing).
-2. Implement `emit(self, record: dict) -> None` — one method, no return value.
-3. **`emit` must never raise** — wrap all I/O in a broad `except Exception` and
+2. Implement `emit(self, record: dict) -> None`: one method, no return value.
+3. **`emit` must never raise**: wrap all I/O in a broad `except Exception` and
    log at WARNING.  A sink that throws can break the decision path.
-4. **Treat the record as read-only** — do not mutate, copy-and-enrich, or
+4. **Treat the record as read-only**: do not mutate, copy-and-enrich, or
    re-log fields beyond what the record already contains.
 5. Register under `[project.entry-points."doberman.audit_sinks"]`.
-6. Never add payload back — the record is already redacted; the sink is a
+6. Never add payload back: the record is already redacted; the sink is a
    forwarder, not an enrichment stage.
 7. If your sink is stateful (e.g. holds a queue or a network connection),
    implement `close() -> None` so callers can drain cleanly on shutdown.

--- a/examples/plugin-detector/README.md
+++ b/examples/plugin-detector/README.md
@@ -1,15 +1,16 @@
 # Tutorial: custom Detector plugin
 
 Doberman discovers third-party **behavioral detectors** through the
-**`doberman.detectors`** Python entry-point group (`DETECTOR_GROUP` in
-`src/doberman/engine/registry.py`). Structurally this seam is identical to
-`doberman.rules` (both contribute `Guardrail`-shaped objects), but detectors run
-in the **subjective** guardrail (Feature 9 — the UEBA-style behavioral layer),
-not the objective one. Core never imports your package by name — install the
-package, enable it by name, and `discover_detectors()` /
+**`doberman.detectors`** Python entry-point group (an entry point is a name a
+package lists in its `pyproject.toml` so other code can find and load it;
+`DETECTOR_GROUP` in `src/doberman/engine/registry.py`). Structurally this seam
+is identical to `doberman.rules` (both contribute `Guardrail`-shaped objects),
+but detectors run in the **subjective** guardrail (the UEBA-style behavioral
+layer), not the objective one. Core never imports your package by name.
+Install the package, enable it by name, and `discover_detectors()` /
 `SubjectiveGuardrail()` pick it up automatically.
 
-This mini-package is a five-minute copy template — a sibling to
+This mini-package is a five-minute copy template, a sibling to
 [`examples/plugin-guardrail/`](../plugin-guardrail/) for the `doberman.detectors`
 seam.
 
@@ -28,7 +29,7 @@ Invariants this example preserves:
 | **Fail-closed core unchanged** | A broken plugin is isolated by core; this package does not catch-and-swallow errors to PASS. |
 | **No core patch** | Registration is entirely via this package's `pyproject.toml`. |
 
-## Opt-in by name (required — every seam, not just this one)
+## Opt-in by name (required for every seam, not just this one)
 
 Installing this package is **not enough on its own**. Every entry-point seam is
 gated by an opt-in allowlist (`doberman.engine.plugin_config`): an entry point
@@ -87,7 +88,7 @@ assert g.evaluate(action, ctx).verdict is Verdict.AUTH
 ```
 
 (Run this only after `doberman plugins enable example_detector`, same as the CLI
-round trip above — the manual smoke goes through real discovery too.)
+round trip above; the manual smoke goes through real discovery too.)
 
 Uninstall when finished so other local experiments are not affected:
 
@@ -96,7 +97,7 @@ pip uninstall -y doberman-example-plugin-detector
 ```
 
 > **Important:** while this package is installed AND enabled, core's "no plugins
-> registered" standalone checks will see it — that is expected. Disable/uninstall
+> registered" standalone checks will see it. That is expected. Disable/uninstall
 > before re-running the full core suite. Default CI does **not** install this
 > package; it only path-imports the detector class for evaluate/raise-only checks.
 
@@ -137,10 +138,10 @@ examples/plugin-detector/
 4. Prefer `ReasonCode` values from `doberman.models` (do not invent free-form codes).
 5. Prefer `ctx.metadata["raw_arguments"]` for matching when present (a redacted `action.target` can hide the real signal).
 6. Never put secrets, full commands/paths, or request payloads into `explanation` or logs.
-7. Only return PASS / AUTH results that *raise* risk for your signal; abstain otherwise — a detector plugin may never return `BLOCK`.
+7. Only return PASS / AUTH results that *raise* risk for your signal; abstain otherwise. A detector plugin may never return `BLOCK`.
 8. Remember your plugin runs against its **own copy** of `ctx` (see `doberman.engine.decision_engine.plugin_ctx`): it can never mutate what a later built-in, another plugin, or the caller sees.
-9. Document (in your own README) that a user must `doberman plugins enable <name>` — installing the package is never enough on its own.
+9. Document (in your own README) that a user must `doberman plugins enable <name>`: installing the package is never enough on its own.
 
 Use `src/doberman/engine/detectors/` (the built-in behavioral detectors, e.g. `TokenChannelDetector`) as the reference template.
 
-This tutorial only steps up **shell execs** with a long pipeline — keep demo scope minimal.
+This tutorial only steps up **shell execs** with a long pipeline. Keep demo scope minimal.

--- a/examples/plugin-guardrail/README.md
+++ b/examples/plugin-guardrail/README.md
@@ -1,8 +1,9 @@
 # Tutorial: custom Guardrail plugin
 
 Doberman discovers third-party rules through the **`doberman.rules`** Python
-entry-point group (`RULE_GROUP` in `src/doberman/engine/registry.py`). Core never
-imports your package by name — install the package, and
+entry-point group (an entry point is a name a package lists in its `pyproject.toml`
+so other code can find and load it; `RULE_GROUP` in `src/doberman/engine/registry.py`).
+Core never imports your package by name. Install the package, and
 `discover_rules()` / `ObjectiveGuardrail()` pick it up automatically.
 
 This mini-package is a five-minute copy template.
@@ -71,7 +72,7 @@ pip uninstall -y doberman-example-plugin-guardrail
 ```
 
 > **Important:** while this package is installed, core's "no plugins installed"
-> standalone checks (`discover_rules() == []`) will fail — that is expected.
+> standalone checks (`discover_rules() == []`) will fail. That is expected.
 > Uninstall before re-running the full core suite. Default CI does **not**
 > install this package; it only path-imports the rule class for evaluate/raise-only
 > checks.
@@ -110,12 +111,12 @@ examples/plugin-guardrail/
 2. Implement `evaluate(self, action, ctx) -> GuardrailResult` (same contract as built-ins).
 3. Register under `[project.entry-points."doberman.rules"]`.
 4. Prefer `ReasonCode` values from `doberman.models` (do not invent free-form codes).
-5. Canonicalize paths with `doberman.canonical.canonicalize` before matching; normalize `\\` → `/` if you accept agent-supplied path strings.
+5. Canonicalize paths (reduce a path to one standard, absolute form, so `./a/../b` and `b` are recognized as the same path) with `doberman.canonical.canonicalize` before matching; normalize `\\` → `/` if you accept agent-supplied path strings.
 6. Prefer `ctx.metadata["raw_arguments"]` for path matching when present (redacted `action.target` can hide the real path).
 7. Never put secrets, full paths, or request payloads into `explanation` or logs.
 8. Only return PASS / AUTH / BLOCK results that *raise* risk for your signal; abstain otherwise.
-9. Do **not** re-implement repo-root confinement unless you mean to — escapes should stay the built-in path rule's job so a solo plugin does not invent a weaker story.
+9. Do **not** re-implement repo-root confinement unless you mean to: escapes should stay the built-in path rule's job, so a solo plugin does not invent a weaker story.
 
 Use `src/doberman/engine/rules/paths.py` as the reference built-in template.
 
-This tutorial only steps up **writes** (not deletes/reads) of the marker file — keep demo scope minimal.
+This tutorial only steps up **writes** (not deletes/reads) of the marker file. Keep demo scope minimal.

--- a/src/doberman/engine/rules/data/README.md
+++ b/src/doberman/engine/rules/data/README.md
@@ -1,8 +1,8 @@
 # Dependency admission bundled lists
 
 Two static, offline JSON snapshots consumed only by
-`doberman.engine.rules.dependency_admission` (C3, v1). Point-in-time,
-refreshed per release, not a live feed — see `README.md`'s known-limitations
+`doberman.engine.rules.dependency_admission` (v1). They are point-in-time,
+refreshed per release, not a live feed. See `README.md`'s known-limitations
 section for the honest caveat shipped alongside this.
 
 ## known_malicious_packages.json
@@ -17,16 +17,16 @@ Every entry below is from the 2017 npm typosquat campaign (credential-stealing
 packages), all removed from the registry and all carrying a GitHub Security
 Advisory. Verified against `api.osv.dev/v1/query` on 2026-09-02:
 
-- `npm` / `crossenv` — typosquat of `cross-env`. GHSA-c2m4-w5hm-vqjw
-- `npm` / `cross-env.js` — typosquat of `cross-env`. GHSA-hwhq-3hrj-v6v5
-- `npm` / `d3.js` — typosquat of `d3`. GHSA-qmjg-g86h-6rc9
-- `npm` / `fabric-js` — typosquat of `fabric`. GHSA-v73m-fjxv-w4rh
-- `npm` / `mongose` — typosquat of `mongoose`. GHSA-894f-rw44-qrw5
-- `npm` / `nodesass` — typosquat of `node-sass`. GHSA-xfmw-2vmm-579c
-- `npm` / `nodesqlite` — typosquat of `node-sqlite`. GHSA-wwf2-5cj8-jx6w
-- `npm` / `jquery.js` — typosquat of `jquery`. GHSA-jp27-cwp2-5qqr
-- `npm` / `openssl.js` — typosquat of `openssl`. GHSA-22gq-x6pg-752j
-- `npm` / `babelcli` — typosquat of `babel-cli`. GHSA-72hv-rp4q-q7f3
+- `npm` / `crossenv`: typosquat of `cross-env`. GHSA-c2m4-w5hm-vqjw
+- `npm` / `cross-env.js`: typosquat of `cross-env`. GHSA-hwhq-3hrj-v6v5
+- `npm` / `d3.js`: typosquat of `d3`. GHSA-qmjg-g86h-6rc9
+- `npm` / `fabric-js`: typosquat of `fabric`. GHSA-v73m-fjxv-w4rh
+- `npm` / `mongose`: typosquat of `mongoose`. GHSA-894f-rw44-qrw5
+- `npm` / `nodesass`: typosquat of `node-sass`. GHSA-xfmw-2vmm-579c
+- `npm` / `nodesqlite`: typosquat of `node-sqlite`. GHSA-wwf2-5cj8-jx6w
+- `npm` / `jquery.js`: typosquat of `jquery`. GHSA-jp27-cwp2-5qqr
+- `npm` / `openssl.js`: typosquat of `openssl`. GHSA-22gq-x6pg-752j
+- `npm` / `babelcli`: typosquat of `babel-cli`. GHSA-72hv-rp4q-q7f3
 
 Verify any of the above at: https://github.com/advisories?query=ecosystem%3Anpm
 (search the package name) or `api.osv.dev/v1/query`.
@@ -38,27 +38,27 @@ shipping an unverifiable claim. Add PyPI entries only once a real advisory is
 found and cited the same way as the npm entries above.
 
 Never list a legitimate package that was merely compromised in one version
-(e.g. `event-stream`, `ua-parser-js`) — this is a name-only list and would
+(e.g. `event-stream`, `ua-parser-js`): this is a name-only list and would
 block the real package forever, not just the compromised release.
 
 ## popular_packages.json
 
 `{ecosystem: [names]}` of well-known, high-download-count package names per
-ecosystem. Used ONLY as (a) the "not itself popular" false-positive guard
-and (b) the edit-distance-1 typosquat target set — never as an allowlist
-that grants anything.
+ecosystem. Used ONLY as (a) the "not itself popular" false-positive (flagging
+something safe as a threat) guard and (b) the edit-distance-1 typosquat target
+set, never as an allowlist that grants anything.
 
 A name on this list is EXEMPT from the typosquat check (it can never itself be
-flagged as one edit away from something popular) — so adding or omitting a name
+flagged as one edit away from something popular). So adding or omitting a name
 here is a security-relevant decision, not cosmetic: a real, legitimate package
 absent from this seed can be gated once (stepped up to `AUTH`) if it happens to
 land one edit from an entry that IS present (e.g. `vuex` vs. `vue`, `boto` vs.
-`boto3` — both fixed by adding the omitted name, see the C3 whole-branch review).
+`boto3`, both fixed by adding the omitted name).
 
 This is a STARTER seed (5-22 names per ecosystem: pypi 22, npm 22, cargo 10,
-rubygems 10, go 5 — 69 names total). Expand toward the
+rubygems 10, go 5, 69 names total). Expand toward the
 ≤2000-per-ecosystem ceiling from a real ranked snapshot before relying on
-this in production — e.g. PyPI's own download-stats BigQuery dataset
+this in production, e.g. PyPI's own download-stats BigQuery dataset
 (`hugovk.github.io/top-pypi-packages`), npm's registry download-count API,
 or crates.io's `/api/v1/crates?sort=downloads` endpoint. Every name added
 must be real and independently checkable; never invent one.

--- a/tools/rule_lab/README.md
+++ b/tools/rule_lab/README.md
@@ -1,10 +1,12 @@
-# rule_lab — raise-only experiment loop over the benchmark harness
+# rule_lab: raise-only experiment loop over the benchmark harness
 
 An autonomous-research pattern (propose → run fixed evaluator → score → memory),
 scoped to the one place it fits Doberman: **tuning rules/detectors against the
-benchmark harness**. It is deliberately *not* a model-training pipeline.
+benchmark harness**. Raise-only means every change this loop proposes can
+tighten a rule, never loosen one. It is deliberately *not* a model-training
+pipeline.
 
-Everything here is orchestration only — it imports the public benchmark CLI and
+Everything here is orchestration only. It imports the public benchmark CLI and
 **never touches `src/doberman`**. Candidates are shipped as external plugins, so
 the safety-critical core stays out of the autonomous loop.
 
@@ -67,8 +69,9 @@ branch on it.
 - **Overfit guard**: tune on one suite (e.g. `agentdojo`), validate on a held-out
   suite (e.g. `synthetic`) via the non-regression predicate. Improvement must
   survive the held-out suite. A candidate tuned and measured on the *same* suite
-  is train-on-test — the held-out check, not the tune ΔASR, is the real signal.
+  is train-on-test. The held-out check, not the tune ΔASR, is the real signal.
   The worker rejects overlapping tune/holdout lists before spending benchmark
   budget.
-- **Human in the loop**: the worker stops at `ACCEPT -> human review`. Merging —
-  and any 2FA-gated loosening — is never autonomous.
+- **Human in the loop**: the worker stops at `ACCEPT -> human review`. Merging is
+  never autonomous, and neither is any loosening gated by 2FA (two-factor
+  authentication).

--- a/tools/rule_lab/proposer.md
+++ b/tools/rule_lab/proposer.md
@@ -1,29 +1,29 @@
-# Proposer agent — rule-lab
+# Proposer agent: rule-lab
 
 You propose **one** candidate change to Doberman's protection and emit a spec.
 You do **not** write the final rule into the core, you do **not** merge, and you
-**cannot** weaken protection — the gate (`scorer.py`) rejects any candidate whose
+**cannot** weaken protection: the gate (`scorer.py`) rejects any candidate whose
 ASR rises or that hard-blocks a benign action. Your job is to find a *tightening*
 that the gate will accept and a human will approve.
 
 ## Inputs you are given
 
 - The `builtins_only` benchmark report (redacted: counts + rates only) for each
-  tune suite. **No payload text is ever provided** — reason about classes of
+  tune suite. **No payload text is ever provided.** Reason about classes of
   attack/benign actions, never specific strings.
 - The `reason_codes` / `verdict_histogram` of the baseline, which show where
   attacks slip through as `PASS` (bypass) or pile up as `AUTH` (fatigue risk).
 
 ## What to look for
 
-1. **Bypass gaps** — an attack class with high `attack.bypassed`. Propose a
+1. **Bypass gaps**: an attack class with high `attack.bypassed`. Propose a
    detector/rule that raises those specific actions to AUTH or BLOCK.
-2. **Fatigue load** — high `auth_burden` / `asr_under_fatigue`. Propose moving a
+2. **Fatigue load**: high `auth_burden` / `asr_under_fatigue`. Propose moving a
    *well-characterised serious* threat from AUTH up to BLOCK (never the reverse).
 3. **Never** propose lowering a verdict, widening a trusted-list, or relaxing a
    threshold. The gate will reject it and it wastes a cycle.
 
-## Output — emit exactly this JSON spec
+## Output: emit exactly this JSON spec
 
 ```json
 {
@@ -41,8 +41,10 @@ that the gate will accept and a human will approve.
 ## Handoff
 
 The candidate-worker turns this spec into an installable plugin (its own package,
-registered via the named entry point — the core never imports it), runs
+registered via the named entry point, a name it lists in its own `pyproject.toml`
+so Doberman can find and load it; the core never imports it), runs
 `worker.py`, and reports the gate verdict. If `final_decision` is `REJECT`, read
 the per-suite `reason` and revise the hypothesis; if `ACCEPT -> human review`,
-stop — a human takes it from the review checkpoint (2FA for anything that could
-ever loosen). Record the spec + deltas + outcome in `doberman-memory`.
+stop. A human takes it from the review checkpoint (2FA, two-factor
+authentication, for anything that could ever loosen). Record the spec + deltas
++ outcome in `doberman-memory`.


### PR DESCRIPTION
## Summary

Plain-English pass over the adapter, example, rule_lab, and rules-data READMEs. The reader is a CS sophomore who has used a terminal and git but may never have run a coding agent.

Same facts, plainer words:

- Terms are defined the first time they appear in each file (hook, PreToolUse, entry point, taint, exfiltration, fail closed, raise-only).
- Active voice, shorter sentences, no em-dashes, no mid-sentence emphasis bold.
- Internal bookkeeping ("Feature 9", slice numbers) removed from user-facing prose.
- Title dashes replaced with colons in four headings (`# Doberman: Codex CLI plugin`, `# rule_lab: ...`, two in `proposer.md`); `## Known limitations (this slice)` in the OpenClaw README is now `## Known limitations`. No other file links to those anchors (`scripts/check_markdown_links.py` passes).

Not changed: every fenced code block, command, flag, path, config key, and version range is byte-identical (checked by script: 27 fences, 0 differences). `tools/rule_lab/proposer.md` keeps one em-dash inside its frozen JSON block.

Files: `adapters/{codex,cursor,openclaw}/README.md`, `examples/plugin-{guardrail,detector,audit-sink}/README.md`, `tools/rule_lab/README.md`, `tools/rule_lab/proposer.md`, `src/doberman/engine/rules/data/README.md`.

## Tests

Docs only. `python scripts/check_markdown_links.py`: 44 files, no broken internal links. Example tests only assert the README files exist.

## Repo

- Repo: `doberman-core`
- [x] Public-release safe: documentation wording only, no enterprise references, no secrets.
