### PR TITLE
land #665: feat(hosthooks): recheck a delete's blast radius before execution (#649)

### DIFF
--- a/changelog.d/665.added.md
+++ b/changelog.d/665.added.md
@@ -1,0 +1,1 @@
+- A delete approved through a host hook now shows its blast radius and is re-checked before it runs, denying if the files changed since approval (#665)

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -509,7 +509,7 @@ subcommand this rule recognizes, so none of them are checked today. All of this 
 against the cheap, common case, a popular-package typo or a documented known-bad name, not a
 guarantee against a compromised software supply chain.
 
-## The preview of how many files a delete would affect is a one-time snapshot, and only the MCP proxy re-checks it before acting
+## The preview of how many files a delete would affect is a one-time snapshot, and the drift check only works when both counts are exact
 
 Before showing an `AUTH` challenge for a recognized delete command (`rm`, `del`, `erase`, `rd`,
 `rmdir`, `Remove-Item`), Doberman computes a bounded, offline count of how many files and
@@ -517,10 +517,11 @@ directories the command's targets would affect, the command's blast radius (how 
 would do). That count is capped, limited to a fixed amount of wall-clock time, and flags anything
 inside `.git` or outside the repo. It's shown alongside the approval prompt.
 
-That count is only a snapshot, taken once. That's exactly why the MCP proxy path recomputes it again
-right before actually forwarding the command, and blocks it (reason code `effect_set_diverged`) if
-the count changed in between, a TOCTOU check (time-of-check-to-time-of-use: making sure nothing
-changed between when Doberman checked and when it actually acts).
+That count is only a snapshot, taken once. That's exactly why Doberman recomputes it again right
+before the command actually runs, and blocks it (reason code `effect_set_diverged`) if the count
+changed in between, a TOCTOU check (time-of-check-to-time-of-use: making sure nothing changed
+between when Doberman checked and when it actually acts). Both the MCP proxy path and the host-hook
+path now do this.
 
 Drift between the two counts is only detectable when both are exact. A preview that hit its cap or
 couldn't be computed (past the 1,000-entry limit, a timeout, or a delete target built with a live
@@ -528,6 +529,7 @@ shell substitution) compares equal to a recount that's also capped or unknown, b
 non-authoritative results share one placeholder value. So `rm -rf node_modules` past the entry cap,
 or any delete built with a dynamic `$(...)`, is never caught by this specific guard.
 
-The host-hook path (Claude Code's or Codex's `PreToolUse` hook) has no equivalent recheck after
-approval today, so this particular protection only covers the MCP proxy path. In this first version,
-the count is for display and the audit log only; it never changes a verdict by itself.
+One host adapter is still outside this: OpenClaw hands an `AUTH` to its own `/approve` flow, which
+resolves outside Doberman's process, so there is no moment inside the hook where a recheck could run.
+Claude Code, Codex, and Cursor all route their approval through the shared host-hook path and are
+covered.

--- a/src/doberman/hosthooks/hookio.py
+++ b/src/doberman/hosthooks/hookio.py
@@ -24,10 +24,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from doberman.branding import DOG
-from doberman.models import Decision, ReasonCode, SecurityObject
+from doberman.models import ActionType, Decision, ReasonCode, SecurityObject
 
 if TYPE_CHECKING:  # annotations only — keeps the hot path free of the auth stack
     from doberman.auth.challenge import Prompter
+    from doberman.models import EffectSet
 
 _REASON = DOG + " Doberman [{verdict}]: {explanation} (reasons: {reasons}; action {action_id})"
 FAILSAFE_REASON = DOG + " Doberman: failing closed — could not evaluate this action safely."
@@ -122,6 +123,71 @@ def resolve_auth(
     )[0]
 
 
