### PR TITLE
fix(hosthooks): source delete operands from the raw command, not the redacted target

### DIFF
--- a/changelog.d/692.security.md
+++ b/changelog.d/692.security.md
@@ -1,0 +1,1 @@
+- A host-hook delete whose path was long enough to be redacted now still gets its blast-radius preview and post-approval recheck (#692)

--- a/src/doberman/hosthooks/claude_code.py
+++ b/src/doberman/hosthooks/claude_code.py
@@ -141,7 +141,11 @@ def _hook_output(permission: str, reason: str) -> dict[str, Any]:
 
 
 def _resolve_auth(
-    decision: Decision, action: SecurityObject, repo_root: str, session_id: str | None = None
+    decision: Decision,
+    action: SecurityObject,
+    repo_root: str,
+    session_id: str | None = None,
+    arguments: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], str]:
     return hookio.resolve_auth_result(
         decision,
@@ -151,6 +155,7 @@ def _resolve_auth(
         message_tone=load_message_tone(repo_root),
         repo_root=repo_root,
         session_id=session_id,
+        arguments=arguments,
     )
 
 
@@ -224,7 +229,11 @@ def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
             # Run Doberman's own action-bound challenge so the human can actually
             # approve in-session (issues #65/#67) — not just be told to.
             hook_result, auth_method = _resolve_auth(
-                result.decision, result.challenge_action, result.repo_root, result.session_id
+                result.decision,
+                result.challenge_action,
+                result.repo_root,
+                result.session_id,
+                tool_input,
             )
             auth_path = AuthPath.host_hook_challenge
             # #505/#399: this is the row that used to read `AUTH ... auth=executed`

--- a/src/doberman/hosthooks/codex.py
+++ b/src/doberman/hosthooks/codex.py
@@ -170,6 +170,7 @@ def evaluate_pre(payload: dict[str, Any]) -> dict[str, Any] | None:
                 message_tone=load_message_tone(result.repo_root),
                 repo_root=result.repo_root,
                 session_id=result.session_id,
+                arguments=tool_input,
             )
             auth_path = AuthPath.host_hook_challenge
             human_confirmed = hookio.challenge_human_confirmed(hook_result, auth_method)

--- a/src/doberman/hosthooks/cursor.py
+++ b/src/doberman/hosthooks/cursor.py
@@ -323,6 +323,9 @@ def evaluate(payload: dict[str, Any]) -> dict[str, Any]:
                     message_tone=load_message_tone(result.repo_root),
                     repo_root=result.repo_root,
                     session_id=result.session_id,
+                    arguments=payload.get("tool_input")
+                    if isinstance(payload.get("tool_input"), dict)
+                    else None,
                 )
                 auth_path = AuthPath.host_hook_challenge
                 human_confirmed = hookio.challenge_human_confirmed(host_out, auth_method)

