### PR TITLE
docs: keep the limitations catalog in the docs, off the README; note the lifecycle-hook vector and judge evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ over each labeled tool call, so the result is deterministic and needs no network
 A labeled detection corpus turns this into a per-category detection-quality measurement, and CI
 gates on any regression. Three more operator-supplied external suites (RedCode-Exec, MSB, and
 LLMail-Inject) are wired in the same way, alongside AgentDojo. Commands, methodology, and published
-results, including failure cases as well as wins, are in [Benchmarks](docs/BENCHMARKS.md).
+results are in [Benchmarks](docs/BENCHMARKS.md).
 
 ---
 
@@ -285,15 +285,6 @@ traces.jsonl` ([format and invariants](docs/BASELINE_SEEDING.md)).
 See [the roadmap](ROADMAP.md) for what's planned and in flight, the
 [GitHub board](https://github.com/users/fu351/projects/5) for day-to-day tracking, and
 [the changelog](CHANGELOG.md) for what has already shipped.
-
-### Known limitations
-
-Doberman is defense-in-depth, not a guarantee: every rule catches one specific kind of attack, and
-every rule has some way around it that a determined attacker could still find. Some gaps come from a
-deliberate trade-off against false positives (flagging something harmless); others are pieces of the
-design, like a runtime egress broker, that don't exist yet. None of them let an attacker turn a
-`BLOCK` into a silent `PASS`: the raise-only and fail-closed guarantees still hold everywhere. See
-[docs/LIMITATIONS.md](docs/LIMITATIONS.md) for the full, current list.
 
 ---
 

--- a/changelog.d/661.docs.md
+++ b/changelog.d/661.docs.md
@@ -1,0 +1,1 @@
+- README drops its Known limitations section; the catalog stays in docs/LIMITATIONS.md via docs/BENCHMARKS.md, which also notes the lifecycle-hook vector and judge evidence (#661).

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -48,6 +48,15 @@ reports both profiles plus the delta between them.
   and the operator metrics alongside `asr`, or you will overstate the protection.
   The [AUTH-gated breakdown](#where-the-strict-gap-sits-auth-gated-attacks-by-shape)
   shows which attack shapes stop at `AUTH` rather than `BLOCK`.
+- They measure tool calls. A hook command that the host itself runs on a
+  lifecycle event (session start, before or after a tool call) is not a tool
+  call and never reaches the decision engine, so a hook bound by a plugin
+  update or a settings edit sits outside every number here. HookPry
+  ([arXiv 2609.03884](https://arxiv.org/abs/2609.03884)) measured that vector
+  across seven harnesses, Claude Code and Codex CLI included: 77% verified
+  success, 0 of 1,000 runs blocked by any harness. A ledger of every installed
+  hook command, scanned with the shell rules, is a roadmap item.
+- The per-rule catalog of known gaps lives in [Known limitations](LIMITATIONS.md).
 
 ## Subjective-layer baseline separation (diagnostic)
 
@@ -150,7 +159,9 @@ true-positive rate per attack class) with no external dependency.
 - **Honest, not tuned.** The corpus is *not* filtered to cases the engine wins.
   Pure natural-language injection scores **TPR 0.0**: the objective layer is
   structurally blind to it (a provenance/subjective concern), and the corpus says
-  so rather than hiding it. Calibration also surfaced a real precision note:
+  so rather than hiding it. Small open classifiers reach F1 0.86 to 0.91 on
+  email and table indirect injection in Mozilla.ai's study (linked under Judge
+  agreement below); an optional classifier extra is a roadmap item. Calibration also surfaced a real precision note:
   reading an `.env.example` template over-blocks, because the secret-path rule
   matches `.env.*` fail-closed.
 - **Redaction + push-safety.** Reports hold counts, rates, category labels, and
@@ -200,6 +211,12 @@ This section measures, offline, whether it is even worth wiring in.
   structurally blind to natural-language injection for the exact same reason
   the deterministic layer is (see the corpus's `injection` row above); this
   bench cannot and does not claim to close that gap.
+- **External evidence for the advisory cap.** Mozilla.ai's 2026 study of open
+  guardrails ([blog post](https://blog.mozilla.ai/can-open-source-guardrails-really-protect-ai-agents/))
+  scored two judge models grading function calls on HammerBench at F1 0.09 to
+  0.50, Cohen's kappa 0.26 against the labels, with different scores on
+  identical inputs. Consistent with that, the judge here is advisory and never
+  decides a verdict alone.
 - **Opt-in, never a live call in CI.** Requires `ANTHROPIC_API_KEY` and
   `DOBERMAN_JUDGE_ENABLED=1` (the same three-way gate
   `HaikuJudgeAdjudicator.adjudicate()` itself enforces: installed, keyed, and

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -404,6 +404,14 @@ with Codex's own `--dangerously-bypass-hook-trust` flag. And a control-plane pat
 from a shell variable, a glob pattern, or a `python -c` payload, isn't caught by this kind of static
 command-text check.
 
+A hook that a plugin update or a settings edit binds to a lifecycle event (session start, before or
+after a tool call) runs as the host itself, not as a tool call, so it never reaches the engine at
+all. HookPry ([arXiv 2609.03884](https://arxiv.org/abs/2609.03884)) measured that vector at 77%
+verified success across seven harnesses, Claude Code and Codex CLI included, with none of 1,000 runs
+blocked. Doberman's install manifest fingerprints only its own hook entries, so `doberman doctor`
+does not notice a foreign hook today. A ledger of every installed hook command, scanned with the
+shell rules, is a roadmap item.
+
 ## An optional AI judge exists for measurement only, not for live decisions
 
 Installing `pip install "doberman-core[judge]"`, setting an `ANTHROPIC_API_KEY`, and setting

--- a/src/doberman/engine/rules/data/README.md
+++ b/src/doberman/engine/rules/data/README.md
@@ -2,8 +2,8 @@
 
 Two static, offline JSON snapshots consumed only by
 `doberman.engine.rules.dependency_admission` (v1). They are point-in-time,
-refreshed per release, not a live feed. See `README.md`'s known-limitations
-section for the honest caveat shipped alongside this.
+refreshed per release, not a live feed. See `docs/LIMITATIONS.md` for the caveat shipped alongside
+this.
 
 ## known_malicious_packages.json
 


### PR DESCRIPTION
## What this PR does

Moves the limitations story off the front page and into the docs that measure it.

- `README.md`: the Known limitations subsection is gone, and the Benchmark paragraph points at `docs/BENCHMARKS.md` without the "failure cases" clause. No claim was added or strengthened; the README says what Doberman does, the docs say what it measures.
- `docs/BENCHMARKS.md`: "What these numbers can and cannot show" gains two bullets: hook commands the host runs on lifecycle events never reach the engine (HookPry, arXiv 2609.03884: 77% verified success, 0 of 1,000 runs blocked across seven harnesses), and a link to the per-rule catalog in `docs/LIMITATIONS.md`. The judge section cites Mozilla.ai's guardrail study (judge models at F1 0.09 to 0.50, kappa 0.26 on function-call grading) as external evidence for keeping the judge advisory. The corpus injection note mentions the classifier numbers from the same study.
- `docs/LIMITATIONS.md`: the control-plane entry gains the plugin-update hook vector.
- `src/doberman/engine/rules/data/README.md`: pointer updated from the removed README section to `docs/LIMITATIONS.md`.

## Tests

Docs only. `python scripts/check_markdown_links.py`: 66 files, no broken internal links.

## Security checklist
- [x] No claim of protection was added; two measured gaps were recorded in the docs that own them.
- [x] No secret, payload, or unredacted text.
