### PR TITLE
feat(rules): protected_branches role.yaml key widens force-push protection

### DIFF
--- a/changelog.d/620.added.md
+++ b/changelog.d/620.added.md
@@ -1,0 +1,1 @@
+- `protected_branches` role.yaml key widens force-push blocking to extra branches, always adding to the defaults, never replacing them (#620)

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -99,10 +99,18 @@ protected_branches:
 ```
 
 This only adds names. The four built-in branches always block and this key can never remove them.
-Names are matched exactly, case-insensitively, with no wildcards or glob patterns. The key sits
-alongside the `role` (or inline `allowed`/`suspicious`/`blocked`) definition in the same file, so a
-`.doberman/role.yaml` that sets only `protected_branches` and no role still falls back to the
-most-restrictive role, the same as any other role.yaml with no usable `role`.
+Names are matched exactly, case-insensitively, with no wildcards or glob patterns. Surrounding
+whitespace and a leading `refs/heads/` are stripped before matching, so `refs/heads/staging` and
+`" staging"` both work the same as `staging`. The key sits alongside the `role` (or inline
+`allowed`/`suspicious`/`blocked`) definition in the same file, so a `.doberman/role.yaml` that sets
+only `protected_branches` and no role still falls back to the most-restrictive role, the same as any
+other role.yaml with no usable `role`.
+
+A malformed `protected_branches` value, such as a plain string instead of a list, a list with a
+non-string entry, or an entry that is blank once whitespace is stripped, fails the whole role closed
+to the most restrictive role. This is not limited to branch protection: a bracket typo here also
+drops the operator's custom `allowed`/`suspicious`/`blocked` path scope, because the whole
+role.yaml file is rejected together, not just this one key.
 
 ## Subjective preference weights, `doberman prefs`
 

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -85,6 +85,25 @@ root are always a hard block, for every role. An explicit `.doberman/role.yaml` 
 precedence over the opt-in default. Turning the opt-in off (`doberman role disable-default`) is a
 weaken, gated behind the same possession-factor confirmation as lowering mode or enforcement.
 
+## Protecting extra branches from force-push, `protected_branches`
+
+Force-pushing to `main`, `master`, `release`, or `develop` always blocks, no configuration needed.
+To protect additional branches for a repo, such as `staging` or a release train branch, add a
+`protected_branches` list to `.doberman/role.yaml`:
+
+```yaml
+role: backend
+protected_branches:
+  - staging
+  - release-2026.9
+```
+
+This only adds names. The four built-in branches always block and this key can never remove them.
+Names are matched exactly, case-insensitively, with no wildcards or glob patterns. The key sits
+alongside the `role` (or inline `allowed`/`suspicious`/`blocked`) definition in the same file, so a
+`.doberman/role.yaml` that sets only `protected_branches` and no role still falls back to the
+most-restrictive role, the same as any other role.yaml with no usable `role`.
+
 ## Subjective preference weights, `doberman prefs`
 
 The adaptive layer's four "care" weights, `confidentiality`, `reversibility`,

--- a/src/doberman/config.py
+++ b/src/doberman/config.py
@@ -109,6 +109,15 @@ def load_active_role(repo_root: str = ".") -> RoleDefinition | None:
         logger.warning("%s is not a mapping; using the most-restrictive role", path)
         return MOST_RESTRICTIVE_ROLE
 
+    # #199: optional 'protected_branches' key -- extra branch names for
+    # DestructiveCommandRule to union into its force-push protection. Parsed
+    # once here (independent of the role branch below) since it is a sibling
+    # of 'role'/the inline keys, not part of either. Invalid → fail closed to
+    # the most-restrictive role, same as every other malformed value here.
+    extra_protected = _extra_protected_branches(data, path)
+    if extra_protected is None:
+        return MOST_RESTRICTIVE_ROLE
+
     # Inline custom role definition takes precedence over a named built-in.
     if any(key in data for key in ("allowed", "suspicious", "blocked")):
         try:
@@ -118,6 +127,7 @@ def load_active_role(repo_root: str = ".") -> RoleDefinition | None:
                 allowed=tuple(data.get("allowed") or ()),
                 suspicious=tuple(data.get("suspicious") or ()),
                 blocked=tuple(data.get("blocked") or ()),
+                protected_branches=extra_protected,
             )
         except (TypeError, ValueError):
             logger.warning("invalid inline role in %s; using the most-restrictive role", path)
@@ -138,7 +148,40 @@ def load_active_role(repo_root: str = ".") -> RoleDefinition | None:
     if role is None:
         logger.warning("unknown role %r; using the most-restrictive role", name)
         return MOST_RESTRICTIVE_ROLE
+    if extra_protected:
+        role = role.model_copy(
+            update={"protected_branches": role.protected_branches + extra_protected}
+        )
     return role
+
+
+def _extra_protected_branches(data: dict, path: Path) -> tuple[str, ...] | None:
+    """Parse+validate the optional 'protected_branches' role.yaml key (#199).
+
+    A list of branch name strings, unioned into DestructiveCommandRule's
+    protected set (see RoleDefinition.protected_branches) -- raise-only by
+    construction, since a union can only ever add names, never drop the
+    built-in DEFAULT_PROTECTED_BRANCHES. Absent/``None`` is valid (``()`` --
+    byte-identical to before this key existed). A non-list value, or any
+    non-string entry, is a schema error: ``None`` is the fail-closed sentinel
+    the caller uses to fall back to MOST_RESTRICTIVE_ROLE, same as every other
+    malformed role.yaml value in this module.
+
+    ponytail: exact string match only, no glob patterns -- YAGNI until a real
+    need for wildcard branch names shows up (would also need
+    ``_git_force_push_to_protected``'s matching to grow glob support).
+    """
+    raw = data.get("protected_branches")
+    if raw is None:
+        return ()
+    if not isinstance(raw, list) or not all(isinstance(b, str) for b in raw):
+        logger.warning(
+            "%s has an invalid 'protected_branches' (must be a list of branch name "
+            "strings); using the most-restrictive role",
+            path,
+        )
+        return None
+    return tuple(raw)
 
 
 def load_policy(repo_root: str = ".") -> PolicyDoc | None:

--- a/src/doberman/config.py
+++ b/src/doberman/config.py
@@ -155,6 +155,22 @@ def load_active_role(repo_root: str = ".") -> RoleDefinition | None:
     return role
 
 
+def _normalize_protected_branch(name: str) -> str:
+    """Strip whitespace, drop a leading 'refs/heads/', lower-case.
+
+    Mirrors ``doberman.engine.rules.commands._normalize_branch_name``, which
+    normalizes the ACTUAL pushed ref the same way before matching -- without
+    this, a copy-pasted 'refs/heads/staging' or ' staging' would pass schema
+    validation here but silently never match a real force-push (#199 review).
+    Kept as a separate copy (not an import) so config.py -- the policy core's
+    role.yaml loader -- doesn't take a dependency on a specific objective rule.
+    """
+    stripped = name.strip().lower()
+    if stripped.startswith("refs/heads/"):
+        stripped = stripped[len("refs/heads/") :]
+    return stripped
+
+
 def _extra_protected_branches(data: dict, path: Path) -> tuple[str, ...] | None:
     """Parse+validate the optional 'protected_branches' role.yaml key (#199).
 
@@ -162,10 +178,13 @@ def _extra_protected_branches(data: dict, path: Path) -> tuple[str, ...] | None:
     protected set (see RoleDefinition.protected_branches) -- raise-only by
     construction, since a union can only ever add names, never drop the
     built-in DEFAULT_PROTECTED_BRANCHES. Absent/``None`` is valid (``()`` --
-    byte-identical to before this key existed). A non-list value, or any
-    non-string entry, is a schema error: ``None`` is the fail-closed sentinel
-    the caller uses to fall back to MOST_RESTRICTIVE_ROLE, same as every other
-    malformed role.yaml value in this module.
+    byte-identical to before this key existed). A non-list value, any
+    non-string entry, or an entry that normalizes to blank (whitespace-only,
+    or just a 'refs/heads/' prefix with nothing after it) is a schema error:
+    ``None`` is the fail-closed sentinel the caller uses to fall back to
+    MOST_RESTRICTIVE_ROLE, same as every other malformed role.yaml value in
+    this module -- a blank entry is as unusable as a non-string one, so it
+    fails the same way rather than being silently dropped.
 
     ponytail: exact string match only, no glob patterns -- YAGNI until a real
     need for wildcard branch names shows up (would also need
@@ -181,7 +200,15 @@ def _extra_protected_branches(data: dict, path: Path) -> tuple[str, ...] | None:
             path,
         )
         return None
-    return tuple(raw)
+    normalized = tuple(_normalize_protected_branch(b) for b in raw)
+    if any(not b for b in normalized):
+        logger.warning(
+            "%s has a blank 'protected_branches' entry (empty, or whitespace-only, "
+            "after normalization); using the most-restrictive role",
+            path,
+        )
+        return None
+    return normalized
 
 
 def load_policy(repo_root: str = ".") -> PolicyDoc | None:

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -2193,7 +2193,16 @@ def delete_class_operands_and_dynamic(command: str) -> tuple[list[str] | None, b
 
 
 class DestructiveCommandRule:
-    """Detect catastrophic and risky shell/git commands; opaque → AUTH."""
+    """Detect catastrophic and risky shell/git commands; opaque → AUTH.
+
+    ``protected_branches`` (constructor) is this instance's own protected set
+    (``DEFAULT_PROTECTED_BRANCHES`` unless a caller overrides it — unchanged
+    behaviour). Per call, ``evaluate`` additionally unions in any names from
+    the active role's ``protected_branches`` (#199: the repo's
+    ``.doberman/role.yaml`` ``protected_branches`` key, see
+    ``doberman.config.load_active_role``) — a pure union, so it can only ever
+    widen force-push protection for that one call, never narrow it.
+    """
 
     def __init__(
         self,
@@ -2204,6 +2213,18 @@ class DestructiveCommandRule:
         # None → derive the bulk threshold from the active security mode (F6);
         # an explicit value overrides the mode (used by tests).
         self._bulk_threshold_override = bulk_threshold
+
+    def _effective_protected(self, ctx: EvalContext) -> tuple[str, ...]:
+        """``self._protected`` plus any role-configured extras (#199), unioned.
+
+        No active role, or a role that doesn't set ``protected_branches``, is
+        a no-op — byte-identical to before this existed.
+        """
+        role = getattr(ctx, "role", None)
+        extra = getattr(role, "protected_branches", ()) or ()
+        if not extra:
+            return self._protected
+        return self._protected + tuple(b for b in extra if b not in self._protected)
 
     def evaluate(self, action: SecurityObject, ctx: EvalContext) -> GuardrailResult:
         # Classify by payload shape, not by the tool's declared action type: a
@@ -2225,9 +2246,11 @@ class DestructiveCommandRule:
         threshold = self._bulk_threshold_override
         if threshold is None:
             threshold = thresholds_for(getattr(ctx, "mode", "balanced")).bulk_delete_threshold
-        return self._classify_line(command, threshold, root)
+        return self._classify_line(command, threshold, root, self._effective_protected(ctx))
 
-    def _classify_line(self, command: str, bulk_threshold: int, root: str) -> GuardrailResult:
+    def _classify_line(
+        self, command: str, bulk_threshold: int, root: str, protected: Iterable[str]
+    ) -> GuardrailResult:
         worst: GuardrailResult = GuardrailResult(verdict=Verdict.PASS, risk=Risk.low)
 
         # Checked against the RAW command, before shlex: POSIX tokenization eats
@@ -2348,7 +2371,7 @@ class DestructiveCommandRule:
                     pending.extend(literal_segments)
                     saw_unparseable = saw_unparseable or literal_ambiguous
 
-            verdict = _segment_verdict(tokens, self._protected, bulk_threshold, root)
+            verdict = _segment_verdict(tokens, protected, bulk_threshold, root)
             if verdict is not None:
                 worst = _max_result(worst, verdict)
                 if worst.verdict is Verdict.BLOCK:

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -94,6 +94,24 @@ _COMMAND_ACTION_TYPES = frozenset(
 #: Branch names whose history is protected — a force-push here is catastrophic.
 DEFAULT_PROTECTED_BRANCHES: tuple[str, ...] = ("main", "master", "release", "develop")
 
+
+def _normalize_branch_name(name: str) -> str:
+    """Normalize a protected-branch name to match how the actual pushed ref
+    gets normalized (see ``_git_force_push_to_protected`` below): strip
+    surrounding whitespace, lower-case, then drop a leading ``refs/heads/``
+    (lower-cased first so a differently-cased prefix still strips). Without
+    this, a copy-pasted ``"refs/heads/staging"`` or ``" staging"`` would pass
+    schema validation but silently never match a real push (#199 review).
+
+    Mirrored in ``doberman.config._extra_protected_branches`` for role.yaml
+    entries -- keep both in sync if this logic changes.
+    """
+    stripped = name.strip().lower()
+    if stripped.startswith("refs/heads/"):
+        stripped = stripped[len("refs/heads/") :]
+    return stripped
+
+
 #: git commit flags that skip hooks or signing (C4). Pre-commit/pre-push hooks
 #: often run tests/lint, and a commit signature vouches for authorship — an
 #: agent quietly disabling either is stepping around a safety net it is
@@ -2209,7 +2227,13 @@ class DestructiveCommandRule:
         protected_branches: Iterable[str] = DEFAULT_PROTECTED_BRANCHES,
         bulk_threshold: int | None = None,
     ) -> None:
-        self._protected = tuple(protected_branches)
+        # Normalized the same way as the config path (#199 review) so a
+        # caller-supplied name with stray whitespace/casing/a refs/heads/
+        # prefix matches like any other entry; a no-op for the defaults
+        # (already normalized) and for any already-normalized override.
+        self._protected = tuple(
+            b for b in (_normalize_branch_name(raw) for raw in protected_branches) if b
+        )
         # None → derive the bulk threshold from the active security mode (F6);
         # an explicit value overrides the mode (used by tests).
         self._bulk_threshold_override = bulk_threshold

--- a/src/doberman/roles/roles.py
+++ b/src/doberman/roles/roles.py
@@ -72,6 +72,12 @@ class RoleDefinition(BaseModel):
     ``allowed``/``suspicious``/``blocked`` are path globs matched against the
     canonical, root-relative, lower-cased target. They are normalized on
     construction (lower-cased, whole-tree patterns dropped).
+
+    ``protected_branches`` (#199) is unrelated to path scope: extra branch
+    names ``engine/rules/commands.py::DestructiveCommandRule`` unions into its
+    own protected set for force-push detection. Exact names only, no glob
+    normalization -- ``_git_force_push_to_protected`` already matches
+    case-insensitively.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -81,6 +87,7 @@ class RoleDefinition(BaseModel):
     allowed: tuple[str, ...] = ()
     suspicious: tuple[str, ...] = ()
     blocked: tuple[str, ...] = ()
+    protected_branches: tuple[str, ...] = ()
 
     def model_post_init(self, _context: object) -> None:
         # Normalize globs once at construction. object.__setattr__ is required

--- a/tests/unit/test_roles_schema.py
+++ b/tests/unit/test_roles_schema.py
@@ -127,6 +127,38 @@ def test_protected_branches_key_parses_for_an_inline_role(tmp_path):
     assert role.protected_branches == ("staging",)
 
 
+def test_protected_branches_entries_are_normalized(tmp_path):
+    # #199 review: the pushed ref is stripped of a 'refs/heads/' prefix and
+    # lower-cased before matching (commands.py), so a configured entry must
+    # be normalized the same way at parse time or it silently never matches.
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text(
+        "role: backend\nprotected_branches: ['refs/heads/Staging', '  Prod ']\n",
+        encoding="utf-8",
+    )
+    role = config.load_active_role(str(tmp_path))
+    assert role is not None
+    assert role.protected_branches == ("staging", "prod")
+
+
+def test_protected_branches_blank_after_normalization_fails_closed(tmp_path):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text("role: backend\nprotected_branches: ['   ']\n", encoding="utf-8")
+    assert config.load_active_role(str(tmp_path)) is MOST_RESTRICTIVE_ROLE
+
+
+def test_protected_branches_refs_heads_only_fails_closed(tmp_path):
+    # 'refs/heads/' with nothing after it normalizes to blank too.
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text(
+        "role: backend\nprotected_branches: ['refs/heads/']\n", encoding="utf-8"
+    )
+    assert config.load_active_role(str(tmp_path)) is MOST_RESTRICTIVE_ROLE
+
+
 def test_protected_branches_empty_list_is_fine(tmp_path):
     cfg = tmp_path / ".doberman"
     cfg.mkdir()

--- a/tests/unit/test_roles_schema.py
+++ b/tests/unit/test_roles_schema.py
@@ -99,6 +99,75 @@ def test_malformed_role_file_fails_closed_to_restrictive(tmp_path):
     assert config.load_active_role(str(tmp_path)) is MOST_RESTRICTIVE_ROLE
 
 
+# --- #199: protected_branches role.yaml key ---
+
+
+def test_protected_branches_key_parses_for_a_named_builtin_role(tmp_path):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text(
+        "role: backend\nprotected_branches: [staging, prod]\n", encoding="utf-8"
+    )
+    role = config.load_active_role(str(tmp_path))
+    assert role is not None
+    assert role.name == "backend"
+    assert role.protected_branches == ("staging", "prod")
+    # The named builtin's own path scope is untouched by the addition.
+    assert "backend/**" in role.allowed
+
+
+def test_protected_branches_key_parses_for_an_inline_role(tmp_path):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text(
+        "role: custom\nallowed: ['app/**']\nprotected_branches: ['staging']\n", encoding="utf-8"
+    )
+    role = config.load_active_role(str(tmp_path))
+    assert role is not None
+    assert role.protected_branches == ("staging",)
+
+
+def test_protected_branches_empty_list_is_fine(tmp_path):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text("role: backend\nprotected_branches: []\n", encoding="utf-8")
+    role = config.load_active_role(str(tmp_path))
+    assert role is not None
+    assert role.protected_branches == ()
+
+
+def test_protected_branches_key_absent_defaults_to_empty(tmp_path):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text("role: backend\n", encoding="utf-8")
+    role = config.load_active_role(str(tmp_path))
+    assert role is not None
+    assert role.protected_branches == ()
+
+
+def test_protected_branches_non_list_value_fails_closed_to_restrictive(tmp_path):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text(
+        'role: backend\nprotected_branches: "staging"\n', encoding="utf-8"
+    )
+    assert config.load_active_role(str(tmp_path)) is MOST_RESTRICTIVE_ROLE
+
+
+def test_protected_branches_non_string_entry_fails_closed_to_restrictive(tmp_path):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text(
+        "role: backend\nprotected_branches: [staging, 1]\n", encoding="utf-8"
+    )
+    assert config.load_active_role(str(tmp_path)) is MOST_RESTRICTIVE_ROLE
+
+
+def test_protected_branches_defaults_to_empty_tuple_on_role_definition():
+    role = RoleDefinition(name="x")
+    assert role.protected_branches == ()
+
+
 def test_load_builtin_roles_is_cached_across_many_calls():
     # Finding (#552): load_builtin_roles() re-read and re-parsed the packaged
     # builtin_roles.yaml on every call -- and it is called from

--- a/tests/unit/test_rule_commands.py
+++ b/tests/unit/test_rule_commands.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 
 import pytest
 
+from doberman import config
 from doberman.engine.rules import commands as commands_module
 from doberman.engine.rules.commands import (
     DestructiveCommandRule,
@@ -199,6 +200,61 @@ def test_constructor_override_unions_with_a_configured_role():
         role=role, metadata={"raw_arguments": {"command": "git push --force origin staging"}}
     )
     assert rule.evaluate(action, ctx).verdict is Verdict.BLOCK
+
+
+# --- #199 review: configured entries are normalized like the pushed ref is
+# (strip whitespace, drop a leading refs/heads/, lower-case) before matching.
+
+
+@pytest.mark.parametrize(
+    "configured",
+    ["refs/heads/staging", "  Staging "],
+)
+def test_configured_extra_branch_is_normalized_before_matching(tmp_path, configured):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text(
+        f"role: backend\nprotected_branches: ['{configured}']\n", encoding="utf-8"
+    )
+    role = config.load_active_role(str(tmp_path))
+    result = _cmd("git push --force origin staging", action_type=ActionType.git_op, role=role)
+    assert result.verdict is Verdict.BLOCK
+    assert result.reason_codes == [ReasonCode.destructive_command]
+
+
+def test_configured_branch_whitespace_only_entry_fails_closed(tmp_path):
+    cfg = tmp_path / ".doberman"
+    cfg.mkdir()
+    (cfg / "role.yaml").write_text("role: backend\nprotected_branches: ['   ']\n", encoding="utf-8")
+    role = config.load_active_role(str(tmp_path))
+    # Fails the whole role closed (most-restrictive), not just the branch key.
+    assert role.name == "restricted"
+    assert role.allowed == ()
+
+
+def test_constructor_override_entry_is_normalized_before_matching():
+    rule = DestructiveCommandRule(protected_branches=["refs/heads/Custom", "  padded  "])
+    action_a = SecurityObject(
+        id="a",
+        ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.git_op,
+        tool_name="shell_exec",
+        target="git push --force origin custom",
+    )
+    ctx_a = EvalContext(metadata={"raw_arguments": {"command": "git push --force origin custom"}})
+    assert rule.evaluate(action_a, ctx_a).verdict is Verdict.BLOCK
+
+    action_b = SecurityObject(
+        id="b",
+        ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.git_op,
+        tool_name="shell_exec",
+        target="git push --force origin padded",
+    )
+    ctx_b = EvalContext(metadata={"raw_arguments": {"command": "git push --force origin padded"}})
+    assert rule.evaluate(action_b, ctx_b).verdict is Verdict.BLOCK
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_rule_commands.py
+++ b/tests/unit/test_rule_commands.py
@@ -27,11 +27,12 @@ from doberman.models import (
     Verdict,
 )
 from doberman.proxy.normalize import normalize
+from doberman.roles.roles import RoleDefinition
 
 RULE = DestructiveCommandRule()
 
 
-def _cmd(command, *, action_type=ActionType.shell_exec):
+def _cmd(command, *, action_type=ActionType.shell_exec, role=None):
     action = SecurityObject(
         id="cmd-1",
         ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
@@ -40,7 +41,7 @@ def _cmd(command, *, action_type=ActionType.shell_exec):
         tool_name="shell_exec",
         target=command,
     )
-    ctx = EvalContext(metadata={"raw_arguments": {"command": command}})
+    ctx = EvalContext(role=role, metadata={"raw_arguments": {"command": command}})
     return RULE.evaluate(action, ctx)
 
 
@@ -131,6 +132,73 @@ def test_force_push_to_feature_branch_is_not_blocked():
 def test_non_force_push_to_feature_branch_is_not_blocked():
     result = _cmd("git push origin my-feature", action_type=ActionType.git_op)
     assert result.verdict is not Verdict.BLOCK
+
+
+# --- #199: protected_branches role.yaml key widens force-push protection ---
+# (config.py parses the key; DestructiveCommandRule.evaluate unions ctx.role's
+# protected_branches into its own set -- see _effective_protected).
+
+
+def test_force_push_to_configured_extra_branch_blocks():
+    role = RoleDefinition(name="x", protected_branches=("staging",))
+    result = _cmd("git push --force origin staging", action_type=ActionType.git_op, role=role)
+    assert result.verdict is Verdict.BLOCK
+    assert result.reason_codes == [ReasonCode.destructive_command]
+
+
+def test_force_push_to_unconfigured_branch_with_role_active_stays_unblocked():
+    role = RoleDefinition(name="x", protected_branches=("staging",))
+    result = _cmd("git push --force origin my-feature", action_type=ActionType.git_op, role=role)
+    assert result.verdict is not Verdict.BLOCK
+
+
+def test_default_protected_branches_still_block_with_extra_configured():
+    # Raise-only: configuring an extra branch must never soften the defaults.
+    role = RoleDefinition(name="x", protected_branches=("staging",))
+    result = _cmd("git push --force origin main", action_type=ActionType.git_op, role=role)
+    assert result.verdict is Verdict.BLOCK
+    assert result.reason_codes == [ReasonCode.destructive_command]
+
+
+def test_constructor_override_behaviour_is_unchanged_with_no_active_role():
+    # DestructiveCommandRule(protected_branches=...) keeps its exact current
+    # behaviour -- a ctx with no active role is a no-op union.
+    rule = DestructiveCommandRule(protected_branches=("custom",))
+
+    def _run(command):
+        action = SecurityObject(
+            id="cmd-1",
+            ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
+            agent_role="unknown",
+            action_type=ActionType.git_op,
+            tool_name="shell_exec",
+            target=command,
+        )
+        ctx = EvalContext(metadata={"raw_arguments": {"command": command}})
+        return rule.evaluate(action, ctx)
+
+    assert _run("git push --force origin custom").verdict is Verdict.BLOCK
+    # "main" is not in this instance's override list, and no role is active.
+    assert _run("git push --force origin main").verdict is not Verdict.BLOCK
+
+
+def test_constructor_override_unions_with_a_configured_role():
+    # An explicit constructor override still gets the config-path addition on
+    # top -- the config path unions with the parameter rather than replacing it.
+    rule = DestructiveCommandRule(protected_branches=("custom",))
+    role = RoleDefinition(name="x", protected_branches=("staging",))
+    action = SecurityObject(
+        id="cmd-1",
+        ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.git_op,
+        tool_name="shell_exec",
+        target="git push --force origin staging",
+    )
+    ctx = EvalContext(
+        role=role, metadata={"raw_arguments": {"command": "git push --force origin staging"}}
+    )
+    assert rule.evaluate(action, ctx).verdict is Verdict.BLOCK
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Slice
- rules / protected branches from a repo config key, #199

## What this PR does

Issue #199 asked for a maintainer decision on how to widen force-push protection beyond the
hardcoded `DEFAULT_PROTECTED_BRANCHES` list (`main`, `master`, `release`, `develop`). The decision:
protected branches beyond the defaults come from an optional `protected_branches` key in the repo's
`.doberman/role.yaml`, a plain list of branch name strings.

Design, fixed:

- **Config key**: `.doberman/role.yaml` may now carry a `protected_branches: [name, ...]` list,
  alongside the existing `role` (or inline `allowed`/`suspicious`/`blocked`) definition.
- **Union with defaults**: the effective protected set is `DEFAULT_PROTECTED_BRANCHES` union the
  configured names. This is a union, not a replace, so it can only ever add branches.
- **Raise-only**: because it is a union, the key can never remove `main`, `master`, `release`, or
  `develop`. There is no code path where configuring this key narrows protection.
- **Exact name match only**, no glob patterns. `_git_force_push_to_protected` already matches
  case-insensitively, so this needed no new matching logic. A `ponytail:` comment in
  `config.py::_extra_protected_branches` names the YAGNI call and the upgrade path (glob support
  would also need to land in `_git_force_push_to_protected`'s matching).

How it is wired:

- `RoleDefinition` (`src/doberman/roles/roles.py`) gains a `protected_branches: tuple[str, ...] = ()`
  field, separate from the path-boundary globs it already carries.
- `config.py::load_active_role` parses and validates the key once (`_extra_protected_branches`),
  independent of whether the role resolves to a named builtin or an inline custom role, and attaches
  it to whichever `RoleDefinition` is returned.
- `DestructiveCommandRule.evaluate` (`src/doberman/engine/rules/commands.py`) unions
  `ctx.role.protected_branches` into its own protected set per call
  (`_effective_protected`). The existing `DestructiveCommandRule(protected_branches=...)` constructor
  override keeps its exact current behaviour: with no active role (every existing caller/test), the
  union is a no-op.

Closes #199

## Tests added (run in CI)

- `tests/unit/test_rule_commands.py`: force-push to a configured extra branch blocks with the same
  verdict and reason codes as a force-push to `main`; an unconfigured branch stays unblocked even
  with a role active; the four defaults still block when an extra branch is configured (raise-only
  regression); the constructor override is unchanged with no active role, and unions correctly when
  a role is active.
- `tests/unit/test_roles_schema.py`: the key parses for both a named-builtin role and an inline
  custom role; an empty list is fine; the key is absent by default; a non-list value and a
  non-string list entry both fail closed to the most-restrictive role; `RoleDefinition`'s
  `protected_branches` defaults to `()`.
- `tests/unit/test_git_verb_keyed_detectors.py` (existing, run as a regression guard, unmodified):
  force-push / history-rewrite verb-keying is untouched by this change.

Covering run: `python -m pytest tests/unit/test_rule_commands.py tests/unit/test_roles_schema.py
tests/unit/test_git_verb_keyed_detectors.py -n 4 -q` — 469 passed.

Also ran the broader set of tests that construct `RoleDefinition` or call `load_active_role`
(`test_role_escalation.py`, `test_role_matcher.py`, `test_role_elevation_satisfies.py`,
`test_policy_sources.py`, `test_policy_catalogue.py`, `test_hosthook_claude_pre.py`,
`test_default_role_opt_in.py`, `test_authority_tiers.py`) as a regression check — all pass.

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (no silent loosening)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation

## Edge cases covered / Deviations from plan / Risks introduced

Edge cases covered:
- Empty `protected_branches: []` is valid (no widening, byte-identical to the key being absent).
- A non-list value (e.g. a bare string) and a non-string list entry (e.g. an integer) both fail
  closed to the most-restrictive role, the same fail-closed pattern every other malformed
  `role.yaml` value in `config.py` already uses.
- A `role.yaml` that sets only `protected_branches` with no `role` name and no inline
  `allowed`/`suspicious`/`blocked` keys still falls back to the most-restrictive role, exactly as it
  did before this key existed (a bare `protected_branches`-only file was already "no usable role").
  This is documented in `docs/TUNING.md` rather than special-cased in code, since role.yaml's stated
  purpose is declaring the active role.
- Force-push to a configured extra branch gets the exact same verdict (`BLOCK`) and reason codes
  (`[destructive_command]`) as a force-push to `main` today.

Deviations from plan: none. The maintainer-agreed direction from the issue thread (config key, union
with defaults, raise-only, exact match) is implemented as specified.

Risks introduced: none identified. The union operation is structurally raise-only (a union can only
add elements), so there is no code path by which this key can weaken existing force-push protection.