--- a/src/doberman/hosthooks/hookio.py
+++ b/src/doberman/hosthooks/hookio.py
@@ -140,6 +140,7 @@ def resolve_auth(
     message_tone: str = "human",
     repo_root: str | None = None,
     session_id: str | None = None,
+    arguments: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Compatibility wrapper returning only the host payload."""
     return resolve_auth_result(
@@ -150,6 +151,7 @@ def resolve_auth(
         message_tone=message_tone,
         repo_root=repo_root,
         session_id=session_id,
+        arguments=arguments,
     )[0]
 
 
@@ -159,7 +161,9 @@ def resolve_auth(
 _COMMAND_BEARING = frozenset({ActionType.shell_exec, ActionType.git_op, ActionType.package_install})
 
 
-def _delete_operands(action: SecurityObject) -> tuple[list[str] | None, bool]:
+def _delete_operands(
+    action: SecurityObject, arguments: dict[str, Any] | None = None
+) -> tuple[list[str] | None, bool]:
     """``(operands, dynamic)`` for a delete-class action, else ``(None, False)``.
 
     Returns immediately for anything that is not a delete-class command, so no
@@ -170,7 +174,16 @@ def _delete_operands(action: SecurityObject) -> tuple[list[str] | None, bool]:
     """
     if action.action_type not in _COMMAND_BEARING:
         return None, False
-    command = (action.target or "").strip()
+    if arguments is None:
+        command = (action.target or "").strip()
+        if command == "<redacted>":
+            return [], True
+    else:
+        from doberman.engine.rules.commands import command_line_from_arguments
+
+        command = (command_line_from_arguments(arguments) or "").strip()
+        if not command and action.target == "<redacted>":
+            return [], True
     if not command:
         return None, False
     from doberman.engine.rules.commands import delete_class_operands_and_dynamic
@@ -227,6 +240,7 @@ def resolve_auth_result(
     message_tone: str = "human",
     repo_root: str | None = None,
     session_id: str | None = None,
+    arguments: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], str]:
     """Run Doberman's tiered challenge for an AUTH and answer the host hook.
 
@@ -270,7 +284,7 @@ def resolve_auth_result(
         # operand list reused for the recheck below (one parse, matching the
         # proxy's own M1 note) — and skipped entirely, with no filesystem walk,
         # for any AUTH that is not a delete-class command.
-        operands, dynamic = _delete_operands(action)
+        operands, dynamic = _delete_operands(action, arguments)
         previewed = None
         challenged = decision
         if operands is not None and repo_root:

--- a/tests/unit/test_hosthook_delete_recheck.py
+++ b/tests/unit/test_hosthook_delete_recheck.py
@@ -94,6 +94,10 @@ def _resolve(command, repo_root, prompter=None):
     )
 
 
+def _long_absolute_path() -> str:
+    return "/" + "/".join(("nested",) * 10) + "/billing-node_modules"
+
+
 def _permission(payload):
     return (payload.get("hookSpecificOutput") or {}).get("permissionDecision")
 
@@ -151,6 +155,106 @@ def test_a_delete_class_auth_now_carries_a_preview_to_the_prompter(target):
 
     assert seen["effects"] is not None, "the challenge saw no blast-radius preview"
     assert seen["effects"].file_count == 3
+
+
+def test_delete_operands_use_raw_arguments_when_target_was_redacted():
+    raw_command = f"rm -rf {_long_absolute_path()}"
+    action = _action("<redacted>")
+
+    operands, dynamic = hookio._delete_operands(action, {"command": raw_command})
+
+    assert operands == [_long_absolute_path()]
+    assert dynamic is False
+
+
+def test_claude_adapter_passes_raw_command_for_redacted_delete_preview(monkeypatch, tmp_path):
+    from doberman.auth.challenge import AuthResult, AuthTier
+    from doberman.hosthooks import claude_code
+    from doberman.hosthooks.spine import SpineResult
+
+    raw_command = f"rm -rf {_long_absolute_path()}"
+    decision = _decision()
+    action = _action("<redacted>")
+    challenged = {"effects": None}
+    calls = {"recheck": 0}
+
+    def _capture(decision_arg, action_arg, **kwargs):
+        challenged["effects"] = decision_arg.effects
+        return AuthResult(
+            approved=True,
+            tier=AuthTier.soft_confirm,
+            method="local_auth",
+            at=datetime(2026, 6, 7, tzinfo=timezone.utc),
+            action_id=action_arg.id,
+        )
+
+    def _effects(operands, dynamic, repo_root):
+        calls["recheck"] += 1
+        from doberman.engine.effects import unknown_effects
+
+        return unknown_effects()
+
+    monkeypatch.setattr("doberman.auth.challenge.run_auth_challenge", _capture)
+    monkeypatch.setattr(hookio, "_effects_for", _effects)
+    monkeypatch.setattr(
+        claude_code.spine,
+        "evaluate_action",
+        lambda *args, **kwargs: SpineResult(
+            decision, action, Verdict.AUTH, "enforce", str(tmp_path), None, action
+        ),
+    )
+    out = claude_code.evaluate_pre(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": raw_command},
+            "cwd": str(tmp_path),
+        }
+    )
+
+    assert _permission(out) == "allow"
+    assert challenged["effects"] is not None
+    assert calls["recheck"] == 2
+
+
+def test_redacted_target_without_raw_arguments_gets_unknown_preview_and_recheck(
+    target, monkeypatch
+):
+    from doberman.auth.challenge import AuthResult, AuthTier
+
+    seen = {}
+
+    def _capture(decision, action, **kwargs):
+        seen["effects"] = decision.effects
+        return AuthResult(
+            approved=True,
+            tier=AuthTier.soft_confirm,
+            method="local_auth",
+            at=datetime(2026, 6, 7, tzinfo=timezone.utc),
+            action_id=action.id,
+        )
+
+    calls = {"n": 0}
+    monkeypatch.setattr("doberman.auth.challenge.run_auth_challenge", _capture)
+    real = hookio._effects_for
+
+    def _counting(operands, dynamic, repo_root):
+        calls["n"] += 1
+        return real(operands, dynamic, repo_root)
+
+    monkeypatch.setattr(hookio, "_effects_for", _counting)
+    out, method = hookio.resolve_auth_result(
+        _decision(),
+        _action("<redacted>"),
+        event=_EVENT,
+        prompter=_Approve(),
+        repo_root=str(target),
+    )
+
+    assert _permission(out) == "allow"
+    assert method == "local_auth"
+    assert seen["effects"].file_count is None
+    assert seen["effects"].dir_count is None
+    assert calls["n"] == 2
 
 
 def test_a_non_delete_auth_gets_no_preview_and_walks_nothing(target, monkeypatch):


