### PR TITLE
land #633: run example plugin suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,16 @@ jobs:
           ${{ runner.os == 'Linux' && 'xvfb-run -a -s "-screen 0 1280x800x24"' || '' }}
           pytest -n auto --dist loadgroup --max-worker-restart=0 --timeout=300 --durations=25 --durations-min=2.0
           ${{ matrix.coverage && '--cov=doberman --cov-report=term-missing --cov-fail-under=90' || '' }}
+      # Install examples only AFTER the standalone suite, on one Linux leg.
+      # Explicit paths keep their real entry-point tests out of root testpaths.
+      - name: Example plugin suites
+        if: runner.os == 'Linux' && matrix.python-version == '3.12'
+        run: |
+          set -euo pipefail
+          for example in examples/plugin-*; do
+            python -m pip install -e "$example"
+            python -m pytest "$example/tests" --timeout=300
+          done
   test-windows:
     # Doberman is a local-first tool that runs on developer machines of every
     # OS, and it carries OS-specific code (e.g. the Windows O_BINARY key-write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,19 @@ in CI. Their tests use fakes there, so exercise the real thing locally when you 
 `-n auto` runs the suite in parallel (pytest-xdist ships in the `dev` extra), the
 same way CI runs it.
 
+After the standalone suite, the Linux 3.12 leg installs and tests the example plugins separately:
+
+```bash
+set -euo pipefail
+for example in examples/plugin-*; do
+  python -m pip install -e "$example"
+  python -m pytest "$example/tests" --timeout=300
+done
+```
+
+Keep these suites out of root `testpaths`: core must pass without example plugins installed.
+Use a separate virtual environment for this command when continuing to test standalone core locally.
+
 CI also verifies that `doberman-core` builds and tests without the private
 enterprise package installed, then runs the same ruff, import-linter, pytest,
 and secret-scan workflow.

--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ See [the roadmap](ROADMAP.md) for what's planned and in flight, the
 Start with [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, CI checks, project invariants, and the
 PR workflow.
 
+The Linux Python 3.12 CI leg installs and tests every `examples/plugin-*` package after the
+standalone core suite. Example suites stay outside root pytest discovery so core is tested without
+the tutorial plugins installed.
+
 CI also runs `python scripts/check_markdown_links.py`, a deterministic offline check for
 repository-local Markdown links and heading anchors. It skips external URLs and fenced code blocks
 and never makes network requests.

--- a/tests/unit/test_example_plugin_ci.py
+++ b/tests/unit/test_example_plugin_ci.py
@@ -1,0 +1,70 @@
+"""Exercise the actual example CI shell without installing plugins into core."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _example_step() -> dict:
+    workflow = yaml.safe_load((ROOT / ".github/workflows/ci.yml").read_text())
+    steps = workflow["jobs"]["test"]["steps"]
+    names = [step.get("name") for step in steps]
+    assert names.index("Example plugin suites") > names.index("Test suite")
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    assert all(
+        not path.startswith("examples")
+        for path in config["tool"]["pytest"]["ini_options"]["testpaths"]
+    )
+    return steps[names.index("Example plugin suites")]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="The example CI step runs on Linux only")
+@pytest.mark.parametrize("failure", ["", "pip", "pytest"])
+def test_example_ci_runs_each_package_and_propagates_failure(tmp_path: Path, failure: str) -> None:
+    # Include a future package to pin discovery, not just the current three names.
+    packages = ["plugin-a", "plugin-b", "plugin-future"]
+    for name in packages:
+        (tmp_path / "examples" / name / "tests").mkdir(parents=True)
+    shim = tmp_path / "python"
+    shim.write_text(
+        "#!/bin/bash\n"
+        'printf "%s\\n" "$*" >> "$CALLS"\n'
+        'if [[ "$2" == "$FAILURE" ]]; then exit 17; fi\n'
+    )
+    shim.chmod(0o755)
+    calls = tmp_path / "calls"
+    result = subprocess.run(  # noqa: S603 - executes the checked-in CI step with a local shim
+        ["bash", "-e", "-o", "pipefail", "-c", _example_step()["run"]],  # noqa: S607
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+            "CALLS": str(calls),
+            "FAILURE": failure,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    expected = [
+        command
+        for name in packages
+        for command in (
+            f"-m pip install -e examples/{name}",
+            f"-m pytest examples/{name}/tests --timeout=300",
+        )
+    ]
+    if failure:
+        assert result.returncode == 17
+        assert calls.read_text().splitlines() == expected[: 1 if failure == "pip" else 2]
+    else:
+        assert result.returncode == 0, result.stderr
+        assert calls.read_text().splitlines() == expected


### PR DESCRIPTION
Lands @be-student's #633 on current main. Authorship stays with the contributor; linear-history main lands it through a landing branch.

What it does: CI installs each example plugin and runs its own test suite on the Linux 3.12 leg, after the standalone-core guarantee.

Landing notes: one conflict in the CI workflow. The job layout changed since this PR's base (the sharded Windows job landed in between). I kept every job on main and placed the new "Example plugin suites" step on the Linux test job. YAML validated. No changelog fragment, per the CI-plumbing rule in changelog.d/README.md.

Closes #595.
