### PR TITLE
test: keep the suite out of the checkout's .doberman store

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,52 @@ _REAL_USER_SETTINGS_BEFORE = (
     _REAL_USER_SETTINGS.read_bytes() if _REAL_USER_SETTINGS.exists() else None
 )
 
+# Every storage/config entry point defaults ``repo_root`` to ".", so a test that
+# hands a hook ``cwd: "."`` (or no root at all) writes a real ``.doberman/`` store
+# into the checkout. Rows pile up there across the run, and any later test that
+# opens the cwd store sees them: the TUI column-order test went red on a CI shard
+# that way. A store already present when the process starts (a developer's live
+# hook keeps one) is not the suite's, so the check below stays off then.
+_CHECKOUT_STORE = Path(__file__).resolve().parents[1] / ".doberman"
+_CHECKOUT_STORE_PRESENT_AT_START = _CHECKOUT_STORE.exists()
+
+
+def _checkout_store_snapshot() -> frozenset[tuple[str, int, int]]:
+    entries: set[tuple[str, int, int]] = set()
+    try:
+        for path in _CHECKOUT_STORE.rglob("*"):
+            try:
+                stat = path.stat()
+            except OSError:  # a journal file vanishing mid-write; the db itself still shows
+                continue
+            if path.is_file():
+                entries.add(
+                    (str(path.relative_to(_CHECKOUT_STORE)), stat.st_size, stat.st_mtime_ns)
+                )
+    except OSError:
+        return frozenset({("<unreadable>", -1, -1)})
+    return frozenset(entries)
+
+
+@pytest.fixture(autouse=True)
+def checkout_store_untouched(request):
+    """Fail any test that creates or changes the checkout's ``.doberman/`` store.
+
+    Under xdist the writer may be a test running alongside this one on another
+    worker; ``-n 0`` attributes exactly.
+    """
+    if _CHECKOUT_STORE_PRESENT_AT_START:
+        yield
+        return
+    before = _checkout_store_snapshot()
+    yield
+    after = _checkout_store_snapshot()
+    assert after == before, (
+        f"{request.node.nodeid} created or changed {_CHECKOUT_STORE}: it (or, under xdist, a test "
+        "running alongside it) used the checkout as its Doberman root. Give it a tmp_path root or "
+        "monkeypatch.chdir(tmp_path); run with -n 0 to attribute exactly."
+    )
+
 
 @pytest.fixture(autouse=True)
 def isolated_user_home(tmp_path, monkeypatch):

--- a/tests/unit/test_hosthook_claude_cursor_compat.py
+++ b/tests/unit/test_hosthook_claude_cursor_compat.py
@@ -259,11 +259,12 @@ def test_no_tool_use_id_means_no_unpaired_dedupe(tmp_path, monkeypatch):
 # --- hot path: the Claude path must never import the Cursor adapter --------
 
 