### PR DESCRIPTION
## What

The host-hook delete guard (blast-radius preview + post-approval TOCTOU recheck, shipped in v0.18.7 for #649/#665) silently does not run when the delete's path is long enough to be redacted.

`_delete_operands` read `action.target`, which is the post-redaction string. `normalize._redact_value` replaces any value carrying a 40+ character unbroken `[A-Za-z0-9+/_-]` run with `<redacted>` — and `/` is in that class, so any ordinary nested absolute path qualifies. The operand source then became `<redacted>`, `_delete_operands` returned `(None, False)`, and `resolve_auth_result` skipped both the preview and the recheck. Reproduced on v0.18.7:

```
rm -rf ./build                                                              -> target "rm -rf ./build" -> (['./build'], False)
rm -rf /home/user/projects/acme-platform/services/billing/node_modules      -> target "<redacted>"      -> (None, False)  # guard skipped
```

The proxy path never had this bug (`executor.py` builds operands from the raw tool arguments via `command_line_from_arguments`). The host-hook port regressed the source.

## Fix

- Thread the raw tool `arguments` through `resolve_auth` / `resolve_auth_result` / `_delete_operands`; build the command with the same `command_line_from_arguments` the proxy uses, so the operand source is never the redacted string.
- Pass the raw `tool_input` at all three live call sites: `claude_code.py`, `codex.py`, `cursor.py`. `openclaw.py` does not call `resolve_auth_result` (it delegates to OpenClaw's own approve flow), so it is untouched — tracked separately.
- Fail closed: a delete whose command line cannot be recovered (redacted target, no raw arguments) now returns unknown effects and still runs the recheck, instead of skipping the guard. "A guard that cannot verify must not report success."

raise-only: no decision that was denied before can now be allowed.

## Verification

- `ruff check`, `ruff format --check`, `lint-imports`: green. (`command_line_from_arguments` comes from the same `engine.rules.commands` module already imported here, so no new import contract.)
- `tests/unit/test_hosthook_delete_recheck.py` + `tests/unit/test_hosthook_claude_cursor_compat.py`: 36 passed. New tests cover a 60-char redacted path with raw args (real operands recovered), the end-to-end challenge (preview computed, recheck runs), and the fail-closed no-args case (unknown effects, guard still runs).
- Broad `tests/unit` sweep: one failure, `test_benchmark_agentdojo_live` — a local pyarrow/NumPy-2 ABI import error (`_ARRAY_API not found`), reproduces on the base commit and is unrelated to this change. GUI-prompter tests excluded locally (the separate nightly-red font-metric hang).
