### PR TITLE
feat(tooling): mirror PostHog Self-driving reports into posthog-labelled issues

### DIFF
--- a/.github/workflows/posthog-inbox.yml
+++ b/.github/workflows/posthog-inbox.yml
@@ -1,0 +1,41 @@
+name: PostHog inbox to issues
+
+# Mirrors PostHog Self-driving reports into GitHub issues labelled `posthog`, so the
+# findings land where maintainers already work. PostHog's own agents stay switched off
+# for this project (its inbox autostart is disabled): PostHog finds, maintainers fix.
+# Idempotent: a hidden marker in each issue body keys the deduplication. Details and the
+# environment contract live in scripts/posthog_inbox_to_issues.py.
+on:
+  schedule:
+    - cron: "41 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print what would be filed instead of filing it"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: posthog-inbox
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    # Forks have neither the key nor the inbox; the script would exit 0 anyway.
+    if: github.repository == 'DobermanCore/Doberman-Core'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Mirror new reports
+        run: python scripts/posthog_inbox_to_issues.py ${{ inputs.dry_run == true && '--dry-run' || '' }}
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog.d/678.added.md
+++ b/changelog.d/678.added.md
@@ -1,1 +1,1 @@
-A scheduled Action mirrors PostHog Self-driving inbox reports into GitHub issues labelled `posthog`, deduplicated and capped (#678).
+- A scheduled Action mirrors PostHog Self-driving inbox reports into GitHub issues labelled `posthog`, deduplicated and capped (#678).

--- a/changelog.d/678.added.md
+++ b/changelog.d/678.added.md
@@ -1,0 +1,1 @@
+A scheduled Action mirrors PostHog Self-driving inbox reports into GitHub issues labelled `posthog`, deduplicated and capped (#678).

--- a/scripts/posthog_inbox_to_issues.py
+++ b/scripts/posthog_inbox_to_issues.py
@@ -1,0 +1,255 @@
+"""Mirror PostHog Self-driving inbox reports into GitHub issues labelled ``posthog``.
+
+PostHog's Self-driving inbox can open pull requests but cannot file GitHub issues, and
+this project keeps its agent pull requests switched off: maintainers do the fixing.
+This script closes the gap. Every report that is visible in the inbox and not yet
+mirrored becomes one GitHub issue carrying the ``posthog`` label, a priority prefix,
+the scout that found it, and a link back to the report. A hidden marker in the issue
+body keys the deduplication, so re-running is idempotent.
+
+Runs from ``.github/workflows/posthog-inbox.yml`` every six hours. Environment:
+
+- ``POSTHOG_API_KEY``: a personal API key with the ``task:read`` scope (reports live
+  under PostHog's task scope). Missing key = print a notice and exit 0, so a fork or an
+  unconfigured checkout never turns the schedule red.
+- ``GITHUB_TOKEN`` and ``GITHUB_REPOSITORY``: provided by GitHub Actions.
+- ``POSTHOG_PROJECT_ID`` (default 579731) and ``POSTHOG_HOST`` (default us.posthog.com).
+
+Stdlib only, HTTPS only, at most ``MAX_NEW_ISSUES_PER_RUN`` new issues per run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+LABEL = "posthog"
+LABEL_COLOR = "F54E00"
+LABEL_DESCRIPTION = "Filed automatically from the PostHog Self-driving inbox"
+MARKER = re.compile(r"<!-- posthog-report: ([0-9a-fA-F-]{36}) -->")
+# Inbox states a human can act on. ``potential`` reports are not surfaced yet, and the
+# resolved / failed / suppressed / PostHog-internal states are not work for maintainers.
+MIRRORED_STATUSES = frozenset({"candidate", "pending_input", "in_progress", "ready"})
+DEFAULT_HOST = "https://us.posthog.com"
+DEFAULT_PROJECT_ID = "579731"
+GITHUB_API = "https://api.github.com"
+MAX_NEW_ISSUES_PER_RUN = 20
+TITLE_LIMIT = 200
+PAGE_SIZE = 100
+
+# (method, url, headers, body) -> (status, headers, body). Injected so tests never touch
+# the network and so the transport is decided once, at construction.
+Fetch = Callable[[str, str, dict[str, str], bytes | None], tuple[int, dict[str, str], bytes]]
+
+
+def urllib_fetch(
+    method: str, url: str, headers: dict[str, str], body: bytes | None
+) -> tuple[int, dict[str, str], bytes]:
+    """The one real transport: HTTPS only, 30 s timeout, HTTP errors returned not raised."""
+    if not url.startswith("https://"):
+        raise ValueError(f"refusing non-HTTPS url: {url}")
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)  # noqa: S310
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - scheme checked
+            return response.status, dict(response.headers), response.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, dict(exc.headers or {}), exc.read()
+
+
+@dataclass(frozen=True)
+class PostHog:
+    host: str
+    project_id: str
+    api_key: str
+    fetch: Fetch
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}", "Accept": "application/json"}
+
+    def reports(self) -> Iterator[dict[str, Any]]:
+        """Every report the inbox API lists, following pagination."""
+        url: str | None = (
+            f"{self.host}/api/projects/{self.project_id}/signals/reports/?limit={PAGE_SIZE}"
+        )
+        while url:
+            status, _headers, raw = self.fetch("GET", url, self._headers(), None)
+            if status != 200:
+                raise RuntimeError(f"PostHog reports request failed: {status} {raw[:200]!r}")
+            page = json.loads(raw)
+            yield from page.get("results", [])
+            url = page.get("next")
+
+    def report_url(self, report_id: str) -> str:
+        return f"{self.host}/project/{self.project_id}/inbox/reports/{report_id}"
+
+
+@dataclass(frozen=True)
+class GitHub:
+    repository: str
+    token: str
+    fetch: Fetch
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "doberman-posthog-inbox",
+            "Content-Type": "application/json",
+        }
+
+    def mirrored_report_ids(self) -> set[str]:
+        """Report ids already carried by an open or closed ``posthog`` issue."""
+        ids: set[str] = set()
+        page = 1
+        while True:
+            url = (
+                f"{GITHUB_API}/repos/{self.repository}/issues"
+                f"?labels={LABEL}&state=all&per_page={PAGE_SIZE}&page={page}"
+            )
+            status, _headers, raw = self.fetch("GET", url, self._headers(), None)
+            if status != 200:
+                raise RuntimeError(f"GitHub issues request failed: {status} {raw[:200]!r}")
+            issues = json.loads(raw)
+            for issue in issues:
+                match = MARKER.search(issue.get("body") or "")
+                if match:
+                    ids.add(match.group(1).lower())
+            if len(issues) < PAGE_SIZE:
+                return ids
+            page += 1
+
+    def ensure_label(self) -> None:
+        url = f"{GITHUB_API}/repos/{self.repository}/labels/{LABEL}"
+        status, _headers, raw = self.fetch("GET", url, self._headers(), None)
+        if status == 200:
+            return
+        if status != 404:
+            raise RuntimeError(f"GitHub label lookup failed: {status} {raw[:200]!r}")
+        payload = {"name": LABEL, "color": LABEL_COLOR, "description": LABEL_DESCRIPTION}
+        status, _headers, raw = self.fetch(
+            "POST", f"{GITHUB_API}/repos/{self.repository}/labels", self._headers(), _dump(payload)
+        )
+        # 422 = the label appeared between the lookup and the create; that is fine.
+        if status not in (201, 422):
+            raise RuntimeError(f"GitHub label create failed: {status} {raw[:200]!r}")
+
+    def create_issue(self, title: str, body: str) -> str:
+        payload = {"title": title, "body": body, "labels": [LABEL]}
+        status, _headers, raw = self.fetch(
+            "POST", f"{GITHUB_API}/repos/{self.repository}/issues", self._headers(), _dump(payload)
+        )
+        if status != 201:
+            raise RuntimeError(f"GitHub issue create failed: {status} {raw[:200]!r}")
+        return str(json.loads(raw)["html_url"])
+
+
+def _dump(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload).encode("utf-8")
+
+
+def is_mirrorable(report: dict[str, Any]) -> bool:
+    return (
+        report.get("status") in MIRRORED_STATUSES
+        and not report.get("already_addressed")
+        and not report.get("dismissal_reason")
+    )
+
+
+def issue_title(report: dict[str, Any]) -> str:
+    title = " ".join(str(report.get("title") or "Untitled PostHog report").split())
+    priority = report.get("priority")
+    prefix = f"[{priority}] " if priority else ""
+    return (prefix + title)[:TITLE_LIMIT]
+
+
+def issue_body(report: dict[str, Any], report_url: str) -> str:
+    summary = str(report.get("summary") or "").strip() or "_PostHog has not written a summary yet._"
+    facts = [
+        f"- Scout: `{report['scout_name']}`" if report.get("scout_name") else None,
+        f"- Actionability: `{report['actionability']}`" if report.get("actionability") else None,
+        f"- Inbox status: `{report.get('status', 'unknown')}`",
+        f"- Signals behind it: {report.get('signal_count', 0)}",
+    ]
+    return "\n".join(
+        [
+            summary,
+            "",
+            *[fact for fact in facts if fact],
+            "",
+            f"[Open the report in PostHog]({report_url})",
+            "",
+            "_Filed automatically from the PostHog Self-driving inbox. It mirrors the finding;"
+            " the fix is a maintainer's call._",
+            f"<!-- posthog-report: {str(report['id']).lower()} -->",
+        ]
+    )
+
+
+def sync(
+    posthog: PostHog,
+    github: GitHub,
+    *,
+    dry_run: bool = False,
+    limit: int = MAX_NEW_ISSUES_PER_RUN,
+    out: Callable[[str], None] = print,
+) -> int:
+    """File one issue per unmirrored, actionable report. Returns how many were filed."""
+    mirrored = github.mirrored_report_ids()
+    created = 0
+    for report in posthog.reports():
+        report_id = str(report.get("id", "")).lower()
+        if not report_id or not is_mirrorable(report) or report_id in mirrored:
+            continue
+        if created >= limit:
+            out(f"reached {limit} new issues; the rest wait for the next run")
+            break
+        title = issue_title(report)
+        if dry_run:
+            out(f"would file: {title}")
+        else:
+            if created == 0:
+                github.ensure_label()
+            url = github.create_issue(title, issue_body(report, posthog.report_url(report_id)))
+            out(f"filed {url} for report {report_id}")
+        created += 1
+    out(f"{created} new issue(s); {len(mirrored)} report(s) were already mirrored")
+    return created
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--dry-run", action="store_true", help="print instead of filing")
+    args = parser.parse_args(argv)
+
+    api_key = os.environ.get("POSTHOG_API_KEY", "")
+    if not api_key:
+        print("POSTHOG_API_KEY is not set; nothing to mirror (this is expected on forks)")
+        return 0
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    if not token or not repository:
+        print("GITHUB_TOKEN and GITHUB_REPOSITORY are required", file=sys.stderr)
+        return 2
+
+    posthog = PostHog(
+        host=os.environ.get("POSTHOG_HOST", DEFAULT_HOST).rstrip("/"),
+        project_id=os.environ.get("POSTHOG_PROJECT_ID", DEFAULT_PROJECT_ID),
+        api_key=api_key,
+        fetch=urllib_fetch,
+    )
+    github = GitHub(repository=repository, token=token, fetch=urllib_fetch)
+    sync(posthog, github, dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_posthog_inbox_to_issues.py
+++ b/tests/unit/test_posthog_inbox_to_issues.py
@@ -1,0 +1,184 @@
+"""The PostHog inbox mirror files one labelled issue per new report and never twice."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from scripts.posthog_inbox_to_issues import (
+    LABEL,
+    MARKER,
+    PAGE_SIZE,
+    GitHub,
+    PostHog,
+    is_mirrorable,
+    issue_body,
+    issue_title,
+    main,
+    sync,
+)
+
+REPORT = {
+    "id": "01A0830C-98F1-7CB3-998A-94ECB2EFDB79",
+    "title": "  Authorization outcomes are\n silent for active CLI traffic ",
+    "summary": "AUTH verdicts arrive with no approved or denied outcome.",
+    "status": "pending_input",
+    "priority": "P2",
+    "actionability": "requires_human_input",
+    "scout_name": "signals-scout-authorization-decision-health",
+    "signal_count": 4,
+}
+
+
+class FakeTransport:
+    """Scripted (method, path) -> (status, json) responses that record every call."""
+
+    def __init__(self, routes: dict[tuple[str, str], tuple[int, Any]]) -> None:
+        self.routes = routes
+        self.calls: list[tuple[str, str, Any]] = []
+
+    def __call__(
+        self, method: str, url: str, headers: dict[str, str], body: bytes | None
+    ) -> tuple[int, dict[str, str], bytes]:
+        path = url.split("//", 1)[1].split("/", 1)[1]
+        self.calls.append((method, path, json.loads(body) if body else None))
+        for (route_method, route_path), (status, payload) in self.routes.items():
+            if route_method == method and path.startswith(route_path):
+                return status, {}, json.dumps(payload).encode()
+        raise AssertionError(f"unexpected request {method} {path}")
+
+
+def _clients(
+    routes: dict[tuple[str, str], tuple[int, Any]],
+) -> tuple[PostHog, GitHub, FakeTransport]:
+    transport = FakeTransport(routes)
+    posthog = PostHog(host="https://us.posthog.com", project_id="1", api_key="k", fetch=transport)
+    github = GitHub(repository="org/repo", token="t", fetch=transport)  # noqa: S106
+    return posthog, github, transport
+
+
+def _routes(reports: list[dict[str, Any]], issues: list[dict[str, Any]]) -> dict:
+    return {
+        ("GET", "api/projects/1/signals/reports/"): (200, {"results": reports, "next": None}),
+        ("GET", "repos/org/repo/issues?labels="): (200, issues),
+        ("GET", "repos/org/repo/labels/posthog"): (404, {}),
+        ("POST", "repos/org/repo/labels"): (201, {}),
+        ("POST", "repos/org/repo/issues"): (
+            201,
+            {"html_url": "https://github.com/org/repo/issues/9"},
+        ),
+    }
+
+
+def test_new_report_becomes_one_labelled_issue_with_marker_and_priority() -> None:
+    posthog, github, transport = _clients(_routes([REPORT], []))
+    out: list[str] = []
+
+    assert sync(posthog, github, out=out.append) == 1
+
+    creates = [call for call in transport.calls if call[:2] == ("POST", "repos/org/repo/issues")]
+    assert len(creates) == 1
+    payload = creates[0][2]
+    assert payload["labels"] == [LABEL]
+    assert payload["title"] == "[P2] Authorization outcomes are silent for active CLI traffic"
+    assert MARKER.search(payload["body"]).group(1) == REPORT["id"].lower()
+    assert "inbox/reports/01a0830c-98f1-7cb3-998a-94ecb2efdb79" in payload["body"]
+    assert "signals-scout-authorization-decision-health" in payload["body"]
+    assert ("POST", "repos/org/repo/labels") in [call[:2] for call in transport.calls]
+    assert out[0].startswith("filed https://github.com/org/repo/issues/9")
+
+
+def test_already_mirrored_reports_are_skipped_case_insensitively() -> None:
+    existing = [{"body": f"old text\n<!-- posthog-report: {REPORT['id'].lower()} -->"}]
+    posthog, github, transport = _clients(_routes([REPORT], existing))
+
+    assert sync(posthog, github) == 0
+    assert all(call[0] == "GET" for call in transport.calls)
+
+
+def test_dry_run_files_nothing_and_says_what_it_would_file() -> None:
+    posthog, github, transport = _clients(_routes([REPORT], []))
+    out: list[str] = []
+
+    assert sync(posthog, github, dry_run=True, out=out.append) == 1
+    assert all(call[0] == "GET" for call in transport.calls)
+    assert out[0] == "would file: [P2] Authorization outcomes are silent for active CLI traffic"
+
+
+def test_per_run_cap_leaves_the_rest_for_the_next_run() -> None:
+    reports = [dict(REPORT, id=f"01a0830c-98f1-7cb3-998a-94ecb2efdb{n:02d}") for n in range(3)]
+    posthog, github, transport = _clients(_routes(reports, []))
+
+    assert sync(posthog, github, limit=2) == 2
+    assert sum(call[:2] == ("POST", "repos/org/repo/issues") for call in transport.calls) == 2
+
+
+def test_mirrored_ids_follow_github_pagination() -> None:
+    first_page = [
+        {"body": f"<!-- posthog-report: {n:08d}-0000-0000-0000-000000000000 -->"}
+        for n in range(PAGE_SIZE)
+    ]
+    routes = {
+        ("GET", f"repos/org/repo/issues?labels=posthog&state=all&per_page={PAGE_SIZE}&page=1"): (
+            200,
+            first_page,
+        ),
+        ("GET", f"repos/org/repo/issues?labels=posthog&state=all&per_page={PAGE_SIZE}&page=2"): (
+            200,
+            [
+                {"body": "<!-- posthog-report: ffffffff-0000-0000-0000-000000000000 -->"},
+                {"body": None},
+            ],
+        ),
+    }
+    _posthog, github, _transport = _clients(routes)
+
+    ids = github.mirrored_report_ids()
+
+    assert len(ids) == PAGE_SIZE + 1
+    assert "ffffffff-0000-0000-0000-000000000000" in ids
+
+
+@pytest.mark.parametrize(
+    ("changes", "expected"),
+    [
+        ({}, True),
+        ({"status": "candidate"}, True),
+        ({"status": "potential"}, False),
+        ({"status": "resolved"}, False),
+        ({"status": "posthog_health_check"}, False),
+        ({"already_addressed": True}, False),
+        ({"dismissal_reason": "not_a_bug"}, False),
+    ],
+)
+def test_only_actionable_undismissed_reports_are_mirrored(
+    changes: dict[str, Any], expected: bool
+) -> None:
+    assert is_mirrorable(dict(REPORT, **changes)) is expected
+
+
+def test_title_and_body_shapes() -> None:
+    assert issue_title({"title": "x" * 300, "priority": None}) == "x" * 200
+    assert issue_title({}) == "Untitled PostHog report"
+    body = issue_body({"id": "abc", "status": "ready"}, "https://x/report")
+    assert body.startswith("_PostHog has not written a summary yet._")
+    assert body.endswith("<!-- posthog-report: abc -->")
+
+
+def test_missing_key_is_a_quiet_no_op(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("POSTHOG_API_KEY", raising=False)
+
+    assert main([]) == 0
+    assert "POSTHOG_API_KEY is not set" in capsys.readouterr().out
+
+
+def test_missing_github_context_is_an_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POSTHOG_API_KEY", "k")
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    assert main([]) == 2


### PR DESCRIPTION
## Slice
- Tooling — mirror PostHog Self-driving inbox reports into GitHub issues

## What this PR does
PostHog's Self-driving inbox can open pull requests but cannot file GitHub issues, and this project keeps its agent pull requests switched off (PostHog finds, maintainers fix). This PR adds a scheduled GitHub Action that turns every actionable, not-yet-mirrored inbox report into one GitHub issue:

- label `posthog` (created on first use, colour PostHog orange), so the origin is obvious at a glance
- title prefixed with the PostHog priority, e.g. `[P2] Authorization outcomes are silent for active CLI traffic`
- body: the report summary, the scout that found it, actionability, inbox status, signal count, and a deep link to the report
- a hidden `<!-- posthog-report: <id> -->` marker keys the deduplication, so re-runs are idempotent and closing an issue never makes it come back
- only `candidate` / `pending_input` / `in_progress` / `ready` reports that are not dismissed or already addressed are mirrored
- at most 20 new issues per run; the rest wait for the next run
- runs every six hours (`41 */6 * * *`) and on `workflow_dispatch` with a `dry_run` input
- stdlib only, HTTPS only, 30 s timeouts; a missing `POSTHOG_API_KEY` prints a notice and exits 0 so forks and unconfigured checkouts never turn the schedule red

Files: `scripts/posthog_inbox_to_issues.py`, `tests/unit/test_posthog_inbox_to_issues.py`, `.github/workflows/posthog-inbox.yml`.

## Tests added (run in CI)
- `tests/unit/test_posthog_inbox_to_issues.py` (15 tests, fake transport, no network): new report becomes exactly one labelled issue with marker, priority prefix, deep link and scout; already-mirrored reports are skipped case-insensitively with no writes; dry-run files nothing; per-run cap leaves the rest; GitHub pagination of existing markers; status/dismissal filter (parametrized); title truncation and body shape; missing key is a quiet exit 0; missing GitHub context is exit 2.

## Security checklist
- [x] Fails closed on error / uncertainty (non-200 responses raise; nothing partial is retried blindly)
- [x] No secret, full file, or unredacted prompt logged or committed (key and token only ever travel in request headers; `secrets.POSTHOG_API_KEY` is repo-scoped)
- [x] Any guardrail/learning change is raise-only (n/a, no runtime code touched)
- [x] Every BLOCK/AUTH carries reason codes + a human explanation (n/a)

## Edge cases covered / Deviations from plan / Risks introduced
- Workflow permissions are `contents: read`, `issues: write` only; the job is gated to `DobermanCore/Doberman-Core`.
- Needs one manual step after merge: a PostHog personal API key with the `task:read` scope stored as the `POSTHOG_API_KEY` repository secret. Until then every run is a no-op that exits 0.
- The PostHog report id is lowercased in the marker and the deep link; GitHub issue bodies keep the marker as an HTML comment so it is invisible in the rendered issue.
