### PR TITLE
fix(render): wrap non-path slash tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ real verdicts with `doberman demo`. MCP-proxy wiring, the dashboard, the TUI, sc
 dashboard can copy their already-redacted decision details as JSON for review handoffs without
 exposing raw targets or paths.
 
+Terminal explanations wrap to 60–78 columns. Paths and URLs remain intact, while other overlong
+tokens are split to stay within the configured width.
+
 ---
 
 ## Verify it end-to-end

--- a/changelog.d/657.fixed.md
+++ b/changelog.d/657.fixed.md
@@ -1,0 +1,1 @@
+- Terminal explanations wrap overlong non-path slash tokens within the configured width while preserving paths and URLs intact. (#657, thanks @be-student)

--- a/src/doberman/render.py
+++ b/src/doberman/render.py
@@ -126,6 +126,40 @@ def _deadline_phrase(span: str) -> str:
 #: restoring them after. Always shorter than `_MIN_WRAP_WIDTH`, so it never
 #: forces `textwrap`'s own long-word splitting.
 _UNBREAKABLE_COMMAND_RE = re.compile(r"'doberman [^']*'")
+_URL_TOKEN_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://")
+_WINDOWS_DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+def _is_unbreakable_token(token: str) -> bool:
+    """Whether a long whitespace-delimited token must remain intact."""
+    if "\x00" in token:  # spaces hidden inside a quoted Doberman command
+        return True
+    value = token.strip("()[]{}<>,;:'\"")
+    if _URL_TOKEN_RE.match(value) or _WINDOWS_DRIVE_PATH_RE.match(value):
+        return True
+    if "\\" in value or value.startswith(("/", "./", "../", "~/")):
+        return True
+    # A slash-bearing option is a compound flag, not a relative path. Other
+    # slash-bearing tokens plausibly name a relative path and stay readable.
+    return "/" in value and not value.startswith("-")
+
+
+class _PathAwareTextWrapper(textwrap.TextWrapper):
+    """Force-break ordinary long tokens while leaving path-shaped ones whole."""
+
+    def _handle_long_word(
+        self,
+        reversed_chunks: list[str],
+        cur_line: list[str],
+        cur_len: int,
+        width: int,
+    ) -> None:
+        if _is_unbreakable_token(reversed_chunks[-1]):
+            if not cur_line:
+                cur_line.append(reversed_chunks.pop())
+            return
+        super()._handle_long_word(reversed_chunks, cur_line, cur_len, width)
+
 
 #: "Next" lines: one accurate, actionable line per verdict - what a human can
 #: actually do about this decision, using only real `doberman` commands/files
@@ -334,12 +368,9 @@ def wrap_detail(
     ``"- name: "`` and want continuation lines to land under the text rather
     than under the marker.
 
-    A ``\\S+`` token containing ``\\`` or ``/`` (a Windows path, a POSIX path,
-    a URL) is never split mid-token, even if that makes a line run past
-    ``width`` — a garbled path is worse than a long line. ponytail: this
-    disables long-word breaking for every token, not just path-shaped ones;
-    upgrade to a token-aware wrapper if a non-path overlong word ever needs
-    force-breaking.
+    Path-shaped tokens (Windows/POSIX paths and URLs) are never split
+    mid-token, even if that makes a line run past ``width`` — a garbled path
+    is worse than a long line. Other overlong tokens are force-broken.
     """
     if width is None:
         width, _ = shutil.get_terminal_size(fallback=(100, 24))
@@ -349,12 +380,12 @@ def wrap_detail(
     # A quoted command must land whole on one line (the TUI/`log --why` show
     # them verbatim): hide its spaces from the wrapper, restore them after.
     protected = _UNBREAKABLE_COMMAND_RE.sub(lambda m: m.group(0).replace(" ", "\x00"), text)
-    wrapped = textwrap.wrap(
-        protected,
+    wrapper = _PathAwareTextWrapper(
         width=width,
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
-        break_long_words=False,
+        break_long_words=True,
         break_on_hyphens=False,
-    ) or [initial_indent]
+    )
+    wrapped = wrapper.wrap(protected) or [initial_indent]
     return [line.replace("\x00", " ") for line in wrapped]

--- a/tests/unit/test_render.py
+++ b/tests/unit/test_render.py
@@ -287,6 +287,27 @@ def test_wrap_detail_never_breaks_inside_a_path_token():
     assert any(windows_path in line for line in lines)
 
 
+def test_wrap_detail_never_breaks_posix_relative_or_url_path_tokens():
+    tokens = [
+        "/var/lib/doberman/" + "nested-directory/" * 4 + "policy.yaml",
+        "src/doberman/" + "nested-directory/" * 4 + "render.py",
+        "https://example.com/" + "long-segment/" * 5 + "resource",
+    ]
+
+    for token in tokens:
+        lines = render.wrap_detail(f"target: {token}", indent=0, width=60)
+        assert any(token in line for line in lines)
+
+
+def test_wrap_detail_force_breaks_a_slash_token_that_is_not_a_path():
+    token = "--foo/bar/baz-some-extremely-long-" + "value" * 16
+    lines = render.wrap_detail(token, indent=0, width=60)
+
+    assert len(lines) > 1
+    assert all(len(line) <= 60 for line in lines)
+    assert "".join(lines) == token
+
+
 def test_next_step_line_known_verdicts_and_pass_has_none():
     # Shared by the `tui` browser's docked "Next" widget and `doberman log
     # --why` (round 4 design critique item 8) - one source of truth.


### PR DESCRIPTION
# Pull Request

## Slice
- Repo: doberman-core
- Feature / Slice: #622 — path-aware terminal wrapping
- Plan reference: GitHub issue #622

## What this PR does
Force-breaks overlong ordinary tokens, including slash-bearing compound flags, while keeping Windows paths, POSIX paths, relative paths, URLs, and quoted Doberman commands intact.

## Tests added (run in CI)
- The issue-shaped compound flag stays within the 60-column clamp.
- Windows, POSIX, relative, and URL tokens remain unbroken.

## Changelog
- [x] `changelog.d/<PR>.fixed.md` fragment added in the follow-up commit

## Public-release safety (doberman-core only)
- [x] Contains nothing from the "not allowed" list
- [x] Core still builds/tests/runs with no enterprise package installed

## Security checklist
- [x] Fails closed on error / uncertainty
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] No guardrail or learning behavior changed
- [x] BLOCK/AUTH behavior is unchanged
- [x] doberman-core does not import doberman_enterprise

## Edge cases covered / Deviations from plan / Risks introduced
- All 31 render tests and 553 CLI/setup/demo/telemetry consumer tests pass. Repository-wide lint, formatting, import contracts, links, parity, changelog compilation, and diff checks pass.
- Implemented with Codex assistance; I reviewed the diff and validation results.

Closes #622
