### PR TITLE
land #655: fix: wire whole_script_confusable detection into MCP admission scan (#646)

### DIFF
--- a/changelog.d/655.fixed.md
+++ b/changelog.d/655.fixed.md
@@ -1,0 +1,1 @@
+- The MCP admission scan now flags whole-script look-alike server names, not only mixed-script ones (#655, thanks @Som0111)

--- a/src/doberman/discovery/mcp_scan.py
+++ b/src/doberman/discovery/mcp_scan.py
@@ -43,6 +43,7 @@ _INVISIBLE_CHANNELS = frozenset(
 _RISK_BY_PATTERN = {
     "invisible_chars": Risk.high,
     "mixed_script": Risk.medium,
+    "whole_script": Risk.medium,
     "templated_url": Risk.high,
     "raw_ip_url": Risk.high,
     "non_https_url": Risk.medium,
@@ -133,6 +134,8 @@ def _scan_server(server: str, source_file: str, config: dict[str, object]) -> se
             findings.add(_finding(server, source_file, "unicode", "invisible_chars"))
         if "mixed_script_confusable" in channels:
             findings.add(_finding(server, source_file, "unicode", "mixed_script"))
+        if "whole_script_confusable" in channels:
+            findings.add(_finding(server, source_file, "unicode", "whole_script"))
 
     env = config.get("env")
     env_values: list[str] = []

--- a/tests/unit/test_mcp_scan.py
+++ b/tests/unit/test_mcp_scan.py
@@ -31,6 +31,18 @@ def test_finds_zero_width_server_name_and_escapes_it(tmp_path):
     assert any("\\u200b" in finding.server for finding in unicode_findings)
 
 
+def test_finds_whole_script_confusable_server_name(tmp_path):
+    # All-Cyrillic look-alike for "server" — no script mixing, so only the
+    # whole-script channel (not mixed_script) should catch it.
+    _write_mcp_config(tmp_path, {"сервер": {"command": "server"}})
+
+    findings = scan_mcp_configs(str(tmp_path))
+
+    unicode_findings = [finding for finding in findings if finding.category == "unicode"]
+    assert any(finding.pattern_class == "whole_script" for finding in unicode_findings)
+    assert not any(finding.pattern_class == "mixed_script" for finding in unicode_findings)
+
+
 def test_finds_templated_exfil_url_in_args(tmp_path):
     _write_mcp_config(
         tmp_path,


### PR DESCRIPTION
Lands #655 (fix: wire whole_script_confusable detection into MCP admission scan) by @Som0111 via a landing branch: their commit cherry-picked onto current main with authorship preserved, because main requires up-to-date branches and refuses merge commits.

Mechanical changes on this branch: added the missing `changelog.d/655.fixed.md` fragment.

Closes #646