-def test_claude_payload_does_not_import_cursor_module():
+def test_claude_payload_does_not_import_cursor_module(tmp_path):
     code = (
         "import sys, json;"
         "from doberman.hosthooks.claude_code import run_pre_hook;"
-        "run_pre_hook(json.dumps({'tool_name':'Bash','tool_input':{'command':'ls'},'cwd':'.'}));"
+        "run_pre_hook(json.dumps({'tool_name':'Bash','tool_input':{'command':'ls'},"
+        f"'cwd':{str(tmp_path)!r}}}));"
         "print('doberman.hosthooks.cursor' in sys.modules)"
     )
     result = subprocess.run(  # noqa: S603 — controlled call: our own interpreter + a fixed string
@@ -282,9 +283,13 @@ def test_post_hook_cursor_shell_abstains(tmp_path):
     assert claude_code.run_post_hook(json.dumps(payload)) is None
 
 
-def test_post_hook_cursor_read_abstains(tmp_path):
+def test_post_hook_cursor_read_abstains(tmp_path, monkeypatch):
     payload = _load("pre_tool_use_read.json", tmp_path)
     payload["hook_event_name"] = "postToolUse"
+    # A Cursor Read payload carries no ``cwd`` at all, and the post hook resolves
+    # its root from ``cwd`` (not ``workspace_roots``), so it records history under
+    # the process cwd: point that at the tmp root, not the checkout.
+    monkeypatch.chdir(tmp_path)
     assert claude_code.run_post_hook(json.dumps(payload)) is None
 
 
@@ -298,12 +303,18 @@ def test_post_hook_cursor_read_abstains(tmp_path):
 # `hook pre` command, not the adapter function directly.
 
 
-def test_real_shell_fixture_bytes_through_cli_are_not_denied_closed():
+def test_real_shell_fixture_bytes_through_cli_are_not_denied_closed(tmp_path):
     from doberman.cli.main import app
 
     raw = (FIXTURES / "pre_tool_use_shell.json").read_bytes()
     assert raw.startswith(b"\xef\xbb\xbf")  # the BOM cursor-agent actually sends
-    result = CliRunner().invoke(app, ["hook", "pre"], input=raw)
+    # Same re-encoding as the Read test below: the captured workspace root is a
+    # scrubbed ``C:\Users\dev\proj``, which the hook would otherwise create (as a
+    # literal directory under the checkout on Linux) to record the decision in.
+    payload = json.loads(raw.decode("utf-8-sig"))
+    payload["workspace_roots"] = [str(tmp_path)]
+    encoded = ("\ufeff" + json.dumps(payload)).encode("utf-8")
+    result = CliRunner().invoke(app, ["hook", "pre"], input=encoded)
     assert result.exit_code == 0
     # "echo hello-doberman" is benign -> abstain (nothing printed), not a deny.
     assert result.stdout.strip() == ""

--- a/tests/unit/test_hosthook_claude_post.py
+++ b/tests/unit/test_hosthook_claude_post.py
@@ -279,7 +279,7 @@ def test_mcp_tool_clean_output_abstains(cwd):
 # ---------------------------------------------------------------------------
 
 
-def test_post_hook_does_not_load_the_numeric_stack():
+def test_post_hook_does_not_load_the_numeric_stack(tmp_path):
     """A PostToolUse hook runs after EVERY tool call — it must stay light.
 
     Asserts (in a clean subprocess) that running the post-hook does NOT import
@@ -293,7 +293,7 @@ def test_post_hook_does_not_load_the_numeric_stack():
         "'tool_name':'Bash',"
         "'tool_input':{'command':'ls'},"
         "'tool_response':'total 0',"
-        "'cwd':'.',"
+        f"'cwd':{str(tmp_path)!r},"
         "}));"
         "print(','.join(m for m in ('river','numpy','scipy') if m in sys.modules))"
     )

--- a/tests/unit/test_hosthook_claude_pre.py
+++ b/tests/unit/test_hosthook_claude_pre.py
@@ -263,7 +263,7 @@ def test_deny_reason_never_echoes_a_secret_in_a_bash_command(cwd):
 # --- hot-path weight (UX guarantee) ----------------------------------------
 
 
-def test_pre_hook_does_not_load_the_numeric_stack():
+def test_pre_hook_does_not_load_the_numeric_stack(tmp_path):
     """A PreToolUse hook runs before EVERY tool call — it must stay light.
 
     Asserts (in a clean subprocess) that running the pre-hook does NOT import
@@ -273,7 +273,8 @@ def test_pre_hook_does_not_load_the_numeric_stack():
     code = (
         "import sys, json;"
         "from doberman.hosthooks.claude_code import run_pre_hook;"
-        "run_pre_hook(json.dumps({'tool_name':'Bash','tool_input':{'command':'ls'},'cwd':'.'}));"
+        "run_pre_hook(json.dumps({'tool_name':'Bash','tool_input':{'command':'ls'},"
+        f"'cwd':{str(tmp_path)!r}}}));"
         "print(','.join(m for m in ('river','numpy','scipy') if m in sys.modules))"
     )
     result = subprocess.run(  # noqa: S603 — controlled call: our own interpreter + a fixed string

--- a/tests/unit/test_hosthook_openclaw.py
+++ b/tests/unit/test_hosthook_openclaw.py
@@ -283,7 +283,10 @@ def test_block_reason_never_echoes_the_secret(cwd):
         json.dumps({"tool_name": "read", "params": {"path": ".env"}, "cwd": "."}),
     ],
 )
