### PR TITLE
test(tui): root the column-order test in tmp_path, not the cwd store

### DIFF
--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -295,10 +295,10 @@ async def test_next_line_present_for_block_and_auth_absent_for_pass(tmp_path):
         assert next_text == ""
 
 
-async def test_columns_are_plain_words_in_the_documented_order():
+async def test_columns_are_plain_words_in_the_documented_order(tmp_path):
     # >=100 columns (round 8 design critique item 2 hides risk/auth below
     # that) so the full documented column set is actually on screen here.
-    app = DecisionExplainerApp(".")
+    app = DecisionExplainerApp(str(tmp_path))
     async with app.run_test(size=(120, 24)) as pilot:
         await _wait_loaded(pilot, app)
         table = app.query_one("#decisions")


### PR DESCRIPTION
## What

`test_columns_are_plain_words_in_the_documented_order` opened `DecisionExplainerApp(".")`, so it read whatever `.doberman/` store the checkout happened to have. The TUI hides the `target` column when every loaded row lacks a target (`_all_targets_missing`), so the test went red whenever an earlier test on the same runner had left a store of target-less rows in the repo root. Landing PR #675 hit it on Windows shard 2 of 4.

The test now roots the app in `tmp_path` like its siblings. With an empty store the column set is the documented one, which is what the test is asserting.

## Verified

- Copied the repo-root store into a scratch worktree, deleted every row that had a target: the original test fails with the exact CI assertion (`target` missing), the fixed test passes.
- Fixed test also passes with no store at all.

## Not in this PR

Some tests write a real `.doberman/` store into the repo root (this checkout has one with 114 decision rows). That leak is a separate cleanup and a good contributor issue.

**Repo:** doberman-core (public). Test-only change, no public-release concern.
