### PR TITLE
fix(storage): guard every additive ALTER against a racing duplicate column

### DIFF
--- a/changelog.d/619.fixed.md
+++ b/changelog.d/619.fixed.md
@@ -1,0 +1,1 @@
+- Every additive schema `ALTER` now tolerates a racing process adding the column first, not just #614's fix (#619)

--- a/src/doberman/storage/db.py
+++ b/src/doberman/storage/db.py
@@ -354,6 +354,24 @@ async def _table_columns(conn: aiosqlite.Connection, table: str) -> list[str]:
     return [row[1] for row in rows]
 
 
+async def _add_column_if_missing(conn: aiosqlite.Connection, table: str, column_def: str) -> bool:
+    """Run ``ALTER TABLE {table} ADD COLUMN {column_def}``, tolerating a second
+    process racing the same additive migration on the same pre-migration DB
+    (originally #556/#614's fix, generalized to every additive ALTER here).
+    The loser hits sqlite3's "duplicate column name" and is swallowed; any
+    other OperationalError re-raises. Returns True when this call actually
+    added the column (False when the race was already lost), so callers can
+    gate a one-time backfill on it.
+    """
+    try:
+        await conn.execute(f"ALTER TABLE {table} ADD COLUMN {column_def}")  # noqa: S608 — fixed literals only
+    except sqlite3.OperationalError as e:
+        if "duplicate column" not in str(e).lower():
+            raise
+        return False
+    return True
+
+
 async def _migrate_legacy(conn: aiosqlite.Connection) -> None:
     """v2 → v3: baselines become per-entity; decisions gain ``entity_id``.
 
@@ -367,13 +385,13 @@ async def _migrate_legacy(conn: aiosqlite.Connection) -> None:
         await conn.execute("DROP TABLE baseline_counts")
     decision_cols = await _table_columns(conn, "decisions")
     if decision_cols and "entity_id" not in decision_cols:
-        await conn.execute("ALTER TABLE decisions ADD COLUMN entity_id TEXT")
+        await _add_column_if_missing(conn, "decisions", "entity_id TEXT")
     # v3 → v4: decisions gain ``session_id`` (HK.5.1) so the host-hook taint
     # ledger can correlate calls within one agent session. Additive ALTER on an
     # existing table; fresh DBs get it from _SCHEMA above. session_taint itself is
     # created additively by executescript (CREATE TABLE IF NOT EXISTS).
     if decision_cols and "session_id" not in decision_cols:
-        await conn.execute("ALTER TABLE decisions ADD COLUMN session_id TEXT")
+        await _add_column_if_missing(conn, "decisions", "session_id TEXT")
     # v8 -> v9: retention stamps (Subj1) — add `last_touched` to every baseline/
     # preference table so `doberman memory prune` can find an entity's most recent
     # activity. Additive ALTER on an existing table; fresh DBs get it from _SCHEMA
@@ -393,8 +411,8 @@ async def _migrate_legacy(conn: aiosqlite.Connection) -> None:
     ):
         cols = await _table_columns(conn, table)
         if cols and "last_touched" not in cols:
-            await conn.execute(f"ALTER TABLE {table} ADD COLUMN last_touched TEXT")  # noqa: S608 — table is a fixed literal above
-            if backfill_from:
+            added = await _add_column_if_missing(conn, table, "last_touched TEXT")
+            if added and backfill_from:
                 await conn.execute(f"UPDATE {table} SET last_touched = {backfill_from}")  # noqa: S608 — fixed literals above
     # v11 -> v12: destination feature keys become keyed fingerprints — the raw
     # host must leave the store (a hostname can embed secret material). Legacy
@@ -420,14 +438,10 @@ async def _migrate_legacy(conn: aiosqlite.Connection) -> None:
             "effects_hits_outside_repo INTEGER",
             "effects_digest_fp TEXT",
         ):
-            try:
-                await conn.execute(f"ALTER TABLE decisions ADD COLUMN {column}")  # noqa: S608 — fixed literals above
-            except sqlite3.OperationalError as e:
-                # Two processes racing this migration on the same pre-v15 DB
-                # (review fix for #556) — the loser tolerates "already added
-                # by the winner" and re-raises anything else.
-                if "duplicate column" not in str(e).lower():
-                    raise
+            # Two processes racing this migration on the same pre-v15 DB
+            # (review fix for #556) — _add_column_if_missing tolerates the
+            # loser's "already added by the winner".
+            await _add_column_if_missing(conn, "decisions", column)
 
 
 async def _ensure_schema(conn: aiosqlite.Connection) -> None:

--- a/tests/unit/test_db_schema.py
+++ b/tests/unit/test_db_schema.py
@@ -303,6 +303,62 @@ async def test_migration_tolerates_a_racing_process_adding_a_column_first(tmp_pa
     assert versions == [SCHEMA_VERSION]
 
 
+# --- v2 -> v3: decisions gain `entity_id` (oldest guarded ALTER) -----------
+
+
+async def test_migration_tolerates_entity_id_already_present(tmp_path):
+    # Mirrors test_migration_tolerates_a_racing_process_adding_a_column_first
+    # for the oldest additive ALTER in _migrate_legacy: two processes racing
+    # the v2->v3 decisions.entity_id ALTER on the same pre-migration DB. Build
+    # a v2-shaped decisions table where entity_id is already present (the
+    # loser's view after the winner committed first) plus one existing row,
+    # and confirm opening doesn't raise "duplicate column name" and still
+    # reaches SCHEMA_VERSION with the row intact.
+    path = db_path(str(tmp_path))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = await aiosqlite.connect(str(path))
+    await conn.executescript(
+        """
+        CREATE TABLE schema_version (version INTEGER NOT NULL);
+        INSERT INTO schema_version (version) VALUES (2);
+        CREATE TABLE decisions (
+            id                INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts                TEXT NOT NULL,
+            action_id         TEXT NOT NULL,
+            agent_role        TEXT,
+            action_type       TEXT,
+            target_path_class TEXT,
+            risk              TEXT,
+            source_context    TEXT,
+            final_verdict     TEXT NOT NULL,
+            decided_layer     TEXT,
+            reason_codes_json TEXT,
+            auth_required     INTEGER NOT NULL DEFAULT 0,
+            auth_result       TEXT,
+            elevation_id      TEXT,
+            entity_id         TEXT
+        );
+        INSERT INTO decisions (ts, action_id, final_verdict)
+            VALUES ('2026-01-01T00:00:00+00:00', 'legacy-action', 'PASS');
+        """
+    )
+    await conn.commit()
+    await conn.close()
+
+    async with open_db(str(tmp_path)) as conn:  # must not raise OperationalError
+        cols = await _columns(conn, "decisions")
+        assert "entity_id" in cols
+        assert "session_id" in cols  # later additive ALTERs still run too
+        async with conn.execute(
+            "SELECT action_id FROM decisions WHERE action_id = 'legacy-action'"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row[0] == "legacy-action"  # existing row survived
+        async with conn.execute("SELECT version FROM schema_version") as cur:
+            versions = [r[0] for r in await cur.fetchall()]
+    assert versions == [SCHEMA_VERSION]
+
+
 def test_db_file_is_owner_only(tmp_path):
     async def _create():
         async with open_db(str(tmp_path)):

--- a/tests/unit/test_db_schema.py
+++ b/tests/unit/test_db_schema.py
@@ -2,11 +2,13 @@
 
 import asyncio
 import os
+import sqlite3
 import stat
 
 import aiosqlite
+import pytest
 
-from doberman.storage.db import SCHEMA_VERSION, db_path, open_db
+from doberman.storage.db import SCHEMA_VERSION, _add_column_if_missing, db_path, open_db
 
 _EXPECTED_TABLES = {
     "schema_version",
@@ -303,17 +305,49 @@ async def test_migration_tolerates_a_racing_process_adding_a_column_first(tmp_pa
     assert versions == [SCHEMA_VERSION]
 
 
+# --- _add_column_if_missing itself (direct unit test, review fix for #619) -
+
+
+async def test_add_column_if_missing_returns_true_then_false_then_reraises(tmp_path):
+    # For a single-column ALTER (unlike the v14->v15 six-column loop),
+    # _migrate_legacy's own "is this column already there" guard short-circuits
+    # before _add_column_if_missing ever runs once the column is present, so
+    # no _migrate_legacy-shaped test can reach the helper's except-branch.
+    # Exercise the helper directly instead: first call adds the column and
+    # returns True; a second call with the same column_def hits sqlite's
+    # "duplicate column name" and returns False without raising; a genuinely
+    # different OperationalError (ALTER against a table that doesn't exist)
+    # still re-raises.
+    path = db_path(str(tmp_path))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = await aiosqlite.connect(str(path))
+    await conn.execute("CREATE TABLE widgets (id INTEGER PRIMARY KEY)")
+    await conn.commit()
+
+    assert await _add_column_if_missing(conn, "widgets", "name TEXT") is True
+    assert "name" in await _columns(conn, "widgets")
+
+    assert await _add_column_if_missing(conn, "widgets", "name TEXT") is False
+
+    with pytest.raises(sqlite3.OperationalError):
+        await _add_column_if_missing(conn, "no_such_table", "name TEXT")
+
+    await conn.close()
+
+
 # --- v2 -> v3: decisions gain `entity_id` (oldest guarded ALTER) -----------
 
 
 async def test_migration_tolerates_entity_id_already_present(tmp_path):
-    # Mirrors test_migration_tolerates_a_racing_process_adding_a_column_first
-    # for the oldest additive ALTER in _migrate_legacy: two processes racing
-    # the v2->v3 decisions.entity_id ALTER on the same pre-migration DB. Build
-    # a v2-shaped decisions table where entity_id is already present (the
-    # loser's view after the winner committed first) plus one existing row,
-    # and confirm opening doesn't raise "duplicate column name" and still
-    # reaches SCHEMA_VERSION with the row intact.
+    # NOT a race-branch test (that would require reaching _add_column_if_missing
+    # with the column already present, but _migrate_legacy's own presence-check
+    # short-circuits first for this single-column ALTER — see
+    # test_add_column_if_missing_returns_true_then_false_then_reraises above for
+    # direct coverage of the helper's guard). This test instead confirms the
+    # ordinary migration path: a v2-shaped decisions table (entity_id already
+    # in the CREATE, as a hand-built fixture would look after any prior
+    # migration) plus one existing row still opens cleanly, migrates to
+    # SCHEMA_VERSION, and keeps its data.
     path = db_path(str(tmp_path))
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = await aiosqlite.connect(str(path))


### PR DESCRIPTION
## Slice
- storage / guard legacy ALTER migrations, follow-up to #614

## What this PR does
- Extracts `_add_column_if_missing(conn, table, column_def)` in `src/doberman/storage/db.py` — the try/except-`sqlite3.OperationalError`/"duplicate column" guard #614 added only for the v14->v15 `effects_*` ALTERs.
- Routes every additive `ALTER TABLE ... ADD COLUMN` in `_migrate_legacy` through the helper: v2->v3 `decisions.entity_id`, v3->v4 `decisions.session_id`, v8->v9 `last_touched` on the five baseline/preference tables, and v14->v15's six `effects_*` columns (the original #614 site, now reusing the shared helper instead of its own inline try/except).
- For the v8->v9 `last_touched` loop, the one-time backfill `UPDATE` now runs only when this call actually added the column (the helper's return value), so a race loser that finds the column already present skips a redundant backfill the winner already did.
- No schema version bump, no new tables, no behavior change for the non-racing path.

## Tests added (run in CI)
- `tests/unit/test_db_schema.py::test_add_column_if_missing_returns_true_then_false_then_reraises` — direct unit test of the helper itself: first call adds a column and returns `True`, a second call with the same `column_def` hits sqlite's "duplicate column name" and returns `False` without raising, and a genuinely different `OperationalError` (ALTER against a nonexistent table) still re-raises. Added because for a single-column ALTER (unlike the v14->v15 six-column loop), `_migrate_legacy`'s own presence-check short-circuits before the helper ever runs once the column exists, so no `_migrate_legacy`-shaped fixture can reach the helper's except-branch.
- `tests/unit/test_db_schema.py::test_migration_tolerates_entity_id_already_present` — confirms the ordinary (non-race) path for the oldest guarded ALTER: a v2-shaped `decisions` table with `entity_id` already present plus one existing row still opens cleanly, migrates to `SCHEMA_VERSION`, and keeps its data.
- Covering run: `tests/unit/test_db_schema.py tests/unit/test_approval_memory.py tests/integration/test_decision_log.py` — 59 passed, 0 failed.

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation

## Edge cases covered / Deviations from plan / Risks introduced
- Edge case: a race loser on the v8->v9 `last_touched` loop no longer re-runs its table's backfill `UPDATE` after losing the ALTER race (gated on the helper's `added` return) — the winner's backfill already covers it, avoiding a redundant no-op write.
- No deviations from the brief.
- Risk (pre-existing gap, behavior change in how it now surfaces): `ALTER TABLE ... ADD COLUMN` autocommits independently of `_ensure_schema`'s trailing `conn.commit()`. If a process crashes between adding a v8->v9 `last_touched` column and running that table's backfill `UPDATE`, the column is durably present but the backfill never ran, and `schema_version` was never bumped — so on the next open, `_migrate_legacy` re-enters, sees the column already there, and skips the whole per-table block, permanently losing the backfill for that table's pre-existing rows. That gap in the retry logic itself predates this PR. What this PR changes: before, a second process racing into the now-present column would crash loudly with an unhandled `sqlite3.OperationalError: duplicate column name`; now `_add_column_if_missing` swallows it and the process silently completes without backfilling. Mitigated because `last_touched IS NULL` is already documented/handled as a safe state (`doberman memory prune` skips an entity with no timestamp in any table rather than guessing an age) — the blast radius is a missed cleanup, not a security or fail-open issue.
