### PR TITLE
fix(auth): honor the configured phone wait on the 2FA tiers; rewrite the TUNING.md phone section

### DIFF
--- a/changelog.d/671.fixed.md
+++ b/changelog.d/671.fixed.md
@@ -1,0 +1,2 @@
+- Phone approvals honor the configured `--wait` on the 2FA tiers; the approval budget no longer caps it at 90 s (#671)
+- TUNING.md phone section rewritten: every AUTH tier reaches the phone, a tap replaces the TOTP code, silence auto-denies at 600 s (#671)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -55,9 +55,13 @@ Security-posture commands used by [the setup guide](SETUP.md). These groups also
 | `doberman 2fa methods enable <name>` | Enable an approval method (opt-in) so a tap replaces the 2FA code when available; TOTP stays as the fallback. | none |
 | `doberman 2fa methods disable <name>` | Disable an approval method; 2FA falls back to the next enabled method or to TOTP. | none |
 | `doberman 2fa methods status` | Show which proof the next 2FA challenge would use, an approval method, or the TOTP code. | none |
+| `doberman phone setup` | Turn on phone approvals over ntfy: generate two secret topics, print the one to subscribe to, send a test notification. | `--server URL`, `--token TOKEN`, `--wait SECONDS` (10-300), `--force` (rotate both topics) |
+| `doberman phone test` | Send another test notification once you're subscribed. | none |
+| `doberman phone status` | Show whether phone approvals are on, the server host, a four-character topic prefix, and the wait; never the reply topic or the token. | none |
+| `doberman phone off` | Turn phone approvals off and delete the local config. | none |
 | `doberman password set` | Set or rotate the local password possession factor. | `--force` (rotate after proving the current password) |
 
-The `2fa` subcommands take no `--path`: TOTP enrollment is a device-wide factor, not a per-repo one.
+The `2fa` and `phone` subcommands take no `--path`: both are device-wide factors, not per-repo ones.
 
 ## Recovery
 

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -186,34 +186,58 @@ disk is the last recorded one. See [POLICY_VERSIONS.md](POLICY_VERSIONS.md).
 
 ## Phone approvals (ntfy), `doberman phone`
 
-When a `two_factor` or `role_elevation` challenge needs a human, Doberman can push it to your phone
-through [ntfy](https://ntfy.sh) (a free, open push notification service; self-hosting is also
-possible) instead of only waiting on a local dialog. The notification carries Approve and Deny
-buttons, so a tap answers the challenge from wherever you are.
+When a challenge needs a human, Doberman can push it to your phone through
+[ntfy](https://ntfy.sh) (a free, open push notification service; self-hosting is also possible)
+instead of only waiting on a local dialog. The notification carries Approve and Deny buttons, so a
+tap answers the challenge from wherever you are.
+
+Every AUTH tier uses it once it is on. On `soft_confirm` and `local_auth` a tap is the
+confirmation. On `two_factor` and `role_elevation` a tap is the second factor and **replaces the
+TOTP code**: nothing else is asked after a tap. Enable it only if a tap on your unlocked phone is a
+good enough second factor for you. It covers the Claude Code, Codex, and Cursor hooks and the MCP
+proxy. OpenClaw hands an AUTH verdict to its own `/approve` flow and never runs Doberman's phone
+challenge.
 
 Four commands:
 
 - `doberman phone setup [--server URL] [--token TOKEN] [--wait SECONDS] [--force]` turns it on. It
   generates two secret topic names, prints the one to subscribe to in the ntfy app (the second,
-  reply topic, is never shown), and sends a test notification.
+  reply topic, is never shown), and sends a test notification. If the test notification fails, the
+  config is kept and the method stays enabled: subscribe, then run `doberman phone test`.
 - `doberman phone test` sends another test notification once you're subscribed.
-- `doberman phone status` shows whether it's on, the server host, and the wait time, never the full
-  topic or token.
+- `doberman phone status` shows whether it's on, the server host, the first four characters of the
+  subscribe topic, and the wait time; never the reply topic or the token.
 - `doberman phone off` turns it off and deletes the local config.
 
 The config file lives at `%LOCALAPPDATA%\doberman\ntfy.json` on Windows, or
 `$XDG_CONFIG_HOME/doberman/ntfy.json` (falling back to `~/.config/doberman/ntfy.json` when that
 variable is unset) on Linux/macOS. `DOBERMAN_NTFY_FILE` overrides the path.
 
-`--wait` sets how many seconds Doberman waits for a tap, clamped to 10-300 (default 60). If nobody
-taps in time, Doberman falls back to the terminal TOTP (one-time code app) prompt. Silence never
-approves or denies anything on its own.
+`--wait` sets how many seconds Doberman waits for a tap, clamped to 10-300 (default 60), on every
+tier. If nobody taps in time, the host hooks move on to the desk dialog (120 s), then the terminal
+prompt, and on the 2FA tiers end at the TOTP code entry; the MCP proxy tries its dashboard first,
+then the phone, then the same fallbacks. Silence is never taken as approval. If no channel answers,
+the whole challenge auto-denies after 600 s and the action is refused. `--wait` changes only the
+phone stage; it cannot extend that ceiling, and the Claude Code hook's 660 s harness timeout stays
+above it.
 
-`--server` points setup at a self-hosted ntfy instance instead of the public `ntfy.sh`. `--token` is
-a bearer token for that server, when it needs one.
+Phone approval is one of the approval methods `doberman 2fa methods list` shows, and the 2FA tiers
+use the first enabled method that is available here, in preference order. If Windows Hello is
+enabled ahead of `ntfy`, the phone never rings for a 2FA challenge on that machine; `doberman 2fa
+methods status` shows which proof the next challenge will use.
+
+`--server` points setup at a self-hosted ntfy instance instead of the public `ntfy.sh`. Use an
+`https://` URL: over plain HTTP the notification and the reply carry the secrets below in the
+clear. `--token` is a bearer token for that server, when it needs one. A token typed on the command
+line lands in shell history, so read it from a file instead (`--token "$(cat ~/.ntfy-token)"` in
+bash, `--token (Get-Content ~/.ntfy-token)` in PowerShell), or edit `ntfy.json` after setup. Scope
+the token to those two topics only, with server ACLs that let only your phone and Doberman read or
+publish them.
 
 Both topic names and the token are secrets, not just the reply topic. The push notification itself
 carries the reply URL, the exact Approve/Deny reply text, and the bearer header, so anyone who can
-read the topic can approve or deny without ever learning the reply topic. If self-hosting, scope the
-token narrowly to those two topics. Prefer letting `phone setup` prompt for `--token` rather than
-typing it on the command line, since a typed argument lands in shell history.
+read the subscribe topic can approve or deny without ever learning the reply topic. The two-topic
+design stops replayed or stale replies and anyone who knows only the reply topic; it does not stop
+a reader of the subscribe topic. If a topic leaks, rotate with `doberman phone setup --force`,
+which generates two new topics. On `ntfy.sh` there is nothing to revoke and `phone off` only
+deletes the local file; on a self-hosted server, also revoke the old token and topic ACLs.

--- a/src/doberman/auth/approval.py
+++ b/src/doberman/auth/approval.py
@@ -36,11 +36,11 @@ from typing import Protocol, runtime_checkable
 
 logger = logging.getLogger("doberman.auth.approval")
 
-#: How long one approval request waits for the human before it gives up and
-#: denies. Kept below :data:`doberman.auth.challenge.DEFAULT_CHALLENGE_TIMEOUT_S`
-#: so the method resolves (visibly denying) before the outer challenge deadline
-#: has to abandon the thread — same discipline as the GUI dialog timeout.
-DEFAULT_APPROVAL_TIMEOUT_S: float = 90.0
+#: The default budget for one approval method's request, equal to the phone's
+#: maximum ``--wait``, so a configured wait is honored on the 2FA tiers. The
+#: 600 s challenge ceiling in :mod:`doberman.auth.challenge` still bounds the
+#: whole flow.
+DEFAULT_APPROVAL_TIMEOUT_S: float = 300.0
 
 
 class ApprovalOutcome(Enum):

--- a/src/doberman/hosthooks/install_cursor.py
+++ b/src/doberman/hosthooks/install_cursor.py
@@ -54,7 +54,7 @@ GATE_EVENTS: tuple[str, ...] = (EVENT_PRE_TOOL, EVENT_SHELL, EVENT_MCP, EVENT_RE
 
 #: Cursor's per-hook timeout (seconds) must outlast Doberman's in-hook approval dialog, or an
 #: unanswered AUTH is denied by the timeout instead of the human.
-GATE_TIMEOUT_S = int(DEFAULT_APPROVAL_TIMEOUT_S) + 30  # 120
+GATE_TIMEOUT_S = int(DEFAULT_APPROVAL_TIMEOUT_S) + 30  # 330
 
 #: sessionStart is a cosmetic heartbeat, not a gate — a short timeout is fine, and
 #: `failClosed: false` (see session_start_entry) means it can never abort a session.

--- a/tests/unit/test_ntfy_phone_approvals.py
+++ b/tests/unit/test_ntfy_phone_approvals.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from doberman.auth import approval_config, ntfy
+from doberman.auth import approval, approval_config, ntfy
 from doberman.auth.approval import ApprovalOutcome, request_approval
 from doberman.auth.challenge import run_auth_challenge
 from doberman.auth.gui_prompter import FallbackPrompter, PrompterUnavailableError
@@ -561,6 +561,17 @@ def test_method_deadline_is_min_of_timeout_and_wait(ntfy_cfg, monkeypatch):
     ntfy.NtfyApprovalMethod().request("p", action_id="a", timeout_s=999)
 
     assert calls[0][2] == 10  # wait_s wins
+
+
+def test_default_budget_never_caps_a_configured_wait(ntfy_cfg, monkeypatch):
+    ntfy.save_config(ntfy.new_config(wait_s=300))
+    approval_config.enable(ntfy.METHOD_NAME)
+    calls = _patch_channel(monkeypatch, "approved")
+
+    request_approval(ntfy.NtfyApprovalMethod(), "p", action_id="a")
+
+    assert calls[0][2] == 300  # a --wait 300 is honored, not capped at the old 90 s default
+    assert approval.DEFAULT_APPROVAL_TIMEOUT_S >= ntfy._WAIT_MAX_S
 
 
 def test_method_not_configured_returns_unavailable_without_asking(ntfy_cfg, monkeypatch):


### PR DESCRIPTION
## What changed and why

**The 90 s cap.** `doberman phone setup --wait 300` clamps the wait to 10-300 seconds
(`ntfy.py`'s `_WAIT_MAX_S`), but `DEFAULT_APPROVAL_TIMEOUT_S` in `approval.py` was 90.0, and
`request_approval` uses it as the `timeout_s` default when the `two_factor`/`role_elevation`
branch in `provider.py` calls it with no timeout. The ntfy method's own deadline is
`min(timeout_s, cfg.wait_s)`, so a configured 300 s wait was silently capped at 90 s on every
2FA tier. `DEFAULT_APPROVAL_TIMEOUT_S` is now `300.0`, equal to the phone's maximum wait, so a
configured wait is honored. The 600 s challenge ceiling in `challenge.py` still bounds the whole
flow, so this is safe.

One knock-on fix: `doberman/hosthooks/install_cursor.py` derives Cursor's gate hook timeout as
`int(DEFAULT_APPROVAL_TIMEOUT_S) + 30`, which now computes to 330 instead of 120. That math was
already dynamic; only a stale inline comment (`# 120`) needed correcting to `# 330`.

**The doc's false claims (`docs/TUNING.md`, "Phone approvals" section).** The old text was wrong
in several ways the code review below fixes:
- **Tier coverage**: it said the phone was consulted on `two_factor`/`role_elevation` only. It
  actually fires on every AUTH tier once enabled (`soft_confirm`/`local_auth` too, where a tap is
  the confirmation).
- **`--token` prompt**: it claimed `phone setup` prompts for `--token`. It does not; a token
  belongs on the command line or in the config file after setup, with the shell-history caveat
  called out explicitly.
- **Silence**: it said silence falls back to the terminal TOTP prompt with no further ceiling. It
  auto-denies at the 600 s challenge ceiling if nothing answers.
- **Fallback order**: it undersold the full fallback chain (desk dialog, terminal, and how the MCP
  proxy tries its dashboard before the phone).
- **OpenClaw**: the old text didn't mention that OpenClaw hands its AUTH verdict to its own
  `/approve` flow and never runs Doberman's phone challenge.

The section is rewritten in full (verbatim replacement text was pre-approved).

## Tests

- `tests/unit/test_ntfy_phone_approvals.py::test_default_budget_never_caps_a_configured_wait`
  (new): saves a config with `wait_s=300`, enables the method, calls `request_approval` with no
  timeout argument, and asserts the recorded deadline is 300 and that
  `DEFAULT_APPROVAL_TIMEOUT_S >= ntfy._WAIT_MAX_S`.
- Mutation-checked: setting the constant back to 90 locally turns the new test red; restored to
  300 afterward.
- Targeted suites, all green: `test_ntfy_phone_approvals.py`, `test_approval.py`,
  `test_cli_approvals.py`, `test_install_hooks_cursor.py` (the last two reference
  `DEFAULT_APPROVAL_TIMEOUT_S`/`windows_hello`), 131 passed.
- `ruff check .`, `ruff format --check .`, `lint-imports` (5/5 contracts kept) all pass.

## Security checklist

- [x] Fails closed on error / uncertainty (unchanged: `request_approval` still denies on any
      exception or non-outcome return; a longer default budget only widens the window a human has
      to answer, it never turns a timeout into an approval)
- [x] No secret, full file, or unredacted prompt logged or committed
- [x] Any guardrail/learning change is raise-only (this widens an approval window, it does not
      loosen any decision; the 600 s challenge ceiling is untouched)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (untouched by this change)
