### PR TITLE
fix(render): force-break overlong non-path tokens in wrap_detail

### DIFF
--- a/changelog.d/622.fixed.md
+++ b/changelog.d/622.fixed.md
@@ -1,0 +1,1 @@
+- Overlong non-path tokens in wrapped CLI output (a hash, or a slash-bearing option) now force-break at the wrap width; real paths and URLs stay whole (#622)

--- a/src/doberman/render.py
+++ b/src/doberman/render.py
@@ -149,6 +149,27 @@ _NEXT_AUTH = (
 _TUI_HINT = "; press w for detail"
 
 
+def _looks_like_path(token: str) -> bool:
+    """True if ``token`` should never be split mid-token by :func:`wrap_detail`.
+
+    A genuine filesystem path or URL is worth letting run past ``width`` — a
+    garbled path a reader can't copy is worse than one long line. This is a
+    *narrow* test, on purpose: only a backslash (a Windows path) or a slash on
+    a token that is not an option flag (a POSIX path or a `scheme://...` URL)
+    qualifies. An option like ``--foo/bar/baz-...`` merely *contains* a slash
+    and is not a path, so it stays breakable — that was the whole of #622.
+    """
+    if "\\" in token:
+        return True
+    return "/" in token and not token.startswith("-")
+
+
+def _force_break(token: str, width: int) -> list[str]:
+    """Hard-split an overlong non-path ``token`` into ``<= width`` chunks."""
+    step = max(1, width)
+    return [token[i : i + step] for i in range(0, len(token), step)]
+
+
 def next_step_line(verdict: str | None, *, tui_hint: bool = True) -> str | None:
     """The "Next" remedy line for a raw verdict string (or `None`/anything
     unrecognized, e.g. PASS) - `None` when there's nothing to act on.
@@ -334,12 +355,12 @@ def wrap_detail(
     ``"- name: "`` and want continuation lines to land under the text rather
     than under the marker.
 
-    A ``\\S+`` token containing ``\\`` or ``/`` (a Windows path, a POSIX path,
-    a URL) is never split mid-token, even if that makes a line run past
-    ``width`` — a garbled path is worse than a long line. ponytail: this
-    disables long-word breaking for every token, not just path-shaped ones;
-    upgrade to a token-aware wrapper if a non-path overlong word ever needs
-    force-breaking.
+    A path-shaped token (see :func:`_looks_like_path` — a Windows path, a
+    POSIX path, a URL) is never split mid-token, even if that makes a line run
+    past ``width``: a garbled path is worse than a long line. Every *other*
+    overlong token (a hash, an opaque id, or an option like ``--foo/bar/...``
+    that merely happens to contain a slash) is force-broken at the width
+    boundary so no rendered line overflows ``width`` (#622).
     """
     if width is None:
         width, _ = shutil.get_terminal_size(fallback=(100, 24))
@@ -357,4 +378,18 @@ def wrap_detail(
         break_long_words=False,
         break_on_hyphens=False,
     ) or [initial_indent]
-    return [line.replace("\x00", " ") for line in wrapped]
+    # `break_long_words=False` keeps paths whole but also lets any other
+    # overlong token overflow: such a token lands alone on its (over-width)
+    # line, so hard-break those unless the token is path-shaped.
+    broken: list[str] = []
+    for line in wrapped:
+        if len(line) <= width:
+            broken.append(line)
+            continue
+        pad = line[: len(line) - len(line.lstrip(" "))]
+        token = line[len(pad) :]
+        if _looks_like_path(token):
+            broken.append(line)
+            continue
+        broken.extend(pad + chunk for chunk in _force_break(token, width - len(pad)))
+    return [line.replace("\x00", " ") for line in broken]

--- a/tests/unit/test_render.py
+++ b/tests/unit/test_render.py
@@ -287,6 +287,36 @@ def test_wrap_detail_never_breaks_inside_a_path_token():
     assert any(windows_path in line for line in lines)
 
 
+def test_wrap_detail_force_breaks_an_overlong_non_path_token():
+    # #622: a token far wider than the clamp that is NOT a path must be
+    # hard-wrapped so no rendered line overflows the width.
+    token = "deadbeefcafefeed" * 8  # 128 chars, no break opportunities
+    lines = render.wrap_detail(token, indent=4, width=60)
+    assert len(lines) > 1
+    assert all(len(line) <= 60 for line in lines)
+    # No character of the token is dropped when it is force-broken.
+    assert "".join(line.strip() for line in lines) == token
+
+
+def test_wrap_detail_force_breaks_an_overlong_option_that_merely_contains_a_slash():
+    # #622: `--foo/bar/...` contains a slash but is an option flag, not a path,
+    # so it must be force-broken rather than allowed to run past the width.
+    option = "--foo/bar/baz-" + "some-extremely-long-value" * 4
+    lines = render.wrap_detail(option, indent=0, width=60)
+    assert len(lines) > 1
+    assert all(len(line) <= 60 for line in lines)
+
+
+def test_wrap_detail_never_breaks_a_posix_path_or_url_token():
+    # The narrowing in #622 must not regress genuine paths/URLs: a POSIX path
+    # and a scheme URL, both far wider than the width, still land whole.
+    posix_path = "/var/lib/doberman/policies/a-very-long-policy-file-name.yaml"
+    url = "https://example.com/some/very/long/path/that/exceeds/the/wrap/width"
+    for token in (posix_path, url):
+        lines = render.wrap_detail(f"see {token} for detail", indent=0, width=40)
+        assert any(token in line for line in lines)
+
+
 def test_next_step_line_known_verdicts_and_pass_has_none():
     # Shared by the `tui` browser's docked "Next" widget and `doberman log
     # --why` (round 4 design critique item 8) - one source of truth.


### PR DESCRIPTION
## What
`render.wrap_detail` used `textwrap.wrap(break_long_words=False)` to keep filesystem paths and URLs from being split mid-token. That flag disables long-word breaking for *every* token, so an overlong non-path token — a hash, an opaque id, or an option like `--foo/bar/baz-...` that merely contains a slash — also escaped breaking and ran past the configured wrap width.

## How
- Add `_looks_like_path()`: a narrow classifier — a backslash (Windows path), or a slash on a token that is not an option flag (POSIX path / `scheme://...` URL). `--foo/bar/...` starts with `-`, so it is not a path.
- After wrapping, force-break any still-over-width line unless its token is path-shaped, preserving indent/hang. Genuine paths and URLs stay whole.

Width clamps, indentation, and the quoted-command protection are unchanged.

## Tests
- New: overlong non-path hash is hard-wrapped (no line over width, no chars lost).
- New: overlong `--foo/bar/...` option is force-broken.
- New: POSIX path and `https://` URL still land whole.
- Existing Windows-path test still passes.
- `ruff`, `lint-imports`, `pytest`, and the changelog check all pass.

Closes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)