### PR TITLE
perf(hosthooks): cache excluded-projects parsing on file content

### DIFF
--- a/changelog.d/618.changed.md
+++ b/changelog.d/618.changed.md
@@ -1,0 +1,1 @@
+- Excluded-project checks are re-parsed only when file content changes, cutting redundant JSON parsing on every host-hook call (#618)

--- a/src/doberman/storage/exclusions.py
+++ b/src/doberman/storage/exclusions.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import os
+from functools import lru_cache
 from pathlib import Path
 
 from doberman.storage.device_metrics import HOME_ENV
@@ -40,6 +41,25 @@ def excluded_projects_path(home: Path | None = None) -> Path:
     return base / ".doberman" / _EXCLUSIONS_FILE
 
 
+@lru_cache(maxsize=8)
+def _parse_excluded_projects_data(raw: bytes) -> dict:
+    """Parse+validate ``excluded_projects.json``, cached on its raw content (#552).
+
+    Same mechanism as :func:`doberman.config._parse_role_yaml_data` and
+    :func:`doberman.egress.artifact._parse_pins_yaml_data`: keyed on the
+    file's ``bytes`` rather than ``(path, mtime_ns)``, because a
+    same-mtime-tick rewrite (coarse filesystem clock resolution, or two fast
+    writes) could hash to the same mtime key and serve a stale list -- e.g. a
+    hook reading right after ``add_exclusion`` still seeing the project as
+    protected. The read itself stays outside this helper (see
+    ``load_excluded_projects``) so this function is pure parse+validate;
+    ``maxsize=8`` bounds memory across a handful of repo roots/edits without
+    unbounded growth. Raises straight through on parse failure -- never
+    cached (``lru_cache`` only memoizes success).
+    """
+    return json.loads(raw.decode("utf-8"))
+
+
 def load_excluded_projects(*, home: Path | None = None) -> list[str]:
     """The raw stored (already-canonical) excluded paths, or ``[]``.
 
@@ -50,7 +70,10 @@ def load_excluded_projects(*, home: Path | None = None) -> list[str]:
     try:
         if not path.exists():
             return []
-        data = json.loads(path.read_text(encoding="utf-8"))
+        # ponytail: one small read per decision; the parse+validate work below
+        # is cached on the bytes themselves, so no staleness ceiling remains.
+        raw = path.read_bytes()
+        data = _parse_excluded_projects_data(raw)
         if not isinstance(data, dict):
             return []
         entries = data.get("excluded")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ from doberman.auth.totp import TOTP_FILE_ENV
 from doberman.egress import artifact as _artifact_module
 from doberman.hosthooks.integrity import MANIFEST_ENV
 from doberman.roles.roles import load_builtin_roles as _load_builtin_roles
+from doberman.storage import exclusions as _exclusions_module
 from doberman.storage import fingerprint as _fingerprint_module
 from doberman.storage.device_metrics import HOME_ENV
 from doberman.storage.fingerprint import KEY_FILE_ENV
@@ -91,16 +92,17 @@ def isolated_fingerprint_key(tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def isolated_role_and_pin_caches():
-    """Clear the #552 content-keyed role/pin parse caches (and the #547-style
-    ``load_builtin_roles`` cache) between tests, same shape as
+    """Clear the #552 content-keyed role/pin/exclusions parse caches (and the
+    #547-style ``load_builtin_roles`` cache) between tests, same shape as
     ``isolated_fingerprint_key`` above: each is an ``lru_cache`` that is
     process-wide unless cleared here, and one test's cached content (or a
-    ``tmp_path`` role/pins file that happens to share bytes with another
-    test's) must never leak into the next.
+    ``tmp_path`` role/pins/exclusions file that happens to share bytes with
+    another test's) must never leak into the next.
     """
     _load_builtin_roles.cache_clear()
     _config_module._parse_role_yaml_data.cache_clear()
     _artifact_module._parse_pins_yaml_data.cache_clear()
