### PR TITLE
fix(hosthooks): pin a timeout on the Claude Code hook entries so an unanswered AUTH cannot fail open at the harness

### DIFF
--- a/changelog.d/660.fixed.md
+++ b/changelog.d/660.fixed.md
@@ -1,0 +1,1 @@
+- Claude Code hook entries written by `doberman install-hooks` now carry a `timeout` that strictly outlasts Doberman's own challenge ceiling, so a Claude Code hook can no longer time out and fail open before Doberman writes its deny (#658)

--- a/changelog.d/660.fixed.md
+++ b/changelog.d/660.fixed.md
@@ -1,1 +1,1 @@
-- Claude Code hook entries written by `doberman install-hooks` now carry a `timeout` that strictly outlasts Doberman's own challenge ceiling, so a Claude Code hook can no longer time out and fail open before Doberman writes its deny (#658)
+- Claude Code hook entries now pin a `timeout` that outlasts Doberman's challenge ceiling, so a timed-out hook cannot fail open before Doberman denies (#660)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -181,13 +181,13 @@ On Claude Code it writes this, or add it by hand:
     "PreToolUse": [
       {
         "matcher": "Bash|Edit|Write|NotebookEdit|WebFetch|WebSearch|mcp__.*",
-        "hooks": [{ "type": "command", "command": "doberman hook pre" }]
+        "hooks": [{ "type": "command", "command": "doberman hook pre", "timeout": 660 }]
       }
     ],
     "PostToolUse": [
       {
         "matcher": "Bash|Edit|Write|NotebookEdit|WebFetch|WebSearch|Read|Glob|Grep|mcp__.*",
-        "hooks": [{ "type": "command", "command": "doberman hook post" }]
+        "hooks": [{ "type": "command", "command": "doberman hook post", "timeout": 660 }]
       }
     ],
     "SessionStart": [
@@ -198,6 +198,9 @@ On Claude Code it writes this, or add it by hand:
   }
 }
 ```
+
+Claude Code's own per-hook timeout defaults to 600s and a timed-out hook fails open (the tool call
+proceeds unmediated), so the `timeout` pin above lets Doberman deny first.
 
 **The pre-hook.** `doberman hook pre` reads the tool call on stdin and runs Doberman's
 deterministic objective floor: path confinement, destructive-command detection, checks for

--- a/src/doberman/cli/doctor.py
+++ b/src/doberman/cli/doctor.py
@@ -194,17 +194,81 @@ def _check_hook_integrity(path: str) -> CheckResult:
     return CheckResult(name, CheckStatus.OK, "nothing to verify (no hooks installed)")
 
 
+def _check_hook_timeout(path: str) -> CheckResult:
+    """#658: a Claude Code PreToolUse/PostToolUse hook entry with no `timeout`
+    (or one too small) times out at Claude Code's own 600s default before
+    Doberman's own challenge ceiling (`DEFAULT_CHALLENGE_TIMEOUT_S`) elapses,
+    and a timed-out hook fails OPEN - the tool call proceeds unmediated. This
+    inspects the LIVE settings.json content per installed scope (mirrors
+    `_check_cursor_hooks`), not just "is something installed", so a stale
+    install from before this pin existed is reported instead of silently
+    trusted.
+    """
+    from doberman.auth.challenge import DEFAULT_CHALLENGE_TIMEOUT_S
+    from doberman.hosthooks.install import _is_doberman_group, hook_install_states, load_settings
+
+    name = "Hook timeout"
+    states = hook_install_states(path)
+    installed_scopes = [scope for scope, _p, ok in states if ok]
+    if not installed_scopes:
+        return CheckResult(
+            name, CheckStatus.OK, "nothing to verify (no Claude Code hooks installed)"
+        )
+
+    problems: list[str] = []
+    good_scopes: list[str] = []
+    for scope, settings_path, ok in states:
+        if not ok:
+            continue
+        try:
+            settings = load_settings(Path(settings_path))
+        except ValueError:
+            problems.append(f"{scope}: settings.json unreadable")
+            continue
+        hooks_section = settings.get("hooks") or {}
+        scope_ok = True
+        for event in ("PreToolUse", "PostToolUse"):
+            groups = hooks_section.get(event)
+            if not isinstance(groups, list):
+                continue
+            for group in groups:
+                if not isinstance(group, dict) or not _is_doberman_group(group):
+                    continue
+                for h in group.get("hooks", []):
+                    timeout = h.get("timeout") if isinstance(h, dict) else None
+                    is_number = isinstance(timeout, (int, float)) and not isinstance(timeout, bool)
+                    if not is_number or timeout <= DEFAULT_CHALLENGE_TIMEOUT_S:
+                        scope_ok = False
+                        problems.append(
+                            f"{scope} {event}: timeout "
+                            f"{f'{timeout}s' if is_number else 'missing'} does not outlast the "
+                            f"{int(DEFAULT_CHALLENGE_TIMEOUT_S)}s challenge ceiling"
+                        )
+        if scope_ok:
+            good_scopes.append(scope)
+
+    if problems:
+        return CheckResult(
+            name,
+            CheckStatus.FAIL,
+            f"stale install ({'; '.join(problems)}) - run `doberman install-hooks` to restore",
+            critical=True,
+        )
+    return CheckResult(name, CheckStatus.OK, f"pinned ({', '.join(good_scopes)})")
+
+
 def _check_cursor_hooks(path: str) -> CheckResult:
     """Weak-registration + liveness self-check for the Cursor adapter (slice 2).
 
-    Unlike Claude/Codex, Cursor's own hook contract can fail OPEN (a crash or
-    timeout runs the tool) unless every gating entry carries ``failClosed:
-    true`` and a timeout that outlasts Doberman's approval dialog - so this
-    check inspects the LIVE hooks.json content, not just "is something
-    installed". A weak registration is a critical FAIL (Doberman may not
-    actually be gating); a missing sessionStart callback is only a WARN (it
-    means "unverified", not "unprotected" - `doctor` cannot always tell them
-    apart from the file alone).
+    Cursor's own hook contract can fail OPEN (a crash or timeout runs the tool)
+    unless every gating entry carries ``failClosed: true`` and a timeout that
+    outlasts Doberman's approval dialog - so this check inspects the LIVE
+    hooks.json content, not just "is something installed". A weak registration
+    is a critical FAIL (Doberman may not actually be gating); a missing
+    sessionStart callback is only a WARN (it means "unverified", not
+    "unprotected" - `doctor` cannot always tell them apart from the file
+    alone). Claude Code's own hook contract can *also* fail open on a timeout -
+    see :func:`_check_hook_timeout` for that check.
     """
     from doberman.hosthooks.install import load_settings
     from doberman.hosthooks.install_cursor import (
@@ -511,6 +575,7 @@ def run_checks(path: str = ".") -> list[CheckResult]:
         _safe_check("Hook command", True, lambda: _check_hook_command(path)),
         _safe_check("Hook integrity", True, lambda: _check_hook_integrity(path)),
         _safe_check("Cursor hooks", True, lambda: _check_cursor_hooks(path)),
+        _safe_check("Hook timeout", True, lambda: _check_hook_timeout(path)),
         _safe_check("Config", True, lambda: _check_config(path)),
         _safe_check("Decision DB", True, lambda: _check_db(path)),
         _safe_check("Enforcement", False, lambda: _check_enforcement(path)),

--- a/src/doberman/cli/main.py
+++ b/src/doberman/cli/main.py
@@ -1549,6 +1549,7 @@ def doctor(
         "Host hooks": "Hooks",
         "Hook command": "Hooks",
         "Hook integrity": "Hooks",
+        "Hook timeout": "Hooks",
         "Config": "Policy",
         "Enforcement": "Policy",
         "Policy version": "Policy",

--- a/src/doberman/hosthooks/install.py
+++ b/src/doberman/hosthooks/install.py
@@ -12,6 +12,8 @@ import shutil
 from pathlib import Path
 from typing import Any
 
+from doberman.auth.challenge import DEFAULT_CHALLENGE_TIMEOUT_S
+
 # ---------------------------------------------------------------------------
 # Hook entry constants
 # ---------------------------------------------------------------------------
@@ -31,6 +33,16 @@ POST_COMMAND = "doberman hook post"
 #: Command registered as the SessionStart hook (prints the session summary).
 DASHBOARD_COMMAND = "doberman session-summary"
 
+#: Claude Code's per-hook timeout (seconds). Claude Code's own default is 600s,
+#: and its docs say a timed-out PreToolUse hook "doesn't block the tool call" -
+#: it fails OPEN, letting the call through the harness's normal permission flow.
+#: Doberman's own challenge ceiling (`DEFAULT_CHALLENGE_TIMEOUT_S`) is also 600s
+#: and starts a second or two later (the hook process has to start and import
+#: first), so the pin here must strictly outlast it or the harness kills the
+#: hook a moment before Doberman would have written its deny (#658). Mirrors
+#: `install_cursor.GATE_TIMEOUT_S`, which does the same for Cursor.
+HOOK_TIMEOUT_S = int(DEFAULT_CHALLENGE_TIMEOUT_S) + 60  # 660
+
 #: Sentinel substring used to detect Doberman-owned hook entries.
 _DOBERMAN_MARKER = "doberman hook "
 
@@ -41,12 +53,12 @@ _SESSION_SUMMARY_MARKER = "doberman session-summary"
 
 _PRE_ENTRY: dict[str, Any] = {
     "matcher": PRE_MATCHER,
-    "hooks": [{"type": "command", "command": PRE_COMMAND}],
+    "hooks": [{"type": "command", "command": PRE_COMMAND, "timeout": HOOK_TIMEOUT_S}],
 }
 
 _POST_ENTRY: dict[str, Any] = {
     "matcher": POST_MATCHER,
-    "hooks": [{"type": "command", "command": POST_COMMAND}],
+    "hooks": [{"type": "command", "command": POST_COMMAND, "timeout": HOOK_TIMEOUT_S}],
 }
 
 # SessionStart isn't scoped to a tool, so - unlike Pre/PostToolUse - this entry

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -652,3 +652,77 @@ def test_doctor_integrity_plugin_only_codex_is_ok(
     r = _integrity(run_checks(str(integrity_env)))
     assert r.status is CheckStatus.OK
     assert r.detail == "nothing to verify (no hooks installed)"
+
+
+# ---------------------------------------------------------------------------
+# Hook timeout (#658): a Claude Code entry that does not outlast Doberman's
+# own challenge ceiling is a stale/weak install, not silently trusted - a
+# timed-out Claude Code hook fails OPEN at the harness.
+# ---------------------------------------------------------------------------
+
+
+def _hook_timeout(results: list[doctor_mod.CheckResult]) -> doctor_mod.CheckResult:
+    return next(r for r in results if r.name == "Hook timeout")
+
+
+def _write_claude_hooks(root: str, timeout) -> None:
+    """Write a Claude Code PreToolUse/PostToolUse Doberman entry with the
+    given `timeout` (omitted entirely when *timeout* is None) - simulates an
+    install from before #658, or one with a too-small pin."""
+    from doberman.hosthooks.install import POST_COMMAND, POST_MATCHER, PRE_COMMAND, PRE_MATCHER
+
+    pre_hook = {"type": "command", "command": PRE_COMMAND}
+    post_hook = {"type": "command", "command": POST_COMMAND}
+    if timeout is not None:
+        pre_hook["timeout"] = timeout
+        post_hook["timeout"] = timeout
+    settings = {
+        "hooks": {
+            "PreToolUse": [{"matcher": PRE_MATCHER, "hooks": [pre_hook]}],
+            "PostToolUse": [{"matcher": POST_MATCHER, "hooks": [post_hook]}],
+        }
+    }
+    write_settings(resolve_settings_path("local", root), settings)
+
+
+def test_doctor_hook_timeout_ok_when_nothing_installed(tmp_path):
+    root = str(tmp_path)
+    r = _hook_timeout(run_checks(root))
+    assert r.status is CheckStatus.OK
+    assert r.detail == "nothing to verify (no Claude Code hooks installed)"
+
+
+def test_doctor_hook_timeout_ok_when_pinned(tmp_path):
+    root = str(tmp_path)
+    _install_hooks(root)  # today's installer output - already pinned
+    r = _hook_timeout(run_checks(root))
+    assert r.status is CheckStatus.OK
+    assert "local" in r.detail
+
+
+def test_doctor_hook_timeout_fails_when_missing(tmp_path):
+    root = str(tmp_path)
+    _write_claude_hooks(root, timeout=None)
+    r = _hook_timeout(run_checks(root))
+    assert r.status is CheckStatus.FAIL
+    assert r.critical is True
+    assert "missing" in r.detail
+    assert "install-hooks" in r.detail
+
+
+def test_doctor_hook_timeout_fails_when_equal_to_the_challenge_ceiling(tmp_path):
+    # 600 == DEFAULT_CHALLENGE_TIMEOUT_S is not enough margin: it must be
+    # STRICTLY greater, or the harness can still kill the hook a moment
+    # before Doberman would have written its deny.
+    root = str(tmp_path)
+    _write_claude_hooks(root, timeout=600)
+    r = _hook_timeout(run_checks(root))
+    assert r.status is CheckStatus.FAIL
+    assert r.critical is True
+
+
+def test_doctor_hook_timeout_ok_when_strictly_above_the_ceiling(tmp_path):
+    root = str(tmp_path)
+    _write_claude_hooks(root, timeout=660)
+    r = _hook_timeout(run_checks(root))
+    assert r.status is CheckStatus.OK

--- a/tests/unit/test_install_hooks.py
+++ b/tests/unit/test_install_hooks.py
@@ -16,8 +16,10 @@ import pytest
 from typer.testing import CliRunner
 
 import doberman.cli.main as cli_module
+from doberman.auth.challenge import DEFAULT_CHALLENGE_TIMEOUT_S
 from doberman.hosthooks.install import (
     DASHBOARD_COMMAND,
+    HOOK_TIMEOUT_S,
     POST_COMMAND,
     POST_MATCHER,
     PRE_COMMAND,
@@ -143,6 +145,56 @@ class TestMergeDobermanHooks:
         snapshot = copy.deepcopy(existing)
         merge_doberman_hooks(existing)
         assert existing == snapshot
+
+
+# ---------------------------------------------------------------------------
+# HOOK_TIMEOUT_S (#658): the Claude Code hook pin must strictly outlast
+# Doberman's own challenge ceiling, or a timed-out hook fails open at the
+# harness before Doberman ever writes its deny.
+# ---------------------------------------------------------------------------
+
+
+class TestHookTimeoutPin:
+    def test_pin_strictly_outlasts_the_challenge_ceiling(self):
+        """Pins the RELATIONSHIP, not just a literal value: if either constant
+        moves (the challenge ceiling raised, or this margin trimmed) without
+        the other keeping pace, this must fail CI rather than silently
+        reopening the #658 race."""
+        assert HOOK_TIMEOUT_S > DEFAULT_CHALLENGE_TIMEOUT_S
+
+    def test_both_entries_carry_the_pin(self):
+        result = merge_doberman_hooks({})
+        pre_group = next(g for g in result["hooks"]["PreToolUse"] if _is_doberman_group(g))
+        post_group = next(g for g in result["hooks"]["PostToolUse"] if _is_doberman_group(g))
+        assert pre_group["hooks"][0]["timeout"] == HOOK_TIMEOUT_S
+        assert post_group["hooks"][0]["timeout"] == HOOK_TIMEOUT_S
+
+    def test_merge_replaces_an_old_entry_with_no_timeout(self):
+        """The idempotent replace in `merge_doberman_hooks` keys on the command
+        string, so re-running install-hooks over a pre-#658 install (same
+        matcher/command, no `timeout`) must swap in the new pinned entry
+        rather than leaving the stale one or duplicating it."""
+        old_settings = {
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher": PRE_MATCHER, "hooks": [{"type": "command", "command": PRE_COMMAND}]}
+                ],
+                "PostToolUse": [
+                    {
+                        "matcher": POST_MATCHER,
+                        "hooks": [{"type": "command", "command": POST_COMMAND}],
+                    }
+                ],
+            }
+        }
+        result = merge_doberman_hooks(old_settings)
+
+        pre_groups = [g for g in result["hooks"]["PreToolUse"] if _is_doberman_group(g)]
+        post_groups = [g for g in result["hooks"]["PostToolUse"] if _is_doberman_group(g)]
+        assert len(pre_groups) == 1
+        assert len(post_groups) == 1
+        assert pre_groups[0]["hooks"][0]["timeout"] == HOOK_TIMEOUT_S
+        assert post_groups[0]["hooks"][0]["timeout"] == HOOK_TIMEOUT_S
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Claude Code runs each command hook with a per-entry timeout that defaults to 600 seconds, and a timed-out PreToolUse hook does not block the tool call: the call continues through the harness's own permission flow. Doberman's own challenge ceiling (`DEFAULT_CHALLENGE_TIMEOUT_S` in `src/doberman/auth/challenge.py`) is also 600 seconds and starts a second or two later than the harness's timer, since the hook process has to start and import first. Ten minutes of silence on the terminal channel then ends with the harness killing the hook a moment before Doberman would have written its deny, so the tool call proceeds. That is a fail-open on silence.

This pins a `timeout` of 660 seconds (`HOOK_TIMEOUT_S`, computed as `int(DEFAULT_CHALLENGE_TIMEOUT_S) + 60`) on both the PreToolUse and PostToolUse entries `doberman install-hooks` writes into Claude Code's `settings.json`, so the harness always gives Doberman's own deadline a chance to fire first. The idempotent replace already in `merge_doberman_hooks` swaps a pre-existing entry with no timeout for the pinned one, so re-running `install-hooks` over an old install fixes it. The hand-written jsonc snippet in `docs/SETUP.md` now matches the installer, and `doberman doctor` gained a new "Hook timeout" check that FAILs (critical) when an installed Claude Code entry is missing the key or has one that does not strictly outlast the challenge ceiling. The `_check_cursor_hooks` docstring, which previously said Claude Code hooks cannot fail open, is corrected and now points at the new check.

Tested with new unit tests in `tests/unit/test_install_hooks.py` (the `HOOK_TIMEOUT_S > DEFAULT_CHALLENGE_TIMEOUT_S` relationship, both entries carrying the pin, and the idempotent replace of a pre-#658 entry) and `tests/unit/test_cli_doctor.py` (the new check FAILs on a missing or too-small timeout and OKs on a good pin or nothing installed). A mutation check confirmed the relationship test goes red when the margin is removed. Existing suites (`test_cli_doctor_json.py`, `test_auth_challenge_timeout.py`, `test_install_integrity.py`) and the full suite still pass.

Closes #658
