### PR TITLE
fix(auth): mask bearer tokens and password flags in the challenge copy

### DIFF
--- a/changelog.d/694.security.md
+++ b/changelog.d/694.security.md
@@ -1,0 +1,1 @@
+- The approval prompt and phone push now mask bearer tokens and password flags, not only name=value secrets (#694)

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -172,8 +172,10 @@ engineering view, `doberman message-tone technical` switches to the terse `[RISK
 …` block, and `doberman message-tone human` switches back. It changes wording only. The change is
 cosmetic, so it needs no possession-factor confirmation, and it never touches the decision, the
 reason codes, or what lands in the decision log.
-The command line shown is rendered from the raw arguments with credential-shaped tokens masked and
-cut at 300 characters; the decision log keeps only its redacted copy.
+The command line shown is rendered from the raw arguments with `Authorization`, `X-Api-Key`, and
+`X-Auth-Token` header values, common password flags, and unbroken 40+ character credential-like
+runs masked, then cut at 300 characters; a base64 value containing `/` is not covered. The decision
+log keeps only its redacted copy.
 
 ## Recovery actions
 
@@ -235,7 +237,9 @@ the token to those two topics only, with server ACLs that let only your phone an
 publish them.
 
 The push itself carries the command the agent asked to run, rendered the same way the desk
-dialog renders it, with credential-shaped tokens masked and the text length-bounded. The gated
+dialog renders it, with `Authorization`, `X-Api-Key`, and `X-Auth-Token` header values, common
+password flags, and unbroken 40+ character credential-like runs masked (a base64 value containing
+`/` is not covered), and the text length-bounded. The gated
 command line therefore leaves the machine and is stored on whichever ntfy server you point at,
 public `ntfy.sh` included, until that message expires. Point `--server` at a self-hosted
 instance if that is not acceptable.

--- a/src/doberman/proxy/normalize.py
+++ b/src/doberman/proxy/normalize.py
@@ -677,6 +677,31 @@ def _extract_target(action_type: ActionType, arguments: dict[str, Any]) -> tuple
 def _mask_secret_tokens(text: str) -> str:
     """Mask the whitespace-delimited tokens that look like a credential."""
 
+    # Challenge copies are sent to human-facing channels (including phone
+    # push), so mask credential-bearing syntax before the generic token pass.
+    text = re.sub(
+        r"(?i)(\b(?:authorization|x-api-key|x-auth-token)\s*:\s*)"
+        r"(?:(bearer|basic|token)\s+)?([^\s'\";,]+)",
+        lambda match: f"{match.group(1)}{match.group(2) + ' ' if match.group(2) else ''}{REDACTED}",
+        text,
+    )
+    text = re.sub(
+        r"(?i)(?<!\S)(-p)(?!ass(?:word)?(?:\b|=))([^\s'\"]+)",
+        rf"\1{REDACTED}",
+        text,
+    )
+    text = re.sub(
+        r"(?i)(?<!\S)(-p\s+|--password(?:=|\s+)|--user(?:=|\s+)[^\s:'\"]+:|"
+        r"-u\s+[^\s:'\"]+:|--http-user(?:=|\s+)[^\s:'\"]+:|"
+        r"--http-password\s+|-pass\s+|-k\s+)([^\s'\"]+)",
+        rf"\1{REDACTED}",
+        text,
+    )
+    # Deliberately excludes '/': slash-bearing values may be paths, which are
+    # the primary reason this prompt-only rendering exists. Known miss: a
+    # base64 value containing '/' is not covered by this floor.
+    text = re.sub(r"(?<![A-Za-z0-9+=_.-])[A-Za-z0-9+=_.-]{40,}(?![A-Za-z0-9+=_.-])", REDACTED, text)
+
     def _mask(match: re.Match[str]) -> str:
         token = match.group(0)
         name, sep, _value = token.partition("=")

--- a/tests/unit/test_auth_display_target.py
+++ b/tests/unit/test_auth_display_target.py
@@ -104,6 +104,25 @@ def test_secret_shaped_token_is_masked_and_the_rest_kept():
     assert "https://api.example.com/repos" in shown
 
 
+def test_credential_flags_headers_and_long_blobs_are_masked():
+    bearer = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9abcdefgh"
+    hex_blob = "a" * 48
+    command = (
+        "curl -H 'Authorization: Bearer "
+        + bearer
+        + "' -H 'X-Api-Key: header-secret' https://example.com "
+        "mysql -phunter2Secret curl -u admin:S3cretP4ssw0rd " + hex_blob
+    )
+    shown = display_target(ActionType.shell_exec, {"command": command})
+    assert shown is not None
+    assert bearer not in shown
+    assert "Authorization: Bearer <redacted>" in shown
+    assert "X-Api-Key: <redacted>" in shown
+    assert "-p<redacted>" in shown
+    assert "admin:<redacted>" in shown
+    assert hex_blob not in shown
+
+
 def test_sensitive_key_value_is_masked():
     shown = display_target(
         ActionType.shell_exec,
@@ -133,6 +152,11 @@ def test_argv_shape_and_file_actions_render_too():
     )
     assert display_target(ActionType.file_write, {"path": _LONG_PATH, "content": "x"}) == _LONG_PATH
     assert display_target(ActionType.file_write, {}) is None
+
+
+def test_nested_path_with_long_components_is_still_shown_in_full():
+    path = "/".join(("nested", "x" * 30, "y" * 30, "file.txt"))
+    assert display_target(ActionType.shell_exec, {"command": f"cat {path}"}) == f"cat {path}"
 
 
 # --- prompt-only plumbing ---------------------------------------------------------

--- a/tests/unit/test_ntfy_phone_approvals.py
+++ b/tests/unit/test_ntfy_phone_approvals.py
@@ -753,6 +753,34 @@ def test_published_message_never_carries_the_raw_secret(ntfy_cfg, monkeypatch):
     assert REDACTED in published["message"]
 
 
+def test_published_message_masks_bearer_token_in_challenge_copy(ntfy_cfg, monkeypatch):
+    ntfy.save_config(ntfy.new_config(wait_s=10))
+    approval_config.enable(ntfy.METHOD_NAME)
+
+    bearer = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9abcdefgh"
+    action = challenge_copy(
+        _action(risk=Risk.low),
+        {"command": f"curl -H 'Authorization: Bearer {bearer}' https://example.com"},
+    )
+    decision = _decision(risk=Risk.low)
+    fake = FakeUrlopen([_FakeResponse(status=200), _FakeResponse(lines=[b""])])
+    real_channel_cls = ntfy.NtfyChannel
+
+    def _real_channel(cfg, **kw):  # noqa: ARG001
+        return real_channel_cls(cfg, urlopen=fake, clock=lambda: 1000.0)
+
+    monkeypatch.setattr(ntfy, "NtfyChannel", _real_channel)
+    recorder = _Recorder(confirm=True)
+    result = run_auth_challenge(
+        decision, action, prompter=FallbackPrompter([ntfy.NtfyPrompter(), recorder]), timeout_s=10
+    )
+
+    assert result.approved is True
+    published = json.loads(fake.requests[0].data)["message"]
+    assert bearer not in published
+    assert REDACTED in published
+
+
 # =============================================================================#
 # Task 2: wiring — built-in method, chains, CLI, doctor                        #
 # =============================================================================#


### PR DESCRIPTION
## What

The approval challenge copy — the text shown on the desk dialog and, since v0.18.7, POSTed to the ntfy phone-approval server — masked fewer credential shapes than the local audit log does. `display_target` deliberately drops the log's 40-char long-run redaction so real paths read in full, and only masked `name=value` pairs whose name is in the sensitive-keys set. Measured on v0.18.7:

```
curl -H 'Authorization: Bearer eyJ...40+chars'   LOGGED <redacted>   DISPLAY shown in full
mysql -phunter2Secret                            LOGGED in full      DISPLAY in full
curl -u admin:S3cretP4ssw0rd                     LOGGED in full      DISPLAY in full
```

`docs/TUNING.md` promises the push goes out "with credential-shaped tokens masked"; for bearer tokens and space-separated / prefix-attached password flags it did not. Prime directive 3 (never expose secrets) applies more to a POST to a public message bus than to a local SQLite row.

## Fix

`_mask_secret_tokens` (which `display_target` already runs) now also masks, before the existing name=value pass:
- `Authorization:` / `X-Api-Key:` / `X-Auth-Token:` header values, including the `Bearer`/`Basic`/`Token` scheme word.
- password flags: `-p<v>` / `-p <v>` / `--password[= ]<v>`, `-u user:<v>` / `--user[= ]user:<v>` / `--http-user`/`--http-password`, `-pass <v>`, `-k <v>` — the secret half only, the user name is kept.
- any unbroken 40+ run of `[A-Za-z0-9+=_.-]` that contains no `/` (a base64 value carrying `/` is a documented, accepted miss, since `/` marks the paths this rendering exists to show in full).

Long paths are unchanged — still shown in full. Masking only ever widens here; nothing that was shown-redacted becomes shown. `docs/TUNING.md` updated to state which shapes are masked and the base64-with-slash miss.

## Verification

- `tests/unit/test_auth_display_target.py` + `tests/unit/test_ntfy_phone_approvals.py`: 74 passed. New cases: bearer header, `mysql -p`, `curl -u user:pass`, `X-Api-Key`, a 48-char blob all masked; the long-path test stays green; the ntfy publish body for a bearer command contains `<redacted>`, not the token.
- Behavioural probe through `normalize()` → `display_target`: every credential above masked, a 60-char nested path still shown in full.
- `ruff check`, `ruff format --check`, `lint-imports` (5/5): green. Full suite not run locally (box under memory pressure; CI covers it) — change is confined to one masking helper + its tests + the doc.