+    _exclusions_module._parse_excluded_projects_data.cache_clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_project_exclusion.py
+++ b/tests/unit/test_project_exclusion.py
@@ -16,6 +16,7 @@ confinement rule.
 """
 
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -24,6 +25,7 @@ from doberman.hosthooks import claude_code, codex
 from doberman.hosthooks import spine as spine_module
 from doberman.hosthooks.openclaw import evaluate_before_tool_call
 from doberman.models import ActionType, EvalContext, SecurityObject, Verdict
+from doberman.storage import exclusions as exclusions_module
 from doberman.storage.exclusions import (
     add_exclusion,
     excluded_projects_path,
@@ -125,6 +127,52 @@ def test_wrong_shaped_json_fails_closed_to_not_excluded(tmp_path):
     path.write_text(json.dumps(["just", "a", "list"]), encoding="utf-8")
 
     assert load_excluded_projects() == []
+
+
+def test_load_excluded_projects_parses_once_for_unchanged_content(tmp_path):
+    # Same finding as #552 (role.yaml, artifact_pins.yaml): load_excluded_projects
+    # re-read AND re-parsed the file on every host-hook invocation with zero
+    # caching. Now content-keyed: the read still happens every call (the file is
+    # tiny), but the expensive JSON parse+validate must run exactly once for N
+    # calls against unchanged content.
+    project = tmp_path / "proj"
+    project.mkdir()
+    path = excluded_projects_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"excluded": [str(project)]}), encoding="utf-8")
+    exclusions_module._parse_excluded_projects_data.cache_clear()
+
+    for _ in range(20):
+        entries = load_excluded_projects()
+        assert entries == [str(project)]
+
+    info = exclusions_module._parse_excluded_projects_data.cache_info()
+    assert info.misses == 1  # the real (disk-touching) parse ran exactly once
+    assert info.hits == 19
+
+
+def test_load_excluded_projects_picks_up_a_same_mtime_rewrite(tmp_path):
+    # The cache must NOT go stale the way a naive (path, mtime_ns) key would: a
+    # same-mtime-tick rewrite (coarse filesystem clock resolution, or two fast
+    # writes -- e.g. `doberman uninstall` immediately followed by a hook read)
+    # must still be picked up on the very next call.
+    first_project = tmp_path / "proj-a"
+    first_project.mkdir()
+    second_project = tmp_path / "proj-b"
+    second_project.mkdir()
+    path = excluded_projects_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"excluded": [str(first_project)]}), encoding="utf-8")
+    exclusions_module._parse_excluded_projects_data.cache_clear()
+
+    assert load_excluded_projects() == [str(first_project)]
+
+    stat_before = path.stat()
+    path.write_text(json.dumps({"excluded": [str(second_project)]}), encoding="utf-8")
+    os.utime(path, ns=(stat_before.st_atime_ns, stat_before.st_mtime_ns))
+    assert path.stat().st_mtime_ns == stat_before.st_mtime_ns  # same-tick, by construction
+
+    assert load_excluded_projects() == [str(second_project)]
 
 
 def test_dober_home_env_isolation_is_honored(tmp_path):


### PR DESCRIPTION
## Slice
- perf / cache `load_excluded_projects` on content, the follow-up left open in #613 / issue #552

## What this PR does
`load_excluded_projects` (`src/doberman/storage/exclusions.py`) re-read and re-parsed
`~/.doberman/excluded_projects.json` on every host-hook invocation — the same #552 finding
already fixed for `role.yaml` and `artifact_pins.yaml` in #613. This applies the identical
pattern: the file read stays outside the cache (one small `read_bytes()` per call), and the
JSON parse+validate step moves into a new pure helper, `_parse_excluded_projects_data`,
wrapped in `functools.lru_cache(maxsize=8)` keyed on the raw bytes. Errors are never
memoized — the read and any raise stay inside the existing `try`/`except Exception` in
`load_excluded_projects`, so a missing or malformed file behaves exactly as before (fails
closed to `[]`). Content keying (not `(path, mtime_ns)`) is deliberate: a same-mtime-tick
rewrite could otherwise serve a stale exclusion list, which would violate the raise-only
rule (a hook reading right after `add_exclusion` could still see the project as protected,
or vice versa for the un-exclude direction). The new cache is added to the autouse
`isolated_role_and_pin_caches` clear fixture in `tests/conftest.py` alongside the existing
role/pins caches so tests stay isolated from each other.

## Tests added (run in CI)
- `tests/unit/test_project_exclusion.py::test_load_excluded_projects_parses_once_for_unchanged_content`
  — 20 calls against unchanged file content parse exactly once (`cache_info().misses == 1`,
  `hits == 19`).
- `tests/unit/test_project_exclusion.py::test_load_excluded_projects_picks_up_a_same_mtime_rewrite`
  — rewrites the file's content, forces the new write back onto the exact same `mtime_ns` via
  `os.utime`, and asserts the next `load_excluded_projects()` call still reflects the new
  content rather than serving a stale cached parse.

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation

## Edge cases covered / Deviations from plan / Risks introduced
- Same-mtime-tick rewrite is explicitly covered (see test above) — the whole reason this is
  content-keyed rather than mtime-keyed.
- A missing file, unreadable file, or malformed JSON still returns `[]` exactly as before —
  the parse+validate cache only wraps `json.loads`, never the `path.exists()` / `read_bytes()`
  / exception handling around it.
- No deviations from the brief; no new risks — this is a pure performance change with no
  behavioral difference for callers (`is_excluded`, `add_exclusion`, `remove_exclusion` all
  go through the same public `load_excluded_projects` entry point, unchanged).