+#: Action types whose ``target`` carries a shell command line. Mirrors the
+#: destructive-command rule's own ``_COMMAND_ACTION_TYPES`` fallback: that is the
+#: only shape from which a delete-class operand list can be recovered here.
+_COMMAND_BEARING = frozenset({ActionType.shell_exec, ActionType.git_op, ActionType.package_install})
+
+
+def _delete_operands(action: SecurityObject) -> tuple[list[str] | None, bool]:
+    """``(operands, dynamic)`` for a delete-class action, else ``(None, False)``.
+
+    Returns immediately for anything that is not a delete-class command, so no
+    filesystem work is ever reached on a non-delete AUTH — the same early-out
+    the proxy relies on. ``dynamic`` marks a delete whose operands include a
+    live shell substitution, where a count would be a guess rather than a
+    preview.
+    """
+    if action.action_type not in _COMMAND_BEARING:
+        return None, False
+    command = (action.target or "").strip()
+    if not command:
+        return None, False
+    from doberman.engine.rules.commands import delete_class_operands_and_dynamic
+
+    return delete_class_operands_and_dynamic(command)
+
+
+def _effects_for(operands: list[str], dynamic: bool, repo_root: str) -> "EffectSet":
+    """The bounded effect set for ``operands``, or the ``unknown`` sentinel.
+
+    ``compute_delete_effects`` is documented never to raise — every OS error,
+    cap, or timeout degrades to the non-authoritative ``unknown`` shade, whose
+    sentinel digest is what makes "a known count became unknown" register as
+    drift rather than as agreement.
+    """
+    from doberman.engine.effects import compute_delete_effects, unknown_effects
+
+    if dynamic:
+        return unknown_effects()
+    return compute_delete_effects(operands, repo_root)
+
+
+def _effect_set_diverged_deny(decision: Decision, event: str) -> dict[str, Any]:
+    """The deny payload for a delete whose effect set changed after approval.
+
+    Worded as its own outcome rather than a generic denial: the human DID
+    approve, and what they approved is not what is on disk now. Carries
+    ``effect_set_diverged`` so ``doberman log --why`` explains it the same way
+    the proxy path's synthetic BLOCK does.
+    """
+    reason = _REASON.format(
+        verdict="BLOCK",
+        explanation=(
+            "The filesystem changed between the approved preview and execution; "
+            "the effect set no longer matches what was shown"
+        ),
+        reasons=ReasonCode.effect_set_diverged.value,
+        action_id=decision.action_id,
+    )
+    return hook_output(
+        event,
+        "deny",
+        f"{reason} Next step: re-run the command so the approval covers what is "
+        "actually on disk now.",
+    )
+
+
 def resolve_auth_result(
     decision: Decision,
     action: SecurityObject,
@@ -148,19 +214,42 @@ def resolve_auth_result(
     Approved *and* bound to THIS action id → ``allow`` the one call. A denial, an
     unavailable channel, or any error → ``deny`` (fail closed). The auth stack is
     imported lazily so the common PASS/BLOCK hot path never pays for it.
+
+    **Delete-class blast radius (#649).** For a delete-class command this also
+    computes the bounded effect preview ADR 0094 defines, attaches it to the
+    decision every prompter renders, and recomputes it once the human answers —
+    denying if the two disagree. Until now that guard existed only on the MCP
+    proxy path (``proxy/executor.py``), so none of the four hosts had it, even
+    though a host hook is how most agents actually reach a tool. This function
+    is the one place all of them turn an approval into an execution, which is
+    why the recheck belongs here rather than in each adapter.
     """
-    # ponytail: no TOCTOU re-decide like the proxy — the hook grants no elevations and
-    # holds no state between calls, so there is nothing to re-check; each call is
-    # challenged independently.
+    # ponytail: no TOCTOU re-DECIDE like the proxy — the hook grants no elevations and
+    # holds no state between calls, so there is no elevation set to refresh; each call
+    # is challenged independently. The delete-class effect-set recheck below is a
+    # different guard and DOES apply here: it compares the filesystem against what the
+    # human was shown, which has nothing to do with elevation state.
     try:
         # Imported + built here (not at module scope) so the PASS/BLOCK hot path stays
         # light, and inside the try so a construction failure (e.g. no tkinter) also
         # fails closed with the actionable channel-error message.
         from doberman.auth.challenge import TIMEOUT_METHOD, run_auth_challenge
 
+        # ADR 0094 preview, before the challenge is rendered: the human approves a
+        # blast radius, so they have to be shown one. Computed once here and the
+        # operand list reused for the recheck below (one parse, matching the
+        # proxy's own M1 note) — and skipped entirely, with no filesystem walk,
+        # for any AUTH that is not a delete-class command.
+        operands, dynamic = _delete_operands(action)
+        previewed = None
+        challenged = decision
+        if operands is not None and repo_root:
+            previewed = _effects_for(operands, dynamic, repo_root)
+            challenged = decision.model_copy(update={"effects": previewed})
+
         active_prompter = prompter if prompter is not None else _default_auth_prompter()
         result = run_auth_challenge(
-            decision,
+            challenged,
             action,
             prompter=active_prompter,
             message_tone=message_tone,
@@ -174,6 +263,21 @@ def resolve_auth_result(
 
     # Approval is bound to THIS action id — never honor a result meant for another call.
     if result.approved and result.action_id == action.id:
+        # #649: recompute the SAME operands against the live filesystem and compare
+        # digests. Any divergence — in either direction, or a known count becoming
+        # unknown — denies: the human approved what the preview showed, not what is
+        # on disk now. A dynamic delete is `unknown` at both ends (same flag, never
+        # recomputed), so it cannot re-deny on dynamism alone, only on a real
+        # mismatch. A failure to recompute is itself a mismatch, because a guard
+        # that cannot verify must not report success.
+        if previewed is not None and operands is not None and repo_root:
+            try:
+                recomputed = _effects_for(operands, dynamic, repo_root)
+                diverged = recomputed.digest != previewed.digest
+            except Exception:  # noqa: BLE001 — cannot verify => cannot allow
+                diverged = True
+            if diverged:
+                return _effect_set_diverged_deny(decision, event), "effect_set_diverged"
         reason = format_reason(decision, "AUTH")
         return (
             hook_output(

--- a/tests/unit/test_hosthook_delete_recheck.py
+++ b/tests/unit/test_hosthook_delete_recheck.py
@@ -1,0 +1,335 @@
+"""#649 — the delete recheck before execution, on the host-hook path.
+
+Before a risky delete runs, Doberman counts what it would touch, shows that to
+the human, and recounts right before execution — denying if the count moved.
+That guard (ADR 0094's TOCTOU compare, reason code ``effect_set_diverged``)
+existed only in ``proxy/executor.py``, so none of the four supported hosts had
+it, even though a host hook is how most agents actually reach a tool.
+
+``hookio.resolve_auth_result`` is the one place every host hook turns an
+approval into an execution, so the guard lives there and every adapter that
+routes through it inherits it.
+
+What each group proves:
+
+* **The preview exists at all** — a delete-class AUTH now reaches the prompter
+  carrying an effect set. Without this there is nothing to recheck against, and
+  the host-hook challenge was previously rendering none.
+* **Divergence denies** — files appearing or disappearing between approval and
+  execution, in either direction, and a known count degrading to unknown.
+* **Agreement still allows** — the guard must not deny an unchanged delete, or
+  it would make every approved delete unusable.
+* **Nothing else pays for it** — a non-delete AUTH performs no filesystem work,
+  and the guard never fires where it has no baseline.
+* **Redaction and fail-closed** — the deny names the category and no path, and
+  a recheck that cannot be computed denies rather than allowing.
+"""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from doberman.hosthooks import hookio
+from doberman.models import (
+    ActionType,
+    Decision,
+    GuardrailResult,
+    ReasonCode,
+    Risk,
+    SecurityObject,
+    Verdict,
+)
+
+_EVENT = "PreToolUse"
+
+
+class _Approve:
+    """A person who is present and approves."""
+
+    def confirm(self, message):
+        return True
+
+    def read_code(self, message):
+        return "000000"
+
+
+def _action(command: str) -> SecurityObject:
+    return SecurityObject(
+        id="act-649",
+        ts=datetime(2026, 6, 7, tzinfo=timezone.utc),
+        agent_role="unknown",
+        action_type=ActionType.shell_exec,
+        tool_name="shell_exec",
+        target=command,
+    )
+
+
+def _decision() -> Decision:
+    result = GuardrailResult(
+        verdict=Verdict.AUTH,
+        risk=Risk.medium,
+        reason_codes=[ReasonCode.bulk_operation],
+        explanation="Bulk delete; authentication required.",
+    )
+    return Decision(
+        action_id="act-649",
+        final_verdict=Verdict.AUTH,
+        final_risk=Risk.medium,
+        objective=result,
+        subjective=None,
+        reason_codes=[ReasonCode.bulk_operation],
+        explanation=result.explanation,
+        decided_at=datetime(2026, 6, 7, tzinfo=timezone.utc),
+    )
+
+
+def _resolve(command, repo_root, prompter=None):
+    return hookio.resolve_auth_result(
+        _decision(),
+        _action(command),
+        event=_EVENT,
+        prompter=prompter or _Approve(),
+        repo_root=str(repo_root),
+    )
+
+
+def _permission(payload):
+    return (payload.get("hookSpecificOutput") or {}).get("permissionDecision")
+
+
+def _reason(payload):
+    return (payload.get("hookSpecificOutput") or {}).get("permissionDecisionReason")
+
+
+@pytest.fixture
+def target(tmp_path):
+    """A directory with three files, the thing the delete would remove."""
+    victim = tmp_path / "scratch"
+    victim.mkdir()
+    for i in range(3):
+        (victim / f"f{i}.txt").write_text("x\n", encoding="utf-8")
+    return tmp_path
+
+
+# --- the preview has to exist before anything can be rechecked --------------
+
+
+def test_a_delete_class_auth_now_carries_a_preview_to_the_prompter(target):
+    """The host-hook challenge previously rendered no blast radius at all, so
+    the human approved a delete with no idea of its size — and there was no
+    baseline a recheck could compare against."""
+    seen = {}
+
+    class _Recording:
+        def confirm(self, message):
+            return True
+
+        def read_code(self, message):
+            return "000000"
+
+    def _capture(decision, action, **kwargs):
+        seen["effects"] = decision.effects
+        from doberman.auth.challenge import AuthResult, AuthTier
+
+        return AuthResult(
+            approved=True,
+            tier=AuthTier.soft_confirm,
+            method="local_auth",
+            at=datetime(2026, 6, 7, tzinfo=timezone.utc),
+            action_id=action.id,
+        )
+
+    import doberman.auth.challenge as challenge_module
+
+    original = challenge_module.run_auth_challenge
+    challenge_module.run_auth_challenge = _capture
+    try:
+        _resolve("rm -rf scratch", target, prompter=_Recording())
+    finally:
+        challenge_module.run_auth_challenge = original
+
+    assert seen["effects"] is not None, "the challenge saw no blast-radius preview"
+    assert seen["effects"].file_count == 3
+
+
+def test_a_non_delete_auth_gets_no_preview_and_walks_nothing(target, monkeypatch):
+    """The early-out matters: a hook runs before every tool call, so a
+    non-delete AUTH must never touch the filesystem."""
+    import doberman.engine.effects as effects_module
+
+    def _boom(*_a, **_k):
+        raise AssertionError("a non-delete AUTH must not walk the filesystem")
+
+    monkeypatch.setattr(effects_module, "compute_delete_effects", _boom)
+    out, _method = _resolve("echo hello", target)
+    assert _permission(out) == "allow"
+
+
+# --- divergence denies ------------------------------------------------------
+
+
+def test_files_appearing_after_approval_denies(target):
+    """The classic sneak: approve a small delete, grow it before it runs."""
+
+    class _ApproveThenGrow:
+        def confirm(self, message):
+            for i in range(5):
+                (target / "scratch" / f"extra{i}.txt").write_text("x\n", encoding="utf-8")
+            return True
+
+        def read_code(self, message):
+            return "000000"
+
+    out, method = _resolve("rm -rf scratch", target, prompter=_ApproveThenGrow())
+    assert _permission(out) == "deny"
+    assert method == "effect_set_diverged"
+
+
+def test_files_disappearing_after_approval_also_denies(target):
+    """Drift in *either* direction is drift: what the human approved is not
+    what would run, and a shrunken set is still not the approved set."""
+
+    class _ApproveThenShrink:
+        def confirm(self, message):
+            (target / "scratch" / "f0.txt").unlink()
+            return True
+
+        def read_code(self, message):
+            return "000000"
+
+    out, method = _resolve("rm -rf scratch", target, prompter=_ApproveThenShrink())
+    assert _permission(out) == "deny"
+    assert method == "effect_set_diverged"
+
+
+def test_a_known_count_becoming_unknown_denies(target, monkeypatch):
+    """A preview the human could read, degrading to a count nobody can
+    vouch for, is not agreement — it is the loss of the thing they approved."""
+    calls = {"n": 0}
+    import doberman.engine.effects as effects_module
+
+    real = effects_module.compute_delete_effects
+
+    def _second_call_is_unknown(operands, repo_root, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return real(operands, repo_root, **kwargs)
+        return effects_module.unknown_effects()
+
+    monkeypatch.setattr(effects_module, "compute_delete_effects", _second_call_is_unknown)
+    out, method = _resolve("rm -rf scratch", target)
+    assert _permission(out) == "deny"
+    assert method == "effect_set_diverged"
+
+
+def test_a_recheck_that_raises_denies(target, monkeypatch):
+    """Fail closed: a guard that cannot verify must not report success."""
+    calls = {"n": 0}
+    import doberman.engine.effects as effects_module
+
+    real = effects_module.compute_delete_effects
+
+    def _second_call_explodes(operands, repo_root, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return real(operands, repo_root, **kwargs)
+        raise OSError("filesystem went away")
+
+    monkeypatch.setattr(effects_module, "compute_delete_effects", _second_call_explodes)
+    out, method = _resolve("rm -rf scratch", target)
+    assert _permission(out) == "deny"
+    assert method == "effect_set_diverged"
+
+
+# --- agreement still allows -------------------------------------------------
+
+
+def test_an_unchanged_delete_is_still_allowed(target):
+    """The guard must not break the ordinary approved delete."""
+    out, method = _resolve("rm -rf scratch", target)
+    assert _permission(out) == "allow"
+    assert method != "effect_set_diverged"
+
+
+def test_a_dynamic_delete_does_not_deny_on_dynamism_alone(target):
+    """A delete whose operands include a live substitution is `unknown` at both
+    ends. Unknown == unknown is agreement, so it must not re-deny on that
+    alone — only a real mismatch denies."""
+    out, method = _resolve("rm -rf $(cat targets.txt)", target)
+    assert _permission(out) == "allow", "dynamism alone is not divergence"
+    assert method != "effect_set_diverged"
+
+
+def test_no_repo_root_means_no_baseline_and_no_spurious_deny(target):
+    """Without a root there is no preview, so there is nothing to compare and
+    the guard must stay out of the way rather than invent a divergence."""
+    out, _method = hookio.resolve_auth_result(
+        _decision(),
+        _action("rm -rf scratch"),
+        event=_EVENT,
+        prompter=_Approve(),
+        repo_root=None,
+    )
+    assert _permission(out) == "allow"
+
+
+# --- a denial is still a denial ---------------------------------------------
+
+
+def test_a_declined_challenge_still_denies_without_reaching_the_recheck(target):
+    """The recheck sits behind the approval branch: a human "no" denies on its
+    own terms, with its own outcome, not as a divergence."""
+
+    class _Decline:
+        def confirm(self, message):
+            return False
+
+        def read_code(self, message):
+            raise AssertionError("not reached")
+
+    out, method = _resolve("rm -rf scratch", target, prompter=_Decline())
+    assert _permission(out) == "deny"
+    assert method != "effect_set_diverged"
+
+
+# --- redaction --------------------------------------------------------------
+
+
+def test_the_divergence_deny_names_the_category_and_no_path(target):
+    """Same contract as every other host-visible reason: the class of problem,
+    never the operand. This string goes back to the agent harness."""
+
+    class _ApproveThenGrow:
+        def confirm(self, message):
+            (target / "scratch" / "customer-export-secret.csv").write_text("x\n", encoding="utf-8")
+            return True
+
+        def read_code(self, message):
+            return "000000"
+
+    out, _method = _resolve("rm -rf scratch", target, prompter=_ApproveThenGrow())
+    reason = _reason(out)
+    assert ReasonCode.effect_set_diverged.value in reason
+    assert "customer-export-secret" not in reason
+    assert "scratch" not in reason
+    assert str(target) not in reason
+
+
+def test_the_divergence_deny_is_valid_hook_output(target):
+    """The harness has to be able to parse it like any other decision."""
+
+    class _ApproveThenGrow:
+        def confirm(self, message):
+            (target / "scratch" / "extra.txt").write_text("x\n", encoding="utf-8")
+            return True
+
+        def read_code(self, message):
+            return "000000"
+
+    out, _ = _resolve("rm -rf scratch", target, prompter=_ApproveThenGrow())
+    specific = out["hookSpecificOutput"]
+    assert specific["hookEventName"] == _EVENT
+    assert specific["permissionDecision"] == "deny"
+    assert isinstance(specific["permissionDecisionReason"], str)
+    json.dumps(out)  # must be serializable back to the harness


### PR DESCRIPTION
Lands #665 (feat(hosthooks): recheck a delete's blast radius before execution) by @harshitagrawal2O via a landing branch: their commits cherry-picked onto current main with authorship preserved, because main requires up-to-date branches and refuses merge commits.

Mechanical changes on this branch: none.

Closes #649
