### PR TITLE
test(ci): run example plugin suites after standalone core tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,16 @@ jobs:
           ${{ runner.os == 'Linux' && 'xvfb-run -a -s "-screen 0 1280x800x24"' || '' }}
           pytest -n auto --dist loadgroup --max-worker-restart=0 --timeout=300 --durations=25 --durations-min=2.0
           ${{ matrix.coverage && '--cov=doberman --cov-report=term-missing --cov-fail-under=90' || '' }}
+      # Install examples only AFTER the standalone suite, on one Linux leg.
+      # Explicit paths keep their real entry-point tests out of root testpaths.
+      - name: Example plugin suites
+        if: runner.os == 'Linux' && matrix.python-version == '3.12'
+        run: |
+          set -euo pipefail
+          for example in examples/plugin-*; do
+            python -m pip install -e "$example"
+            python -m pytest "$example/tests" --timeout=300
+          done
   package-smoke-test:
     name: package-smoke-test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,19 @@ in CI. Their tests use fakes there, so exercise the real thing locally when you 
 `-n auto` runs the suite in parallel (pytest-xdist ships in the `dev` extra), the
 same way CI runs it.
 
+After the standalone suite, the Linux 3.12 leg installs and tests the example plugins separately:
+
+```bash
+set -euo pipefail
+for example in examples/plugin-*; do
+  python -m pip install -e "$example"
+  python -m pytest "$example/tests" --timeout=300
+done
+```
+
+Keep these suites out of root `testpaths`: core must pass without example plugins installed.
+Use a separate virtual environment for this command when continuing to test standalone core locally.
+
 CI also verifies that `doberman-core` builds and tests without the private
 enterprise package installed, then runs the same ruff, import-linter, pytest,
 and secret-scan workflow.

--- a/README.md
+++ b/README.md
@@ -302,6 +302,10 @@ design, like a runtime egress broker, that don't exist yet. None of them let an 
 Start with [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, CI checks, project invariants, and the
 PR workflow.
 
+The Linux Python 3.12 CI leg installs and tests every `examples/plugin-*` package after the
+standalone core suite. Example suites stay outside root pytest discovery so core is tested without
+the tutorial plugins installed.
+
 CI also runs `python scripts/check_markdown_links.py`, a deterministic offline check for
 repository-local Markdown links and heading anchors. It skips external URLs and fenced code blocks
 and never makes network requests.

--- a/tests/unit/test_example_plugin_ci.py
+++ b/tests/unit/test_example_plugin_ci.py
@@ -1,0 +1,70 @@
+"""Exercise the actual example CI shell without installing plugins into core."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _example_step() -> dict:
+    workflow = yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text())
+    steps = workflow["jobs"]["test"]["steps"]
+    names = [step.get("name") for step in steps]
+    assert names.index("Example plugin suites") > names.index("Test suite")
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    assert all(
+        not path.startswith("examples")
+        for path in config["tool"]["pytest"]["ini_options"]["testpaths"]
+    )
+    return steps[names.index("Example plugin suites")]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="The example CI step runs on Linux only")
+@pytest.mark.parametrize("failure", ["", "pip", "pytest"])
+def test_example_ci_runs_each_package_and_propagates_failure(tmp_path: Path, failure: str) -> None:
+    # Include a future package to pin discovery, not just the current three names.
+    packages = ["plugin-a", "plugin-b", "plugin-future"]
+    for name in packages:
+        (tmp_path / "examples" / name / "tests").mkdir(parents=True)
+    shim = tmp_path / "python"
+    shim.write_text(
+        "#!/bin/bash\n"
+        'printf "%s\\n" "$*" >> "$CALLS"\n'
+        'if [[ "$2" == "$FAILURE" ]]; then exit 17; fi\n'
+    )
+    shim.chmod(0o755)
+    calls = tmp_path / "calls"
+    result = subprocess.run(  # noqa: S603 - executes the checked-in CI step with a local shim
+        ["bash", "-e", "-o", "pipefail", "-c", _example_step()["run"]],  # noqa: S607
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+            "CALLS": str(calls),
+            "FAILURE": failure,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    expected = [
+        command
+        for name in packages
+        for command in (
+            f"-m pip install -e examples/{name}",
+            f"-m pytest examples/{name}/tests --timeout=300",
+        )
+    ]
+    if failure:
+        assert result.returncode == 17
+        assert calls.read_text().splitlines() == expected[: 1 if failure == "pip" else 2]
+    else:
+        assert result.returncode == 0, result.stderr
+        assert calls.read_text().splitlines() == expected


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: #595 — run the example plugin suites in CI
- Plan reference: https://github.com/DobermanCore/Doberman-Core/issues/595

## What this PR does

Fixes #595. Root pytest discovery currently excludes the example plugins, so their own tests can regress while CI remains green. Add a Linux/Python 3.12 step that installs and tests each `examples/plugin-*` package after the standalone core suite. Root `testpaths` remains unchanged, and installation or pytest failures stop the step immediately. Future example packages are included by the same glob.

README and CONTRIBUTING describe the sequence and recommend a separate local environment for example tests.

## Tests added (run in CI)
- `tests/unit/test_example_plugin_ci.py` executes the actual CI shell with a local command shim: discovers a future example, preserves install-before-test order, and propagates failures from both commands. It also guards standalone-before-examples ordering and exclusion from root discovery. This shell-specific check skips Windows; the production step runs only on Linux.
- Actual workflow step executed locally in a separate environment: 12 audit-sink, 9 detector, and 12 guardrail tests passed.
- A temporary failing audit-sink test made the actual step exit 1; the probe was restored, then all 33 tests passed. No failing probe is committed.
- Static checks: ruff, format, import boundaries, offline Markdown links, changelog validation, and parity generation passed.
- Full core suite: 5,401 passed, 4 skipped; 92.54% coverage (90% gate), as an unprivileged user in Linux/Python 3.12.14 with Xvfb. The same process then executed the actual CI example step: all 33 tests passed..

Final Linux validation used the official `python:3.12-bookworm` image, Xvfb, and an unprivileged runner user. Earlier macOS runs exposed environment differences (temporary-path entropy, color settings, nested venv inheritance, and Tk threading), and an initial root container run bypassed the unreadable-directory fixture's permissions. The final run corrects those execution conditions without changing application code or existing assertions.

## Changelog
- [x] CI plumbing has no user-visible behavior change; no fragment required under `changelog.d/README.md`.

## Public-release safety (doberman-core only)
- [x] No enterprise/hosted code, proprietary detection, customer data, secrets, or commercial-license code added.
- [x] Core validation runs with no enterprise or example plugin packages installed.

## Security checklist
- [x] Install/test errors fail the CI step; core decision behavior is unchanged.
- [x] No secret, private file, or unredacted prompt logged or committed.
- [x] Guardrail, learning, BLOCK/AUTH explanations, and enterprise import boundaries are unchanged.

## Edge cases covered / Deviations from plan / Risks introduced
- Future example discovery, install failure, test failure, and standalone isolation covered.
- No production-code changes. No new dependencies or workflow permissions.
- macOS local verification is not a substitute for the requested Linux CI run; upstream CI must confirm that leg.

Implemented with OpenAI Codex assistance.