-def test_always_emits_exactly_one_json_document(stdin_text):
+def test_always_emits_exactly_one_json_document(stdin_text, tmp_path, monkeypatch):
+    # The payloads say ``cwd: "."`` (the wire shape); resolve it to a tmp root so
+    # the hook records into that, never into the checkout's ``.doberman/``.
+    monkeypatch.chdir(tmp_path)
     out = run_before_tool_call_hook(stdin_text)
     assert out is not None
     assert "\n" not in out
@@ -295,7 +298,7 @@ def test_always_emits_exactly_one_json_document(stdin_text):
 # --- hot-path weight (subprocess-per-call UX guarantee) ----------------------
 
 
-def test_hook_does_not_load_the_numeric_stack():
+def test_hook_does_not_load_the_numeric_stack(tmp_path):
     """The subprocess bridge spawns a fresh interpreter PER CALL — it must stay light.
 
     Asserts (in a clean subprocess) that running the hook does NOT import
@@ -304,7 +307,8 @@ def test_hook_does_not_load_the_numeric_stack():
     code = (
         "import sys, json;"
         "from doberman.hosthooks.openclaw import run_before_tool_call_hook;"
-        "run_before_tool_call_hook(json.dumps({'tool_name':'exec','params':{'command':'ls'},'cwd':'.'}));"
+        "run_before_tool_call_hook(json.dumps({'tool_name':'exec','params':{'command':'ls'},"
+        f"'cwd':{str(tmp_path)!r}}}));"
         "print(','.join(m for m in ('river','numpy','scipy') if m in sys.modules))"
     )
     result = subprocess.run(  # noqa: S603 — controlled call: our own interpreter + a fixed string


### PR DESCRIPTION
## What

Five hook tests handed the adapters a payload with `cwd: "."` (four in-process OpenClaw payloads, and the pre/post/OpenClaw/Cursor-compat "does not load the numeric stack" subprocess probes), so each hook recorded its decision into the checkout's `.doberman/doberman.db`. One Cursor-compat post-hook test sends a Read payload that has no `cwd` at all, and the post hook resolves its root from `cwd`, so it recorded into the process cwd, the checkout again. Rows piled up there across a run, and any later test that opened the cwd store saw them: that is how the TUI column-order test went red on a Windows shard in #675 (#677 rooted that test in `tmp_path`; this PR removes the writers).

- The `cwd: "."` payloads now resolve to `tmp_path` (`monkeypatch.chdir` for the in-process ones, the real tmp path in the subprocess payloads).
- The Cursor Read post-hook test runs under `monkeypatch.chdir(tmp_path)`.
- The raw-bytes Cursor Shell CLI test re-encodes the capture with a `tmp_path` workspace root and the BOM kept, the same reshape its Read sibling already did. Its scrubbed root `C:\Users\dev\proj` is a relative path on Linux, so the hook was creating a directory of that literal name under the checkout to record into.
- `tests/conftest.py`: an autouse fixture fails any test that creates or changes `<checkout>/.doberman` during the run. It stays off when the store already exists at process start (a developer's live hook keeps one), since nothing can be attributed to the suite then. Under xdist the blamed test may be a neighbour on another worker; the message says so and `-n 0` attributes exactly.

## Verified

- Full suite with a per-test watcher in a clean worktree (`-n 4`), then each suspect file alone (`-n 0`): the writers are exactly the tests above; `test_effects.py`, `test_rule_dependency_admission.py` and the plugin-discovery integration test were neighbours on the same worker.
- After the fix, the four hook files run alone leave no store behind and pass with the guard active (44, 23, 38, 21 tests).
- The guard itself: a throwaway test that writes one file into the checkout store errors at teardown with the guard's message.

## Not changed

The post hook resolves a Cursor-origin payload's root from `cwd`, not `workspace_roots`, unlike the pre path. Real Cursor runs the hook from the workspace, so this only shows up when a payload carries no `cwd`. Left as is; worth a look if the Cursor post path ever records under the wrong repo.

**Repo:** doberman-core (public). Test-only change, no public-release concern.
