### PR TITLE
fix(telemetry): make pytest a kill switch and count AUTH approvals and denials

### DIFF
--- a/changelog.d/673.fixed.md
+++ b/changelog.d/673.fixed.md
@@ -1,0 +1,1 @@
+- Telemetry no longer sends from a pytest run (`PYTEST_CURRENT_TEST` is a kill switch), and the daily summary now counts how many AUTH prompts were approved and denied (#673)

--- a/changelog.d/673.fixed.md
+++ b/changelog.d/673.fixed.md
@@ -1,1 +1,1 @@
-- Telemetry no longer sends from a pytest run (`PYTEST_CURRENT_TEST` is a kill switch), and the daily summary now counts how many AUTH prompts were approved and denied (#673)
+- Telemetry stays silent during pytest runs (`PYTEST_CURRENT_TEST` is a kill switch), and the daily summary counts approved and denied AUTH prompts (#673)

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -28,7 +28,7 @@ The event-specific data is:
 | `telemetry_disabled` | Telemetry is disabled; this is sent before the local flag changes | None |
 | `setup_completed` | Setup finishes successfully | `mode`, `host`, `hooks_installed`, `global_install`, `source` |
 | `cli_command` | A CLI command runs, except `hook`, `serve`, and `telemetry` | `command` (the command name only, such as `doctor` or `taint.clear`) |
-| `usage_summary` | At most once every 24 hours, alongside a CLI command | Lifetime `total`, `pass`, `auth`, and `block` counts, plus `days_since_first_seen` |
+| `usage_summary` | At most once every 24 hours, alongside a CLI command | Lifetime `total`, `pass`, `auth`, and `block` counts, how many of those AUTH prompts were `approved` or `denied`, plus `days_since_first_seen` |
 
 Doberman also sends a random UUID as the event's distinct id and a UTC event timestamp. The id is
 created when telemetry is first enabled. It is not derived from the machine, user, hostname, or
@@ -65,6 +65,7 @@ These environment variables force telemetry off even when the local state says e
 - `DO_NOT_TRACK` set to any non-empty value other than `0`
 - `DOBERMAN_TELEMETRY=0`, `false`, or `off`
 - `CI` set to any non-empty value
+- `PYTEST_CURRENT_TEST` set, which the pytest test runner does for every test, so a test suite never reports as an install
 
 `doberman telemetry status` shows active kill switches.
 

--- a/src/doberman/storage/device_metrics.py
+++ b/src/doberman/storage/device_metrics.py
@@ -7,8 +7,8 @@ user (scoped by virtue of living in their home directory), giving a lifetime
 "how many times has Doberman stepped in" summary.
 
 Redaction discipline matches the decision log: this store holds **only** a
-verdict class (PASS/AUTH/BLOCK) and a count — never a path, reason code, role,
-or any other per-action detail.
+verdict class (PASS/AUTH/BLOCK), whether an AUTH prompt was approved or denied,
+and a count — never a path, reason code, role, or any other per-action detail.
 
 Location override: pass ``home=`` directly, or set the ``DOBERMAN_HOME`` env
 var (tests point this at a temp dir so the real user rollup is never touched —
@@ -30,7 +30,19 @@ HOME_ENV = "DOBERMAN_HOME"
 
 _DB_NAME = "metrics.db"
 
-_EMPTY_METRICS = {"total": 0, "pass": 0, "auth": 0, "block": 0, "first_seen": None}
+#: Rollup keys for the two AUTH outcomes; ``record_decision`` writes one beside the verdict.
+AUTH_APPROVED = "AUTH_APPROVED"
+AUTH_DENIED = "AUTH_DENIED"
+
+_EMPTY_METRICS = {
+    "total": 0,
+    "pass": 0,
+    "auth": 0,
+    "block": 0,
+    "approved": 0,
+    "denied": 0,
+    "first_seen": None,
+}
 
 
 def _db_path(home: Path | None = None) -> Path:
@@ -94,7 +106,7 @@ def record_decision_metric(verdict: str, *, home: Path | None = None) -> None:
 def read_metrics(*, home: Path | None = None) -> dict:
     """Read the device-global rollup for ``doberman dashboard``.
 
-    Returns ``{total, pass, auth, block, first_seen}`` — all zero/None if the
+    Returns ``{total, pass, auth, block, approved, denied, first_seen}`` — all zero/None if the
     store doesn't exist yet. Never raises (a dashboard read must never crash
     the CLI or a SessionStart hook).
     """
@@ -108,11 +120,15 @@ def read_metrics(*, home: Path | None = None) -> dict:
             row = conn.execute("SELECT value FROM meta WHERE key = 'first_seen'").fetchone()
         finally:
             conn.close()
+        verdicts = {key: counts.get(key, 0) for key in ("PASS", "AUTH", "BLOCK")}
         return {
-            "total": sum(counts.values()),
-            "pass": counts.get("PASS", 0),
-            "auth": counts.get("AUTH", 0),
-            "block": counts.get("BLOCK", 0),
+            "total": sum(verdicts.values()),
+            "pass": verdicts["PASS"],
+            "auth": verdicts["AUTH"],
+            "block": verdicts["BLOCK"],
+            # AUTH outcomes stay out of ``total``: each is already counted as an AUTH.
+            "approved": counts.get(AUTH_APPROVED, 0),
+            "denied": counts.get(AUTH_DENIED, 0),
             "first_seen": row[0] if row else None,
         }
     except Exception:  # noqa: BLE001 — a dashboard read must never crash the CLI

--- a/src/doberman/storage/log.py
+++ b/src/doberman/storage/log.py
@@ -26,7 +26,7 @@ from pathlib import PurePosixPath
 
 from doberman.models import ActionType, Decision, EffectSet, SecurityObject
 from doberman.storage.db import open_db
-from doberman.storage.device_metrics import record_decision_metric
+from doberman.storage.device_metrics import AUTH_APPROVED, AUTH_DENIED, record_decision_metric
 from doberman.storage.fingerprint import fingerprint
 from doberman.storage.sinks import emit_to_sinks
 
@@ -88,6 +88,22 @@ _SELECT_SESSION_DECISIONS = (
 # "blocked", "error", "approved", "denied", "executed", ...). A NULL
 # auth_result (still pending) is deliberately kept.
 _RESOLVED_DECISIONS_PREDICATE = "(final_verdict <> 'AUTH' OR auth_result IS NOT NULL)"
+
+# AUTH outcomes for the device rollup. Every path that persists an AUTH row writes either one
+# of these denial words or the name of what let the action run ("executed", "approved",
+# "totp", "soft_confirm+memory", ...), so anything outside this set counts as approved.
+_AUTH_DENIED_RESULTS = frozenset(
+    {
+        "denied",
+        "blocked",
+        "unclaimable",
+        "timeout",
+        "autodeny",
+        "async_timeout",
+        "async_denied",
+        "error",
+    }
+)
 _DELETE_RESOLVED_DECISIONS = "DELETE FROM decisions WHERE " + _RESOLVED_DECISIONS_PREDICATE  # noqa: S608 — fixed clause, params bound
 _DECISION_COLUMNS = [
     "id",
@@ -300,6 +316,9 @@ async def record_decision(
     # depth — record_decision_metric already swallows its own failures).
     try:
         record_decision_metric(record["final_verdict"])
+        if record["final_verdict"] == "AUTH" and record["auth_result"]:
+            denied = record["auth_result"] in _AUTH_DENIED_RESULTS
+            record_decision_metric(AUTH_DENIED if denied else AUTH_APPROVED)
     except Exception:  # noqa: BLE001 — the device rollup must never break execution
         logger.warning("device metrics rollup failed for action %s; continuing", decision.action_id)
 

--- a/src/doberman/telemetry.py
+++ b/src/doberman/telemetry.py
@@ -42,7 +42,9 @@ _EVENT_PROPERTIES = {
     "telemetry_disabled": frozenset(),
     "setup_completed": frozenset({"mode", "host", "hooks_installed", "global_install", "source"}),
     "cli_command": frozenset({"command"}),
-    "usage_summary": frozenset({"total", "pass", "auth", "block", "days_since_first_seen"}),
+    "usage_summary": frozenset(
+        {"total", "pass", "auth", "block", "approved", "denied", "days_since_first_seen"}
+    ),
 }
 _SENDER_THREADS: list[threading.Thread] = []
 _THREADS_LOCK = threading.Lock()
@@ -145,6 +147,10 @@ def _forced_off_reasons() -> tuple[str, ...]:
         reasons.append("DOBERMAN_TELEMETRY disables telemetry")
     if os.environ.get("CI", ""):
         reasons.append("CI is set")
+    if os.environ.get("PYTEST_CURRENT_TEST", ""):
+        # The Core test suite clears the other kill switches to exercise sending, and leaked
+        # about 30,000 anonymous ids into the real project between 2026-08-27 and 09-08.
+        reasons.append("running under pytest")
     if _project_key().startswith(_PLACEHOLDER_PREFIX):
         reasons.append("PostHog project key is still the placeholder")
     return tuple(reasons)
@@ -314,9 +320,13 @@ def capture(
             method="POST",
         )
 
+        # Bound now, not inside the thread: a sender that outlives a test's monkeypatch must
+        # keep the stub instead of finding the real transport again.
+        opener = urllib.request.urlopen
+
         def send() -> None:
             try:
-                with urllib.request.urlopen(request, timeout=3):  # noqa: S310 — fixed HTTPS host
+                with opener(request, timeout=3):  # noqa: S310 — fixed HTTPS host
                     pass
             except Exception:  # noqa: BLE001 — telemetry transport is best-effort
                 return
@@ -363,6 +373,8 @@ def maybe_send_usage_summary(home: Path | None = None, now: datetime | None = No
                     "pass": int(metrics["pass"]),
                     "auth": int(metrics["auth"]),
                     "block": int(metrics["block"]),
+                    "approved": int(metrics.get("approved", 0)),
+                    "denied": int(metrics.get("denied", 0)),
                     "days_since_first_seen": days,
                 },
                 home=home,

--- a/tests/unit/test_device_metrics.py
+++ b/tests/unit/test_device_metrics.py
@@ -65,7 +65,15 @@ def _decision_and_action(verdict: Verdict, action_id: str) -> tuple[Decision, Se
 class TestRecordAndReadMetrics:
     def test_absent_store_reads_all_zeros(self, tmp_path):
         metrics = read_metrics(home=tmp_path / "nope")
-        assert metrics == {"total": 0, "pass": 0, "auth": 0, "block": 0, "first_seen": None}
+        assert metrics == {
+            "total": 0,
+            "pass": 0,
+            "auth": 0,
+            "block": 0,
+            "approved": 0,
+            "denied": 0,
+            "first_seen": None,
+        }
 
     def test_increments_the_right_counter(self, tmp_path):
         record_decision_metric("PASS", home=tmp_path)
@@ -86,9 +94,17 @@ class TestRecordAndReadMetrics:
             "pass": 3,
             "auth": 1,
             "block": 1,
+            "approved": 0,
+            "denied": 0,
             "first_seen": metrics["first_seen"],
         }
         assert metrics["first_seen"] is not None
+
+    def test_auth_outcomes_ride_beside_the_verdict_and_stay_out_of_total(self, tmp_path):
+        for key in ("AUTH", "AUTH_APPROVED", "AUTH", "AUTH_DENIED", "PASS"):
+            record_decision_metric(key, home=tmp_path)
+        m = read_metrics(home=tmp_path)
+        assert (m["total"], m["auth"], m["approved"], m["denied"]) == (3, 2, 1, 1)
 
     def test_first_seen_is_set_once(self, tmp_path):
         record_decision_metric("PASS", home=tmp_path)
@@ -159,6 +175,19 @@ class TestRecordDecisionRollupWiring:
         await record_decision(decision, action, repo_root=str(tmp_path))
         # isolated_device_metrics_home fixture points DOBERMAN_HOME at a temp dir.
         assert read_metrics()["pass"] == 1
+
+    async def test_record_decision_counts_auth_outcomes(self, tmp_path):
+        for action_id, auth_result in (
+            ("act-auth-yes", "totp"),
+            ("act-auth-no", "autodeny"),
+            ("act-auth-pending", None),
+        ):
+            decision, action = _decision_and_action(Verdict.AUTH, action_id)
+            await record_decision(
+                decision, action, repo_root=str(tmp_path), auth_result=auth_result
+            )
+        m = read_metrics()
+        assert (m["total"], m["auth"], m["approved"], m["denied"]) == (3, 3, 1, 1)
 
     async def test_record_decision_survives_a_failing_metric_write(self, tmp_path, monkeypatch):
         def boom(*args, **kwargs):

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -22,6 +22,22 @@ app = cli_module.app
 runner = CliRunner()
 
 
+def _telemetry_live(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear every kill switch so ``is_enabled()`` is True, and swallow the transport: until
+    2026-09-08 these runs posted a real ``setup_completed`` to the project on every test run."""
+    for name in ("DOBERMAN_TELEMETRY", "CI", "DO_NOT_TRACK", "PYTEST_CURRENT_TEST"):
+        monkeypatch.delenv(name, raising=False)
+
+    class _Sent:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda request, timeout=None: _Sent())
+
+
 @pytest.fixture(autouse=True)
 def _doberman_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pin `doberman` as resolvable so a healthy wired-hooks run reads as
@@ -1152,9 +1168,7 @@ def test_yes_telemetry_section_shows_compact_summary_not_full_explanation(
     below it (no redundant "Telemetry:" label - the header already said it) -
     never the full explanation, and never a 3rd mention from `Also:` (that
     pointer now lives only in this section - see the `Also:` tests)."""
-    monkeypatch.delenv("DOBERMAN_TELEMETRY", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    _telemetry_live(monkeypatch)
     result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
     assert result.exit_code == 0, result.output
     assert "Counts and command names only." not in result.output
@@ -1182,9 +1196,7 @@ def test_yes_summary_always_shows_telemetry_on_line(
     # `_forced_off_reasons`) - clear every kill switch, not just the one this
     # test is nominally about, so this is deterministic on CI too (CI sets
     # `CI=true`, which previously made this "on" assertion fail there).
-    monkeypatch.delenv("DOBERMAN_TELEMETRY", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    _telemetry_live(monkeypatch)
     result = runner.invoke(app, ["setup", "--yes", "--path", str(tmp_path)])
     assert result.exit_code == 0, result.output
     assert "on - anonymous usage counts; `doberman telemetry off` to opt out" in result.output
@@ -1202,9 +1214,7 @@ def test_yes_summary_shows_telemetry_off_when_forced_off(tmp_path: Path) -> None
 def test_telemetry_summary_line_shows_even_after_help_already_marked_the_notice_seen(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.delenv("DOBERMAN_TELEMETRY", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    _telemetry_live(monkeypatch)
     from doberman import telemetry
 
     telemetry.first_run_notice()  # simulate: a user who read `--help` first
@@ -1629,9 +1639,7 @@ def test_setup_help_never_prints_the_telemetry_notice(
     """item 3/10: `--help` never runs setup's own body (Click prints help and
     exits first), so the generic first-run notice must never show above the
     usage text either."""
-    monkeypatch.delenv("DOBERMAN_TELEMETRY", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    _telemetry_live(monkeypatch)
     result = runner.invoke(app, ["setup", "--help"])
     assert result.exit_code == 0, result.output
     assert "sends anonymous usage counts" not in result.output

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -32,12 +32,14 @@ class _Response:
 
 
 def _ready(telemetry, tmp_path, monkeypatch):
-    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-    monkeypatch.delenv("DOBERMAN_TELEMETRY", raising=False)
-    monkeypatch.delenv("CI", raising=False)
+    _clear_kill_switches(monkeypatch)
     monkeypatch.setenv("DOBERMAN_HOME", str(tmp_path))
-    telemetry.enable(home=tmp_path)
     monkeypatch.setenv(telemetry.ENV_KEY, _KEY)
+    # Stub the transport BEFORE enabling. Until 2026-09-08 this helper enabled first, and the
+    # "telemetry_enabled" event of every test that used it went to the real project.
+    _capture_requests(telemetry, monkeypatch)
+    telemetry.enable(home=tmp_path)
+    telemetry._join_sender_threads(timeout=1.0)
 
 
 def _capture_requests(telemetry, monkeypatch):
@@ -60,6 +62,43 @@ def _clear_kill_switches(monkeypatch):
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
     monkeypatch.delenv("DOBERMAN_TELEMETRY", raising=False)
     monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+
+def test_pytest_is_a_kill_switch(tmp_path, monkeypatch):
+    """The test runner's own marker forces telemetry off: a suite run never reads as an install."""
+    from doberman import telemetry
+
+    for name in ("DO_NOT_TRACK", "DOBERMAN_TELEMETRY", "CI"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "tests/unit/test_telemetry.py::x (call)")
+    monkeypatch.setenv(telemetry.ENV_KEY, _KEY)
+    requests = _capture_requests(telemetry, monkeypatch)
+
+    assert "running under pytest" in telemetry.status(home=tmp_path).forced_off_reasons
+    assert telemetry.is_enabled(home=tmp_path) is False
+    telemetry.capture("cli_command", {"command": "doctor"}, home=tmp_path)
+    telemetry.enable(home=tmp_path)
+    assert _bodies(telemetry, requests) == []
+
+
+def test_sender_keeps_the_transport_it_was_created_with(tmp_path, monkeypatch):
+    """A sender bound to a stub must not find the real transport once the stub is gone."""
+    from doberman import telemetry
+
+    _ready(telemetry, tmp_path, monkeypatch)
+    held = []
+    monkeypatch.setattr(threading.Thread, "start", lambda self: held.append(self))
+    requests = _capture_requests(telemetry, monkeypatch)
+    telemetry.capture("cli_command", {"command": "doctor"}, home=tmp_path)
+    assert len(held) == 1
+
+    def later(request, timeout):
+        raise AssertionError("the sender reached a transport installed after capture()")
+
+    monkeypatch.setattr("urllib.request.urlopen", later)
+    held[0].run()
+    assert [json.loads(r.data)["event"] for r, _t in requests] == ["cli_command"]
 
 
 def test_default_on_first_capture_creates_id_and_posts(tmp_path, monkeypatch):
@@ -332,7 +371,7 @@ def test_usage_summary_sends_at_most_once_per_day(tmp_path, monkeypatch):
     from doberman import telemetry
 
     _ready(telemetry, tmp_path, monkeypatch)
-    for verdict in ("PASS", "PASS", "AUTH", "BLOCK"):
+    for verdict in ("PASS", "PASS", "AUTH", "AUTH_APPROVED", "BLOCK"):
         record_decision_metric(verdict, home=tmp_path)
     requests = _capture_requests(telemetry, monkeypatch)
 
@@ -350,6 +389,8 @@ def test_usage_summary_sends_at_most_once_per_day(tmp_path, monkeypatch):
         "pass": 2,
         "auth": 1,
         "block": 1,
+        "approved": 1,
+        "denied": 0,
         "days_since_first_seen": 0,
     }
     assert {key: bodies[0]["properties"][key] for key in expected} == expected


### PR DESCRIPTION
## What

The PostHog project showed 30,191 distinct CLI ids since 2026-08-27 and exactly one device seen on two different days. The os/python/version mix matched the CI matrix. The Core test suite was sending real events: `tests/unit/test_telemetry.py::_ready` called `enable()` before stubbing the transport (a real `telemetry_enabled` with the shipped key on every run), and three `setup --yes` tests in `test_setup_wizard.py` cleared every kill switch with no stub at all (`setup_completed`, 4,149 times).

- `PYTEST_CURRENT_TEST` is now a kill switch in `telemetry._forced_off_reasons()`, next to `DO_NOT_TRACK`, `DOBERMAN_TELEMETRY=0` and `CI`. A test suite is never an install.
- The sender thread binds `urllib.request.urlopen` at `capture()` time, so a thread that outlives a test's monkeypatch keeps the stub instead of finding the real transport.
- `record_decision` writes `AUTH_APPROVED` / `AUTH_DENIED` into the device rollup beside the verdict when an AUTH row carries an `auth_result` (denial set: `denied`, `blocked`, `unclaimable`, `timeout`, `autodeny`, `async_timeout`, `async_denied`, `error`; anything else let the action run). `read_metrics` returns `approved` and `denied`; `total` stays pass + auth + block.
- `usage_summary` carries `approved` and `denied`; `docs/TELEMETRY.md` updated.

## Tests

- `test_pytest_is_a_kill_switch`, `test_sender_keeps_the_transport_it_was_created_with` (telemetry)
- `test_auth_outcomes_ride_beside_the_verdict_and_stay_out_of_total`, `test_record_decision_counts_auth_outcomes` (device metrics)
- `_ready` stubs before enabling; the wizard tests route through `_telemetry_live()` which clears the four switches and swallows the transport.
- Local: `pytest tests/unit/test_telemetry.py tests/unit/test_device_metrics.py tests/unit/test_setup_wizard.py tests/unit/test_cli_telemetry_bare.py tests/unit/test_cli_uninstall.py tests/unit/test_update_check.py tests/unit/test_friction_tune.py` → 187 passed; `ruff check`, `ruff format --check`, `lint-imports` clean.

## Follow-up

The PostHog dashboards ("Doberman CLI", "Doberman Landing") key on devices seen on two or more days, so the historical noise stays out; the "single-day ids per day" tile should fall to zero once this ships.
