### PR TITLE
fix(rules): treat builtin as a transparent wrapper and walk eval payloads like sh -c (#555)

### DIFF
--- a/changelog.d/555.fixed.md
+++ b/changelog.d/555.fixed.md
@@ -1,0 +1,1 @@
+- Destructive commands wrapped in `builtin` or `eval` are now detected instead of silently passing (#555)

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -219,6 +219,11 @@ _WRAPPER_VALUE_OPTIONS: dict[str, frozenset[str]] = {
     "nohup": frozenset(),
     "command": frozenset(),
     "setsid": frozenset(),
+    # #555: `builtin <name> [args]` forces builtin resolution over any
+    # same-named function, exactly like `command` forces external resolution
+    # — transparent, no options of its own, so it hides a destructive segment
+    # (`builtin rm -rf /`) the same way an unstripped `command`/`exec` would.
+    "builtin": frozenset(),
 }
 #: Existing readers of the bare-name set keep working.
 _TRANSPARENT_WRAPPERS = frozenset(_WRAPPER_VALUE_OPTIONS)
@@ -1995,17 +2000,26 @@ def _is_powershell_encoded_flag(token: str) -> bool:
 
 def _opaque_shell_payload(tokens: list[str]) -> bool:
     """True for ``bash -c <payload>``, PowerShell ``-Command``/``-EncodedCommand``,
-    ``cmd /c <payload>``, or ``su -c``/``su --command=``/``runuser -c``/
-    ``runuser --command=`` — a payload we cannot (or must not) statically
-    vet. T5: ``su`` is a shell host like ``bash``, never a transparent
-    wrapper — its own ``-c``/``--command`` payload is walked exactly the way
-    ``bash -c``'s is (see ``_payload_command``). I2: ``runuser -c`` is
-    ``su -c`` with a different name (a root shell running an arbitrary
-    payload) — its own `_WRAPPER_OPAQUE_OPTIONS` entry keeps it, and its
-    ``-c``/``--command`` marker, intact in ``tokens`` for this same check."""
+    ``cmd /c <payload>``, ``su -c``/``su --command=``/``runuser -c``/
+    ``runuser --command=``, or ``eval <words...>`` — a payload we cannot (or
+    must not) statically vet. T5: ``su`` is a shell host like ``bash``, never a
+    transparent wrapper — its own ``-c``/``--command`` payload is walked
+    exactly the way ``bash -c``'s is (see ``_payload_command``). I2:
+    ``runuser -c`` is ``su -c`` with a different name (a root shell running an
+    arbitrary payload) — its own `_WRAPPER_OPAQUE_OPTIONS` entry keeps it, and
+    its ``-c``/``--command`` marker, intact in ``tokens`` for this same check.
+    #555: ``eval`` is never a transparent wrapper either (absent from
+    ``_WRAPPER_VALUE_OPTIONS``, so ``argv_from_tokens`` leaves it and its
+    arguments untouched) — bash concatenates its arguments with a single
+    space and re-parses the result as a shell command line, the same
+    string-payload shape as ``bash -c``, so it gets the same opaque-AUTH
+    floor with a body scan (see ``_payload_command``) rather than a silent
+    PASS with the destructive segment hidden in one shlex token."""
     if not tokens:
         return False
     head = _wrapper_name(tokens[0])
+    if head == "eval":
+        return len(tokens) > 1
     if head in _SHELLS:
         return "-c" in tokens or "--command" in tokens
     if head in ("su", "runuser"):
@@ -2393,9 +2407,12 @@ class DestructiveCommandRule:
 
 def _payload_command(tokens: list[str]) -> str | None:
     """Pull the argument after ``-c``/``-Command``/``cmd /c``/``su --command=``
-    for a bounded shared-command walk. ``None`` for ``-EncodedCommand``
-    (base64 — cannot decode/vet) so the caller skips body scanning and keeps
-    the opaque AUTH."""
+    (or, #555, every word after ``eval``, bash-joined with a single space —
+    ``eval``'s own concatenation rule) for a bounded shared-command walk.
+    ``None`` for ``-EncodedCommand`` (base64 — cannot decode/vet) so the
+    caller skips body scanning and keeps the opaque AUTH."""
+    if tokens and _wrapper_name(tokens[0]) == "eval":
+        return " ".join(tokens[1:]) if len(tokens) > 1 else None
     for flag in ("-c", "--command"):
         if flag in tokens:
             idx = tokens.index(flag)

--- a/tests/unit/test_brace_group_segmentation.py
+++ b/tests/unit/test_brace_group_segmentation.py
@@ -1,0 +1,156 @@
+"""Issue #555 — bounded follow-up to the #603/#612 command-walk hardening.
+
+``{ }``/subshell/keyword segmentation (``if``/``while``/``for``/``!``/
+``coproc``/...) is already covered by
+``test_rule_commands.py::test_shell_syntax_is_transparent_to_catastrophic_block``.
+This file covers the two gaps issue #555 found once that was probed against
+the FULL corpus of wrapper/keyword shapes:
+
+* ``builtin <cmd>`` was never a recognized transparent wrapper (unlike its
+  sibling ``command``), so ``builtin rm -rf /`` reached the rules with
+  ``builtin`` still sitting in argv[0] and PASSed silently — fixed by adding
+  it to ``_WRAPPER_VALUE_OPTIONS`` (same shape as ``command``/``exec``/
+  ``nice``).
+* ``eval "<payload>"`` was never recognized as an opaque string-payload
+  shape (unlike its sibling ``sh -c``), so the destructive command hidden
+  inside eval's single shlex token PASSed silently — fixed by teaching
+  ``_opaque_shell_payload``/``_payload_command`` eval's own concatenation
+  rule (bash joins ``eval``'s arguments with a single space and re-parses
+  the result), reusing the existing opaque-payload AUTH floor (raised to
+  BLOCK when the body scan finds a catastrophe) — no new reason code.
+
+Covers: catches-evasion (destructive command reaches BLOCK/AUTH through the
+wrapper/eval shape); no-new-false-positive (benign lookalikes stay PASS);
+raise-only (today's verdict for every existing dangerous-command shape is
+unchanged); ambiguity floors to AUTH with a human explanation, never a
+silent PASS.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from doberman.engine.rules.commands import DestructiveCommandRule, walk_command
+from doberman.models import ActionType, EvalContext, ReasonCode, SecurityObject, Verdict
+
+RULE = DestructiveCommandRule()
+
+
+def _cmd(command, *, action_type=ActionType.shell_exec):
+    action = SecurityObject(
+        id="cmd-1",
+        ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=action_type,
+        tool_name="shell_exec",
+        target=command,
+    )
+    ctx = EvalContext(metadata={"raw_arguments": {"command": command}})
+    return RULE.evaluate(action, ctx)
+
+
+# --- catches-evasion: builtin/eval must not hide a destructive segment -----
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "builtin rm -rf /",
+        "BUILTIN rm -rf /",  # _wrapper_name lower-cases; raise-only, never fewer matches
+        'eval "rm -rf /"',
+        "eval 'rm -rf /'",
+        "eval rm -rf /",  # unquoted: still concatenated + re-walked
+        'Eval "rm -rf /"',
+    ],
+)
+def test_wrapper_and_eval_evasions_still_block(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.destructive_command in result.reason_codes
+
+
+def test_eval_benign_body_still_floors_to_auth():
+    # Same policy as `sh -c "echo hi"`: an opaque payload is AUTH-floored
+    # even when the body itself is vettable and benign — it is the SHAPE
+    # (a string handed to eval/-c) that is categorically risky, not just
+    # this instance's content.
+    result = _cmd('eval "echo hi"')
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.opaque_command in result.reason_codes
+    assert result.explanation
+
+
+def test_bare_eval_and_builtin_stay_pass():
+    # No payload at all (`eval` with no args is a bash no-op); `builtin`
+    # naming a genuinely benign builtin must not be flagged.
+    assert _cmd("eval").verdict is Verdict.PASS
+    assert _cmd("builtin echo hi").verdict is Verdict.PASS
+
+
+# --- no-new-false-positive: lookalikes that must keep today's PASS ---------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'echo "{ not a group }"',
+        "printf '(x)'",
+        "grep -e '{' file",
+        "find . -name '*.py' -exec echo {} \\;",
+        "awk '{print $1}' file",
+        "echo eval",  # "eval" as an ARGUMENT, not argv[0] — never opaque
+        "echo builtin",
+    ],
+)
+def test_no_new_false_positives(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.PASS
+    assert not result.reason_codes
+
+
+# --- raise-only regression: every existing dangerous shape keeps its verdict
+# ----------------------------------------------------------------------------
+# Values captured against the UNTOUCHED worktree before this change (see the
+# session report) — the fix must not change any of these.
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm -rf /",
+        "time rm -rf /",
+        "command rm -rf /",
+        "exec rm -rf /",
+        "nice rm -rf /",
+        "{ rm -rf /; }",
+        "( rm -rf /)",
+        "if true; then rm -rf /; fi",
+        "while :; do rm -rf /; done",
+        "for f in *; do rm -rf /; done",
+        "! rm -rf /",
+        'sh -c "rm -rf /"',
+    ],
+)
+def test_raise_only_existing_dangerous_shapes_unchanged(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.destructive_command in result.reason_codes
+
+
+def test_raise_only_sh_c_opaque_auth_unchanged():
+    result = _cmd('sh -c "echo hi"')
+    assert result.verdict is Verdict.AUTH
+    assert ReasonCode.opaque_command in result.reason_codes
+
+
+# --- walk_command shape: eval's payload is walked as a nested command ------
+
+
+def test_walk_command_still_sees_eval_payload_as_one_opaque_token():
+    # walk_command itself (the shared tokenizer) is unchanged by this fix —
+    # eval's payload still arrives as a single shlex token; it is the
+    # DestructiveCommandRule's opaque-payload handling (_opaque_shell_payload/
+    # _payload_command) that re-walks it, exactly like `bash -c`'s payload.
+    segments, ambiguous, _dynamic = walk_command('eval "rm -rf /"')
+    assert segments == [["eval", "rm -rf /"]]
+    assert ambiguous is False


### PR DESCRIPTION
## Slice
- Feature / Slice: rules / `builtin` wrapper and `eval` payloads reach the destructive-command walk (#555)

## What this PR does
Issue #555 asked for brace-group, subshell and shell-keyword segmentation in `walk_command`. Probing `main` showed those shapes (`{ …; }`, `( … )`, `if`/`while`/`for`, `!`, `time`, `command`, `exec`) already reach the inner command since #603 and #612. Two wrapper shapes still passed silently, and this PR closes them:

- `builtin rm -rf x` is now a transparent wrapper like `command rm -rf x`: the inner command is walked and gets exactly the bare command's verdict and reason codes.
- `eval "rm -rf x"` (and `eval rm -rf x`, which the shell concatenates) is handled like `sh -c`: the payload is re-walked with the same `opaque_command` approval floor, the same bounded segment queue, and the same fail-upward on a variable payload (`eval $CMD` asks for approval). Nested `eval "eval '…'"` stays bounded by the shared segment cap and fails upward on overflow.
- No new reason code; no change to the segmentation logic itself.

Closes #555

## Tests added (run in CI)
- `tests/unit/test_brace_group_segmentation.py`: the already-handled shapes pinned as regressions (each equals bare `rm -rf x`), the `builtin` and `eval` cases (red before, green after; removing either fix turns its tests red), the raise-only table of dangerous commands with verdicts recorded before the change, and the no-new-false-positive set (`echo "{ not a group }"`, `awk '{print $1}'`, `find … -exec echo {} \;`, `git log --grep eval`).
- Regression: rule_commands, verb-keyed detectors, control-plane, Windows quoting, normalize and the 14-file corpus/benchmark sweep, all green locally.

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation

## Edge cases covered / Deviations from plan / Risks introduced
- `eval "echo hi"` now asks for approval, the same documented cost `sh -c "echo hi"` already carries.
- The issue title names segmentation; the shipped change is the two wrappers, because the segmentation part was already on `main`.
