### PR TITLE
fix: wire whole_script_confusable detection into MCP admission scan (#646)

### DIFF
--- a/src/doberman/discovery/mcp_scan.py
+++ b/src/doberman/discovery/mcp_scan.py
@@ -43,6 +43,7 @@ _INVISIBLE_CHANNELS = frozenset(
 _RISK_BY_PATTERN = {
     "invisible_chars": Risk.high,
     "mixed_script": Risk.medium,
+    "whole_script": Risk.medium,
     "templated_url": Risk.high,
     "raw_ip_url": Risk.high,
     "non_https_url": Risk.medium,
@@ -133,6 +134,8 @@ def _scan_server(server: str, source_file: str, config: dict[str, object]) -> se
             findings.add(_finding(server, source_file, "unicode", "invisible_chars"))
         if "mixed_script_confusable" in channels:
             findings.add(_finding(server, source_file, "unicode", "mixed_script"))
+        if "whole_script_confusable" in channels:
+            findings.add(_finding(server, source_file, "unicode", "whole_script"))
 
     env = config.get("env")
     env_values: list[str] = []

--- a/tests/unit/test_mcp_scan.py
+++ b/tests/unit/test_mcp_scan.py
@@ -31,6 +31,18 @@ def test_finds_zero_width_server_name_and_escapes_it(tmp_path):
     assert any("\\u200b" in finding.server for finding in unicode_findings)
 
 
+def test_finds_whole_script_confusable_server_name(tmp_path):
+    # All-Cyrillic look-alike for "server" — no script mixing, so only the
+    # whole-script channel (not mixed_script) should catch it.
+    _write_mcp_config(tmp_path, {"сервер": {"command": "server"}})
+
+    findings = scan_mcp_configs(str(tmp_path))
+
+    unicode_findings = [finding for finding in findings if finding.category == "unicode"]
+    assert any(finding.pattern_class == "whole_script" for finding in unicode_findings)
+    assert not any(finding.pattern_class == "mixed_script" for finding in unicode_findings)
+
+
 def test_finds_templated_exfil_url_in_args(tmp_path):
     _write_mcp_config(
         tmp_path,


### PR DESCRIPTION
…#646)

# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: #646 — wire whole_script_confusable into MCP admission scan
- Plan reference: N/A (bug fix)

## What this PR does
Connects the existing whole_script_confusable detection channel to the MCP 
admission scan. The detector in tokens.py already identified whole-script 
Unicode attacks (e.g. all-Cyrillic server names) but mcp_scan.py never 
checked that channel — so detections were silently dropped. This PR wires 
the two together with 2 additive lines.

## Tests added (run in CI)
- test_finds_whole_script_confusable_server_name — uses all-Cyrillic look-alike 
  server name, asserts whole_script finding fires and mixed_script does not

## Changelog
- [ ] changelog.d fragment not added — awaiting PR number assignment

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with NO enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Change is raise-only — adds a new finding, does not loosen any guardrail
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- Strictly additive — existing mixed_script and invisible_chars paths untouched
- tokens.py not modified
- New finding uses same Risk.medium severity as mixed_script (same threat class)
